### PR TITLE
Fix typo in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ allprojects {
 
 subprojects {
     group = 'org.partiql'
-    rersion = '0.2.5-SNAPSHOT'
+    version = '0.2.5-SNAPSHOT'
 }
 
 buildDir = new File(rootProject.projectDir, "gradle-build/" + project.name)


### PR DESCRIPTION
Fix to `build.gradle` that was causing build failures.

`rersion` -> `version`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
