### PR TITLE
Migrate Travis CI to Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,63 @@
+name: "Build and Report Generation"
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 9, 11]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build and test
+        run: ./gradlew build
+
+  report-generation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Generate test coverage report
+        run: ./gradlew build jacocoTestReport
+
+      # Upload coverage for CLI, LANG, PTS, TEST_SCRIPT, and EXAMPLES
+      - name: Upload CLI coverage
+        uses: codecov/codecov-action@v1
+        with:
+          directory: cli/build/reports
+          flags: CLI
+
+      - name: Upload LANG coverage
+        uses: codecov/codecov-action@v1
+        with:
+          directory: lang/build/reports
+          flags: LANG
+
+      - name: Upload PTS coverage
+        uses: codecov/codecov-action@v1
+        with:
+          directory: pts/build/reports
+          flags: PTS
+
+      - name: Upload TEST_SCRIPT coverage
+        uses: codecov/codecov-action@v1
+        with:
+          directory: testscript/build/reports
+          flags: TEST_SCRIPT
+
+      - name: Upload EXAMPLES coverage
+        uses: codecov/codecov-action@v1
+        with:
+          directory: examples/build/reports
+          flags: EXAMPLES


### PR DESCRIPTION
Migrate Travis CI to Github Actions (#317).

Initial commit adds GH Actions for building/testing and uploading codcov. Once that passes, will delete `.travis.yml`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
