### PR TITLE
Make SqlLexer aware of Ion BLOBs and CLOBs (#236)

### DIFF
--- a/lang/src/org/partiql/lang/syntax/SqlLexer.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlLexer.kt
@@ -361,6 +361,15 @@ class SqlLexer(private val ion: IonSystem) : Lexer {
                     }
                 }
 
+                delta("{", INCOMPLETE) {
+                    delta("{", INCOMPLETE) {
+                        selfRepeatingDelegate(INCOMPLETE)
+                        delta("}", INCOMPLETE) {
+                            delta("}", INCOMPLETE, delegate = quoteState)
+                        }
+                    }
+                }
+
                 delta(BACKTICK_CHARS, TERMINAL, LITERAL, ION_LITERAL, replacement = REPLACE_NOTHING, delegate = initialState)
             }
 

--- a/lang/test/org/partiql/lang/syntax/SqlLexerTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlLexerTest.kt
@@ -164,12 +164,15 @@ class SqlLexerTest : TestBase() {
 
     @Test
     fun quotedIon() = assertTokens(
-        "`1e0` `{a:5}` `/*`*/\"`\"` `//`\n'''`'''`",
+        "`1e0` `{a:5}` `/*`*/\"`\"` `//`\n'''`'''` `{{ +AB//A== }}` `{{ \"not a comment //\" }}`",
         token(LITERAL, "1e0", 1, 1),
         token(LITERAL, "{a:5}", 1, 7),
         token(LITERAL, "\"`\"", 1, 15),
-        token(LITERAL, "\"`\"", 1, 26)
+        token(LITERAL, "\"`\"", 1, 26),
+        token(LITERAL, "{{ +AB//A== }}", 2, 10),
+        token(LITERAL, "{{ \"not a comment //\" }}", 2, 27)
     )
+
 
     @Test
     fun quotedStrings() = assertTokens(


### PR DESCRIPTION
Previously, "//" to EOL was being treated as an Ion comment and removed,
when between "{{" and "}}".

Fixes #236.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
