### PR TITLE
adds REPL commands

### DIFF
--- a/cli/src/org/partiql/cli/Repl.kt
+++ b/cli/src/org/partiql/cli/Repl.kt
@@ -88,7 +88,7 @@ internal class Repl(private val valueFactory: ExprValueFactory,
 
         private fun listCommands(source: String) {
             output.println("")
-            output.println("""|!add_to_global_env: adds a value to the global environment, similar to '-e' 
+            output.println("""|!add_to_global_env: adds a value to the global environment
                               |!list_commands: print this message""".trimMargin())
         }
     }

--- a/cli/test/org/partiql/cli/ReplTest.kt
+++ b/cli/test/org/partiql/cli/ReplTest.kt
@@ -110,7 +110,7 @@ class ReplTest {
         val actual = repl.runAndOutput().split("\n").map { it.trim() }
 
         // we only assert the lines that have the command output to ignore the prompt and OK message
-        assertEquals("!add_to_global_env: adds a value to the global environment, similar to '-e'", actual[1])
+        assertEquals("!add_to_global_env: adds a value to the global environment", actual[1])
         assertEquals("!list_commands: print this message", actual[2])
     }
 }


### PR DESCRIPTION
Refactors the REPL to have a more explicit state machine so we can add
REPL specific commands.

Two commands added:
* list_commands: list all REPL commands
* add_to_global_env: adds a value to the REPL global environment. This
is useful for users that want to add new "tables" in the repl without
having to use a file.

To use it:
PartiQL> !add_to_global_env {'myTable': <<{'a': 1}, {'a': 2}>>}

will add a binding from 'myTable' to <<{'a': 1}, {'a': 2}>>

I'll add user documentation and more tests before merging. Want to get
some early feedback on this change


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
