### PR TITLE
Uses a set to optimize IN clause when right side is all literals

### DIFF
--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -452,7 +452,8 @@ internal class EvaluatingCompiler(
 
                 thunkEnv(metas) { env ->
                     val value = leftArg(env)
-                    inSet.any { it.exprEquals(value) }.exprValue()
+                    // we can use contains as exprEquals uses the DEFAULT_COMPARATOR
+                    inSet.contains(value).exprValue()
                 }
             }
             

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -446,9 +446,7 @@ internal class EvaluatingCompiler(
             rightArg is ListExprNode && rightArg.values.all { it is Literal } -> {
                 val inSet = rightArg.values
                     .map { it as Literal }
-                    .fold(TreeSet<ExprValue>(DEFAULT_COMPARATOR)) { set, el ->
-                        set.also { it.add(valueFactory.newFromIonValue(el.ionValue)) }
-                    }
+                    .mapTo(TreeSet<ExprValue>(DEFAULT_COMPARATOR)) { valueFactory.newFromIonValue(it.ionValue) }
 
                 thunkEnv(metas) { env ->
                     val value = leftArg(env)

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -19,9 +19,7 @@ import com.amazon.ion.*
 import org.partiql.lang.ast.*
 import org.partiql.lang.ast.passes.*
 import org.partiql.lang.errors.*
-import org.partiql.lang.eval.ExprValueType.*
 import org.partiql.lang.eval.binding.*
-import org.partiql.lang.eval.isUnknown
 import org.partiql.lang.syntax.SqlParser
 import org.partiql.lang.util.*
 import java.math.*
@@ -246,28 +244,29 @@ internal class EvaluatingCompiler(
 
     private fun compileNAry(expr: NAry): ThunkEnv {
         val (op, args, metas: MetaContainer) = expr
-        val argThunks = args.map { compileExprNode(it) }
-
+        
+        fun argThunks() = args.map { compileExprNode(it) }
+        
         return when (op) {
-            NAryOp.ADD           -> compileNAryAdd(argThunks, metas)
-            NAryOp.SUB           -> compileNArySub(argThunks, metas)
-            NAryOp.MUL           -> compileNaryMul(argThunks, metas)
-            NAryOp.DIV           -> compileNAryDiv(argThunks, metas)
-            NAryOp.MOD           -> compileNAryMod(argThunks, metas)
-            NAryOp.EQ            -> compileNAryEq(argThunks, metas)
-            NAryOp.NE            -> compileNAryNe(argThunks, metas)
-            NAryOp.LT            -> compileNaryLt(argThunks, metas)
-            NAryOp.LTE           -> compileNAryLte(argThunks, metas)
-            NAryOp.GT            -> compileNAryGt(argThunks, metas)
-            NAryOp.GTE           -> compileNAryGte(argThunks, metas)
-            NAryOp.BETWEEN       -> compileNAryBetween(argThunks, metas)
-            NAryOp.LIKE          -> compileNAryLike(args, argThunks, metas)
-            NAryOp.IN            -> compileNAryIn(argThunks, metas)
-            NAryOp.NOT           -> compileNAryNot(argThunks, metas)
-            NAryOp.AND           -> compileNAryAnd(argThunks, metas)
-            NAryOp.OR            -> compileNAryOr(argThunks, metas)
-            NAryOp.STRING_CONCAT -> compileNAryStringConcat(argThunks, metas)
-            NAryOp.CALL          -> compileNAryCall(args, argThunks, metas)
+            NAryOp.ADD           -> compileNAryAdd(argThunks(), metas)
+            NAryOp.SUB           -> compileNArySub(argThunks(), metas)
+            NAryOp.MUL           -> compileNaryMul(argThunks(), metas)
+            NAryOp.DIV           -> compileNAryDiv(argThunks(), metas)
+            NAryOp.MOD           -> compileNAryMod(argThunks(), metas)
+            NAryOp.EQ            -> compileNAryEq(argThunks(), metas)
+            NAryOp.NE            -> compileNAryNe(argThunks(), metas)
+            NAryOp.LT            -> compileNaryLt(argThunks(), metas)
+            NAryOp.LTE           -> compileNAryLte(argThunks(), metas)
+            NAryOp.GT            -> compileNAryGt(argThunks(), metas)
+            NAryOp.GTE           -> compileNAryGte(argThunks(), metas)
+            NAryOp.BETWEEN       -> compileNAryBetween(argThunks(), metas)
+            NAryOp.LIKE          -> compileNAryLike(args, argThunks(), metas)
+            NAryOp.IN            -> compileNAryIn(args, metas) 
+            NAryOp.NOT           -> compileNAryNot(argThunks(), metas)
+            NAryOp.AND           -> compileNAryAnd(argThunks(), metas)
+            NAryOp.OR            -> compileNAryOr(argThunks(), metas)
+            NAryOp.STRING_CONCAT -> compileNAryStringConcat(argThunks(), metas)
+            NAryOp.CALL          -> compileNAryCall(args, argThunks(), metas)
 
             NAryOp.INTERSECT,
             NAryOp.INTERSECT_ALL,
@@ -437,17 +436,38 @@ internal class EvaluatingCompiler(
     }
 
     private fun compileNAryIn(
-        argThunks: List<ThunkEnv>,
+        args: List<ExprNode>,
         metas: MetaContainer): ThunkEnv {
-        val needleThunk = argThunks[0]
-        val haystackThunk = argThunks[1]
-        return thunkEnv(metas) { env ->
-            val needle = needleThunk(env)
-            val haystack = haystackThunk(env)
-            haystack.any { it.exprEquals(needle) }.exprValue()
+        val leftArg = compileExprNode(args[0])
+        val rightArg = args[1]
+        
+        return when {
+            // When the right arg is a list of literals we use a Set to speed up the predicate
+            rightArg is ListExprNode && rightArg.values.all { it is Literal } -> {
+                val inSet = rightArg.values
+                    .map { it as Literal }
+                    .fold(TreeSet<ExprValue>(DEFAULT_COMPARATOR)) { set, el ->
+                        set.also { it.add(valueFactory.newFromIonValue(el.ionValue)) }
+                    }
+
+                thunkEnv(metas) { env ->
+                    val value = leftArg(env)
+                    inSet.any { it.exprEquals(value) }.exprValue()
+                }
+            }
+            
+            else -> {
+                val rightArgThunk = compileExprNode(rightArg)
+
+                thunkEnv(metas) { env ->
+                    val value = leftArg(env)
+                    val rigthArgExprValue = rightArgThunk(env)
+                    rigthArgExprValue.any { it.exprEquals(value) }.exprValue()
+                }
+            }
         }
     }
-
+    
     private fun compileNAryNot(
         argThunks: List<ThunkEnv>,
         metas: MetaContainer): ThunkEnv {


### PR DESCRIPTION
*Issue #, if available:*
resolves #25

*Description of changes:*
Uses a `TreeSet` with the default comparator when the right argument of an IN clause is a list of literals speeding up the predicate. Changes make IN clause for this use case between ~14% to ~30% faster. 

Benchark setup is the query `SELECT COUNT(*) FROM myTable t WHERE t IN <IN_LIST>` where IN list has 10, 100, 1,000 or 5,000 literals and `myTable` is always a list with 10,000 elements. To trigger the query we are forced to call `ionValue` on the resulting `ExprValue` so we use a `COUNT` to minimize the the time spent materializing Ion objects in that operation. 

Benchmark numbers bellow: 
```
InClauseWithLiterals.optimizedWith5000Literals  thrpt   10   0.110 ± 0.027  ops/s
InClauseWithLiterals.with5000Literals           thrpt   10   0.078 ± 0.012  ops/s
InClauseWithLiterals.optimizedWith1000Literals  thrpt   10   0.596 ± 0.136  ops/s
InClauseWithLiterals.with1000Literals           thrpt   10   0.479 ± 0.010  ops/s
InClauseWithLiterals.optimizedWith100Literals   thrpt   10   5.326 ± 1.935  ops/s
InClauseWithLiterals.with100Literals            thrpt   10   5.219 ± 0.364  ops/s
InClauseWithLiterals.optimizedWith10Literals    thrpt   10  61.258 ± 4.269  ops/s
InClauseWithLiterals.with10Literals             thrpt   10  46.861 ± 1.242  ops/s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
