### PR TITLE
Fix issue causing the REPL's output stream to be prematurely closed

### DIFF
--- a/cli/src/org/partiql/cli/main.kt
+++ b/cli/src/org/partiql/cli/main.kt
@@ -23,6 +23,7 @@ import org.partiql.cli.functions.*
 import joptsimple.*
 import org.partiql.lang.*
 import java.io.*
+import kotlin.system.exitProcess
 
 // TODO how can a user pass the catalog here?
 private val ion = IonSystemBuilder.standard().build()
@@ -142,12 +143,12 @@ fun main(args: Array<String>) = try {
 catch (e: OptionException) {
     System.err.println("${e.message}\n")
     optParser.printHelpOn(System.err)
-    System.exit(1)
+    exitProcess(1)
 
 }
 catch (e: Exception) {
-    System.err.println("${e.message}\n")
-    System.exit(1)
+    e.printStackTrace(System.err)
+    exitProcess(1)
 }
 
 private fun runRepl(environment: Bindings) {

--- a/lang/src/org/partiql/lang/util/ExprValueFormatter.kt
+++ b/lang/src/org/partiql/lang/util/ExprValueFormatter.kt
@@ -107,7 +107,10 @@ class ConfigurableExprValueFormatter(private val config: Configuration) : ExprVa
         private fun prettyPrintIonLiteral(value: ExprValue) {
             val ionValue = value.ionValue
             out.append("`")
-            IonTextWriterBuilder.standard().build(out).use { writer -> ionValue.writeTo(writer) }
+
+            // We intentionally do *not* want to call [IonWriter.close()] on the [IonWriter] here because
+            // that will also call 'out.close()`, which is bad because we probably have more stuff to write!
+            ionValue.writeTo(IonTextWriterBuilder.standard().build(out))
             out.append("`")
         }
 


### PR DESCRIPTION
This was happening any time the REPL attempted to pretty print a `FLOAT`, `TIMESTAMP`, `SYMBOL`, `CLOB`, `BLOB`, or  `SEXP`.

The problem was caused because the instance of `IonWriter` returned from `IonSystemBuilder.standard().build(outputStream)` closes the `OutputStream` when `IonWriter.close()` is called.  (We should also consider if this is a bug in `ion-java` or not and if its possible to fix this since this behavior is now expected in places where it is currently being used.

In any case, this PR implements a simple work-around.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
