### PR TITLE
Fix #228 by removing invalid sanity check.

### DIFF
--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -718,9 +718,6 @@ class SqlParser(private val ion: IonSystem) : Parser {
         if(type != TYPE) {
             errMalformedParseTree("Expected ParseType.TYPE instead of $type")
         }
-        if(children.size > 1) {
-            errMalformedParseTree("Apparently DataType needs multiple lengths, sizes, etc")
-        }
         val sqlDataType = SqlDataType.forTypeName(token!!.keywordText!!)
         if(sqlDataType == null) {
             errMalformedParseTree("Invalid DataType: ${token.keywordText!!}")

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -909,18 +909,112 @@ class SqlParserTest : SqlParserTestBase() {
         "(term (exp (cast (term (exp (lit 5))) (term (exp (type character_varying))))))"
     )
 
+
     @Test
-    fun castArg() = assertExpression(
+    fun castASVarChar() = assertExpression(
         """(cast
-             (+ (lit 5) (id a case_insensitive))
+             (id a case_insensitive)
+             (type character_varying)
+           )
+        """,
+        "CAST(a AS VARCHAR)",
+        """(term (exp (cast (term (exp (id a case_insensitive)))
+                            (term (exp (type character_varying)))
+           )))
+        """
+    )
+
+    @Test
+    fun castASVarCharWithLength() = assertExpression(
+        """(cast
+             (id a case_insensitive)
              (type character_varying 1)
            )
         """,
-        "CAST(5 + a AS VARCHAR(1))",
-        """(term (exp (cast (term (exp (+ (term (exp (lit 5)))
-                                          (term (exp (id a case_insensitive)))
-                            )))
+        "CAST(a AS VARCHAR(1))",
+        """(term (exp (cast (term (exp (id a case_insensitive)))
                             (term (exp (type character_varying 1)))
+           )))
+        """
+    )
+
+    @Test
+    fun castAsDecimal() = assertExpression(
+        """(cast
+             (id a case_insensitive)
+             (type decimal)
+           )
+        """,
+        "CAST(a AS DECIMAL)",
+        """(term (exp (cast (term (exp (id a case_insensitive)))
+                            (term (exp (type decimal)))
+           )))
+        """
+    )
+
+    @Test
+    fun castAsDecimalScaleOnly() = assertExpression(
+        """(cast
+             (id a case_insensitive)
+             (type decimal 1)
+           )
+        """,
+        "CAST(a AS DECIMAL(1))",
+        """(term (exp (cast (term (exp (id a case_insensitive)))
+                            (term (exp (type decimal 1)))
+           )))
+        """
+    )
+    @Test
+    fun castAsDecimalScaleAndPrecision() = assertExpression(
+        """(cast
+             (id a case_insensitive)
+             (type decimal 1 2)
+           )
+        """,
+        "CAST(a AS DECIMAL(1, 2))",
+        """(term (exp (cast (term (exp (id a case_insensitive)))
+                            (term (exp (type decimal 1 2)))
+           )))
+        """
+    )
+    @Test
+    fun castAsNumeric() = assertExpression(
+        """(cast
+             (id a case_insensitive)
+             (type numeric)
+           )
+        """,
+        "CAST(a AS NUMERIC)",
+        """(term (exp (cast (term (exp (id a case_insensitive)))
+                            (term (exp (type numeric)))
+           )))
+        """
+    )
+
+    @Test
+    fun castAsNumericScaleOnly() = assertExpression(
+        """(cast
+             (id a case_insensitive)
+             (type numeric 1)
+           )
+        """,
+        "CAST(a AS NUMERIC(1))",
+        """(term (exp (cast (term (exp (id a case_insensitive)))
+                            (term (exp (type numeric 1)))
+           )))
+        """
+    )
+    @Test
+    fun castAsNumericScaleAndPrecision() = assertExpression(
+        """(cast
+             (id a case_insensitive)
+             (type numeric 1 2)
+           )
+        """,
+        "CAST(a AS NUMERIC(1, 2))",
+        """(term (exp (cast (term (exp (id a case_insensitive)))
+                            (term (exp (type numeric 1 2)))
            )))
         """
     )


### PR DESCRIPTION
Fixes #228 

This sanity check threw an exception from SqlParser whenever a data type reference that included more than one argument was encountered.  The check appears to have been completely erroneous from the start and on removivng it, no other modifications were needed.

This commit also adds a few tests to SqlParserTests to cover this scenario and prevent regressions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
