### PR TITLE
LET (from `FROM` clauses) implementation - Parsing and ExprNode conversions

### DIFF
--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -202,7 +202,7 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
     }
 
     private fun IonWriterContext.writeSelect(expr: Select) {
-        val (setQuantifier, projection, from, where, groupBy, having, limit, _: MetaContainer) = expr
+        val (setQuantifier, projection, from, fromLet, where, groupBy, having, limit, _: MetaContainer) = expr
 
         writeSelectProjection(projection, setQuantifier)
 

--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -204,6 +204,10 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
     private fun IonWriterContext.writeSelect(expr: Select) {
         val (setQuantifier, projection, from, fromLet, where, groupBy, having, limit, _: MetaContainer) = expr
 
+        if (fromLet != null) {
+            throw UnsupportedOperationException("LET clause is not supported by the V0 AST")
+        }
+
         writeSelectProjection(projection, setQuantifier)
 
         sexp {

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -133,6 +133,7 @@ fun ExprNode.toAstExpr(): PartiqlAst.Expr {
                     },
                     project = node.projection.toAstSelectProject(),
                     from = node.from.toAstFromSource(),
+                    fromLet = node.fromLet?.toAstLetSource(),
                     where = node.where?.toAstExpr(),
                     group = node.groupBy?.toAstGroupSpec(),
                     having = node.having?.toAstExpr(),
@@ -255,6 +256,17 @@ private fun FromSource.toAstFromSource(): PartiqlAst.FromSource {
                 thiz.variables.atName?.name,
                 thiz.variables.byName?.name)
         }
+    }
+}
+
+private fun LetSource.toAstLetSource(): PartiqlAst.Let {
+    val thiz = this
+    return PartiqlAst.build {
+        let(
+            thiz.bindings.map {
+                letBinding(it.expr.toAstExpr(), it.name.name)
+            }
+        )
     }
 }
 

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -239,14 +239,13 @@ private class StatementTransformer(val ion: IonSystem) {
             this.letBindings.map {
                 LetBinding(
                     it.expr.toExprNode(),
-                    it.name.toSymbolicName()!!
-                    //SymbolicName(it.name.text, it.metas.toPartiQlMetaContainer())
+                    it.name.toSymbolicName()
                 )
             }
         )
     }
 
