### PR TITLE
includes all runtime dependencies in the cli jar

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -21,8 +21,8 @@ jar {
                 "Main-Class": "org.partiql.cli.Main")
     }
     
-    // includes all compile dependencies in the jar
-    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    // includes all runtime dependencies in the jar
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
 }
 
 


### PR DESCRIPTION
closes #57 

tested out by running a full build and then executing: 
```
java -jar cli/build/libs/cli-1.0.0.jar
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
