### PR TITLE
(Build) Extend Travis TTL to 20 minutes 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ jdk:
   - openjdk9
   - openjdk11
 
-script: ./gradlew build
+script: travis_wait ./gradlew build # JDK8 tests take a little more than 10 minutes, travis_wait extends TTL to 20minutes 
 
 jobs:
   include:
     stage: report generation
     jdk: openjdk11
-    script: ./gradlew build 
+    script: travis_wait ./gradlew build 
     after_success:
       - bash <(curl -s https://codecov.io/bash) -s cli/build/reports  -F CLI 
       - bash <(curl -s https://codecov.io/bash) -s lang/build/reports -F LANG 


### PR DESCRIPTION

*Description of changes:*

JDK8 builds tend to go over the 10 minute TTL from travis and get killed. `travis_wait` extends that TTL to 20 minutes. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