-    private fun SymbolPrimitive?.toSymbolicName() = this?.let { SymbolicName(it.text, it.metas.toPartiQlMetaContainer()) }
+    private fun SymbolPrimitive.toSymbolicName() = SymbolicName(this.text, this.metas.toPartiQlMetaContainer())
 
     private fun GroupBy.toGroupBy(): org.partiql.lang.ast.GroupBy =
         GroupBy(

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -10,6 +10,7 @@ import org.partiql.lang.domains.PartiqlAst.FromSource
 import org.partiql.lang.domains.PartiqlAst.GroupBy
 import org.partiql.lang.domains.PartiqlAst.GroupingStrategy
 import org.partiql.lang.domains.PartiqlAst.JoinType
+import org.partiql.lang.domains.PartiqlAst.Let
 import org.partiql.lang.domains.PartiqlAst.PathStep
 import org.partiql.lang.domains.PartiqlAst.ProjectItem
 import org.partiql.lang.domains.PartiqlAst.Projection
@@ -167,6 +168,7 @@ private class StatementTransformer(val ion: IonSystem) {
                     setQuantifier = setq?.toSetQuantifier() ?: org.partiql.lang.ast.SetQuantifier.ALL,
                     projection = project.toSelectProjection(),
                     from = from.toFromSource(),
+                    fromLet = fromLet?.toLetSource(),
                     where = where?.toExprNode(),
                     groupBy = group?.toGroupBy(),
                     having = having?.toExprNode(),
@@ -231,6 +233,18 @@ private class StatementTransformer(val ion: IonSystem) {
             is JoinType.Right -> JoinOp.RIGHT
             is JoinType.Full -> JoinOp.OUTER
         }
+
+    private fun Let.toLetSource(): LetSource {
+        return LetSource(
+            this.letBindings.map {
+                LetBinding(
+                    it.expr.toExprNode(),
+                    it.name.toSymbolicName()!!
+                    //SymbolicName(it.name.text, it.metas.toPartiQlMetaContainer())
+                )
+            }
+        )
+    }
 
     private fun SymbolPrimitive?.toSymbolicName() = this?.let { SymbolicName(it.text, it.metas.toPartiQlMetaContainer()) }
 

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -333,13 +333,14 @@ data class Select(
     val setQuantifier: SetQuantifier = SetQuantifier.ALL,
     val projection: SelectProjection,
     val from: FromSource,
+    val fromLet: LetSource? = null,
     val where: ExprNode? = null,
     val groupBy: GroupBy? = null,
     val having: ExprNode? = null,
     val limit: ExprNode? = null,
     override val metas: MetaContainer
 ) : ExprNode() {
-    override val children: List<AstNode> = listOfNotNull(projection, from, where, groupBy, having, limit)
+    override val children: List<AstNode> = listOfNotNull(projection, from, fromLet, where, groupBy, having, limit)
 }
 
 //********************************
@@ -630,6 +631,25 @@ data class FromSourceUnpivot(
     override val variables: LetVariables,
     override val metas: MetaContainer
 ) : FromSourceLet(), HasMetas {
+    override val children: List<AstNode> = listOf(expr)
+}
+
+//********************************
+// LET clause
+//********************************
+
+/** Represents a list of LetBindings */
+data class LetSource(
+    val bindings: List<LetBinding>
+) : AstNode() {
+    override val children: List<AstNode> = bindings
+}
+
+/** Represents `<expr> AS <name>` */
+data class LetBinding(
+    val expr: ExprNode,
+    val name: SymbolicName
+) : AstNode() {
     override val children: List<AstNode> = listOf(expr)
 }
 

--- a/lang/src/org/partiql/lang/ast/passes/AstSanityValidator.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstSanityValidator.kt
@@ -62,7 +62,7 @@ object AstSanityValidator {
                     }
                 }
                 is Select -> {
-                    val (_, projection, _, _, groupBy, having, _, metas) = node
+                    val (_, projection, _, _, _, groupBy, having, _, metas) = node
 
                     if(groupBy != null) {
                         if (groupBy.grouping == GroupingStrategy.PARTIAL) {

--- a/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
@@ -87,7 +87,7 @@ open class AstWalker(private val visitor: AstVisitor) {
                     }
                 }
                 is Select       -> case {
-                    val (_, projection, from, where, groupBy, having, limit, _: MetaContainer) = expr
+                    val (_, projection, from, fromLet, where, groupBy, having, limit, _: MetaContainer) = expr
                     walkSelectProjection(projection)
                     walkFromSource(from)
                     walkExprNode(where)

--- a/lang/src/org/partiql/lang/errors/ErrorCode.kt
+++ b/lang/src/org/partiql/lang/errors/ErrorCode.kt
@@ -282,6 +282,11 @@ enum class ErrorCode(private val category: ErrorCategory,
         LOC_TOKEN,
         "expected identifier for alias"),
 
+    PARSE_EXPECTED_AS_FOR_LET(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "expected AS for LET clause"),
+
     PARSE_UNSUPPORTED_CALL_WITH_STAR(
         ErrorCategory.PARSER,
         LOC_TOKEN,

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -904,7 +904,7 @@ internal class EvaluatingCompiler(
         val allFromSourceAliases = fold.walkFromSource(pigGeneratedAst.from, emptySet())
 
         return nestCompilationContext(ExpressionContext.NORMAL, emptySet()) {
-            val (setQuantifier, projection, from, _, groupBy, having, _, metas: MetaContainer) = selectExpr
+            val (setQuantifier, projection, from, fromLet, _, groupBy, having, _, metas: MetaContainer) = selectExpr
 
             val fromSourceThunks = compileFromSources(from)
             val sourceThunks = compileQueryWithoutProjection(selectExpr, fromSourceThunks)

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -258,6 +258,7 @@ internal val DATE_PART_KEYWORDS: Set<String> = DatePart.values()
     "tuple",
     "remove",
     "index",
+    "let",
 
     // Ion type names
 

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -1852,7 +1852,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
         rem = child.remaining
 
         if (rem.head?.type != AS) {
-            rem.head.err("Expected AS following LET expr", PARSE_EXPECTED_AS_FOR_LET)
+            rem.head.err("Expected $AS following $LET expr", PARSE_EXPECTED_AS_FOR_LET)
         }
 
         rem = rem.tail
@@ -1870,7 +1870,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
             child = rem.parseExpression()
             rem = child.remaining
             if (rem.head?.type != AS) {
-                rem.head.err("Expected AS following LET expr", PARSE_EXPECTED_AS_FOR_LET)
+                rem.head.err("Expected $AS following $LET expr", PARSE_EXPECTED_AS_FOR_LET)
             }
 
             rem = rem.tail

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -62,6 +62,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
         PROJECT_ALL,           // Wildcard, i.e. the * in `SELECT * FROM f` and a.b.c.* in `SELECT a.b.c.* FROM f`
         PATH_WILDCARD,
         PATH_UNPIVOT,
+        LET,
         SELECT_LIST,
         SELECT_VALUE,
         DISTINCT,
@@ -553,6 +554,11 @@ class SqlParser(private val ion: IonSystem) : Parser {
 
                 val fromSource = fromList.children[0].toFromSource()
 
+                val fromLet = unconsumedChildren.firstOrNull { it.type == LET }?.let {
+                    unconsumedChildren.remove(it)
+                    it.toLetSource()
+                }
+
                 val whereExpr = unconsumedChildren.firstOrNull { it.type == WHERE }?.let {
                     unconsumedChildren.remove(it)
                     it.children[0].toExprNode()
@@ -600,6 +606,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
                     setQuantifier = setQuantifier,
                     projection = projection,
                     from = fromSource,
+                    fromLet = fromLet,
                     where = whereExpr,
                     groupBy = groupBy,
                     having = havingExpr,
@@ -722,6 +729,22 @@ class SqlParser(private val ion: IonSystem) : Parser {
             )
         }
         return head.unwrapAliasesAndUnpivot()
+    }
+
+    private fun ParseNode.toLetSource(): LetSource {
+        val letBindings = this.children.map { it.toLetBinding() }
+        return LetSource(letBindings)
+    }
+
+    private fun ParseNode.toLetBinding(): LetBinding {
+        val metas = token.toSourceLocationMetaContainer()
+        val (asAliasSymbol, parseNode) = unwrapAsAlias()
+        if (asAliasSymbol == null) {
+            this.errMalformedParseTree("Unsupported syntax for ${this.type}")
+        }
+        else {
+            return LetBinding(parseNode.toExprNode(), asAliasSymbol)
+        }
     }
 
     private fun ParseNode.unwrapAliasesAndUnpivot(): FromSource {
@@ -987,6 +1010,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
             "substring" -> tail.parseSubstring(head!!)
             "trim" -> tail.parseTrim(head!!)
             "extract" -> tail.parseExtract(head!!)
+            "let" -> tail.parseLet()
             in FUNCTION_NAME_KEYWORDS -> when (tail.head?.type) {
                 LEFT_PAREN ->
                     tail.tail.parseFunctionCall(head!!)
@@ -1540,6 +1564,12 @@ class SqlParser(private val ion: IonSystem) : Parser {
             }
         }
 
+        if (rem.head?.keywordText == "let") {
+            val letParseNode = rem.parseLet()
+            rem = letParseNode.remaining
+            children.add(letParseNode)
+        }
+
         parseOptionalSingleExpressionClause(WHERE)
 
         if (rem.head?.keywordText == "group") {
@@ -1813,6 +1843,48 @@ class SqlParser(private val ion: IonSystem) : Parser {
             }
             else      -> rem.head.err("Expected one of: $DATE_PART_KEYWORDS", PARSE_EXPECTED_DATE_PART)
         }
+    }
+
+    private fun List<Token>.parseLet(): ParseNode {
+        val letClauses = ArrayList<ParseNode>()
+        var rem = this.tail
+        var child = rem.parseExpression()
+        rem = child.remaining
+
+        if (rem.head?.type != AS) {
+            rem.head.err("Expected AS following LET expr", PARSE_EXPECTED_AS_FOR_LET)
+        }
+
+        rem = rem.tail
+
+        if (rem.head?.type?.isIdentifier() != true) {
+            rem.head.err("Expected identifier for $AS-alias", PARSE_EXPECTED_IDENT_FOR_ALIAS)
+        }
+
+        var name = rem.head
+        rem = rem.tail
+        letClauses.add(ParseNode(AS_ALIAS, name, listOf(child), rem))
+
+        while (rem.head?.type == COMMA) {
+            rem = rem.tail
+            child = rem.parseExpression()
+            rem = child.remaining
+            if (rem.head?.type != AS) {
+                rem.head.err("Expected AS following LET expr", PARSE_EXPECTED_AS_FOR_LET)
+            }
+
+            rem = rem.tail
+
+            if (rem.head?.type?.isIdentifier() != true) {
+                rem.head.err("Expected identifier for $AS-alias", PARSE_EXPECTED_IDENT_FOR_ALIAS)
+            }
+
+            name = rem.head
+
+            rem = rem.tail
+            letClauses.add(ParseNode(AS_ALIAS, name, listOf(child), rem))
+        }
+        return ParseNode(LET, null, letClauses, rem)
     }
 
     private fun List<Token>.parseListLiteral(): ParseNode =

--- a/lang/test/org/partiql/lang/ast/AstNodeTest.kt
+++ b/lang/test/org/partiql/lang/ast/AstNodeTest.kt
@@ -275,20 +275,21 @@ class AstNodeTest {
         val from = FromSourceExpr(literal("2"), LetVariables())
 
         assertEquals(listOf(projection, from),
-                     Select(SetQuantifier.ALL, projection, from, null, null, null, null, emptyMeta).children)
+                     Select(SetQuantifier.ALL, projection, from, null, null, null, null, null, emptyMeta).children)
     }
 
     @Test
     fun selectWithAllChildren() {
         val projection = SelectProjectionValue(literal("1"))
         val from = FromSourceExpr(literal("2"), LetVariables())
+        val fromLet = LetSource(emptyList())
         val where = literal("3")
         val groupBy = GroupBy(GroupingStrategy.FULL, listOf())
         val having = literal("4")
         val limit = literal("5")
 
-        assertEquals(listOf(projection, from, where, groupBy, having, limit),
-                     Select(SetQuantifier.ALL, projection, from, where, groupBy, having, limit, emptyMeta).children)
+        assertEquals(listOf(projection, from, fromLet, where, groupBy, having, limit),
+                     Select(SetQuantifier.ALL, projection, from, fromLet, where, groupBy, having, limit, emptyMeta).children)
     }
 
     @Test

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -287,6 +287,17 @@ class ParserErrorsTest : TestBase() {
     }
 
     @Test
+    fun expectedAsForLet() {
+        checkInputThrowingParserException("SELECT a FROM foo LET bar b",
+            ErrorCode.PARSE_EXPECTED_AS_FOR_LET,
+            mapOf(
+                Property.LINE_NUMBER to 1L,
+                Property.COLUMN_NUMBER to 27L,
+                Property.TOKEN_TYPE to TokenType.IDENTIFIER,
+                Property.TOKEN_VALUE to ion.newSymbol("b")))
+    }
+
+    @Test
     fun expectedIdentForAlias() {
         checkInputThrowingParserException("select a as true from data",
             ErrorCode.PARSE_EXPECTED_IDENT_FOR_ALIAS,
@@ -308,6 +319,17 @@ class ParserErrorsTest : TestBase() {
                 Property.TOKEN_TYPE to TokenType.LITERAL,
                 Property.TOKEN_VALUE to ion.newBool(true)))
 
+    }
+
+    @Test
+    fun expectedIdentForAliasLet() {
+        checkInputThrowingParserException("SELECT a FROM foo LET bar AS",
+            ErrorCode.PARSE_EXPECTED_IDENT_FOR_ALIAS,
+            mapOf(
+                Property.LINE_NUMBER to 1L,
+                Property.COLUMN_NUMBER to 29L,
+                Property.TOKEN_TYPE to TokenType.EOF,
+                Property.TOKEN_VALUE to ion.newSymbol("EOF")))
     }
 
     @Test

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3108,11 +3108,7 @@ class SqlParserTest : SqlParserTestBase() {
         select(
             project = projectX,
             from = scan(id("table1")),
-            fromLet = let(
-                letBinding(
-                    lit(ionInt(1)),
-                    "A")
-            )
+            fromLet = let(letBinding(lit(ionInt(1)), "A"))
         )
     }
 
@@ -3121,14 +3117,7 @@ class SqlParserTest : SqlParserTestBase() {
         select(
             project = projectX,
             from = scan(id("table1")),
-            fromLet = let(
-                letBinding(
-                    lit(ionInt(1)),
-                    "A"),
-                letBinding(
-                    lit(ionInt(2)),
-                    "B")
-            )
+            fromLet = let(letBinding(lit(ionInt(1)), "A"), letBinding(lit(ionInt(2)), "B"))
         )
     }
 
@@ -3137,11 +3126,7 @@ class SqlParserTest : SqlParserTestBase() {
         select(
             project = projectX,
             from = scan(id("table1")),
-            fromLet = let(
-                letBinding(
-                    id("table1"),
-                    "A")
-            )
+            fromLet = let(letBinding(id("table1"), "A"))
         )
     }
 
@@ -3150,11 +3135,7 @@ class SqlParserTest : SqlParserTestBase() {
         select(
             project = projectX,
             from = scan(id("table1")),
-            fromLet = let(
-                letBinding(
-                    call("foo", emptyList()),
-                    "A")
-            )
+            fromLet = let(letBinding(call("foo", emptyList()), "A"))
         )
     }
 
@@ -3164,14 +3145,7 @@ class SqlParserTest : SqlParserTestBase() {
         select(
             project = projectX,
             from = scan(id("table1")),
-            fromLet = let(
-                letBinding(
-                    call("foo", listOf(
-                            lit(ionInt(42)),
-                            lit(ionString("bar")))
-                        ),
-                    "A")
-            )
+            fromLet = let(letBinding(call("foo", listOf(lit(ionInt(42)), lit(ionString("bar")))), "A"))
         )
     }
 
@@ -3181,11 +3155,7 @@ class SqlParserTest : SqlParserTestBase() {
         select(
             project = projectX,
             from = scan(id("table1")),
-            fromLet = let(
-                letBinding(
-                    call("foo", listOf(id("table1"))),
-                    "A")
-            )
+            fromLet = let(letBinding(call("foo", listOf(id("table1"))), "A"))
         )
     }
 }

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -14,10 +14,14 @@
 
 package org.partiql.lang.syntax
 
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.ionString
 import org.junit.Test
 import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.ast.sourceLocation
+import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.id
 
 /**
  * Originally just meant to test the parser, this class now tests several different things because
@@ -3091,5 +3095,97 @@ class SqlParserTest : SqlParserTestBase() {
         val withoutSemicolon = parse("(1+1)")
 
         assertEquals(withoutSemicolon, withSemicolon)
+    }
+
+    //****************************************
+    // LET clause parsing
+    //****************************************
+
+    private val projectX = PartiqlAst.build { projectList(projectExpr(id("x"))) }
+
+    @Test
+    fun selectFromLetTest() = assertExpression("SELECT x FROM table1 LET 1 AS A") {
+        select(
+            project = projectX,
+            from = scan(id("table1")),
+            fromLet = let(
+                letBinding(
+                    lit(ionInt(1)),
+                    "A")
+            )
+        )
+    }
+
+    @Test
+    fun selectFromLetTwoBindingsTest() = assertExpression("SELECT x FROM table1 LET 1 AS A, 2 AS B") {
+        select(
+            project = projectX,
+            from = scan(id("table1")),
+            fromLet = let(
+                letBinding(
+                    lit(ionInt(1)),
+                    "A"),
+                letBinding(
+                    lit(ionInt(2)),
+                    "B")
+            )
+        )
+    }
+
+    @Test
+    fun selectFromLetTableBindingTest() = assertExpression("SELECT x FROM table1 LET table1 AS A") {
+        select(
+            project = projectX,
+            from = scan(id("table1")),
+            fromLet = let(
+                letBinding(
+                    id("table1"),
+                    "A")
+            )
+        )
+    }
+
+    @Test
+    fun selectFromLetFunctionBindingTest() = assertExpression("SELECT x FROM table1 LET foo() AS A") {
+        select(
+            project = projectX,
+            from = scan(id("table1")),
+            fromLet = let(
+                letBinding(
+                    call("foo", emptyList()),
+                    "A")
+            )
+        )
+    }
+
+    @Test
+    fun selectFromLetFunctionWithLiteralsTest() = assertExpression(
+        "SELECT x FROM table1 LET foo(42, 'bar') AS A") {
+        select(
+            project = projectX,
+            from = scan(id("table1")),
+            fromLet = let(
+                letBinding(
+                    call("foo", listOf(
+                            lit(ionInt(42)),
+                            lit(ionString("bar")))
+                        ),
+                    "A")
+            )
+        )
+    }
+
+    @Test
+    fun selectFromLetFunctionWithVariablesTest() = assertExpression(
+        "SELECT x FROM table1 LET foo(table1) AS A") {
+        select(
+            project = projectX,
+            from = scan(id("table1")),
+            fromLet = let(
+                letBinding(
+                    call("foo", listOf(id("table1"))),
+                    "A")
+            )
+        )
     }
 }

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -40,6 +40,22 @@ abstract class SqlParserTestBase : TestBase() {
 
     protected fun assertExpression(
         source: String,
+        pigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
+    ) {
+        val parsedExprNode = parse(source)
+
+        val expectedPartiQlAst = PartiqlAst.build { pigBuilder() }.toIonElement().toString()
+        // Convert the query to ExprNode
+
+        val partiqlAst = loadIonSexp(expectedPartiQlAst)
+        partiqlAssert(parsedExprNode, partiqlAst, source)
+
+        pigDomainAssert(parsedExprNode, partiqlAst.toIonElement().asSexp())
+        pigExprNodeTransformAsserts(parsedExprNode)
+    }
+
+    protected fun assertExpression(
+        source: String,
         expectedSexpAstV0String: String,
         pigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
     ) {


### PR DESCRIPTION
Part 1 of implementation for `LET` clause (#179) as defined in the high-level [spec](https://github.com/partiql/partiql-spec/issues/15).

Currently just implementing `LET` following `FROM` clauses as they are what's most clearly defined in the high-level spec and use cases.

Future supported clauses will be added later (especially because of #281, _Incorrect execution order for_ `LIMIT` _clause during query execution_)


Current status relating to `LET` following `FROM` clauses (from_let):
- [x] PIG domain model of `LET` clauses (separate [PR](https://github.com/partiql/partiql-lang-kotlin/pull/278))
- [x] `ExprNode` representation of `LET` clauses
- [x] Conversion between `PartiqlAst` and `ExprNode` for `LET` clauses
- [x] V0 Ast Serliazation for `LET` clauses
- [x] Parsing of `LET` clauses
- [x] `LET` parsing tests
(Evaluation to be done in a separate PR before merging into `from-let-final` feature branch)

Possible additions:
- test conversion between `PartiqlAst` and `ExprNode`
- test V0 ast (de)serializer outputs intended error when parsing `LET` clauses

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
