### PR TITLE
Expose pig-runtime as API dependency

### DIFF
--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
     api 'com.amazon.ion:ion-java:[1.4.0,)'
     api 'com.amazon.ion:ion-element:0.2.0'
-    implementation 'org.partiql:partiql-ir-generator-runtime:0.3.0'
+    api 'org.partiql:partiql-ir-generator-runtime:0.3.0'
 
     // test-time dependencies
     testImplementation 'org.jetbrains.kotlin:kotlin-reflect'


### PR DESCRIPTION
This is needed so clients do not need to take a separate dependency on the PIG runtime library.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
