### PR TITLE
Execute PartiQL query when a line ending in a semi-colon is read.

### DIFF
--- a/cli/src/org/partiql/cli/Repl.kt
+++ b/cli/src/org/partiql/cli/Repl.kt
@@ -41,6 +41,7 @@ private enum class ReplState {
     /** Reading a PartiQL query. Transitions to execute when one of the execution tokens is found. */
     READ_PARTIQL,
 
+    /** Read a trailing semi-colon. Add the current line to the buffer and transition to execute. */
     LAST_PARTIQL_LINE,
 
     /** Ready to execute a PartiQL query. */

--- a/cli/test/org/partiql/cli/ReplTest.kt
+++ b/cli/test/org/partiql/cli/ReplTest.kt
@@ -164,6 +164,19 @@ class ReplTest {
     }
 
     @Test
+    fun querySemiColon() {
+        ReplTester().assertReplPrompt("""
+            #Welcome to the PartiQL REPL!
+            #PartiQL> 1+1;
+            #===' 
+            #2
+            #--- 
+            #OK! (0 ms)
+            #PartiQL> 
+        """.trimMargin("#"))
+    }
+
+    @Test
     fun multipleQuery() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!


### PR DESCRIPTION
*Issue #, if available:*

#248 CLI: Execute PartiQL query when a line ending with a semi-colon is read

*Description of changes:*

Add a new state to the REPL state machine, `LAST_PARTIQL_LINE`. Transition to this state from `READY` or `READ_PARTIQL` when the input line ends with a `;`. `LAST_PARTIQL_LINE` simply appends the current line to the buffer and transitions to the `EXECUTE_PARTIQL` state.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
