### PR TITLE
Temporarily disable REPL tests due to race condition.

### DIFF
--- a/cli/test/org/partiql/cli/ReplTest.kt
+++ b/cli/test/org/partiql/cli/ReplTest.kt
@@ -21,7 +21,6 @@ import org.junit.*
 import org.junit.Assert.*
 import org.partiql.lang.*
 import java.io.*
-import java.lang.StringBuilder
 import java.util.concurrent.*
 import kotlin.concurrent.*
 
@@ -147,6 +146,7 @@ private class ReplTester(bindings: Bindings<ExprValue> = Bindings.empty()) {
 
 }
 
+@Ignore("https://github.com/partiql/partiql-lang-kotlin/issues/266")
 class ReplTest {
 
     @Test


### PR DESCRIPTION
This race condition is not caused by production code--just the tests.

This one is driving me bonkers--I don't have the time to fix this properly right now.  I've created #266 so we don't forget to un-`@Ingore` this later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
