### PR TITLE
Adds PrettyPrint for ExprValues

### DIFF
--- a/cli/src/org/partiql/cli/ExprValuePrettyPrinter.kt
+++ b/cli/src/org/partiql/cli/ExprValuePrettyPrinter.kt
@@ -1,0 +1,107 @@
+package org.partiql.cli
+
+import com.amazon.ion.system.*
+import org.partiql.lang.eval.*
+import org.partiql.lang.eval.ExprValueType.*
+import java.io.*
+import java.nio.charset.*
+
+private val charset = Charset.forName("UTF-8") 
+private val indentation = "  ".toByteArray(charset)
+
+private val newLine = "\n".toByteArray(charset)
+private val missingBytes = "MISSING".toByteArray(charset)
+private val nullBytes = "NULL".toByteArray(charset)
+
+interface ExprValuePrettyPrinter {
+    fun prettyPrint(value: ExprValue)
+}
+
+internal class NonConfigurableExprValuePrettyPrinter(private val output: OutputStream): ExprValuePrettyPrinter {
+    private var currentIndentation: Int = 0
+
+    override fun prettyPrint(value: ExprValue) {
+        currentIndentation = 0
+
+        recursivePrettyPrint(value)
+    }
+
+    private fun recursivePrettyPrint(value: ExprValue): Unit {
+        when (value.type) {
+
+            MISSING                                    -> output.write(missingBytes)
+            NULL                                       -> output.write(nullBytes)
+
+            BOOL                                       -> write(value.scalar.booleanValue().toString())
+
+            INT, DECIMAL                               -> write(value.scalar.numberValue().toString())
+
+            STRING                                     -> write("'${value.scalar.stringValue()}'")
+
+            // fallback to an Ion literal for all types that don't have a native PartiQL representation
+            FLOAT, TIMESTAMP, SYMBOL, CLOB, BLOB, SEXP -> prettyPrintIonLiteral(value)
+
+            LIST                                       -> prettyPrintContainer(value, "[", "]")
+            BAG                                        -> prettyPrintContainer(value, "<<", ">>")
+            STRUCT                                     -> prettyPrintContainer(value, "{", "}") { v ->
+                val fieldName = v.name!!.scalar.stringValue()
+                write("'$fieldName': ")
+
+                recursivePrettyPrint(v)
+            }
+        }
+    }
+
+
+    private fun prettyPrintContainer(value: ExprValue,
+                                     openingMarker: String,
+                                     closingMarker: String,
+                                     prettyPrintElement: (ExprValue) -> Unit = { v -> recursivePrettyPrint(v) }) {
+        
+        val iterator = value.iterator()
+        
+        if(iterator.hasNext()){
+            write("$openingMarker\n")
+
+            currentIndentation += 1
+            
+            val firstElement = iterator.next()
+            writeIndentation()
+            prettyPrintElement(firstElement)
+
+            iterator.forEach { v ->
+                write(",\n")
+                writeIndentation()
+                prettyPrintElement(v)
+            }
+            
+            currentIndentation -= 1
+
+            output.write(newLine)
+            writeIndentation()
+            write(closingMarker)
+        }
+        else {
+            // empty container
+            write("$openingMarker$closingMarker")
+        }
+    }
+
+
+    private fun prettyPrintIonLiteral(value: ExprValue) {
+        val ionValue = value.ionValue
+        write("`")
+        IonTextWriterBuilder.standard().build(output).use { writer -> ionValue.writeTo(writer) }
+        write("`")
+    }
+
+    private fun write(s: String) {
+        output.write(s.toByteArray(charset))
+    }
+
+    private fun writeIndentation() {
+        IntRange(1, currentIndentation).forEach { output.write(indentation) }
+    }
+}
+
+

