### PR TITLE
Upgrade JUnitParams to 1.1.1

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
-    testImplementation 'pl.pragmatists:JUnitParams:[1.0.0,1.1.0)'
+    testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
 }
 
 jacocoTestReport {

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     // test-time dependencies
     testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
-    testImplementation 'pl.pragmatists:JUnitParams:[1.0.0,1.1.0)'
+    testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
     testImplementation 'org.assertj:assertj-core:[3.11.0,3.12.0)'
     
     // PTS

--- a/pts/build.gradle
+++ b/pts/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     // test-time dependencies
     testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
-    testImplementation 'pl.pragmatists:JUnitParams:[1.0.0,1.1.0)'
+    testImplementation 'pl.pragmatists:JUnitParams:1.1.1'
     testImplementation 'org.assertj:assertj-core:[3.11.0,3.12.0)'
     testImplementation project(':lang')
     testImplementation project(':testscript')


### PR DESCRIPTION
This should (hopefully) fix our pathologically long build times in openjdk8.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
