### PR TITLE
Respect ProjectionIterationBehavior.UNFILTERED within star projection

### DIFF
--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -21,7 +21,6 @@ import org.partiql.lang.ast.passes.*
 import org.partiql.lang.errors.*
 import org.partiql.lang.eval.binding.*
 import org.partiql.lang.syntax.SqlParser
-import org.partiql.lang.syntax.*
 import org.partiql.lang.util.*
 import java.math.*
 import java.util.*
@@ -1091,7 +1090,13 @@ internal class EvaluatingCompiler(
                                                             val name = syntheticColumnName(columns.size).exprValue()
                                                             columns.add(value.namedValue(name))
                                                         } else {
-                                                            for (childValue in value.filter { it.type != ExprValueType.MISSING }) {
+                                                            val valuesToProject = when(compileOptions.projectionIteration) {
+                                                                ProjectionIterationBehavior.FILTER_MISSING -> {
+                                                                    value.filter { it.type != ExprValueType.MISSING }
+                                                                }
+                                                                ProjectionIterationBehavior.UNFILTERED -> value
+                                                            }
+                                                            for (childValue in valuesToProject) {
                                                                 val namedFacet = childValue.asFacet(Named::class.java)
                                                                 val name = namedFacet?.name
                                                                            ?: syntheticColumnName(columns.size).exprValue()

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerTests.kt
@@ -14,8 +14,10 @@
 
 package org.partiql.lang.eval
 
+import com.amazon.ion.system.IonSystemBuilder
 import org.junit.Ignore
 import org.junit.Test
+import org.partiql.lang.CompilerPipeline
 import org.partiql.lang.syntax.ParserException
 
 class EvaluatingCompilerTests : EvaluatorTestBase() {
@@ -1490,6 +1492,26 @@ class EvaluatingCompilerTests : EvaluatorTestBase() {
         val actual = eval(query, compileOptions = options).iterator().next()
         assertEquals("100, MISSING, 200", actual.iterator().asSequence().joinToString(separator = ", "))
     }
+
+    @Test
+    fun projectionIterationBehaviorUnfiltered_select_list() =
+        assertEvalExprValue(
+            source = "select a from <<{'a': MISSING}>>",
+            expected = "<<{'a': MISSING}>>",
+            compileOptions = CompileOptions.build {
+                projectionIteration(ProjectionIterationBehavior.UNFILTERED)
+            }
+        )
+
+    @Test
+    fun projectionIterationBehaviorUnfiltered_select_star() =
+        assertEvalExprValue(
+            source = "select * from <<{'a': MISSING}>>",
+            expected = "<<{'a': MISSING}>>",
+            compileOptions = CompileOptions.build {
+                projectionIteration(ProjectionIterationBehavior.UNFILTERED)
+            }
+        )
 
     @Test
     fun undefinedQualifiedVariableWithUndefinedVariableBehaviorError() {


### PR DESCRIPTION
Fixes #246

We previously ignored this compile option.  The fix prevents the filtering of `MISSING` values from star projection when `ProjectionIterationBehavior.UNFILTERED` is set. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
