### PR TITLE
Bump minor versions after v0.1.3 hotfix was released separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID | Artifact ID | Recommended Version |
 |----------|-------------|---------------------| 
-| `org.partiql` | `partiql-lang-kotlin` | `0.1.2`
+| `org.partiql` | `partiql-lang-kotlin` | `0.1.3`
 
 
 For Maven builds, add this to your `pom.xml`:

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
 
 subprojects {
     group = 'org.partiql'
-    version = '0.1.3-SNAPSHOT'
+    version = '0.1.4-SNAPSHOT'
 }
 
 buildDir = new File(rootProject.projectDir, "gradle-build/" + project.name)


### PR DESCRIPTION
The `v0.1.3` branch was created so we can do a hotfix.  This PR accounts for the version bump that was required: 

- Change 0.1.3 to 0.1.4 in root `build.gradle`
- Change 0.1.2 to 0.1.3 in `README.md` so it displays the correct version on
the repository home page.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
