### PR TITLE
Stored Procedures - call with unnamed args (parsing + PIG definition)

### DIFF
--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -31,7 +31,7 @@
             // Stored procedure calls are only allowed at the top level of a query and cannot be used as an expression
             // Currently supports stored procedure calls with the unnamed argument syntax:
             //     EXEC <symbol> [<expr>.*]
-            (exec func_name::symbol args::(* expr 0)))
+            (exec procedure_name::symbol args::(* expr 0)))
 
         // The expressions that can result in values.
         (sum expr

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -26,7 +26,12 @@
                 (where where::(? expr)))
 
             // Data definition operations also cannot be composed with other `expr` nodes.
-            (ddl op::ddl_op))
+            (ddl op::ddl_op)
+
+            // Stored procedure calls are only allowed at the top level of a query and cannot be used as an expression
+            // Currently supports stored procedure calls with the unnamed argument syntax:
+            //     EXEC <symbol> [<expr>.*]
+            (exec func_name::symbol args::(* expr 0)))
 
         // The expressions that can result in values.
         (sum expr

--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -94,6 +94,7 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
                     is DropTable         -> case { writeDropTable(expr) }
                     is DropIndex         -> case { writeDropIndex(expr) }
                     is Parameter         -> case { writeParameter(expr)}
+                    is Exec              -> throw UnsupportedOperationException("EXEC clause not supported by the V0 AST")
                 }.toUnit()
             }
         }

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -55,7 +55,7 @@ private fun ExprNode.toAstExec() : PartiqlAst.Statement {
 
     return PartiqlAst.build {
         when (node) {
-            is Exec -> exec(node.funcName.name, node.args.map { it.toAstExpr() }, metas)
+            is Exec -> exec(node.procedureName.name, node.args.map { it.toAstExpr() }, metas)
             else -> error("Can't convert ${node.javaClass} to PartiqlAst.Statement.Exec")
         }
     }

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -16,6 +16,7 @@ fun ExprNode.toAstStatement(): PartiqlAst.Statement {
 
         is CreateTable, is CreateIndex, is DropTable, is DropIndex -> toAstDdl()
 
+        is Exec -> toAstExec()
     }
 }
 
@@ -30,7 +31,7 @@ private fun ExprNode.toAstDdl(): PartiqlAst.Statement {
         when(thiz) {
             is Literal, is LiteralMissing, is VariableReference, is Parameter, is NAry, is CallAgg, is Typed,
             is Path, is SimpleCase, is SearchedCase, is Select, is Struct, is Seq,
-            is DataManipulation -> error("Can't convert ${thiz.javaClass} to PartiqlAst.ddl")
+            is DataManipulation, is Exec -> error("Can't convert ${thiz.javaClass} to PartiqlAst.ddl")
 
             is CreateTable -> ddl(createTable(thiz.tableName), metas)
             is CreateIndex -> ddl(createIndex(identifier(thiz.tableName, caseSensitive()), thiz.keys.map { it.toAstExpr() }), metas)
@@ -44,6 +45,18 @@ private fun ExprNode.toAstDdl(): PartiqlAst.Statement {
             is DropTable ->
                 // case-sensitivity of table names cannot be represented with ExprNode.
                 ddl(dropTable(identifier(thiz.tableName, caseSensitive())), metas)
+        }
+    }
+}
+
+private fun ExprNode.toAstExec() : PartiqlAst.Statement {
+    val node = this
+    val metas = metas.toElectrolyteMetaContainer()
+
+    return PartiqlAst.build {
+        when (node) {
+            is Exec -> exec(node.funcName.name, node.args.map { it.toAstExpr() }, metas)
+            else -> error("Can't convert ${node.javaClass} to PartiqlAst.Statement.Exec")
         }
     }
 }
@@ -147,8 +160,8 @@ fun ExprNode.toAstExpr(): PartiqlAst.Expr {
                     SeqType.BAG -> bag(node.values.map { it.toAstExpr() })
                 }
 
-            // These are handled by `toAstDml()`
-            is DataManipulation, is CreateTable, is CreateIndex, is DropTable, is DropIndex ->
+            // These are handled by `toAstDml()`, `toAstDdl()`, and `toAstExec()`
+            is DataManipulation, is CreateTable, is CreateIndex, is DropTable, is DropIndex, is Exec ->
                 error("Can't transform ${node.javaClass} to a PartiqlAst.expr }")
         }
     }

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -2,6 +2,7 @@ package org.partiql.lang.ast
 
 import com.amazon.ion.IonSystem
 import com.amazon.ionelement.api.toIonValue
