### PR TITLE
Typing mistake in tutorial

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -941,7 +941,7 @@ the `projects` array.
 ```
 
 Notice the new feature: `AT o`. While `p` ranges over the elements
-of the array `e.projects`, the variable `o` is assigned tot he index of
+of the array `e.projects`, the variable `o` is assigned to the index of
 the element in the array. The query returns: 
 
 ```{include=tutorial/code/q13.output}


### PR DESCRIPTION
Minor typing mistake in the tutorial that wouldn't be picked up by a spell checker.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
