### PR TITLE
(Docs) Include GettingStarted in Tutorial

### DIFF
--- a/docs/README-AUTHORS.md
+++ b/docs/README-AUTHORS.md
@@ -6,6 +6,9 @@ You will need to install the following software
 * Make 
 * Pandoc 
     * https://pandoc.org/installing.html
+* Pandoc Filters 
+    * [pandoc-include](https://github.com/DCsunset/pandoc-include). Include other md files 
+    * [pandoc-include-code](https://github.com/owickstrom/pandoc-include-code). Include files from inside md code blocks. 
 * texlive 
     * https://www.tug.org/texlive/
 

--- a/docs/common.mk
+++ b/docs/common.mk
@@ -56,6 +56,8 @@ PDFOPTIONS += $(TEXTEMPLATE)
 PDFOPTIONS += $(TEXLISTINGS)
 PDFOPTIONS += $(RESOURCEPATH)
 
+PANDOCFILTERS := --filter pandoc-include --filter pandoc-include-code
+
 BIBOPTIONS := --filter pandoc-citeproc
 
 MARKDOWNOPTIONS := -f markdown+tex_math_single_backslash
@@ -68,16 +70,16 @@ all: html pdf epub
 
 # generate tex output and stop. useful for debugging issues with PDF 
 tex: outputdirs haspandoc hasxetex
-	$(PANDOC) $(SRC) $(PDFOPTIONS) $(BIBOPTIONS)  -o $(OUTPUTPATH)/$(TARGET).tex
+	$(PANDOC) $(SRC) $(PDFOPTIONS) $(PANDOCFILTERS) $(BIBOPTIONS)  -o $(OUTPUTPATH)/$(TARGET).tex
 
 pdf: outputdirs haspandoc hasxetex
-	$(PANDOC) $(SRC) $(PDFOPTIONS) $(BIBOPTIONS)  -o $(OUTPUTPATH)/$(TARGET).pdf
+	$(PANDOC) $(SRC) $(PDFOPTIONS) $(PANDOCFILTERS)  $(BIBOPTIONS)  -o $(OUTPUTPATH)/$(TARGET).pdf
 
 epub: outputdirs haspandoc 
-	$(PANDOC) $(SRC) $(EPUBOPTIONS) $(BIBOPTIONS) -o $(OUTPUTPATH)/$(TARGET).epub
+	$(PANDOC) $(SRC) $(EPUBOPTIONS) $(PANDOCFILTERS) $(BIBOPTIONS) -o $(OUTPUTPATH)/$(TARGET).epub
 
 html: outputdirs haspandoc
-	$(PANDOC) $(SRC) $(HTMLOPTIONS) $(MARKDOWNOPTIONS) $(BIBOPTIONS) -o $(OUTPUTPATH)/$(TARGET).html
+	$(PANDOC) $(SRC) $(HTMLOPTIONS) $(MARKDOWNOPTIONS) $(PANDOCFILTERS) $(BIBOPTIONS) -o $(OUTPUTPATH)/$(TARGET).html
 	cp -r $(SUPPORTFILES) $(OUTPUTPATH)/.
 
 

--- a/docs/dev/CODE-STYLE.md
+++ b/docs/dev/CODE-STYLE.md
@@ -4,7 +4,7 @@
 of `ktlint`.**
 
 This document serves as style guide and includes code conventions and idioms for [Kotlin](https://kotlinlang.org/) 
-in the \SqlName project.
+in the PartiQL project.
  
 We use [Kotlin official coding conventions](http://kotlinlang.org/docs/reference/coding-conventions.html) document as 
 a base. If it's not specified here use that as a reference. 

--- a/docs/dev/Design.md
+++ b/docs/dev/Design.md
@@ -1,1 +1,1 @@
-# \SqlName Design Overview
+# PartiQL Design Overview

--- a/docs/dev/README-AST-INTRO.md
+++ b/docs/dev/README-AST-INTRO.md
@@ -2,7 +2,7 @@
 
 It seems the term "AST" is often extended to mean more things than just "Abstract Syntax Tree" and our use of the term
 is no different. A better term might have been "Abstract Semantic Tree" because our AST was defined with the goal of
-modeling the intent of the \SqlName source and *not* the exact syntax. Thus, the original SQL from which an AST was
+modeling the intent of the PartiQL source and *not* the exact syntax. Thus, the original SQL from which an AST was
 constituted cannot be derived, however the *semantics* of that SQL are guaranteed to be preserved. One example that
 demonstrates this is the fact that we model a `CROSS JOIN` in the same way that we model an `INNER JOIN` with a
 condition of `TRUE`. Semantically, these have the exact same function and so they also have the same representation in
@@ -11,7 +11,7 @@ the AST.
 ## It *is* Actually a Tree
 
 Language implementations often use the term "Abstract Syntax Tree" to refer to a data structure that is actually a
-graph. Our implementation for \SqlName's AST is a tree and *not* a graph. It contains no cycles and each node can only
+graph. Our implementation for PartiQL's AST is a tree and *not* a graph. It contains no cycles and each node can only
 reference its children.
 
 ##  It's Immutable
@@ -26,11 +26,11 @@ The AST employs a number of patterns and utilizes certain features of Kotlin to 
 Without any introduction, the reasoning behind these patterns may not be completely apparent at first glance. What
 follows is an is an attempt to document those patterns and features.
 
-### Inheritance Mirrors The \SqlName Grammar
+### Inheritance Mirrors The PartiQL Grammar
 
 The top-most type of the AST is `org.partiql.lang.ast.ExprNode`. Most of the classes of the AST derive
 from this class. Most child nodes are also of type `ExprNode`. However, there are several cases where the types of child
-nodes that are allowed are constrained (or extended) by \SqlName's grammar. For example, not every type of `ExprNode`
+nodes that are allowed are constrained (or extended) by PartiQL's grammar. For example, not every type of `ExprNode`
 can exist as components of a path expression (i.e. `a.b.c`). Additionally, some path components are allowed that do not
 make sense outside of the context of a path expression (i.e. `a.*.b` and `a[*].b`). If *all* nodes of the AST inherited
 from `ExprNode` it would be easy to accidentally construct ASTs which are structurally invalid. Thus, each grammar

--- a/docs/dev/README-AST-V1.md
+++ b/docs/dev/README-AST-V1.md
@@ -1,8 +1,8 @@
 
-# \SqlName AST
+# PartiQL AST
 
-By AST in this document we refer to the data structure used to represent an \SqlName query. 
-This is also the version of the AST provided to clients that consume the \SqlName AST. 
+By AST in this document we refer to the data structure used to represent an PartiQL query. 
+This is also the version of the AST provided to clients that consume the PartiQL AST. 
 
 ## Notation
 
@@ -91,9 +91,9 @@ SEXP      ::= `(` ION_VALUE ... `)`
 In the case of `SEXP` we refer to the name immediately following the `SEXP` 's open parenthesis as its **tag**.
 For example the `SEXP` `(lit 2)` is tagged with the symbol `lit`.
 
-## \SqlName AST data definition 
+## PartiQL AST data definition 
 
-Starting with version 1 of the \SqlName AST, each AST must be wrapped in an `ast` node:
+Starting with version 1 of the PartiQL AST, each AST must be wrapped in an `ast` node:
 
 ```
 (ast (version 1)
@@ -103,7 +103,7 @@ Starting with version 1 of the \SqlName AST, each AST must be wrapped in an `ast
 If the top-most node of the AST does not have the tag `ast` then we assume that it is a 
 [legacy version 0 AST](README-AST-V0.md).
 
-Within `(root ...)` we represent a valid \SqlName expression as a tree (`SEXP`) of **optionally** wrapped nodes called 
+Within `(root ...)` we represent a valid PartiQL expression as a tree (`SEXP`) of **optionally** wrapped nodes called 
 **term**s.
 
 ```
@@ -113,15 +113,15 @@ TERM ::= `(` `term` `(` `exp` EXP `)`
 
 The wrapper `term` contains 2 sub `SEXP` 
 
-* the \SqlName expression or expression fragment being wrapped tagged with `exp` 
-* the meta information for the \SqlName expression or expression fragment tagged with `meta`
+* the PartiQL expression or expression fragment being wrapped tagged with `exp` 
+* the meta information for the PartiQL expression or expression fragment tagged with `meta`
 
 The `meta` child node of `term` is optional but usually holds information on the location of the expression 
 in the original query. The definition of `META` is purposely left open to allow for the addition of meta 
-information on the AST by consumers of the \SqlName such as query rewriters.
+information on the AST by consumers of the PartiQL such as query rewriters.
 
-The \SqlName implementation shall use the `$` prefix for all of its meta node tags.  A naming convention such
-as reverse domain name notation should be used for meta node tags introduced by consumers of the \SqlName AST
+The PartiQL implementation shall use the `$` prefix for all of its meta node tags.  A naming convention such
+as reverse domain name notation should be used for meta node tags introduced by consumers of the PartiQL AST
 to avoid naming conflicts.
 
 ```
@@ -154,7 +154,7 @@ The `term` wrapper is optional and so the previous example can be stripped down 
     (lit customerId)
 ```
 
-### \SqlName AST "Grammar" 
+### PartiQL AST "Grammar" 
 
 ```
 EXP ::= 

--- a/docs/dev/README-DESIGN.md
+++ b/docs/dev/README-DESIGN.md
@@ -1,11 +1,11 @@
-## \SqlName Parser, Compiler, and Evaluator Design
-This document provides the high-level design overview of the \SqlName parser and evaluator. The high-level pipeline of compilation is illustrated as follows:
+## PartiQL Parser, Compiler, and Evaluator Design
+This document provides the high-level design overview of the PartiQL parser and evaluator. The high-level pipeline of compilation is illustrated as follows:
 
 ![Parser and Compiler Diagram](img/parser-compiler.png)
 
-* The **lexer** is a hybrid direct/table driven lexical analyzer for \SqlName lexemes that produce high-level tokens.
+* The **lexer** is a hybrid direct/table driven lexical analyzer for PartiQL lexemes that produce high-level tokens.
   * SQL is very keyword heavy, so having our own lexer implementation allows us to more easily normalize things like keywords that consist of multiple lexemes (e.g. `CHARACTER VARYING`)
-* The **parser** is a basic [recursive decent parser][recursive-descent] for the \SqlName language that produces an AST as an Ion S-expression.
+* The **parser** is a basic [recursive decent parser][recursive-descent] for the PartiQL language that produces an AST as an Ion S-expression.
   * For infix operator parsing, the parser is implemented as a Top-Down Operator Precedence (TDOP) [Pratt parser][pratt-parser].
 * The **semantic analyzer** is a placeholder for general purpose semantic analysis.  This is not yet implemented, but important optimizations such as determining which paths/columns are relevant for a given query will be done by this phase.  Decoupling of the parser from the compiler, means that any application can do their own validation and processing of the AST.
 * The **compiler** converts the AST nodes into [context threaded][context-threading] code.
@@ -50,7 +50,7 @@ public static void main(String[] args) throws Exception {
 It can be seen that the above example leverages lexical closures (lambdas) to build an object graph of state to represent the actual interpretation, the actual dispatch leverages the native call stack differs from straight compiled code in that each "opcode" is a virtual call.
 
 ### Evaluation Strategy
-Evaluation is done by first compiling source text of an \SqlName expression into an instance of `Expression` which provides the entry point to evaluation:
+Evaluation is done by first compiling source text of an PartiQL expression into an instance of `Expression` which provides the entry point to evaluation:
 
 ![Parser/Compiler/Expression Class Diagram](img/compiler-class.png)
 
@@ -65,7 +65,7 @@ All `ExprValue` implementations indicate what type of value they are and impleme
 Modeling relations (collections) as `Iterable`/`Iterator` allows the evaluator to compose the relational operators (e.g. projection, filter, joins) as lazy `Iterators` that are composed with one another.  This functional pipeline is very similar to what is done in full query engines and is also similar to how [Java 8 streams][java-streams] work.
 
 #### Lazy Evaluation Example
-We can use our simple integer evaluator example to demonstrate how the \SqlName evaluator lazily evaluates.  Let's change this example to add a functional interface as the integer value (i.e. a **[thunk][thunk]** representing an integer).
+We can use our simple integer evaluator example to demonstrate how the PartiQL evaluator lazily evaluates.  Let's change this example to add a functional interface as the integer value (i.e. a **[thunk][thunk]** representing an integer).
 
 ```java
 interface IntValue {
@@ -109,7 +109,7 @@ public static void main(String[] args) throws Exception {
 }
 ```
 
-Note that now, all values require an additional virtual dispatch to get the underlying value.  `ExprValue` can be thought of as a thunk for all of the types of values in \SqlName.
+Note that now, all values require an additional virtual dispatch to get the underlying value.  `ExprValue` can be thought of as a thunk for all of the types of values in PartiQL.
 
 [recursive-descent]: https://en.wikipedia.org/wiki/Recursive_descent_parser
 [pratt-parser]: http://eli.thegreenplace.net/2010/01/02/top-down-operator-precedence-parsing

--- a/docs/dev/TEST_SCRIPT_SPEC.md
+++ b/docs/dev/TEST_SCRIPT_SPEC.md
@@ -5,15 +5,15 @@
 
 - `driver` A program which executes `commands` in a `test script` and sends `commands` to a `car` to execute the tests 
 contained within.
-- `car` A program with an embedded implementation of \SqlName that accepts `commands` from the `driver` for the purpose
-of testing \SqlName.
+- `car` A program with an embedded implementation of PartiQL that accepts `commands` from the `driver` for the purpose
+of testing PartiQL.
 - `test script` A file containing zero or more `commands`.
 - `command` An element of a `test script` which specifies an action to be taken such as execute SQL and verify the 
 result, or set defaults for `compile options` and `environment`.  `Commands` do not exist outside of `test scripts`.
 - `command validation rule` A rule used by the `driver` to determine if a `command` is valid and can be executed.
     - If any `command` in a `test script` fails validation, the `driver` reports an error and no tests are executed.
 - `test` A command that specifies:
-    - \SqlName query to be executed
+    - PartiQL query to be executed
     - A snippet of Ion which is the expected result which may be:
         - Ion
         - An error code and expected property value (line, column, etc).
@@ -21,7 +21,7 @@ result, or set defaults for `compile options` and `environment`.  `Commands` do 
 SQL of each test.
 - `default environment` An element of each `test script`'s runtime state which is an environment to be used by tests 
 that do not explicitly specify an environment.
-- `compile options` A collection of key/value pairs specifying options that affect how \SqlName is compiled.
+- `compile options` A collection of key/value pairs specifying options that affect how PartiQL is compiled.
 - `default compile options` An element of a test script's runtime state which specifies the `compile options` that are 
 used by tests that do not explicitly define their compile options. 
 - `session` A collection of key/value pairs used for the interpreter's evaluation session, specifying values such as 
@@ -46,8 +46,8 @@ failures are reported.
 
 Is a program that:
 
-- Is implementation specific, i.e. one will be implemented for each \SqlName implementation.
-- Accepts commands from the driver and executes them for a given \SqlName implementation.
+- Is implementation specific, i.e. one will be implemented for each PartiQL implementation.
+- Accepts commands from the driver and executes them for a given PartiQL implementation.
 - Returns the commands results or error details to the driver for verification.
 
 ## Test Scripts
@@ -73,8 +73,8 @@ At runtime, test scripts do not have a notion of a "scope".  They have mutable g
 | Global State Element | Command to Change | Defaults |
 -----------------------|----------------|----------------|
 | default environment | `set_default_environment` | An empty environment. |
-| default compile options | `set_default_compile_options` | The \SqlName implementation's default compile options. |
-| session | `set_default_session` | The \SqlName implementation's default session values, except `utcnow` must be `2000-01-01T00:00:00+00:00` |
+| default compile options | `set_default_compile_options` | The PartiQL implementation's default compile options. |
+| session | `set_default_session` | The PartiQL implementation's default session values, except `utcnow` must be `2000-01-01T00:00:00+00:00` |
 
 Before beginning execution of a test script, the driver must set the global runtime state to the above 
 defaults.  Once changed with any `set_*` command, new global state will be present during execution of any test 
@@ -122,7 +122,7 @@ again, causing an an infinite loop.
 
 Sets the default compile options used by tests which do not specify compile options of their own.  Any unspecified
 compile options will be set to their default values.  The compile options will be used when compiling the SQL of any
-test that does not specify its own compilation options. The default values are determined by the \SqlName
+test that does not specify its own compilation options. The default values are determined by the PartiQL
 implementation.  If no `set_compile_options` command is present, all tests not specifying their own compilation options
 will execute with the default compile options.
 
@@ -220,7 +220,7 @@ are left unspecified will be set to their default values.
  
 #### `test`
 
-Executes the specified \SqlName query against the specified environment with the specified compile options and verifies the
+Executes the specified PartiQL query against the specified environment with the specified compile options and verifies the
 expected result or expected error.
  
 If no environment is specified, the default environment (set by the `set_default_environment` command) is used.
@@ -242,10 +242,10 @@ If no compile options are specified, the default compile options are used (set b
 ```
 
 When the Ion value paired with the `expected` field has a `result::` annotation, the test must be considered failed  
-if the result of evaluating `sql` doesn't match `expected` exactly, as defined by \SqlName's data equality rules 
-(section 6.0.2 of the \SqlName specification).  
+if the result of evaluating `sql` doesn't match `expected` exactly, as defined by PartiQL's data equality rules 
+(section 6.0.2 of the PartiQL specification).  
 
-There is a 1:1 correlation between types of `\SqlName` and Ion with a single exception:  \SqlName 
+There is a 1:1 correlation between types of `PartiQL` and Ion with a single exception:  PartiQL 
 additionally defines a bag type--which differs from a list only in that the order of the items in the bag are undefined.
 The implications of this is that when two bags are compared, the order of the elements do not matter.  More 
 specifically: two bags are the equivalent if every element that appears `n` times in the first bag also appears `n` 
@@ -262,7 +262,7 @@ Given that Ion does not have `<<` and `>>` notation to indicate a literal bag th
     }
 ```
 
-| `expected` Field Example | \SqlName Equivalent | Description 
+| `expected` Field Example | PartiQL Equivalent | Description 
 ---|---|---
 | `[(bag 1 2 3)]` | `[<<1, 2, 3>]` | A list containing a bag of three integers. |
 | `(bag { foo: (bag 1 2 3) })` | `<<{ 'foo': <<1, 2, 3>> >>` | A bag containing a struct with field `foo` that is also a bag. |
@@ -337,7 +337,7 @@ The `expected` field is either annotated with `result` or `error`:
 
 #### `benchmark`
 
-Executes the set of benchmarks for the specified \SqlName query against the specified environment with the specified compile 
+Executes the set of benchmarks for the specified PartiQL query against the specified environment with the specified compile 
 options and aggregates the benchmark results or error 
 
 `benchmark` command specification is based on the `test` command specification. The differences are: 
@@ -480,7 +480,7 @@ within the `driver`.  `for` command variables may be used to specify environment
 
 ##### Known issues:
 
-- [\SqlName Test suite: support annotated variable references for test expectation](https://github.com/partiql/partiql-lang-kotlin/issues/24)
+- [PartiQL Test suite: support annotated variable references for test expectation](https://github.com/partiql/partiql-lang-kotlin/issues/24)
 
 ## A Complete Example
 

--- a/docs/dev/img/Exceptions.md
+++ b/docs/dev/img/Exceptions.md
@@ -1,8 +1,8 @@
 # Evaluation Exceptions
 
 During evaluation the interpreter can only throw `EvaluationException`s. They fall into two categories: 
-* ​Direct exceptions thrown by the evaluation of an \SqlName query, for example `No such binding: <binding name>`
-* Wrapped exceptions that originate out of evaluation an \SqlName query, for example: `/ by zero` an `ArithmeticException` 
+* ​Direct exceptions thrown by the evaluation of an PartiQL query, for example `No such binding: <binding name>`
+* Wrapped exceptions that originate out of evaluation an PartiQL query, for example: `/ by zero` an `ArithmeticException` 
   thrown by Java when dividing a number by zero. One important thing to note is that only `T extends java.lang.Exception` 
   are wrapped by an `EvaluationException`. `T extends java.lang.Errors`, e.g. `OutOfMemoryError`, are not `Exception`s 
   and therefore not wrapped.

--- a/docs/macros.md
+++ b/docs/macros.md
@@ -1,4 +1,0 @@
-
-
-\newcommand{\SqlName}{PartiQL }
-

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -1,3 +1,6 @@
+
+!include user/GettingStarted.md
+
 # Introduction 
 
 PartiQL provides SQL-compatible unified query access across multiple

--- a/docs/user/BuiltInFunctions.md
+++ b/docs/user/BuiltInFunctions.md
@@ -140,7 +140,7 @@ CAST(1         AS boolean) -- true
 CAST(`1e0`     AS boolean) -- true (float)
 CAST(`1d0`     AS boolean) -- true (decimal)
 CAST('a'       AS boolean) -- false
-CAST('true'    AS boolean) -- true (\SqlName string 'true')
+CAST('true'    AS boolean) -- true (PartiQL string 'true')
 CAST(`'true'`  AS boolean) -- true (Ion symbol `'true'`)
 CAST(`'false'` AS boolean) -- false (Ion symbol `'false'`)
 
@@ -358,7 +358,7 @@ DATE_DIFF(day, `2010-01-01T23:00T`, `2010-01-02T01:00T`) -- 0 (need to be at lea
 
 ### EXISTS
 
-Given an \SqlName value returns `true` if and only if the value is a non-empty sequence, returns `false` otherwise. 
+Given an PartiQL value returns `true` if and only if the value is a non-empty sequence, returns `false` otherwise. 
 
 Signature
 : `EXISTS: Any -> Boolean`
@@ -367,7 +367,7 @@ Header
 : `EXISTS(val)`
 
 Purpose 
-: Given an \SqlName value, `val`, returns `true` if and only if `val` is a non-empty sequence, returns `false` otherwise. 
+: Given an PartiQL value, `val`, returns `true` if and only if `val` is a non-empty sequence, returns `false` otherwise. 
 This function does **not** propagate `null` and `missing`.  
 
 
@@ -671,7 +671,7 @@ TO_TIMESTAMP('Febrary 2016', 'MMMM yyyy')     -- `2016-02T`
 ```
 Notes:
 
-[All SIM items for \SqlName's `TO_TIMESTAMP` function](https://i.amazon.com/issues/search?q=status%3A(Open)+(TO_TIMESTAMP)+containingFolder%3A(0efa7b8c-5170-4de7-a8e7-d0975778a686)&sort=lastUpdatedConversationDate+desc&selectedDocument=0b5e3cc3-40bc-40cf-854b-977f4ae4e08d).
+[All SIM items for PartiQL's `TO_TIMESTAMP` function](https://i.amazon.com/issues/search?q=status%3A(Open)+(TO_TIMESTAMP)+containingFolder%3A(0efa7b8c-5170-4de7-a8e7-d0975778a686)&sort=lastUpdatedConversationDate+desc&selectedDocument=0b5e3cc3-40bc-40cf-854b-977f4ae4e08d).
 
 Internally, this is implemented with Java 8's `java.time` package.  There are a few differences between Ion's 
 timestamp and the `java.time` package that create a few hypothetically infrequently encountered caveats that do not 

--- a/docs/user/CLI.md
+++ b/docs/user/CLI.md
@@ -1,4 +1,4 @@
-# \SqlName CLI
+# PartiQL CLI
 
 ```
 PartiQL CLI
@@ -224,7 +224,7 @@ OK! (5 ms)
 
 ## Initial Environment
 
-The initial environment for the REPL can be setup with a configuration file, which should be an \SqlName file with a 
+The initial environment for the REPL can be setup with a configuration file, which should be an PartiQL file with a 
 single `struct` containing the initial *global environment*.
 
 For example a file named `config.sql`, containing the following:

--- a/docs/user/COOKBOOK.md
+++ b/docs/user/COOKBOOK.md
@@ -1,6 +1,6 @@
 # Code Examples 
 
-Code examples on how to use the \SqlName library inside your code base. Please consult the `kdoc` for more 
+Code examples on how to use the PartiQL library inside your code base. Please consult the `kdoc` for more 
 information on individual classes and interfaces.
 
 ## Java

--- a/docs/user/GettingStarted.md
+++ b/docs/user/GettingStarted.md
@@ -1,20 +1,20 @@
 # Getting Started 
 
-\SqlName provides an interactive shell, or Read Eval Print Loop (REPL),
-that allows users to write and evaluate \SqlName queries. 
+PartiQL provides an interactive shell, or Read Eval Print Loop (REPL),
+that allows users to write and evaluate PartiQL queries. 
 
 ## Prerequisites 
 
-\SqlName requires the Java Runtime (JVM) to be installed on your machine.
+PartiQL requires the Java Runtime (JVM) to be installed on your machine.
 You can obtain the *latest* version of the Java Runtime from either  
 
 1. [OpenJDK](https://openjdk.java.net/install/), and [OpenJDK for Windows](https://developers.redhat.com/products/openjdk)  
 1. [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/index.html)
 
-## Download the \SqlName REPL 
+## Download the PartiQL REPL 
  
 Each [release](https://github.com/partiql/partiql-lang-kotlin/releases)
-of \SqlName comes with an archive that contains the \SqlName REPL as a
+of PartiQL comes with an archive that contains the PartiQL REPL as a
 zip file.
 
 1. [Download](https://github.com/partiql/partiql-lang-kotlin/releases/download/v0.1.0-alpha/partiql-cli-0.1.0.zip)
@@ -31,12 +31,12 @@ the latest `partiql-cli` zip archive to your machine.
 │   └── tutorial.pdf
 ```
 
-## Running the \SqlName REPL 
+## Running the PartiQL REPL 
 
 ### Windows 
 
 Run (double click) on `particl.bat`. This should open a command line
-prompt and start the \SqlName REPL. The \SqlName REPL prompt should look like this 
+prompt and start the PartiQL REPL. The PartiQL REPL prompt should look like this 
 
 ```
 Welcome to the PartiQL REPL!
@@ -47,16 +47,16 @@ PartiQL>
 
 1. Open a terminal and navigate to the `partiql-cli` folder we created when we extracted `partiql-cli.zip`. 
 1. Run the executable `partiql` file, by typing `./partiql` and hit
-enter. This should start the \SqlName REPL and should look like this
+enter. This should start the PartiQL REPL and should look like this
 
 ```
 Welcome to the PartiQL REPL!
 PartiQL>
 ```
 
-## Testing the \SqlName REPL 
+## Testing the PartiQL REPL 
 
-Let's write a simple query to verify that our \SqlName REPL is working. At the `PartiQL>` prompt type 
+Let's write a simple query to verify that our PartiQL REPL is working. At the `PartiQL>` prompt type 
 
 ```
 PartiQL> SELECT * FROM [1,2,3]
@@ -84,8 +84,8 @@ PartiQL>
 
 ```
 
-Congratulations! You succesfuly installed and run the \SqlName REPL.
-The \SqlName REPL is now waiting for more input. To exit the \SqlName
+Congratulations! You succesfuly installed and run the PartiQL REPL.
+The PartiQL REPL is now waiting for more input. To exit the PartiQL
 REPL press 
 
 * `Control+D` in OSX or Unix 

--- a/docs/user/Guide.md
+++ b/docs/user/Guide.md
@@ -1,11 +1,11 @@
 
-# \SqlName User Guide 
+# PartiQL User Guide 
 
 ## Introduction 
 
-This is the \SqlName implementation's user guide. The goal of this
-document is to provide to users of \SqlName information on the features
-implemented and any deviation from the \SqlName specification.
+This is the PartiQL implementation's user guide. The goal of this
+document is to provide to users of PartiQL information on the features
+implemented and any deviation from the PartiQL specification.
 
 
 
@@ -13,7 +13,7 @@ implemented and any deviation from the \SqlName specification.
 
 ### Decimal
 
-\SqlName decimals are based on [Ion decimals] from the Ion Specification[@IonSpec] but with a maximum precision of 38 
+PartiQL decimals are based on [Ion decimals] from the Ion Specification[@IonSpec] but with a maximum precision of 38 
 digits, numbers outside this precision range will be rounded using a round [half even strategy]. Examples: 
 
     1.00000000000000000000000000000000000000000001 -> 1.0000000000000000000000000000000000000

--- a/docs/user/Preface.md
+++ b/docs/user/Preface.md
@@ -4,9 +4,9 @@
 
  *This document is an early draft, contributions welcome!*
 
-## What is \SqlName 
+## What is PartiQL 
 
- \SqlName is an implementation of
+ PartiQL is an implementation of
  [SQL++](http://db.ucsd.edu/wp-content/uploads/pdfs/375.pdf) based upon
  [Ion's](http://amzn.github.io/ion-docs/) type system. PartiQL is based on SQL92
  and provides support for working with schemaless hierarchical data. 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,4 +1,4 @@
 # Contents 
 
 * [User Guide](Guide.md)
-* [How to use the \SqlName REPL](CLI.md)
+* [How to use the PartiQL REPL](CLI.md)

--- a/docs/user/TemplateBuiltInFunctions.md
+++ b/docs/user/TemplateBuiltInFunctions.md
@@ -1,5 +1,5 @@
 
-This is the template for writing documentations for an \SqlName built-in function. 
+This is the template for writing documentations for an PartiQL built-in function. 
 
 The template uses Pandoc's definition lists feature https://pandoc.org/MANUAL.html#definition-lists
 

--- a/docs/user/Tutorial.md
+++ b/docs/user/Tutorial.md
@@ -1,3 +1,3 @@
-# \SqlName Tutorial 
+# PartiQL Tutorial 
 
 TBD


### PR DESCRIPTION
1. Adds pandoc filters for includes
1. Includes GettingStarted.md in Tutorial.md
1. Removes the LaTeX macro for `\SqlName`.

The diff is rather large due to the search-and-replace for `\SqlName` to
`PartiQL`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
