### PR TITLE
Change Maven URL so it doesn't include a version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ GitHub issues list for details.)
 
 ## Using In Your Project
 
-This project is published to [Maven Central](https://search.maven.org/artifact/org.partiql/partiql-lang-kotlin/0.1.0/jar).
+This project is published to [Maven Central](https://search.maven.org/artifact/org.partiql/partiql-lang-kotlin).
 
 | Group ID | Artifact ID | Recommended Version |
 |----------|-------------|---------------------| 


### PR DESCRIPTION
Simply changes the Maven URL to point to:

https://search.maven.org/artifact/org.partiql/partiql-lang-kotlin

Instead of:

https://search.maven.org/artifact/org.partiql/partiql-lang-kotlin/0.1.0/jar

This way we don't have to update it with every version bump.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