+import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.domains.PartiqlAst.CaseSensitivity
 import org.partiql.lang.domains.PartiqlAst.DdlOp
 import org.partiql.lang.domains.PartiqlAst.DmlOp
@@ -33,6 +34,7 @@ private class StatementTransformer(val ion: IonSystem) {
             is Statement.Query -> stmt.toExprNode()
             is Statement.Dml -> stmt.toExprNode()
             is Statement.Ddl -> stmt.toExprNode()
+            is Statement.Exec -> stmt.toExprNode()
         }
 
     private fun ElectrolyteMetaContainer.toPartiQlMetaContainer(): PartiQlMetaContainer {
@@ -343,5 +345,9 @@ private class StatementTransformer(val ion: IonSystem) {
                     ),
                     metas = metas)
         }
+    }
+
+    private fun Statement.Exec.toExprNode(): ExprNode {
+        return Exec(funcName.toSymbolicName(), this.args.toExprNodeList(), metas.toPartiQlMetaContainer())
     }
 }

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -348,6 +348,6 @@ private class StatementTransformer(val ion: IonSystem) {
     }
 
     private fun Statement.Exec.toExprNode(): ExprNode {
-        return Exec(funcName.toSymbolicName(), this.args.toExprNodeList(), metas.toPartiQlMetaContainer())
+        return Exec(procedureName.toSymbolicName(), this.args.toExprNodeList(), metas.toPartiQlMetaContainer())
     }
 }

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -103,6 +103,9 @@ sealed class ExprNode : AstNode(), HasMetas {
             is Parameter       -> {
                 copy(metas = metas)
             }
+            is Exec            -> {
+                copy(metas = metas)
+            }
         }
     }
 }
@@ -208,6 +211,19 @@ data class Typed(
     override val metas: MetaContainer
 ) : ExprNode() {
     override val children: List<AstNode> = listOf(expr, type)
+}
+
+//********************************
+// Stored procedure clauses
+//********************************
+
+/** Represents a call to a stored procedure, i.e. `EXEC stored_procedure [<expr>.*]` */
+data class Exec(
+    val funcName: SymbolicName,
+    val args: List<ExprNode>,
+    override val metas: MetaContainer
+) : ExprNode() {
+    override val children: List<AstNode> = args
 }
 
 //********************************

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -219,7 +219,7 @@ data class Typed(
 
 /** Represents a call to a stored procedure, i.e. `EXEC stored_procedure [<expr>.*]` */
 data class Exec(
-    val funcName: SymbolicName,
+    val procedureName: SymbolicName,
     val args: List<ExprNode>,
     override val metas: MetaContainer
 ) : ExprNode() {

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -49,6 +49,7 @@ open class AstRewriterBase : AstRewriter {
             is CreateIndex       -> rewriteCreateIndex(node)
             is DropTable         -> rewriteDropTable(node)
             is DropIndex         -> rewriteDropIndex(node)
+            is Exec              -> rewriteExec(node)
         }
 
     open fun rewriteMetas(itemWithMetas: HasMetas): MetaContainer = itemWithMetas.metas
@@ -396,6 +397,12 @@ open class AstRewriterBase : AstRewriter {
         DropIndex(
             node.tableName,
             rewriteVariableReference(node.identifier) as VariableReference,
+            rewriteMetas(node))
+
+    open fun rewriteExec(node: Exec): Exec =
+        Exec(
+            rewriteSymbolicName(node.funcName),
+            node.args.map { rewriteExprNode(it) },
             rewriteMetas(node))
 
 }

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -401,7 +401,7 @@ open class AstRewriterBase : AstRewriter {
 
     open fun rewriteExec(node: Exec): Exec =
         Exec(
-            rewriteSymbolicName(node.funcName),
+            rewriteSymbolicName(node.procedureName),
             node.args.map { rewriteExprNode(it) },
             rewriteMetas(node))
 

--- a/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
@@ -117,7 +117,7 @@ open class AstWalker(private val visitor: AstVisitor) {
                     }
                 }
                 is CreateTable, is DropTable, is DropIndex -> case { }
-                is Exec         -> throw UnsupportedOperationException("EXEC clause is not supported by the V0 AST")
+                is Exec -> case { }
             }.toUnit()
         }
     }

--- a/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
@@ -16,6 +16,7 @@ package org.partiql.lang.ast.passes
 
 import org.partiql.lang.ast.*
 import org.partiql.lang.util.*
