### PR TITLE
fix: bigDecimalOf no-ops when given an Ion decimal 

### DIFF
--- a/lang/src/org/partiql/lang/util/NumberExtensions.kt
+++ b/lang/src/org/partiql/lang/util/NumberExtensions.kt
@@ -25,7 +25,7 @@ private val MATH_CONTEXT = MathContext(38, RoundingMode.HALF_EVEN) // TODO shoul
  * and factory methods
  */
 internal fun bigDecimalOf(num: Number, mc: MathContext = MATH_CONTEXT): BigDecimal = when (num) {
-    Decimal.NEGATIVE_ZERO -> num as Decimal
+    is Decimal            -> num
     is Int                -> BigDecimal(num, mc)
     is Long               -> BigDecimal(num, mc)
     is Double             -> BigDecimal(num, mc)

--- a/lang/test/org/partiql/lang/util/NumbersTest.kt
+++ b/lang/test/org/partiql/lang/util/NumbersTest.kt
@@ -14,6 +14,7 @@
 
 package org.partiql.lang.util
 
+import com.amazon.ion.Decimal
 import org.partiql.lang.*
 import org.junit.Test
 import java.math.BigDecimal
@@ -77,4 +78,12 @@ class NumbersTest : TestBase() {
     @Test fun cmpBigDecimalLess() = assertTrue((1L as Number).compareTo(dec("2")) < 0)
     @Test fun cmpBigDecimalEquals() = assertEquals(0, (dec("1") as Number).compareTo(1L))
     @Test fun cmpBigDecimalMore() = assertTrue((2L as Number).compareTo(dec("1")) > 0)
+
+    @Test
+    fun bigDecimalOf() {
+        assertEquals(bigDecimalOf(Decimal.NEGATIVE_ZERO), Decimal.NEGATIVE_ZERO)
+        assertEquals(bigDecimalOf(BigDecimal.ZERO), BigDecimal.ZERO)
+        assertEquals(bigDecimalOf(0L), BigDecimal.ZERO)
+        assertEquals(bigDecimalOf(1), BigDecimal.ONE)
+    }
 }


### PR DESCRIPTION
Closes #293 
*Description of changes:*

`bigDecimalOf` special cased `Decimal.NEGATIVE_ZERO` in a `when` clause and then cast to `Decimal`. This caused a class cast exception because `BigDecimal.ZERO == Decimal.NEGATIVE_ZERO` leading to a downcast that failed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