--- a/cli/test/org/partiql/cli/NonConfigurableExprValuePrettyPrinterTest.kt
+++ b/cli/test/org/partiql/cli/NonConfigurableExprValuePrettyPrinterTest.kt
@@ -1,0 +1,181 @@
+package org.partiql.cli
+
+import com.amazon.ion.system.*
+import junitparams.*
+import org.junit.*
+import org.junit.runner.*
+import org.partiql.lang.*
+import org.partiql.lang.eval.*
+import java.io.*
+import java.nio.charset.*
+import kotlin.test.*
+
+
+@RunWith(JUnitParamsRunner::class)
+class NonConfigurableExprValuePrettyPrinterTest {
+
+    private val ion = IonSystemBuilder.standard().build()
+    private val compiler = CompilerPipeline.standard(ion)
+
+    private val output = ByteArrayOutputStream()
+    private val prettyPrinter = NonConfigurableExprValuePrettyPrinter(output)
+    
+    private fun evalQuery(q: String) = compiler.compile(q).eval(EvaluationSession.standard())
+    private fun prettyPrint(v: ExprValue): String {
+        prettyPrinter.prettyPrint(v)
+        return output.toString("UTF-8")
+    }
+
+    fun unknownExamples()
+        = arrayOf(
+        "missing" to "MISSING",
+        "MISSING" to "MISSING",
+
+        "null" to "NULL",
+        "NULL" to "NULL",
+        "`null`" to "NULL"
+    ).map { listOf(it.first, it.second) }
+    
+    fun examples() 
+        = arrayOf(
+            // Bool
+            "true" to "true",
+            "false" to "false",
+            "`true`" to "true",
+
+            // Int
+            "1" to "1",
+            "`1`" to "1",
+
+            // Decimal
+            "1.0" to "1.0",
+            "`1.0`" to "1.0",
+
+            // String 
+            "'some text'" to "'some text'",
+            "`\"some text\"`" to "'some text'",
+
+            // Ion Literals
+            "`1e0`" to "`1e0`",
+            "`2019T`" to "`2019T`",
+            "`symbol`" to "`symbol`",
+            "`{{\"clob value\"}}`" to "`{{\"clob value\"}}`",
+            "`{{VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE=}}`" to "`{{VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE=}}`",
+            "`(sym 1 2 3)`" to "`(sym 1 2 3)`",
+
+             // List
+            "[]" to "[]",
+
+            "[1,2,3]" to """
+                |[
+                |  1,
+                |  2,
+                |  3
+                |]""".trimMargin(),
+
+            "`[1,2,3]`" to """
+                |[
+                |  1,
+                |  2,
+                |  3
+                |]""".trimMargin(),
+            
+            "[1,2,[1]]" to """
+                |[
+                |  1,
+                |  2,
+                |  [
+                |    1
+                |  ]
+                |]""".trimMargin(),
+
+            // Bag
+            "<<>>" to "<<>>",
+
+            "<<1,2,3>>" to """
+                |<<
+                |  1,
+                |  2,
+                |  3
+                |>>""".trimMargin(),
+            
+
+            "<<1,2,<<1>> >>" to """
+                |<<
+                |  1,
+                |  2,
+                |  <<
+                |    1
+                |  >>
+                |>>""".trimMargin(),
+
+            // Struct
+            "{}" to "{}",
+
+            "{'foo': 1, 'bar': 2}" to """
+                |{
+                |  'foo': 1,
+                |  'bar': 2
+                |}""".trimMargin(),
+
+            "`{foo: 1, bar: 2,}`" to """
+                |{
+                |  'foo': 1,
+                |  'bar': 2
+                |}""".trimMargin(),
+
+            "{'foo': 1, 'bar': 2, 'baz': {'a': 10}}" to """
+                |{
+                |  'foo': 1,
+                |  'bar': 2,
+                |  'baz': {
+                |    'a': 10
+                |  }
+                |}
+                """.trimMargin(),
+                 
+            // Mixed containers
+            "<<{'foo': 1, 'bar': [1,2,3], 'baz': {'books': <<>>}}>>" to """
+                |<<
+                |  {
+                |    'foo': 1,
+                |    'bar': [
+                |      1,
+                |      2,
+                |      3
+                |    ],
+                |    'baz': {
+                |      'books': <<>>
+                |    }
+                |  }
+                |>>
+                """.trimMargin()
+             
+
+
+        ).map { listOf(it.first, it.second) }
+
+
+    @Test
+    @Parameters(method = "unknownExamples")
+    fun testUnknown(expression: String, expected: String) {
+
+        val value = evalQuery(expression)
+        val actual = prettyPrint(value)
+
+        assertEquals(expected, actual)
+        assertEquals(value.type, evalQuery(actual).type)
+    }
+    
+    @Test
+    @Parameters(method = "examples")
+    fun test(expression: String, expected: String) {
+        val value = evalQuery(expression)
+        val actual = prettyPrint(value)
+        
+        assertEquals(expected, actual)
+
+        // the pretty print is valid PartiQL and represents the same value
+        assertTrue(evalQuery("$expression = $actual").scalar.booleanValue()!!)
+    }
+}

