### PR TITLE
Replaced "sqlcli" occurences to "partiql"

### DIFF
--- a/cli/src/org/partiql/cli/main.kt
+++ b/cli/src/org/partiql/cli/main.kt
@@ -53,7 +53,7 @@ private val formatter = object : BuiltinHelpFormatter(120, 2) {
               |     partiql --query="SELECT * FROM input_data" --output-format=ION_BINARY --input=/logs/log.ion
               |
               |To pipe input data in via stdin:
-              |     cat /logs/log.ion | sqlcli --query="SELECT * FROM input_data" --format=ION_BINARY > output.10n
+              |     cat /logs/log.ion | partiql --query="SELECT * FROM input_data" --format=ION_BINARY > output.10n
               |
               |${super.format(options)}
         """.trimMargin()

--- a/cli/test/org/partiql/cli/functions/WriteFileTest.kt
+++ b/cli/test/org/partiql/cli/functions/WriteFileTest.kt
@@ -30,7 +30,7 @@ class WriteFileTest {
     private fun String.exprValue() = valueFactory.newFromIonValue(ion.singleValue(this))
     private fun readFile(path: String) = File(dirPath(path)).readText()
 
-    private fun dirPath(fname: String = "") = "/tmp/sqlclitest/$fname"
+    private fun dirPath(fname: String = "") = "/tmp/partiqltest/$fname"
 
     @Before
     fun setUp() {

--- a/docs/user/CLI.md
+++ b/docs/user/CLI.md
@@ -16,7 +16,7 @@ The cli can output using PartiQL syntax or Ion using the --output-format option,
      partiql --query="SELECT * FROM input_data" --output-format=ION_BINARY --input=/logs/log.ion
 
 To pipe input data in via stdin:
-     cat /logs/log.ion | sqlcli --query="SELECT * FROM input_data" --format=ION_BINARY > output.10n
+     cat /logs/log.ion | partiql --query="SELECT * FROM input_data" --format=ION_BINARY > output.10n
 
 Option                                Description
 ------                                -----------
@@ -259,7 +259,7 @@ $ ./gradlew :cli:run -q --console=plain --args='-e config.sql'
 Or if you have extracted one of the compressed archives:
 
 ```
-$ ./bin/sqlcli -e config.sql
+$ ./bin/partiql -e config.sql
 ```
 
 Expressions can then use the environment defined by `config.sql`:


### PR DESCRIPTION
*Description of changes:*
I found occurrences to "sqlcli" in the documentation that make me think that it is an original name of "partiql" and that these occurrences were forgotten before the release.

For the sake of everyone's understanding, I would like to fix them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
