### PR TITLE
Test script runner fix

### DIFF
--- a/testscript/pts/test-scripts/temp/temp.sqlts
+++ b/testscript/pts/test-scripts/temp/temp.sqlts
@@ -1,7 +1,0 @@
-
-test::{
-    id: 'substring valid cases 2 arguments with FROM syntax',
-    statement: "substring('foo', 1)",
-    expected: (success "oo")
-}
-

--- a/testscript/pts/test-scripts/temp/temp.sqlts
+++ b/testscript/pts/test-scripts/temp/temp.sqlts
@@ -1,0 +1,7 @@
+
+test::{
+    id: 'substring valid cases 2 arguments with FROM syntax',
+    statement: "substring('foo', 1)",
+    expected: (success "oo")
+}
+


### PR DESCRIPTION
While preparing to delete the old testframework I noticed that the new `:pts` project wasn't failing tests that should have been failing.

I traced the problem to the `PtsRunner` class, which was identifying test failures correctly but was incorrectly notifying the `RunNotifier` instance.  It was calling `fireTestStarted` for every test but only calling `fireTestFinished` for tests that passed and only calling `fireTestFailed` instead.  (The [RunNotifier javadoc](http://junit.sourceforge.net/javadoc/org/junit/runner/notification/RunNotifier.html#fireTestFinished(org.junit.runner.Description)) states that it should always be called because runners expect `fireTestStarted` and `fireTestFinished` calls to occur in pairs.

This problem manifested itself in the command-line Gradle build (and therefore CI environments) as well as in the IntelliJ JUnit test runner.  Luckily, once I fixed, none of the tests in `master` which were executed by `PtsRunner` were failing so this problem was caught before it caused a serious issue.

This change will cause the `fireTestFinished` method to *always* be executed regardless of whether or not the test has passed.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
