### PR TITLE
Fix for SelectListItemAlias subqueries

### DIFF
--- a/lang/src/org/partiql/lang/eval/visitors/SelectListItemAliasVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/SelectListItemAliasVisitorTransform.kt
@@ -1,11 +1,9 @@
 package org.partiql.lang.eval.visitors
 
-import org.partiql.lang.domains.extractSourceLocation
-
 import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.extractSourceLocation
 import org.partiql.lang.eval.extractColumnAlias
 import org.partiql.pig.runtime.SymbolPrimitive
-
 
 /**
  * Specifies any previously unspecified select list item aliases.
@@ -45,13 +43,16 @@ class SelectListItemAliasVisitorTransform : PartiqlAst.VisitorTransform() {
                             when (it.asAlias) {
                                 //  Synthesize a column name if one was not specified in the query.
                                 null -> projectExpr_(
-                                    expr = it.expr,
+                                    expr = transformExpr(it.expr),
                                     asAlias = SymbolPrimitive(
                                         text = it.expr.extractColumnAlias(idx),
                                         metas = node.extractSourceLocation()
                                     )
                                 )
-                                else -> it
+                                else -> projectExpr_(
+                                    expr = transformExpr(it.expr),
+                                    asAlias = it.asAlias
+                                )
                             }
                         else -> it
                     }
@@ -60,4 +61,3 @@ class SelectListItemAliasVisitorTransform : PartiqlAst.VisitorTransform() {
         }
     }
 }
-

--- a/lang/test/org/partiql/lang/eval/visitors/SelectListItemAliasVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/SelectListItemAliasVisitorTransformTests.kt
@@ -180,8 +180,26 @@ class SelectListItemAliasVisitorTransformTests : VisitorTransformTestBase() {
                 """,
                 """
                 SELECT 
-                    (SELECT n FROM p) _1,
-                    (SELECT q FROM r) AS o
+                    (SELECT n AS n FROM p) AS _1,
+                    (SELECT q AS q FROM r) AS o
+                FROM foo
+                """
+            ),
+            TransformTestCase(
+                """
+                SELECT 
+                    (SELECT 
+                        (SELECT n FROM p1) FROM p),
+                    (SELECT 
+                        (SELECT q FROM r1) FROM r) AS o
+                FROM foo
+                """,
+                """
+                SELECT 
+                    (SELECT 
+                        (SELECT n AS n FROM p1) AS _1 FROM p) AS _1,
+                    (SELECT 
+                        (SELECT q AS q FROM r1) AS _1 FROM r) AS o
                 FROM foo
                 """
             )
@@ -192,5 +210,3 @@ class SelectListItemAliasVisitorTransformTests : VisitorTransformTestBase() {
     @ArgumentsSource(ArgsProvider::class)
     fun test(tc: TransformTestCase) = runTestForIdempotentTransform(tc, SelectListItemAliasVisitorTransform())
 }
-
-


### PR DESCRIPTION
Fixes #321. Also adds a deeper nested `SELECT` test case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