--- a/cli/test/org/partiql/cli/ReplTest.kt
+++ b/cli/test/org/partiql/cli/ReplTest.kt
@@ -158,7 +158,6 @@ class ReplTest {
             #===' 
             #2
             #--- 
-            #Result type was INT
             #OK! (0 ms)
             #PartiQL> 
         """.trimMargin("#"))
@@ -173,14 +172,12 @@ class ReplTest {
             #===' 
             #2
             #--- 
-            #Result type was INT
             #OK! (0 ms)
             #PartiQL> 2 + 2
             #   | 
             #===' 
             #4
             #--- 
-            #Result type was INT
             #OK! (0 ms)
             #PartiQL> 
         """.trimMargin("#"))
@@ -194,6 +191,7 @@ class ReplTest {
             #PartiQL> 1 + 1
             #   | !!
             #===' 
+            #
             #(
             #  ast
             #  (
@@ -216,7 +214,6 @@ class ReplTest {
             #  )
             #)
             #--- 
-            #Result type was SEXP
             #OK! (0 ms)
             #PartiQL> 
         """.trimMargin("#"))
@@ -229,6 +226,7 @@ class ReplTest {
             #PartiQL> 1 + 1
             #   | !?
             #===' 
+            #
             #(
             #  ast
             #  (
@@ -305,7 +303,6 @@ class ReplTest {
             #  )
             #)
             #--- 
-            #Result type was SEXP
             #OK! (0 ms)
             #PartiQL> 
         """.trimMargin("#"))
@@ -319,29 +316,29 @@ class ReplTest {
             #   | 
             #===' 
             #{
-            #  myTable:[
+            #  'myTable': <<
             #    {
-            #      a:1
+            #      'a': 1
             #    },
             #    {
-            #      a:2
+            #      'a': 2
             #    }
-            #  ]
+            #  >>
             #}
             #--- 
-            #Result type was STRUCT
             #OK! (0 ms)
             #PartiQL> SELECT * FROM myTable
             #   | 
             #===' 
-            #{
-            #  a:1
-            #}
-            #{
-            #  a:2
-            #}
+            #<<
+            #  {
+            #    'a': 1
+            #  },
+            #  {
+            #    'a': 2
+            #  }
+            #>>
             #--- 
-            #Result type was BAG and contained 2 items
             #OK! (0 ms)
             #PartiQL> 
         """.trimMargin("#"))
@@ -361,14 +358,13 @@ class ReplTest {
             #   | 
             #===' 
             #{
-            #  foo:[
+            #  'foo': [
             #    1,
             #    2,
             #    3
             #  ]
             #}
             #--- 
-            #Result type was STRUCT
             #OK! (0 ms)
             #PartiQL> 
         """.trimMargin("#"))
@@ -381,10 +377,8 @@ class ReplTest {
             #PartiQL> !global_env
             #   | 
             #===' 
-            #{
-            #}
+            #{}
             #--- 
-            #Result type was STRUCT
             #OK! (0 ms)
             #PartiQL> 
         """.trimMargin("#"))
@@ -398,33 +392,31 @@ class ReplTest {
             #   | 
             #===' 
             #{
-            #  myTable:[
+            #  'myTable': <<
             #    {
-            #      a:1
+            #      'a': 1
             #    },
             #    {
-            #      a:2
+            #      'a': 2
             #    }
-            #  ]
+            #  >>
             #}
             #--- 
-            #Result type was STRUCT
             #OK! (0 ms)
             #PartiQL> !global_env
             #   | 
             #===' 
             #{
-            #  myTable:[
+            #  'myTable': <<
             #    {
-            #      a:1
+            #      'a': 1
             #    },
             #    {
-            #      a:2
+            #      'a': 2
             #    }
-            #  ]
+            #  >>
             #}
             #--- 
-            #Result type was STRUCT
             #OK! (0 ms)
             #PartiQL> 
         """.trimMargin("#"))


### PR DESCRIPTION
Adds a pretty printer that prints out ExprVales using PartiQL syntax so
the printed ExprValue can be evaluated by PartiQL

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
