### PR TITLE
(Eval)  Null as false for Join with On condition

### DIFF
--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -1267,7 +1267,9 @@ internal class EvaluatingCompiler(
                             .filter { (bindEnv: (Environment) -> Environment, _) ->
                                 // make sure we operate with lexical scoping
                                 val filterEnv = bindEnv(rootEnv).flipToLocals()
-                                filter(filterEnv).booleanValue()
+                                val filterResult = filter(filterEnv)
+                                if (filterResult.isUnknown()) { false }
+                                else { filterResult.booleanValue() }
                             }
                             .iterator()
                     }

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -1268,8 +1268,11 @@ internal class EvaluatingCompiler(
                                 // make sure we operate with lexical scoping
                                 val filterEnv = bindEnv(rootEnv).flipToLocals()
                                 val filterResult = filter(filterEnv)
-                                if (filterResult.isUnknown()) { false }
-                                else { filterResult.booleanValue() }
+                                if (filterResult.isUnknown()) {
+                                    false
+                                } else {
+                                    filterResult.booleanValue()
+                                }
                             }
                             .iterator()
                     }

--- a/lang/test/org/partiql/lang/eval/JoinWithOnConditionTest.kt
+++ b/lang/test/org/partiql/lang/eval/JoinWithOnConditionTest.kt
@@ -1,0 +1,113 @@
+package org.partiql.lang.eval
+
+import junitparams.Parameters
+import org.junit.Test
+
+
+class JoinWithOnConditionTest : EvaluatorTestBase() {
+
+    val sessionNoNulls = mapOf(
+            "t1" to """
+               [ 
+               {id: 1, val:"a"},
+               {id: 2, val:"b"},
+               {id: 3, val:"c"},
+               ]
+            """,
+            "t2" to """
+               [ 
+               {id: 1, val: 10},
+               {id: 2, val: 20},
+               {id: 3, val:30},
+               ]
+            """
+    ).toSession()
+
+    val sessionNullIdRow = mapOf(
+            "t1" to """
+               [ 
+               {id: 1, val:"a"},
+               {id: 2, val:"b"},
+               {id: 3, val:"c"},
+               ]
+            """,
+            "t2" to """
+               [ 
+               {id: 1,    val: 10},
+               {id: null, val: 20},
+               {id: 3,    val:30},
+               ]
+            """
+    ).toSession()
+
+    val sessionNullTable: EvaluationSession = mapOf(
+            "t1" to """
+               [ 
+               {id: 1, val:"a"},
+               {id: 2, val:"b"},
+               {id: 3, val:"c"},
+               ]
+            """,
+            "t2" to """ null """
+    ).toSession()
+
+    val sessionNullTableRow: EvaluationSession = mapOf(
+            "t1" to """
+               [ 
+               {id: 1, val:"a"},
+               {id: 2, val:"b"},
+               {id: 3, val:"c"},
+               ]
+            """,
+            "t2" to """[ null ]"""
+    ).toSession()
+
+
+    val sqlUnderTest = """ 
+                            SELECT t1.id  AS id, 
+                                   t1.val AS val1,
+                                   t2.val AS val2
+                            FROM t1 AS t1 JOIN t2 as t2 ON t1.id = t2.id
+                        """
+    @Test
+    @Parameters
+    fun joinWithOnConditionTest(pair: Pair<EvaluatorTestCase, EvaluationSession>): Unit =
+            runTestCase(pair.first, pair.second)
+
+    fun parametersForJoinWithOnConditionTest(): List<Pair<EvaluatorTestCase, EvaluationSession>> {
+
+        return listOf(
+                Pair(EvaluatorTestCase(
+                        "JOIN ON with no nulls",
+                        sqlUnderTest,
+                        """
+                            << 
+                            {'id':1, 'val1':'a', 'val2':10},
+                            {'id':2, 'val1':'b', 'val2':20},
+                            {'id':3, 'val1':'c', 'val2':30}
+                            >>
+                        """), sessionNoNulls),
+                Pair(EvaluatorTestCase(
+                        "JOIN ON with no nulls",
+                        sqlUnderTest,
+                        """
+                            << 
+                            {'id':1, 'val1':'a', 'val2':10},
+                            {'id':3, 'val1':'c', 'val2':30}
+                            >>
+                        """), sessionNullIdRow),
+                Pair(EvaluatorTestCase(
+                        "JOIN ON with no nulls",
+                        sqlUnderTest,
+                        """
+                            <<>>
+                        """), sessionNullTable),
+                Pair(EvaluatorTestCase(
+                        "JOIN ON with no nulls",
+                        sqlUnderTest,
+                        """
+                            <<>>
+                        """), sessionNullTableRow)
+        )
+    }
+}

