### PR TITLE
Prepare for v0.1.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID | Artifact ID | Recommended Version |
 |----------|-------------|---------------------| 
-| `org.partiql` | `partiql-lang-kotlin` | `0.1.1`
+| `org.partiql` | `partiql-lang-kotlin` | `0.1.2`
 
 
 For Maven builds, add this to your `pom.xml`:

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
 
 subprojects {
     group = 'org.partiql'
-    version = '0.1.2-SNAPSHOT'
+    version = '0.1.2'
 }
 
 buildDir = new File(rootProject.projectDir, "gradle-build/" + project.name)


### PR DESCRIPTION
Removes `-SNAPSHOT` and MV bumps the recommended version in `README.md`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
