### PR TITLE
Closes CLI stream for partiql format

### DIFF
--- a/cli/src/org/partiql/cli/Cli.kt
+++ b/cli/src/org/partiql/cli/Cli.kt
@@ -45,7 +45,7 @@ internal class Cli(private val valueFactory: ExprValueFactory,
             when (format) {
                 ION_TEXT   -> valueFactory.ion.newTextWriter(output).use { printIon(it, result) }
                 ION_BINARY -> valueFactory.ion.newBinaryWriter(output).use { printIon(it, result) }
-                PARTIQL    -> OutputStreamWriter(output).write(result.toString())
+                PARTIQL    -> OutputStreamWriter(output).use { it.write(result.toString()) }
             }
         }
     }

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -32,12 +32,14 @@ class CliTest {
         output.reset()
     }
 
-    private fun makeCli(query: String, input: String, bindings: Bindings<ExprValue> = Bindings.empty()) =
+    private fun makeCli(query: String,
+                        input: String, bindings: Bindings<ExprValue> = Bindings.empty(),
+                        outputFormat: OutputFormat = OutputFormat.ION_TEXT) =
         Cli(
             valueFactory,
             input.byteInputStream(Charsets.UTF_8),
             output,
-            OutputFormat.ION_TEXT,
+            outputFormat,
             compilerPipeline,
             bindings,
             query)
@@ -101,5 +103,13 @@ class CliTest {
         val actual = subject.runAndOutput()
 
         assertAsIon("{a: 1}", actual)
+    }
+
+    @Test
+    fun withPartiQLOutput() {
+        val subject = makeCli("SELECT * FROM input_data", "{a: 1}", outputFormat = OutputFormat.PARTIQL)
+        val actual = subject.runAndOutput()
+
+        assertEquals("<<{'a': 1}>>", actual)
     }
 }


### PR DESCRIPTION
resolves #206

Closes the output writer for the `PARTIQL` output format so the output is actually flushed 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