--- a/testscript/pts/test-scripts/join/join-with-condition.sqlts
+++ b/testscript/pts/test-scripts/join/join-with-condition.sqlts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+set_default_environment::{
+
+    table1: [
+        { id: 1, val: 'a'},
+        { id: 2, val: 'b'},
+        { id: 3, val: 'c'},
+    ],
+
+    table1_null_id: [
+        { id: 1, val: 'a'},
+        { id: null, val: 'b'},
+        { id: 3, val: 'c'},
+    ],
+
+    table1_null_row: [
+        null
+    ],
+
+    table1_null: null
+}
+
+test::{
+    id: 'join on column - all column values non-null',
+    statement: '''
+        SELECT t1.id AS id,
+               t1.val AS val1,
+               t2.val AS val2
+        FROM table1 AS t1 JOIN table1 AS t2 ON t1.id = t2.id
+    ''',
+    expected: (success (bag {id:1,val1:'a',val2:'a'}
+                            {id:2,val1:'b',val2:'b'}
+                            {id:3,val1:'c',val2:'c'} ))
+}
+
+test::{
+    id: 'join on column - some column values are null',
+    statement: '''
+        SELECT t1.id AS id,
+               t1.val AS val1,
+               t2.val AS val2
+        FROM table1 AS t1 JOIN  table1_null_id AS t2 ON t1.id = t2.id
+    ''',
+    expected: (success (bag {id:1,val1:'a',val2:'a'}
+                            {id:3,val1:'c',val2:'c'} ))
+}
+
+test::{
+    id: 'join on column - 1 table contains 1 row with the value null',
+    statement: '''
+        SELECT t1.id AS id,
+               t1.val AS val1,
+               t2.val AS val2
+        FROM table1 AS t1 JOIN  table1_null_row AS t2 ON t1.id = t2.id
+    ''',
+    expected: (success (bag ))
+}
+
+test::{
+    id: 'join on column - ON conidition = true ',
+    statement: '''
+        SELECT t1.id AS id,
+               t1.val AS val1,
+               t2.val AS val2
+        FROM table1 AS t1 JOIN table1 AS t2 ON true
+    ''',                                            // what `JOIN t, p` expands into
+    expected: (success (bag {id:1,val1:'a',val2:'a'}
+                            {id:1,val1:'a',val2:'b'}
+                            {id:1,val1:'a',val2:'c'}
+                            {id:2,val1:'b',val2:'a'}
+                            {id:2,val1:'b',val2:'b'}
+                            {id:2,val1:'b',val2:'c'}
+                            {id:3,val1:'c',val2:'a'}
+                            {id:3,val1:'c',val2:'b'}
+                            {id:3,val1:'c',val2:'c'}))
+
+}
+
+test::{
+    id: 'join on column - ON condition = false',
+    statement: '''
+        SELECT t1.id AS id,
+               t1.val AS val1,
+               t2.val AS val2
+        FROM table1 AS t1 JOIN table1 AS t2 ON false
+    ''',                                           // empty result set
+    expected: (success (bag ))
+}


### PR DESCRIPTION
*Description of changes:*

Expression given as `ON` for `JOIN` treat Unknowns (`null`, `missing`) as `false` removing the row from JOIN's result set. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
