### PR TITLE
(Build) Enable travis and codecoverage 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,17 @@ script: ./gradlew build
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
+jobs:
+  include:
+    stage: report generation
+    jdk: openjdk11
+    script: ./gradlew build 
+    after_success:
+      - bash <(curl -s https://codecov.io/bash) -s cli/build/reports  -F CLI 
+      - bash <(curl -s https://codecov.io/bash) -s lang/build/reports -F LANG 
+      - bash <(curl -s https://codecov.io/bash) -s pts/build/reports -F PTS
+      - bash <(curl -s https://codecov.io/bash) -s testscript/build/reports -F TEST_SCRIPT
+      - bash <(curl -s https://codecov.io/bash) -s examples/build/reports -F EXAMPLES
 
 ## See: https://docs.travis-ci.com/user/languages/java/#caching
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ jdk:
 
 script: ./gradlew build
 
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-
 jobs:
   include:
     stage: report generation

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ jdk:
   - openjdk11
 
 script: ./gradlew build
- 
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
+
 ## See: https://docs.travis-ci.com/user/languages/java/#caching
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: java
+jdk: 
+  - openjdk8
+  - openjdk9
+  - openjdk11
+
+script: ./gradlew build
+ 
+## See: https://docs.travis-ci.com/user/languages/java/#caching
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/build.gradle
+++ b/build.gradle
@@ -31,14 +31,13 @@ allprojects {
         mavenCentral()
         jcenter()    // needed for detekt
     }
+
+
 }
 
 subprojects {
     group = 'org.partiql'
     version = '0.1.1-SNAPSHOT'
-
-
-
 }
 
 buildDir = new File(rootProject.projectDir, "gradle-build/" + project.name)
@@ -72,6 +71,9 @@ subprojects {
             test.resources.srcDirs = ["test-resources"]
         }
 
+        test {
+            finalizedBy jacocoTestReport
+        }
         
 
     })
@@ -80,6 +82,10 @@ subprojects {
         sourceSets {
             main.kotlin.srcDirs = ["src"]
             test.kotlin.srcDirs = ["test"]
+        }
+
+        test {
+            finalizedBy jacocoTestReport
         }
     })
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,18 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.11' apply false
     // https://arturbosch.github.io/detekt/groovydsl.html
-    id "io.gitlab.arturbosch.detekt" version "1.0.0-RC16" apply false
+    id 'io.gitlab.arturbosch.detekt' version '1.0.0-RC16' apply false
+
 }
 
 allprojects {
+    apply plugin: 'jacoco'
+
+    jacoco {
+        toolVersion = '0.8.5'
+        reportsDir = file("$buildDir/reports/jacoco/")
+    }
+
     repositories {
         mavenCentral()
         jcenter()    // needed for detekt
@@ -28,6 +36,9 @@ allprojects {
 subprojects {
     group = 'org.partiql'
     version = '0.1.1-SNAPSHOT'
+
+
+
 }
 
 buildDir = new File(rootProject.projectDir, "gradle-build/" + project.name)
@@ -50,19 +61,27 @@ configure(subprojects.findAll { it.name != 'example' }) {
 }
 
 subprojects {
+
+
     plugins.withId('java', { _ ->
+
         sourceSets {
             main.java.srcDirs = ["src"]
             main.resources.srcDirs = ["resources"]
             test.java.srcDirs = ["test"]
             test.resources.srcDirs = ["test-resources"]
         }
+
+        
+
     })
     plugins.withId('org.jetbrains.kotlin.jvm', { _ ->
+
         sourceSets {
             main.kotlin.srcDirs = ["src"]
             test.kotlin.srcDirs = ["test"]
         }
     })
+
 }
 

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -39,3 +39,12 @@ dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'pl.pragmatists:JUnitParams:[1.0.0,1.1.0)'
 }
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+        csv.enabled false
+        html.destination file("${buildDir}/reports/jacoco/html")
+    }
+}

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -32,3 +32,12 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-test'
     implementation 'junit:junit:4.12'
 }
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+        csv.enabled false
+        html.destination file("${buildDir}/reports/jacoco/html")
+    }
+}

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -23,7 +23,6 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'io.gitlab.arturbosch.detekt'
     id 'signing'
-    id 'jacoco'
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
@@ -126,25 +125,11 @@ signing {
     sign publishing.publications.maven
 }
 
-jacoco {
-    // You may modify the Jacoco version here
-    toolVersion = "0.8.5"
-}
-
-test {
-  //  useJUnitPlatform()
-    jacoco {
-        destinationFile = file("${buildDir}/jacoco/test.exec")
-    }
-}
-
-test.finalizedBy(jacocoTestReport)
-
 jacocoTestReport {
-    // Adjust the output of the test report
     reports {
-        html.enabled true
         xml.enabled true
+        html.enabled true
         csv.enabled false
+        html.destination file("${buildDir}/reports/jacoco/html")
     }
 }

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -23,6 +23,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'io.gitlab.arturbosch.detekt'
     id 'signing'
+    id 'jacoco'
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
@@ -37,6 +38,8 @@ dependencies {
     // interpreter's API use kotlin.sequences.Sequence<ExprValue>.  Once that has been removed, we can change
     // 'api' below to 'implementation' to effect this.
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+
+
     api 'com.amazon.ion:ion-java:[1.4.0,)'
 
     // test-time dependencies
@@ -123,3 +126,25 @@ signing {
     sign publishing.publications.maven
 }
 
+jacoco {
+    // You may modify the Jacoco version here
+    toolVersion = "0.8.5"
+}
+
+test {
+  //  useJUnitPlatform()
+    jacoco {
+        destinationFile = file("${buildDir}/jacoco/test.exec")
+    }
+}
+
+test.finalizedBy(jacocoTestReport)
+
+jacocoTestReport {
+    // Adjust the output of the test report
+    reports {
+        html.enabled true
+        xml.enabled true
+        csv.enabled false
+    }
+}

--- a/pts/build.gradle
+++ b/pts/build.gradle
@@ -43,3 +43,12 @@ dependencies {
     testImplementation project(':lang')
     testImplementation project(':testscript')
 }
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+        csv.enabled false
+        html.destination file("${buildDir}/reports/jacoco/html")
+    }
+}

--- a/testscript/build.gradle
+++ b/testscript/build.gradle
@@ -31,3 +31,11 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+        csv.enabled false
+        html.destination file("${buildDir}/reports/jacoco/html")
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
Closes #45 

*Description of changes:*

This PR adds `.travis.yml` and enables JaCoCo for all subprojects. 

Send request to the PartiQL Github Organization to allow Travis and Codecov.io access to this repo.
Once the request is accepted the token setup for Codecove needs to be passed to the Travis configuration.

I tried to remove duplication of Gradle code from sub projects as much as I could from my (limited) Gradle knowledge. There is still some replication (see reports configuration block in each sub-project). I tried some ideas from Google searches but they did not work for this project's setup.
 I am open to any other ideas that could remove Gradle code duplication.  

Links to builds and code coverage reports:

* [Travis Build](https://travis-ci.com/therapon/partiql-lang-kotlin/builds/134810711)
* [Codecove](https://codecov.io/gh/therapon/partiql-lang-kotlin/branch/ts-travis)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
