### PR TITLE
Add JUnit5 and vintage compatibility layer.

### DIFF
--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -49,10 +49,14 @@ dependencies {
 
     // test-time dependencies
     testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
-    testImplementation 'org.jetbrains.kotlin:kotlin-test'
+//    testImplementation 'org.jetbrains.kotlin:kotlin-test'
+    testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testImplementation 'pl.pragmatists:JUnitParams:[1.0.0,1.1.0)'
     testImplementation 'org.assertj:assertj-core:[3.11.0,3.12.0)'
-    
+
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
     // PTS
     testImplementation project(':testscript')
 }

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'
     // PTS
     testImplementation project(':testscript')
 }

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -49,7 +49,6 @@ dependencies {
 
     // test-time dependencies
     testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
-//    testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testImplementation 'pl.pragmatists:JUnitParams:[1.0.0,1.1.0)'
     testImplementation 'org.assertj:assertj-core:[3.11.0,3.12.0)'

--- a/lang/test/org/partiql/lang/ast/PathComponentExprTest.kt
+++ b/lang/test/org/partiql/lang/ast/PathComponentExprTest.kt
@@ -17,7 +17,7 @@ package org.partiql.lang.ast
 import com.amazon.ion.*
 import com.amazon.ion.system.*
 import junitparams.*
-import org.junit.*
+import org.junit.Test
 import org.junit.runner.*
 import kotlin.test.*
 

--- a/lang/test/org/partiql/lang/ast/SourceLocationMetaTest.kt
+++ b/lang/test/org/partiql/lang/ast/SourceLocationMetaTest.kt
@@ -16,6 +16,7 @@ package org.partiql.lang.ast
 
 import com.amazon.ion.system.*
 import org.junit.*
+import org.junit.Test
 import kotlin.test.*
 
 class SourceLocationMetaTest {

--- a/lang/test/org/partiql/lang/ast/VariableReferenceTest.kt
+++ b/lang/test/org/partiql/lang/ast/VariableReferenceTest.kt
@@ -15,6 +15,7 @@
 package org.partiql.lang.ast
 
 import org.junit.*
+import org.junit.Test
 import kotlin.test.*
 
 class VariableReferenceTest {

--- a/lang/test/org/partiql/lang/ast/passes/AstWalkerTests.kt
+++ b/lang/test/org/partiql/lang/ast/passes/AstWalkerTests.kt
@@ -19,6 +19,7 @@ import org.partiql.lang.ast.*
 import org.partiql.lang.syntax.*
 import junitparams.*
 import org.junit.*
+import org.junit.Test
 import org.junit.runner.*
 import kotlin.test.*
 

--- a/lang/test/org/partiql/lang/ast/passes/SubstitutionRewriterTest.kt
+++ b/lang/test/org/partiql/lang/ast/passes/SubstitutionRewriterTest.kt
@@ -18,6 +18,7 @@ import com.amazon.ion.*
 import com.amazon.ion.system.*
 import org.partiql.lang.ast.*
 import org.junit.*
+import org.junit.Test
 import kotlin.test.*
 
 class SubstitutionRewriterTest {

--- a/lang/test/org/partiql/lang/eval/EvaluationSessionTest.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluationSessionTest.kt
@@ -17,6 +17,7 @@ package org.partiql.lang.eval
 import com.amazon.ion.*
 import org.partiql.lang.util.*
 import org.junit.*
+import org.junit.Test
 import kotlin.test.*
 
 class EvaluationSessionTest {

--- a/lang/test/org/partiql/lang/eval/ExprValueFactoryTest.kt
+++ b/lang/test/org/partiql/lang/eval/ExprValueFactoryTest.kt
@@ -19,6 +19,7 @@ import org.junit.*
 import org.junit.runner.*
 import com.amazon.ion.*
 import com.amazon.ion.system.*
+import org.junit.Test
 import java.math.*
 import kotlin.test.*
 

--- a/lang/test/org/partiql/lang/eval/LikePredicateTest.kt
+++ b/lang/test/org/partiql/lang/eval/LikePredicateTest.kt
@@ -19,6 +19,7 @@ import org.partiql.lang.errors.*
 import org.partiql.lang.util.*
 import org.assertj.core.api.*
 import org.junit.*
+import org.junit.Test
 import kotlin.test.*
 
 class LikePredicateTest : EvaluatorTestBase() {

--- a/lang/test/org/partiql/lang/eval/NodeMetadataTest.kt
+++ b/lang/test/org/partiql/lang/eval/NodeMetadataTest.kt
@@ -19,6 +19,7 @@ import org.partiql.lang.util.*
 import junitparams.*
 import org.assertj.core.api.Assertions.*
 import org.junit.*
+import org.junit.Test
 import org.junit.runner.*
 import kotlin.test.*
 

--- a/lang/test/org/partiql/lang/eval/builtins/TimestampParserTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/TimestampParserTest.kt
@@ -20,6 +20,7 @@ import org.partiql.lang.eval.*
 import junitparams.*
 import junitparams.naming.*
 import org.junit.*
+import org.junit.Test
 import org.junit.runner.*
 import java.lang.reflect.*
 import java.time.format.*

--- a/lang/test/org/partiql/lang/eval/builtins/TimestampTemporalAccessorTests.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/TimestampTemporalAccessorTests.kt
@@ -24,6 +24,7 @@ import java.time.format.*
 import java.util.*
 import kotlin.test.*
 import org.assertj.core.api.Assertions.*
+import org.junit.Test
 import java.time.*
 import java.time.temporal.*
 

--- a/lang/test/org/partiql/lang/eval/builtins/timestamp/TimestampFormatPatternParserTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/timestamp/TimestampFormatPatternParserTest.kt
@@ -17,6 +17,7 @@ package org.partiql.lang.eval.builtins.timestamp
 import org.partiql.lang.util.*
 import junitparams.*
 import org.junit.*
+import org.junit.Test
 import org.junit.runner.*
 import kotlin.test.*
 

--- a/lang/test/org/partiql/lang/util/AstExtensions.kt
+++ b/lang/test/org/partiql/lang/util/AstExtensions.kt
@@ -18,6 +18,7 @@ package org.partiql.lang.util
 import com.amazon.ion.*
 import com.amazon.ion.system.*
 import org.junit.*
+import org.junit.Test
 import kotlin.test.*
 
 /**

--- a/lang/test/org/partiql/lang/util/ConfigurableExprValueFormatterTest.kt
+++ b/lang/test/org/partiql/lang/util/ConfigurableExprValueFormatterTest.kt
@@ -3,6 +3,7 @@ package org.partiql.lang.util
 import com.amazon.ion.system.*
 import junitparams.*
 import org.junit.*
+import org.junit.Test
 import org.junit.runner.*
 import org.partiql.lang.*
 import org.partiql.lang.eval.*


### PR DESCRIPTION
This allows us to start using JUnit5 APIs now without having to migrate the entire test suite to JUnit5.

JUnit5 has better assertions and test parameterization that is well integrated with the IDE which will improve developer productivity.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
