### PR TITLE
Stop treating date parts as if they are string literals

### DIFF
--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -219,8 +219,6 @@ internal val DATE_PART_KEYWORDS: Set<String> = DatePart.values()
     "then",
     "time",
     "timestamp",
-    "timezone_hour",
-    "timezone_minute",
     "to",
     "transaction",
     "translate",

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -247,9 +247,9 @@ internal val DATE_PART_KEYWORDS: Set<String> = DatePart.values()
     "work",
     "write",
     "zone"
-)
-    .union(TRIM_SPECIFICATION_KEYWORDS)
-    .union(DATE_PART_KEYWORDS)
+).union(TRIM_SPECIFICATION_KEYWORDS)
+// Note: DATE_PART_KEYWORDs are not keywords in the traditional sense--they are only keywords within
+// the context of the DATE_ADD, DATE_DIFF and EXTRACT functions, for which [SqlParser] has special support.
 
 /** PartiQL additional keywords. */
 @JvmField internal val SQLPP_KEYWORDS = setOf(

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -108,6 +108,8 @@ internal val DATE_PART_KEYWORDS: Set<String> = DatePart.values()
     "exists",
     "external",
     "extract",
+    "date_add",
+    "date_diff",
     "false",
     "fetch",
     "first",

--- a/lang/src/org/partiql/lang/syntax/SqlLexer.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlLexer.kt
@@ -520,11 +520,6 @@ class SqlLexer(private val ion: IonSystem) : Lexer {
                                         tokenType = TRIM_SPECIFICATION
                                         ion.newString(lower)
                                     }
-                                    lower in DATE_PART_KEYWORDS -> {
-                                        // used to determine the type of trim
-                                        tokenType = DATE_PART
-                                        ion.newString(lower)
-                                    }
                                     lower in BOOLEAN_KEYWORDS -> {
                                         // literal boolean
                                         tokenType = LITERAL

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -1824,7 +1824,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
         val maybeDatePart = this.head
         return when  {
             maybeDatePart?.type == IDENTIFIER && DATE_PART_KEYWORDS.contains(maybeDatePart.text?.toLowerCase()) -> {
-                ParseNode(ATOM, maybeDatePart, listOf(), this.tail)
+                ParseNode(ATOM, maybeDatePart.copy(type = DATE_PART), listOf(), this.tail)
             }
             else -> maybeDatePart.err("Expected one of: $DATE_PART_KEYWORDS", PARSE_EXPECTED_DATE_PART)
         }

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -799,7 +799,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
         fun headPrecedence() = rem.head?.infixPrecedence ?: 0
 
         // XXX this is a Pratt Top-Down Operator Precedence implementation
-        while (!rem.isEmpty() && precedence < headPrecedence()) {
+        while (rem.isNotEmpty() && precedence < headPrecedence()) {
             val op = rem.head!!
             if (!op.isBinaryOperator && op.keywordText !in SPECIAL_INFIX_OPERATORS) {
                 // unrecognized operator
@@ -1009,6 +1009,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
             "substring" -> tail.parseSubstring(head!!)
             "trim" -> tail.parseTrim(head!!)
             "extract" -> tail.parseExtract(head!!)
+            "date_add", "date_diff" -> tail.parseDateAddOrDateDiff(head!!)
             in FUNCTION_NAME_KEYWORDS -> when (tail.head?.type) {
                 LEFT_PAREN ->
                     tail.tail.parseFunctionCall(head!!)
@@ -1046,7 +1047,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
             else -> atomFromHead()
         }
         QUESTION_MARK -> ParseNode(PARAMETER, head!!, listOf(), tail)
-        LITERAL, NULL, MISSING, TRIM_SPECIFICATION, DATE_PART -> atomFromHead()
+        LITERAL, NULL, MISSING, TRIM_SPECIFICATION -> atomFromHead()
         else -> err("Unexpected term", PARSE_UNEXPECTED_TERM)
     }.let { parseNode ->
         // for many of the terms here we parse the tail, assuming the head as
@@ -1819,8 +1820,18 @@ class SqlParser(private val ion: IonSystem) : Parser {
         return ParseNode(ParseType.CALL, name, arguments, rem.tail)
     }
 
+    private fun List<Token>.expectDatePart(): ParseNode =
+        when (this.head?.type) {
+            DATE_PART -> {
+                val datePartToken = this.head!!
+                ParseNode(ATOM, datePartToken, listOf(), this.drop(1))
+            }
+            else -> this.head.err("Expected one of: $DATE_PART_KEYWORDS", PARSE_EXPECTED_DATE_PART)
+        }
+
+
     /**
-     * Parses extract
+     * Parses extract function call.
      *
      * Syntax is EXTRACT(<date_part> FROM <timestamp>).
      */
@@ -1828,19 +1839,29 @@ class SqlParser(private val ion: IonSystem) : Parser {
         if (head?.type != LEFT_PAREN) err("Expected $LEFT_PAREN",
                                           PARSE_EXPECTED_LEFT_PAREN_BUILTIN_FUNCTION_CALL)
 
-        var rem = tail
+        val datePart = this.drop(1).expectDatePart().deriveExpectedKeyword("from")
+        val rem = datePart.remaining
+        val timestamp = rem.parseExpression().deriveExpected(RIGHT_PAREN)
 
-        return when (rem.head?.type) {
-            DATE_PART -> {
-                val datePart = rem.parseExpression().deriveExpectedKeyword("from")
-                rem = datePart.remaining
+        return ParseNode(CALL, name, listOf(datePart, timestamp), timestamp.remaining)
+    }
 
-                val timestamp = rem.parseExpression().deriveExpected(RIGHT_PAREN)
+    /**
+     * Parses a function call using that has the syntax of date_add and date_diff.
+     *
+     * Syntax is <func>(<date_part>, <timestamp>, <timestamp>) where <func>
+     * is the value of [name].
+     */
+    private fun List<Token>.parseDateAddOrDateDiff(name: Token): ParseNode {
+        if (head?.type != LEFT_PAREN) err("Expected $LEFT_PAREN",
+                                          PARSE_EXPECTED_LEFT_PAREN_BUILTIN_FUNCTION_CALL)
 
-                ParseNode(ParseType.CALL, name, listOf(datePart, timestamp), timestamp.remaining)
-            }
-            else      -> rem.head.err("Expected one of: $DATE_PART_KEYWORDS", PARSE_EXPECTED_DATE_PART)
-        }
+        val datePart = this.drop(1).expectDatePart().deriveExpected(COMMA)
+
+        val timestamp1 = datePart.remaining.parseExpression().deriveExpected(COMMA)
+        val timestamp2 = timestamp1.remaining.parseExpression().deriveExpected(RIGHT_PAREN)
+
+        return ParseNode(CALL, name, listOf(datePart, timestamp1, timestamp2), timestamp2.remaining)
     }
 
     private fun List<Token>.parseLet(): ParseNode {
@@ -1909,7 +1930,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
             type = STRUCT
         ).deriveExpected(RIGHT_CURLY)
 
-    private fun List<Token>. parseTableValues(): ParseNode =
+    private fun List<Token>.parseTableValues(): ParseNode =
         parseCommaList {
             var rem = this
             if (rem.head?.type != LEFT_PAREN) {

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -1824,8 +1824,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
         val maybeDatePart = this.head
         return when  {
             maybeDatePart?.type == IDENTIFIER && DATE_PART_KEYWORDS.contains(maybeDatePart.text?.toLowerCase()) -> {
-                val datePartToken = maybeDatePart!!
-                ParseNode(ATOM, datePartToken, listOf(), this.tail)
+                ParseNode(ATOM, maybeDatePart, listOf(), this.tail)
             }
             else -> maybeDatePart.err("Expected one of: $DATE_PART_KEYWORDS", PARSE_EXPECTED_DATE_PART)
         }

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -881,29 +881,6 @@ class ParserErrorsTest : TestBase() {
                                                 Property.TOKEN_VALUE to ion.newSymbol("from")))
     }
 
-
-    @Test
-    fun invalidContextForDatePart() {
-        // Regression test for https://github.com/partiql/partiql-lang-kotlin/issues/314
-        // Proves that date part reserved words cannot be used like string literals.
-        checkInputThrowingParserException("foo || year",
-                                          ErrorCode.PARSE_UNEXPECTED_TERM,
-                                          mapOf(Property.LINE_NUMBER to 1L,
-                                                Property.COLUMN_NUMBER to 8L,
-                                                Property.TOKEN_TYPE to TokenType.DATE_PART,
-                                                Property.TOKEN_VALUE to ion.newString("year")))
-    }
-
-    @Test
-    fun callExtractInvalidDatePart() {
-        checkInputThrowingParserException("extract(foobar from b)",
-                                          ErrorCode.PARSE_EXPECTED_DATE_PART,
-                                          mapOf(Property.LINE_NUMBER to 1L,
-                                                Property.COLUMN_NUMBER to 9L,
-                                                Property.TOKEN_TYPE to TokenType.IDENTIFIER,
-                                                Property.TOKEN_VALUE to ion.newSymbol("foobar")))
-    }
-
     @Test
     fun callExtractMissingFrom() {
         checkInputThrowingParserException("extract(year b)",

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerTests.kt
@@ -1741,6 +1741,34 @@ class EvaluatingCompilerTests : EvaluatorTestBase() {
     fun projectOfSexp() = assertEvalExprValue("SELECT * FROM `(1 2)` as foo", "<<{'_1': `(1 2)` }>>")
 
     @Test
-    fun projectOfUnpivotPath()= assertEvalExprValue("SELECT * FROM <<{'name': 'Marrowstone Brewing'}, {'name': 'Tesla'}>>.*",
+    fun projectOfUnpivotPath() = assertEvalExprValue("SELECT * FROM <<{'name': 'Marrowstone Brewing'}, {'name': 'Tesla'}>>.*",
         "<<{'_1': <<{'name': 'Marrowstone Brewing'}, {'name': 'Tesla'}>>}>>")
+
+    /**
+     * Regression test for https://github.com/partiql/partiql-lang-kotlin/issues/314
+     *
+     * Ensures that date parts can be used as variable names.
+     */
+    @Test
+    fun datePartsAsVariableNames() =
+        assertEvalExprValue(
+            """
+            SELECT VALUE [year, month, day, hour, minute, second]
+            FROM 1968 AS year, 4 AS month, 3 as day, 12 as hour, 31 as minute, 59 as second 
+            """,
+            "<<[1968, 4, 3, 12, 31, 59]>>")
+
+    /**
+     * Regression test for https://github.com/partiql/partiql-lang-kotlin/issues/121
+     *
+     * Ensures that date parts can be used as struct field names.
+     */
+    @Test
+    fun datePartsAsStructFieldNames() =
+        assertEvalExprValue(
+            """
+            SELECT VALUE [x.year, x.month, x.day, x.hour, x.minute, x.second]
+            FROM << { 'year': 1968, 'month': 4, 'day': 3, 'hour': 12, 'minute': 31, 'second': 59 }>> AS x
+            """,
+            "<<[1968, 4, 3, 12, 31, 59]>>")
 }

--- a/lang/test/org/partiql/lang/eval/builtins/DateAddEvaluationTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/DateAddEvaluationTest.kt
@@ -42,16 +42,10 @@ class DateAddEvaluationTest : EvaluatorTestBase() {
     fun dateAddSecond() = assertEval("date_add(second, 1, `2017-01-10T05:30:55Z`)", "2017-01-10T05:30:56Z")
 
     @Test
-    fun dateAddNull01() = assertEval("date_add(null, 1, `2017-01-10T05:30:55Z`)", "null")
-
-    @Test
     fun dateAddNull02() = assertEval("date_add(second, null, `2017-01-10T05:30:55Z`)", "null")
 
     @Test
     fun dateAddNull03() = assertEval("date_add(second, 1, null)", "null")
-
-    @Test
-    fun dateAddMissing01() = assertEval("date_add(missing, 1, `2017-01-10T05:30:55Z`)", "null")
 
     @Test
     fun dateAddMissing02() = assertEval("date_add(second, missing, `2017-01-10T05:30:55Z`)", "null")
@@ -63,16 +57,6 @@ class DateAddEvaluationTest : EvaluatorTestBase() {
     fun dateAddWithBindings() = assertEval("date_add(second, a, b)", "2017-01-10T05:30:56Z", mapOf(
         "a" to "1",
         "b" to "2017-01-10T05:30:55Z").toSession())
-
-    @Test
-    fun lessArguments() = assertThrows("date_add takes exactly 3 arguments, received: 2", NodeMetadata(1, 1)) {
-        voidEval("date_add(year, 1)")
-    }
-
-    @Test
-    fun moreArguments() = assertThrows("date_add takes exactly 3 arguments, received: 4", NodeMetadata(1, 1)) {
-        voidEval("date_add(year, 1, `2017T`, 1)")
-    }
 
     @Test
     fun wrongArgumentTypes() = assertThrows("No such binding: foobar", NodeMetadata(1, 16)) {

--- a/lang/test/org/partiql/lang/eval/builtins/DateDiffEvaluationTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/DateDiffEvaluationTest.kt
@@ -58,12 +58,6 @@ class DateDiffEvaluationTest : EvaluatorTestBase() {
                                            "1",
                                            mapOf("a" to "2016-01-10T05:30:55Z",
                                                  "b" to "2017-01-10T05:30:55Z").toSession())
-
-    @Test
-    fun wrongArgumentTypes1() = assertThrows("Expected text: 1", NodeMetadata(1, 1)) {
-        voidEval("date_diff(1, `2016-01-10T05:30:55Z`, `2017-01-10T05:30:55Z`)")
-    }
-
     @Test
     fun wrongArgumentTypes2() = assertThrows("Expected timestamp: 1", NodeMetadata(1, 1)) {
         voidEval("date_diff(second, 1, `2017-01-10T05:30:55Z`)")

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -963,57 +963,57 @@ class SqlParserTest : SqlParserTestBase() {
     @Test
     fun callDateArithYear() = assertDateArithmetic(
         "date_<op>(year, a, b)",
-        "(call date_<op> (lit \"year\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_<op> (lit \"year\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit year) (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit year) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithMonth() = assertDateArithmetic(
         "date_<op>(month, a, b)",
-        "(call date_<op> (lit \"month\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_<op> (lit \"month\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit month) (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit month) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithDay() = assertDateArithmetic(
         "date_<op>(day, a, b)",
-        "(call date_<op> (lit \"day\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_<op> (lit \"day\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit day) (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit day) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithHour() = assertDateArithmetic(
         "date_<op>(hour, a, b)",
-        "(call date_<op> (lit \"hour\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_<op> (lit \"hour\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit hour) (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit hour) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithMinute() = assertDateArithmetic(
         "date_<op>(minute, a, b)",
-        "(call date_<op> (lit \"minute\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_<op> (lit \"minute\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit minute) (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit minute) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithSecond() = assertDateArithmetic(
         "date_<op>(second, a, b)",
-        "(call date_<op> (lit \"second\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_<op> (lit \"second\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit second) (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit second) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test // invalid evaluation, but valid parsing
     fun callDateArithTimezoneHour() = assertDateArithmetic(
         "date_<op>(timezone_hour, a, b)",
-        "(call date_<op> (lit \"timezone_hour\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_<op> (lit \"timezone_hour\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit timezone_hour) (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit timezone_hour) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test // invalid evaluation, but valid parsing
     fun callDateArithTimezoneMinute() = assertDateArithmetic(
         "date_<op>(timezone_minute, a, b)",
-        "(call date_<op> (lit \"timezone_minute\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_<op> (lit \"timezone_minute\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit timezone_minute) (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit timezone_minute) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
 
@@ -1023,57 +1023,57 @@ class SqlParserTest : SqlParserTestBase() {
     @Test
     fun callExtractYear() = assertExpression(
         "extract(year from a)",
-        "(call extract (lit \"year\") (id a case_insensitive))",
-        "(call extract (lit \"year\") (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit year) (id a case_insensitive))",
+        "(call extract (lit year) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractMonth() = assertExpression(
         "extract(month from a)",
-        "(call extract (lit \"month\") (id a case_insensitive))",
-        "(call extract (lit \"month\") (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit month) (id a case_insensitive))",
+        "(call extract (lit month) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractDay() = assertExpression(
         "extract(day from a)",
-        "(call extract (lit \"day\") (id a case_insensitive))",
-        "(call extract (lit \"day\") (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit day) (id a case_insensitive))",
+        "(call extract (lit day) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractHour() = assertExpression(
         "extract(hour from a)",
-        "(call extract (lit \"hour\") (id a case_insensitive))",
-        "(call extract (lit \"hour\") (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit hour) (id a case_insensitive))",
+        "(call extract (lit hour) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractMinute() = assertExpression(
         "extract(minute from a)",
-        "(call extract (lit \"minute\") (id a case_insensitive))",
-        "(call extract (lit \"minute\") (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit minute) (id a case_insensitive))",
+        "(call extract (lit minute) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractSecond() = assertExpression(
         "extract(second from a)",
-        "(call extract (lit \"second\") (id a case_insensitive))",
-        "(call extract (lit \"second\") (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit second) (id a case_insensitive))",
+        "(call extract (lit second) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractTimezoneHour() = assertExpression(
         "extract(timezone_hour from a)",
-        "(call extract (lit \"timezone_hour\") (id a case_insensitive))",
-        "(call extract (lit \"timezone_hour\") (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit timezone_hour) (id a case_insensitive))",
+        "(call extract (lit timezone_hour) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractTimezoneMinute() = assertExpression(
         "extract(timezone_minute from a)",
-        "(call extract (lit \"timezone_minute\") (id a case_insensitive))",
-        "(call extract (lit \"timezone_minute\") (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit timezone_minute) (id a case_insensitive))",
+        "(call extract (lit timezone_minute) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -936,114 +936,86 @@ class SqlParserTest : SqlParserTestBase() {
     )
 
     //****************************************
-    // date part
+    // call date_add and date_diff (special syntax)
     //****************************************
-    @Test
-    fun datePartYear() = assertExpression(
-        "year",
-        "(lit \"year\")")
+
+    private fun assertDateArithmetic(
+        templateSql: String,
+        templateExpectedV0: String,
+        templateExpectedPartiqlAst: String
+    ) {
+        applyAndAssertDateArithmeticFunctions("add", templateSql, templateExpectedV0, templateExpectedPartiqlAst)
+    }
+
+    private fun applyAndAssertDateArithmeticFunctions(
+        operation: String,
+        templateSql: String,
+        templateExpectedV0: String,
+        templateExpectedPartiqlAst: String
+    ) {
+        assertExpression(
+            templateSql.replace("<op>", operation),
+            templateExpectedV0.replace("<op>", operation),
+            templateExpectedPartiqlAst.replace("<op>", operation))
+
+    }
 
     @Test
-    fun datePartMonth() = assertExpression(
-        "month",
-        "(lit \"month\")")
-
-    @Test
-    fun datePartDay() = assertExpression(
-        "day",
-        "(lit \"day\")")
-
-    @Test
-    fun datePartHour() = assertExpression(
-        "hour",
-        "(lit \"hour\")")
-
-    @Test
-    fun datePartMinutes() = assertExpression(
-        "minute",
-        "(lit \"minute\")")
-
-    @Test
-    fun datePartSeconds() = assertExpression(
-        "second",
-        "(lit \"second\")")
-
-    @Test
-    fun datePartTimestampHour() = assertExpression(
-        "timezone_hour",
-        "(lit \"timezone_hour\")")
-
-    @Test
-    fun datePartTimezoneMinute() = assertExpression(
-        "timezone_minute",
-        "(lit \"timezone_minute\")")
-
-
-    //****************************************
-    // call date add (special syntax)
-    //****************************************
-    @Test
-    fun callDateAddYear() = assertExpression(
-        "date_add(year, a, b)",
-        "(call date_add (lit \"year\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_add (lit \"year\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+    fun callDateArithYear() = assertDateArithmetic(
+        "date_<op>(year, a, b)",
+        "(call date_<op> (lit \"year\") (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit \"year\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
-    fun callDateAddMonth() = assertExpression(
-        "date_add(month, a, b)",
-        "(call date_add (lit \"month\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_add (lit \"month\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+    fun callDateArithMonth() = assertDateArithmetic(
+        "date_<op>(month, a, b)",
+        "(call date_<op> (lit \"month\") (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit \"month\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
-    fun callDateAddDay() = assertExpression(
-        "date_add(day, a, b)",
-        "(call date_add (lit \"day\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_add (lit \"day\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+    fun callDateArithDay() = assertDateArithmetic(
+        "date_<op>(day, a, b)",
+        "(call date_<op> (lit \"day\") (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit \"day\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
-    fun callDateAddHour() = assertExpression(
-        "date_add(hour, a, b)",
-        "(call date_add (lit \"hour\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_add (lit \"hour\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+    fun callDateArithHour() = assertDateArithmetic(
+        "date_<op>(hour, a, b)",
+        "(call date_<op> (lit \"hour\") (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit \"hour\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
-    fun callDateAddMinute() = assertExpression(
-        "date_add(minute, a, b)",
-        "(call date_add (lit \"minute\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_add (lit \"minute\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+    fun callDateArithMinute() = assertDateArithmetic(
+        "date_<op>(minute, a, b)",
+        "(call date_<op> (lit \"minute\") (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit \"minute\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
-    fun callDateAddSecond() = assertExpression(
-        "date_add(second, a, b)",
-        "(call date_add (lit \"second\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_add (lit \"second\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+    fun callDateArithSecond() = assertDateArithmetic(
+        "date_<op>(second, a, b)",
+        "(call date_<op> (lit \"second\") (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit \"second\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test // invalid evaluation, but valid parsing
-    fun callDateAddTwoArguments() = assertExpression(
-        "date_add(second, a)",
-        "(call date_add (lit \"second\") (id a case_insensitive))",
-        "(call date_add (lit \"second\") (id a (case_insensitive) (unqualified)))"
+    fun callDateArithTimezoneHour() = assertDateArithmetic(
+        "date_<op>(timezone_hour, a, b)",
+        "(call date_<op> (lit \"timezone_hour\") (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit \"timezone_hour\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test // invalid evaluation, but valid parsing
-    fun callDateAddTimezoneHour() = assertExpression(
-        "date_add(timezone_hour, a, b)",
-        "(call date_add (lit \"timezone_hour\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_add (lit \"timezone_hour\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+    fun callDateArithTimezoneMinute() = assertDateArithmetic(
+        "date_<op>(timezone_minute, a, b)",
+        "(call date_<op> (lit \"timezone_minute\") (id a case_insensitive) (id b case_insensitive))",
+        "(call date_<op> (lit \"timezone_minute\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
-    @Test // invalid evaluation, but valid parsing
-    fun callDateAddTimezoneMinute() = assertExpression(
-        "date_add(timezone_minute, a, b)",
-        "(call date_add (lit \"timezone_minute\") (id a case_insensitive) (id b case_insensitive))",
-        "(call date_add (lit \"timezone_minute\") (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
-    )
 
     //****************************************
     // call extract (special syntax)

--- a/testscript/pts/test-scripts/builtin-functions/date_add.sqlts
+++ b/testscript/pts/test-scripts/builtin-functions/date_add.sqlts
@@ -145,20 +145,12 @@ for::{
     ],
 
     variable_sets: [
-        {  time_part: "null",    quantity: 1,         timestamp: "`2017T`", result: (success null ) },
         {  time_part: year,      quantity: "null",    timestamp: "`2017T`", result: (success null ) },
         {  time_part: year,      quantity: 1,         timestamp: "null",    result: (success null ) },
-        {  time_part: "missing", quantity: 1,         timestamp: "`2017T`", result: (success null ) },
         {  time_part: year,      quantity: "missing", timestamp: "`2017T`", result: (success null ) },
         {  time_part: year,      quantity: 1,         timestamp: "missing", result: (success null ) },
-        {  time_part: "null",    quantity: "missing", timestamp: "`2017T`", result: (success null ) },
-        {  time_part: "null",    quantity: 1,         timestamp: "missing", result: (success null ) },
-        {  time_part: "missing", quantity: "null",    timestamp: "`2017T`", result: (success null ) },
         {  time_part: year,      quantity: "null",    timestamp: "missing", result: (success null ) },
-        {  time_part: "missing", quantity: 1,         timestamp: "null",    result: (success null ) },
         {  time_part: year,      quantity: "missing", timestamp: "null",    result: (success null ) },
-        {  time_part: "null",    quantity: "null",    timestamp: "null",    result: (success null ) },
-        {  time_part: "missing", quantity: "missing", timestamp: "missing", result: (success null ) },
     ]
 }
 

--- a/testscript/pts/test-scripts/builtin-functions/date_diff.sqlts
+++ b/testscript/pts/test-scripts/builtin-functions/date_diff.sqlts
@@ -236,25 +236,15 @@ for::{
     ],
 
     variable_sets: [
-        { result: (success null), time_part: "null", left: "`2017T`", right: "`2017T`" },
         { result: (success null), time_part: "year", left: "null",    right: "`2017T`" },
         { result: (success null), time_part: "year", left: "`2017T`", right: "null" },
 
-        { result: (success null), time_part: "missing", left: "`2017T`", right: "`2017T`" },
         { result: (success null), time_part: "year",    left: "missing", right: "`2017T`" },
         { result: (success null), time_part: "year",    left: "`2017T`", right: "missing" },
 
-        { result: (success null), time_part: "null", left: "missing", right: "`2017T`" },
-        { result: (success null), time_part: "null", left: "`2017T`", right: "missing" },
-
-        { result: (success null), time_part: "missing", left: "null", right: "`2017T`" },
         { result: (success null), time_part: "year",    left: "null", right: "missing" },
 
-        { result: (success null), time_part: "missing", left: "`2017T`", right: "null" },
         { result: (success null), time_part: "year",    left: "missing", right: "null" },
-
-        { result: (success null), time_part: "missing", left: "missing", right: "missing" },
-        { result: (success null), time_part: "null",    left: "null",    right: "null" },
     ]
 }
 


### PR DESCRIPTION
This also required adding/enhancing parser support for the special
functions extract, date_add and date_diff functions all of which
have special syntax.

This is "technically" a breaking chance as evidenced by the
changes required to the tests related to these which previously
expected these keywords to be values instead of the grammatical
elements that they actually are.  For instance, this commit
removes several tests that attempt to pass NULL and MISSING
values instead of a date part to these functions.

Fixes #121 and #314.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
