### PR TITLE
Use the thread-safe StringBuffer instead of StringBuilder in CLI test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,10 @@ subprojects {
 
     tasks.withType(Test) {
         maxHeapSize = "4g"
+        testLogging {
+            events "failed"
+            exceptionFormat "full"
+        }
     }
 
 

--- a/cli/test/org/partiql/cli/ReplTest.kt
+++ b/cli/test/org/partiql/cli/ReplTest.kt
@@ -91,7 +91,9 @@ private class ReplTester(bindings: Bindings<ExprValue> = Bindings.empty()) {
         while (replThread.isAlive || output.size() > 0) {
             Thread.sleep(SLEEP_TIME)
             if (output.size() > 0) {
-                actualReplPrompt.append(output.toString())
+                synchronized(actualReplPrompt) {
+                    actualReplPrompt.append(output.toString())
+                }
                 output.reset()
                 outputPhaser.arrive()
             }
@@ -117,7 +119,9 @@ private class ReplTester(bindings: Bindings<ExprValue> = Bindings.empty()) {
 
         val inputLines = extractInputLines(expectedPromptText)
         inputLines.forEach { line ->
-            actualReplPrompt.append(line)
+            synchronized(actualReplPrompt) {
+                actualReplPrompt.append(line)
+            }
 
             inputPipe.write(line.toByteArray(Charsets.UTF_8))
             // flush to repl input

--- a/cli/test/org/partiql/cli/ReplTest.kt
+++ b/cli/test/org/partiql/cli/ReplTest.kt
@@ -80,7 +80,7 @@ private class ReplTester(bindings: Bindings<ExprValue> = Bindings.empty()) {
 
     private val repl = Repl(valueFactory, input, output, parser, compiler, bindings, zeroTimer)
 
-    private val actualReplPrompt = StringBuilder()
+    private val actualReplPrompt = StringBuffer()
 
     private val outputPhaser = Phaser()
 


### PR DESCRIPTION
This is somewhat of a shot in the dark to try to fix what appears to be a race condition in some of our test infrastructure for the CLI sub-project that is causing tests to fail intermittently. i.e. like in this [build](https://travis-ci.org/github/partiql/partiql-lang-kotlin/builds/713101679).

I will retry the travis build a several times before requesting review.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