+import java.lang.UnsupportedOperationException
 
 /**
  * Contains the logic necessary to walk every node in the AST and invokes methods of [AstVisitor] along the way.
@@ -116,6 +117,7 @@ open class AstWalker(private val visitor: AstVisitor) {
                     }
                 }
                 is CreateTable, is DropTable, is DropIndex -> case { }
+                is Exec         -> throw UnsupportedOperationException("EXEC clause is not supported by the V0 AST")
             }.toUnit()
         }
     }

--- a/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
@@ -16,7 +16,6 @@ package org.partiql.lang.ast.passes
 
 import org.partiql.lang.ast.*
 import org.partiql.lang.util.*
-import java.lang.UnsupportedOperationException
 
 /**
  * Contains the logic necessary to walk every node in the AST and invokes methods of [AstVisitor] along the way.

--- a/lang/src/org/partiql/lang/errors/ErrorCode.kt
+++ b/lang/src/org/partiql/lang/errors/ErrorCode.kt
@@ -297,6 +297,16 @@ enum class ErrorCode(private val category: ErrorCategory,
         LOC_TOKEN,
         "Aggregate function calls take 1 argument only"),
 
+    PARSE_NO_STORED_PROCEDURE_PROVIDED(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "No stored procedure provided"),
+
+    PARSE_EXEC_AT_UNEXPECTED_LOCATION(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "EXEC call found at unexpected location"),
+
     PARSE_MALFORMED_JOIN(
         ErrorCategory.PARSER,
         LOC_TOKEN,

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -278,6 +278,8 @@ internal class EvaluatingCompiler(
             is CreateIndex,
             is DropIndex,
             is DropTable -> compileDdl(expr)
+            is Exec              -> compileExec(expr)
+
         }
     }
 
@@ -1922,6 +1924,10 @@ internal class EvaluatingCompiler(
                     }, internal = false
             )
         }
+    }
+
+    private fun compileExec(node: ExprNode): ThunkEnv {
+        TODO()
     }
 
     /** A special wrapper for `UNPIVOT` values as a BAG. */

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -278,7 +278,7 @@ internal class EvaluatingCompiler(
             is CreateIndex,
             is DropIndex,
             is DropTable -> compileDdl(expr)
-            is Exec              -> compileExec(expr)
+            is Exec      -> compileExec(expr)
 
         }
     }

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -337,8 +337,8 @@ class SqlParser(private val ion: IonSystem) : Parser {
                 }
             }
             EXEC -> {
-                val funcName = SymbolicName(token?.text!!.toLowerCase(), token.toSourceLocationMetaContainer())
-                Exec(funcName, children.map { it.toExprNode() }, metas)
+                val procedureName = SymbolicName(token?.text!!.toLowerCase(), token.toSourceLocationMetaContainer())
+                Exec(procedureName, children.map { it.toExprNode() }, metas)
             }
             CALL_AGG -> {
                 val funcExpr =
@@ -1724,16 +1724,16 @@ class SqlParser(private val ion: IonSystem) : Parser {
             rem.err("No stored procedure provided", PARSE_NO_STORED_PROCEDURE_PROVIDED)
         }
 
-        val funcName = rem.head
+        val procedureName = rem.head
         rem = rem.tail
 
         // Stored procedure has no args
         if (rem.head?.type == EOF) {
-            return ParseNode(EXEC, funcName, emptyList(), rem)
+            return ParseNode(EXEC, procedureName, emptyList(), rem)
         }
 
         return rem.parseArgList(aliasSupportType = NONE, mode = NORMAL_ARG_LIST)
-                  .copy(type = EXEC, token = funcName)
+                  .copy(type = EXEC, token = procedureName)
     }
 
     /**

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -114,7 +114,8 @@ class SqlParser(private val ion: IonSystem) : Parser {
         DROP_TABLE,
         DROP_INDEX,
         CREATE_INDEX,
-        PARAMETER;
+        PARAMETER,
+        EXEC;
 
         val identifier = name.toLowerCase()
     }
@@ -334,6 +335,10 @@ class SqlParser(private val ion: IonSystem) : Parser {
                         NAry(NAryOp.CALL, listOf(funcExpr) + children.map { it.toExprNode() }, metas)
                     }
                 }
+            }
+            EXEC -> {
+                val funcName = SymbolicName(token?.text!!.toLowerCase(), token.toSourceLocationMetaContainer())
+                Exec(funcName, children.map { it.toExprNode() }, metas)
             }
             CALL_AGG -> {
                 val funcExpr =
@@ -1015,6 +1020,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
                     tail.tail.parseFunctionCall(head!!)
                 else -> err("Unexpected keyword", PARSE_UNEXPECTED_KEYWORD)
             }
+            "exec" -> tail.parseExec()
             else -> err("Unexpected keyword", PARSE_UNEXPECTED_KEYWORD)
         }
         LEFT_PAREN -> {
@@ -1712,6 +1718,24 @@ class SqlParser(private val ion: IonSystem) : Parser {
         }
     }
 
+    private fun List<Token>.parseExec(): ParseNode {
+        var rem = this
+        if (rem.head?.type == EOF) {
+            rem.err("No stored procedure provided", PARSE_NO_STORED_PROCEDURE_PROVIDED)
+        }
+
+        val funcName = rem.head
+        rem = rem.tail
+
+        // Stored procedure has no args
+        if (rem.head?.type == EOF) {
+            return ParseNode(EXEC, funcName, emptyList(), rem)
+        }
+
+        return rem.parseArgList(aliasSupportType = NONE, mode = NORMAL_ARG_LIST)
+                  .copy(type = EXEC, token = funcName)
+    }
+
     /**
      * Parses substring
      *
@@ -2214,9 +2238,23 @@ class SqlParser(private val ion: IonSystem) : Parser {
         return ParseNode(ARG_LIST, null, items, rem)
     }
 
+    /**
+     * Checks that the given [Token] list does not have `EXEC` calls outside of the top level query. Throws
+     * an error if so.
+     */
+    private fun List<Token>.checkForUnexpectedExec() {
+        for ((index, token) in this.withIndex()) {
+            if (token.keywordText == "exec" && index != 0) {
+                token.err("EXEC call found at unexpected location", PARSE_EXEC_AT_UNEXPECTED_LOCATION)
+            }
+        }
+    }
+
     /** Entry point into the parser. */
     override fun parseExprNode(source: String): ExprNode {
-        val node = SqlLexer(ion).tokenize(source).parseExpression()
+        val tokens = SqlLexer(ion).tokenize(source)
+        tokens.checkForUnexpectedExec()
+        val node = tokens.parseExpression()
         val rem = node.remaining
         if (!rem.onlyEndOfStatement()) {
             when(rem.head?.type ) {

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -1727,9 +1727,13 @@ class SqlParser(private val ion: IonSystem) : Parser {
         val procedureName = rem.head
         rem = rem.tail
 
-        // Stored procedure has no args
+        // Stored procedure call has no args
         if (rem.head?.type == EOF) {
             return ParseNode(EXEC, procedureName, emptyList(), rem)
+        }
+
+        else if (rem.head?.type == LEFT_PAREN) {
+            rem.err("Unexpected $LEFT_PAREN found following stored procedure call", PARSE_UNEXPECTED_TOKEN)
         }
 
         return rem.parseArgList(aliasSupportType = NONE, mode = NORMAL_ARG_LIST)

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -1546,4 +1546,67 @@ class ParserErrorsTest : TestBase() {
             Property.TOKEN_TYPE to TokenType.EOF,
             Property.TOKEN_VALUE to ion.newSymbol("EOF")))
 
+    //****************************************
+    // EXEC clause parsing errors
+    //****************************************
+
+    @Test
+    fun execNoStoredProcedureProvided() = checkInputThrowingParserException(
+        "EXEC",
+        ErrorCode.PARSE_NO_STORED_PROCEDURE_PROVIDED,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 5L,
+            Property.TOKEN_TYPE to TokenType.EOF,
+            Property.TOKEN_VALUE to ion.newSymbol("EOF")))
+
+    @Test
+    fun execCommaBetweenStoredProcedureAndArg() = checkInputThrowingParserException(
+        "EXEC foo, arg0, arg1",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 9L,
+            Property.TOKEN_TYPE to TokenType.COMMA,
+            Property.TOKEN_VALUE to ion.newSymbol(",")))
+
+    @Test
+    fun execArgTrailingComma() = checkInputThrowingParserException(
+        "EXEC foo arg0, arg1,",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 21L,
+            Property.TOKEN_TYPE to TokenType.EOF,
+            Property.TOKEN_VALUE to ion.newSymbol("EOF")))
+
+    @Test
+    fun execAtUnexpectedLocation() = checkInputThrowingParserException(
+        "EXEC EXEC",
+        ErrorCode.PARSE_EXEC_AT_UNEXPECTED_LOCATION,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 6L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("exec")))
+
+    @Test
+    fun execAtUnexpectedLocationAfterExec() = checkInputThrowingParserException(
+        "EXEC foo EXEC",
+        ErrorCode.PARSE_EXEC_AT_UNEXPECTED_LOCATION,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 10L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("exec")))
+
+    @Test
+    fun execAtUnexpectedLocationInExpression() = checkInputThrowingParserException(
+        "SELECT * FROM (EXEC undrop 'foo')",
+        ErrorCode.PARSE_EXEC_AT_UNEXPECTED_LOCATION,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 16L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("exec")))
 }

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -1581,6 +1581,26 @@ class ParserErrorsTest : TestBase() {
             Property.TOKEN_VALUE to ion.newSymbol("EOF")))
 
     @Test
