### PR TITLE
Issue #118, generate pom.xml and sign build artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,9 @@ allprojects {
     }
 }
 
-
 subprojects {
-    version = '0.1.0'
+    group = 'org.partiql'
+    version = '0.1.0-SNAPSHOT'
 }
 
 buildDir = new File(rootProject.projectDir, "gradle-build/" + project.name)
@@ -48,7 +48,6 @@ configure(subprojects.findAll { it.name != 'example' }) {
         }
     }
 }
-
 
 subprojects {
     plugins.withId('java', { _ ->

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -21,10 +21,11 @@ plugins {
     id 'maven-publish'
     id 'org.jetbrains.kotlin.jvm'
     id 'io.gitlab.arturbosch.detekt'
+
+    id "signing"
 }
 
-version = '0.1.0'
-group = 'org.partiql.lang'
+
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
@@ -62,16 +63,70 @@ tasks.register('javadocJar', Jar) {
 
 publishing {
     publications {
-        create('maven', MavenPublication) {
-            artifactId = 'partiql-lang-kotlin'
+        maven(MavenPublication) {
+            // group id and version are set in the root build.gradle for all projects.
+            artifactId = "partiql-lang-kotlin"
 
-            from(components['java'])
-            artifact(tasks['sourcesJar'])
-            artifact(tasks['javadocJar'])
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+
+            pom {
+                name = "PartiQL-Lang-Kotlin"
+                packaging = "jar"
+                url = "https://github.com/amzn/ion-schema-kotlin"
+                description = "An implementation of PartiQL for the JVM written in Kotlin."
+                scm {
+                    connection = "scm:git@github.com:partiql/partiql-lang-kotlin.git"
+                    developerConnection = "scm:git@github.com:partiql/partiql-lang-kotlin.git"
+                    url = "git@github.com:partiql/partiql-lang-kotlin.git"
+                }
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+                developers {
+                    developer {
+                        name = "Amazon Ion Team"
+                        email = "partiql-community@amazon.com"
+                        organization = "PartiQL"
+                        organizationUrl = "https://github.com/partiql"
+                    }
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            credentials {
+                username ossrhUsername
+                password ossrhPassword
+            }
         }
     }
 }
 
+// The below enables developers and CI servers who do not have the GPG keys needed for signing to build locally,
+// while also signing release builds.
+// Signatures are only required when publishing to maven central anyway. We may need a more sophisticated means of
+// determining if we should sign the build artifacts someday, but this should suffice for now.
+if(!version.endsWith("SNAPSHOT")) {
+    println("""
+*******************************************************************************
+Note: 
 
+The build artifacts will be signed because this is NOT a SNAPSHOT version. 
+Signing will fail if you have not configured a ~/.gradle/gradle.properties 
+file with the correct values.  
+*******************************************************************************
+""")
+
+    signing {
+        sign publishing.publications.maven
+    }
+}
 
 

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -21,7 +21,6 @@ plugins {
     id 'maven-publish'
     id 'org.jetbrains.kotlin.jvm'
     id 'io.gitlab.arturbosch.detekt'
-
     id "signing"
 }
 

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -19,12 +19,11 @@ plugins {
     id 'java-library'
     // https://docs.gradle.org/5.0/userguide/publishing_maven.html#header
     id 'maven-publish'
+    id 'org.jetbrains.dokka' version '0.9.18'
     id 'org.jetbrains.kotlin.jvm'
     id 'io.gitlab.arturbosch.detekt'
-    id "signing"
+    id 'signing'
 }
-
-
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
@@ -50,14 +49,20 @@ dependencies {
     testImplementation project(':testscript')
 }
 
-tasks.register('sourcesJar', Jar) {
-    from(sourceSets.main.allJava)
-    classifier = 'sources'
+dokka {
+    outputFormat = "html"
+    outputDirectory = "$buildDir/javadoc"
+    //todo: includes = ["path/to/module.md"]
 }
 
-tasks.register('javadocJar', Jar) {
-    from(tasks.javadoc)
-    classifier = 'javadoc'
+task sourcesJar(type: Jar) {
+    from "src"
+    classifier = "sources"
+}
+
+task javadocJar(type: Jar) {
+    from dokka
+    classifier = "javadoc"
 }
 
 publishing {
@@ -71,9 +76,9 @@ publishing {
             artifact javadocJar
 
             pom {
-                name = "PartiQL-Lang-Kotlin"
+                name = "PartiQL Lang Kotlin"
                 packaging = "jar"
-                url = "https://github.com/amzn/ion-schema-kotlin"
+                url = "https://partiql.org/"
                 description = "An implementation of PartiQL for the JVM written in Kotlin."
                 scm {
                     connection = "scm:git@github.com:partiql/partiql-lang-kotlin.git"
@@ -89,7 +94,7 @@ publishing {
                 developers {
                     developer {
                         name = "Amazon Ion Team"
-                        email = "partiql-community@amazon.com"
+                        email = "ion-team@amazon.com"
                         organization = "PartiQL"
                         organizationUrl = "https://github.com/partiql"
                     }
@@ -108,24 +113,13 @@ publishing {
     }
 }
 
-// The below enables developers and CI servers who do not have the GPG keys needed for signing to build locally,
-// while also signing release builds.
-// Signatures are only required when publishing to maven central anyway. We may need a more sophisticated means of
-// determining if we should sign the build artifacts someday, but this should suffice for now.
-if(!version.endsWith("SNAPSHOT")) {
-    println("""
-*******************************************************************************
-Note: 
+signing {
+    // Allow publishing to maven local even if we don't have the signing keys
+    // This works because when not required, the signing task will be skipped
+    // if signing.keyId, signing.password, signing.secretKeyRingFile, etc are
+    // not present in gradle.properties.
+    required { !gradle.taskGraph.hasTask(":lang:publishToMavenLocal") }
 
-The build artifacts will be signed because this is NOT a SNAPSHOT version. 
-Signing will fail if you have not configured a ~/.gradle/gradle.properties 
-file with the correct values.  
-*******************************************************************************
-""")
-
-    signing {
-        sign publishing.publications.maven
-    }
+    sign publishing.publications.maven
 }
-
 

--- a/lang/gradle.properties
+++ b/lang/gradle.properties
@@ -1,0 +1,6 @@
+
+
+# Required for the maven publish plugin--these properties must be present even if they contain placeholder values.
+ossrhUsername=EMPTY
+ossrhPassword=EMPTY
+


### PR DESCRIPTION
This is being done in preparation for publishing to maven central.

To ensure the ability to publish development versions of the library to the local maven repository for developers that do not have the GPG keys installed is not broken, we only attempt to sign the build artifacts when we are not building a "-SNAPSHOT" version.