+    fun execUnexpectedParen() = checkInputThrowingParserException(
+        "EXEC foo()",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 9L,
+            Property.TOKEN_TYPE to TokenType.LEFT_PAREN,
+            Property.TOKEN_VALUE to ion.newSymbol("(")))
+
+    @Test
+    fun execUnexpectedParenWithArgs() = checkInputThrowingParserException(
+        "EXEC foo(arg0, arg1)",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 9L,
+            Property.TOKEN_TYPE to TokenType.LEFT_PAREN,
+            Property.TOKEN_VALUE to ion.newSymbol("(")))
+
+    @Test
     fun execAtUnexpectedLocation() = checkInputThrowingParserException(
         "EXEC EXEC",
         ErrorCode.PARSE_EXEC_AT_UNEXPECTED_LOCATION,

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -16,10 +16,8 @@ package org.partiql.lang.syntax
 
 import com.amazon.ion.Decimal
 import com.amazon.ionelement.api.ionDecimal
-import com.amazon.ionelement.api.ionFloat
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.ionString
-import com.amazon.ionelement.api.ionSymbol
 import org.junit.Test
 import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.ast.SourceLocationMeta

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -14,8 +14,12 @@
 
 package org.partiql.lang.syntax
 
+import com.amazon.ion.Decimal
+import com.amazon.ionelement.api.ionDecimal
+import com.amazon.ionelement.api.ionFloat
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.ionString
+import com.amazon.ionelement.api.ionSymbol
 import org.junit.Test
 import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.ast.SourceLocationMeta
@@ -3129,5 +3133,54 @@ class SqlParserTest : SqlParserTestBase() {
             from = scan(id("table1")),
             fromLet = let(letBinding(call("foo", listOf(id("table1"))), "A"))
         )
+    }
+
+    //****************************************
+    // EXEC clause parsing
+    //****************************************
+    @Test
+    fun execNoArgs() = assertExpression(
+        "EXEC foo") {
+        exec("foo", emptyList())
+    }
+
+    @Test
+    fun execOneStringArg() = assertExpression(
+        "EXEC foo 'bar'") {
+        exec("foo", listOf(lit(ionString("bar"))))
+    }
+
+    @Test
+    fun execOneIntArg() = assertExpression(
+        "EXEC foo 1") {
+        exec("foo", listOf(lit(ionInt(1))))
+    }
+
+    @Test
+    fun execMultipleArg() = assertExpression(
+        "EXEC foo 'bar0', `1d0`, 2, [3]") {
+        exec("foo", listOf(lit(ionString("bar0")), lit(ionDecimal(Decimal.valueOf(1))), lit(ionInt(2)), list(lit(ionInt(3)))))
+    }
+
+    @Test
+    fun execWithMissing() = assertExpression(
+        "EXEC foo MISSING") {
+        exec("foo", listOf(missing()))
+    }
+
+    @Test
+    fun execWithBag() = assertExpression(
+        "EXEC foo <<1>>") {
+        exec("foo", listOf(bag(lit(ionInt(1)))))
+    }
+
+    @Test
+    fun execWithSelectQuery() = assertExpression(
+        "EXEC foo SELECT baz FROM bar") {
+        exec("foo", listOf(
+            select(
+                project = projectList(projectExpr(id("baz"))),
+                from = scan(id("bar"))
+            )))
     }
 }

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -103,9 +103,10 @@ abstract class SqlParserTestBase : TestBase() {
      */
     private fun unwrapQuery(statement: PartiqlAst.Statement) : SexpElement {
        return when (statement) {
-            is PartiqlAst.Statement.Query -> statement.expr.toIonElement()
-            is PartiqlAst.Statement.Dml,
-            is PartiqlAst.Statement.Ddl -> statement.toIonElement()
+           is PartiqlAst.Statement.Query -> statement.expr.toIonElement()
+           is PartiqlAst.Statement.Dml,
+           is PartiqlAst.Statement.Ddl,
+           is PartiqlAst.Statement.Exec -> statement.toIonElement()
         }
     }
 


### PR DESCRIPTION
Adds parsing and PIG definition of stored procedure calls with the unnamed argument syntax defined in PartiQL spec issue #[17](https://github.com/partiql/partiql-spec/issues/17).

A valid call to a stored procedure as part of this PR is defined by `EXEC <symbol> [<expr>.*]` and is only a valid PartiQL statement when in the top level query.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.