### PR TITLE
Stored Procedures - call with unnamed args (evaluation)

### DIFF
--- a/examples/src/kotlin/org/partiql/examples/CustomProceduresExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/CustomProceduresExample.kt
@@ -1,0 +1,128 @@
+package org.partiql.examples
+
+import com.amazon.ion.IonDecimal
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import org.partiql.examples.util.Example
+import org.partiql.lang.CompilerPipeline
+import org.partiql.lang.errors.ErrorCode
+import org.partiql.lang.errors.Property
+import org.partiql.lang.errors.PropertyValueMap
+import org.partiql.lang.eval.BindingCase
+import org.partiql.lang.eval.BindingName
+import org.partiql.lang.eval.Bindings
+import org.partiql.lang.eval.EvaluationException
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.ExprValueType
+import org.partiql.lang.eval.builtins.storedprocedure.StoredProcedure
+import org.partiql.lang.eval.builtins.storedprocedure.StoredProcedureSignature
+import org.partiql.lang.eval.stringValue
+import java.io.PrintStream
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+private val ion = IonSystemBuilder.standard().build()
+
+/**
+ * A simple custom stored procedure that calculates the moon weight for each crewmate of the given crew, storing the
+ * moon weight in the [EvaluationSession] global bindings. This procedure also returns the number of crewmates we
+ * calculated the moon weight for, returning -1 if no crew is found.
+ *
+ * This example demonstrates how to create a custom stored procedure, check argument types, and modify the
+ * [EvaluationSession].
+ */
+class CalculateCrewMoonWeight(private val valueFactory: ExprValueFactory): StoredProcedure {
+    private val MOON_GRAVITATIONAL_CONSTANT = BigDecimal(1.622 / 9.81)
+
+    // [StoredProcedureSignature] takes two arguments:
+    //   1. the name of the stored procedure
+    //   2. the arity of this stored procedure. Checks to arity are taken care of by the evaluator. However, we must
+    //      still check that the passed arguments are of the right type in our implementation of the procedure.
+    override val signature = StoredProcedureSignature(name = "calculate_crew_moon_weight", arity = 1)
+
+    // `call` is where you define the logic of the stored procedure given an [EvaluationSession] and a list of
+    // arguments
+    override fun call(session: EvaluationSession, args: List<ExprValue>): ExprValue {
+        // We first check that the first argument is a string
+        val crewName = args.first()
+        if (crewName.type != ExprValueType.STRING) {
+            val errorContext = PropertyValueMap().also {
+                it[Property.EXPECTED_ARGUMENT_TYPES] = "STRING"
+                it[Property.ACTUAL_ARGUMENT_TYPES] = crewName.type.name
+                it[Property.FUNCTION_NAME] = signature.name
+            }
+            throw EvaluationException("First argument to ${signature.name} was not a string",
+                ErrorCode.EVALUATOR_INCORRECT_TYPE_OF_ARGUMENTS_TO_PROCEDURE_CALL,
+                errorContext,
+                internal = false)
+        }
+
+        // Next we check if the given `crewName` is in the [EvaluationSession]'s global bindings. If not, we return 0.
+        val sessionGlobals = session.globals
+        val crewBindings = sessionGlobals[BindingName(crewName.stringValue(), BindingCase.INSENSITIVE)]
+            ?: return valueFactory.newInt(-1)
+
+        // Now that we've confirmed the given `crewName` is in the session's global bindings, we calculate and store
+        // the moon weight for each crewmate in the crew.
+        // In addition, we keep a running a tally of how many crewmates we do this for.
+        var numCalculated = 0
+        for (crewmateBinding in crewBindings) {
+            val crewmate = crewmateBinding.ionValue as IonStruct
+            val mass = crewmate["mass"] as IonDecimal
+            val moonWeight = (mass.decimalValue() * MOON_GRAVITATIONAL_CONSTANT).setScale(1, RoundingMode.HALF_UP)
+            crewmate.add("moonWeight", ion.newDecimal(moonWeight))
+
+            numCalculated++
+        }
+        return valueFactory.newInt(numCalculated)
+    }
+}
+
+/**
+ * Demonstrates the use of custom stored procedure [CalculateCrewMoonWeight] in PartiQL queries.
+ */
+class CustomProceduresExample(out: PrintStream) : Example(out) {
+    override fun run() {
+        /**
+         * To make custom stored procedures available to the PartiQL query being executed, they must be passed to
+         * [CompilerPipeline.Builder.addProcedure].
+         */
+        val pipeline = CompilerPipeline.build(ion) {
+            addProcedure(CalculateCrewMoonWeight(valueFactory))
+        }
+
+        // Here, we initialize the crews to be stored in our global session bindings
+        val initialCrews = Bindings.ofMap(
+            mapOf(
+                "crew1" to pipeline.valueFactory.newFromIonValue(
+                    ion.singleValue("""[ { name: "Neil",    mass: 80.5 }, 
+                                         { name: "Buzz",    mass: 72.3 },
+                                         { name: "Michael", mass: 89.9 } ]""")),
+                "crew2" to pipeline.valueFactory.newFromIonValue(
+                    ion.singleValue("""[ { name: "James", mass: 77.1 }, 
+                                         { name: "Spock", mass: 81.6 } ]"""))
+            )
+        )
+        val session = EvaluationSession.build { globals(initialCrews) }
+
+        val crew1BindingName = BindingName("crew1", BindingCase.INSENSITIVE)
+        val crew2BindingName = BindingName("crew2", BindingCase.INSENSITIVE)
+
+        out.println("Initial global session bindings:")
+        print("Crew 1:", "${session.globals[crew1BindingName]}")
+        print("Crew 2:", "${session.globals[crew2BindingName]}")
+
+        // We call our custom stored procedure using PartiQL's `EXEC` clause. Here we call our stored procedure
+        // 'calculate_crew_moon_weight' with the arg 'crew1', which outputs the number of crewmates we've calculated
+        // the moon weight for
+        val procedureCall = "EXEC calculate_crew_moon_weight 'crew1'"
+        val procedureCallOutput = pipeline.compile(procedureCall).eval(session)
+        print("Number of calculated moon weights:", "$procedureCallOutput")
+
+        out.println("Updated global session bindings:")
+        print("Crew 1:", "${session.globals[crew1BindingName]}")
+        print("Crew 2:", "${session.globals[crew2BindingName]}")
+    }
+}

--- a/examples/src/kotlin/org/partiql/examples/CustomProceduresExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/CustomProceduresExample.kt
@@ -47,6 +47,8 @@ class CalculateCrewMoonWeight(private val valueFactory: ExprValueFactory): Store
     override fun call(session: EvaluationSession, args: List<ExprValue>): ExprValue {
         // We first check that the first argument is a string
         val crewName = args.first()
+        // In the future the evaluator will also verify function argument types, but for now we must verify their type
+        // manually
         if (crewName.type != ExprValueType.STRING) {
             val errorContext = PropertyValueMap().also {
                 it[Property.EXPECTED_ARGUMENT_TYPES] = "STRING"

--- a/examples/src/kotlin/org/partiql/examples/util/Main.kt
+++ b/examples/src/kotlin/org/partiql/examples/util/Main.kt
@@ -15,6 +15,7 @@ private val examples = mapOf(
         // Kotlin Examples
         CsvExprValueExample::class.java.simpleName to CsvExprValueExample(System.out),
         CustomFunctionsExample::class.java.simpleName to CustomFunctionsExample(System.out),
+        CustomProceduresExample::class.java.simpleName to CustomProceduresExample(System.out),
         EvaluationWithBindings::class.java.simpleName to EvaluationWithBindings(System.out),
         EvaluationWithLazyBindings::class.java.simpleName to EvaluationWithLazyBindings(System.out),
         ParserErrorExample::class.java.simpleName to ParserErrorExample(System.out),

--- a/examples/test/org/partiql/examples/CustomProceduresExampleTest.kt
+++ b/examples/test/org/partiql/examples/CustomProceduresExampleTest.kt
@@ -1,0 +1,24 @@
+package org.partiql.examples
+
+import org.partiql.examples.util.Example
+import java.io.PrintStream
+
+class CustomProceduresExampleTest : BaseExampleTest() {
+    override fun example(out: PrintStream): Example = CustomProceduresExample(out)
+
+    override val expected = """
+        |Initial global session bindings:
+        |Crew 1:
+        |    [{'name': 'Neil', 'mass': 80.5}, {'name': 'Buzz', 'mass': 72.3}, {'name': 'Michael', 'mass': 89.9}]
+        |Crew 2:
+        |    [{'name': 'James', 'mass': 77.1}, {'name': 'Spock', 'mass': 81.6}]
+        |Number of calculated moon weights:
+        |    3
+        |Updated global session bindings:
+        |Crew 1:
+        |    [{'name': 'Neil', 'mass': 80.5, 'moonWeight': 13.3}, {'name': 'Buzz', 'mass': 72.3, 'moonWeight': 12.0}, {'name': 'Michael', 'mass': 89.9, 'moonWeight': 14.9}]
+        |Crew 2:
+        |    [{'name': 'James', 'mass': 77.1}, {'name': 'Spock', 'mass': 81.6}]
+        |
+    """.trimMargin()
+}

--- a/lang/src/org/partiql/lang/CompilerPipeline.kt
+++ b/lang/src/org/partiql/lang/CompilerPipeline.kt
@@ -40,6 +40,7 @@ data class StepContext(
 
     /**
      * Returns a list of all stored procedures which are available for execution.
+     * Only includes the custom stored procedures added while the [CompilerPipeline] was being built.
      */
     val procedures: @JvmSuppressWildcards Map<String, StoredProcedure>
 )
@@ -69,6 +70,7 @@ interface CompilerPipeline  {
 
     /**
      * Returns a list of all stored procedures which are available for execution.
+     * Only includes the custom stored procedures added while the [CompilerPipeline] was being built.
      */
     val procedures: @JvmSuppressWildcards Map<String, StoredProcedure>
 

--- a/lang/src/org/partiql/lang/errors/ErrorAndErrorContexts.kt
+++ b/lang/src/org/partiql/lang/errors/ErrorAndErrorContexts.kt
@@ -72,6 +72,7 @@ enum class Property(val propertyName: String, val propertyType: PropertyType) {
     LIKE_PATTERN("pattern", STRING_CLASS),
     LIKE_ESCAPE("escape_char", STRING_CLASS),
     FUNCTION_NAME("function_name", STRING_CLASS),
+    PROCEDURE_NAME("procedure_name", STRING_CLASS),
     EXPECTED_ARGUMENT_TYPES("expected_types", STRING_CLASS),
     ACTUAL_ARGUMENT_TYPES("actual_types", STRING_CLASS),
     FEATURE_NAME("FEATURE_NAME", STRING_CLASS),

--- a/lang/src/org/partiql/lang/errors/ErrorCode.kt
+++ b/lang/src/org/partiql/lang/errors/ErrorCode.kt
@@ -417,15 +417,38 @@ enum class ErrorCode(private val category: ErrorCategory,
                 "No such function: ${errorContext?.get(Property.FUNCTION_NAME)?.stringValue() ?: UNKNOWN} "
         },
 
+    EVALUATOR_NO_SUCH_PROCEDURE(
+        ErrorCategory.EVALUATOR,
+        LOCATION + setOf(Property.PROCEDURE_NAME),
+        ""){
+            override fun getErrorMessage(errorContext: PropertyValueMap?): String =
+                "No such stored procedure: ${errorContext?.get(Property.PROCEDURE_NAME)?.stringValue() ?: UNKNOWN} "
+        },
+
     EVALUATOR_INCORRECT_NUMBER_OF_ARGUMENTS_TO_FUNC_CALL(
         ErrorCategory.EVALUATOR,
         LOCATION + setOf(Property.EXPECTED_ARITY_MIN, Property.EXPECTED_ARITY_MAX),
         "Incorrect number of arguments to function call"),
 
+    EVALUATOR_INCORRECT_NUMBER_OF_ARGUMENTS_TO_PROCEDURE_CALL(
+        ErrorCategory.EVALUATOR,
+        LOCATION + setOf(Property.EXPECTED_ARITY_MIN, Property.EXPECTED_ARITY_MAX),
+        "Incorrect number of arguments to procedure call"),
+
     EVALUATOR_INCORRECT_TYPE_OF_ARGUMENTS_TO_FUNC_CALL(
         ErrorCategory.EVALUATOR,
         LOCATION + setOf(Property.EXPECTED_ARGUMENT_TYPES, Property.ACTUAL_ARGUMENT_TYPES, Property.FUNCTION_NAME),
         "Incorrect type of arguments to function call") {
+        override fun getErrorMessage(errorContext: PropertyValueMap?): String =
+            "Invalid argument types for ${errorContext?.get(Property.FUNCTION_NAME) ?: UNKNOWN}, " +
+            "expected: ${errorContext?.get(Property.EXPECTED_ARGUMENT_TYPES) ?: UNKNOWN} " +
+            "got: ${errorContext?.get(Property.ACTUAL_ARGUMENT_TYPES) ?: UNKNOWN}"
+    },
+
+    EVALUATOR_INCORRECT_TYPE_OF_ARGUMENTS_TO_PROCEDURE_CALL(
+        ErrorCategory.EVALUATOR,
+        LOCATION + setOf(Property.EXPECTED_ARGUMENT_TYPES, Property.ACTUAL_ARGUMENT_TYPES, Property.FUNCTION_NAME),
+        "Incorrect type of arguments to procedure call") {
         override fun getErrorMessage(errorContext: PropertyValueMap?): String =
             "Invalid argument types for ${errorContext?.get(Property.FUNCTION_NAME) ?: UNKNOWN}, " +
             "expected: ${errorContext?.get(Property.EXPECTED_ARGUMENT_TYPES) ?: UNKNOWN} " +

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -21,6 +21,7 @@ import org.partiql.lang.ast.passes.*
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.errors.*
 import org.partiql.lang.eval.binding.*
+import org.partiql.lang.eval.builtins.storedprocedure.StoredProcedure
 import org.partiql.lang.eval.like.PatternPart
 import org.partiql.lang.eval.like.executePattern
 import org.partiql.lang.eval.like.parsePattern
@@ -54,7 +55,7 @@ import kotlin.collections.*
 internal class EvaluatingCompiler(
     private val valueFactory: ExprValueFactory,
     private val functions: Map<String, ExprFunction>,
-    private val procedures: Map<String, ExprFunction>,
+    private val procedures: Map<String, StoredProcedure>,
     private val compileOptions: CompileOptions = CompileOptions.standard()
 ) {
     private val thunkFactory = ThunkFactory(compileOptions.thunkOptions)
@@ -1929,7 +1930,6 @@ internal class EvaluatingCompiler(
 
     private fun compileExec(node: Exec): ThunkEnv {
         val (procedureName, args, metas: MetaContainer) = node
-        val argThunks = args.map { compileExprNode(it) }
         val procedure = procedures[procedureName.name] ?: err(
             "No such stored procedure: ${procedureName.name}",
             ErrorCode.EVALUATOR_NO_SUCH_PROCEDURE,
@@ -1938,9 +1938,35 @@ internal class EvaluatingCompiler(
             },
             internal = false)
 
+        // Check arity
+        if (args.size !in procedure.signature.arity) {
+            val errorContext = errorContextFrom(metas).also {
+                it[Property.EXPECTED_ARITY_MIN] = procedure.signature.arity.first
+                it[Property.EXPECTED_ARITY_MAX] = procedure.signature.arity.last
+            }
+
+            val message = when {
+                procedure.signature.arity.first == 1 && procedure.signature.arity.last == 1 ->
+                    "${procedure.signature.name} takes a single argument, received: ${args.size}"
+                procedure.signature.arity.first == procedure.signature.arity.last ->
+                    "${procedure.signature.name} takes exactly ${procedure.signature.arity.first} arguments, received: ${args.size}"
+                else ->
+                    "${procedure.signature.name} takes between ${procedure.signature.arity.first} and " +
+                        "${procedure.signature.arity.last} arguments, received: ${args.size}"
+            }
+
+            throw EvaluationException(message,
+                ErrorCode.EVALUATOR_INCORRECT_NUMBER_OF_ARGUMENTS_TO_PROCEDURE_CALL,
+                errorContext,
+                internal = false)
+        }
+
+        // Compile the procedure's arguments
+        val argThunks = args.map { compileExprNode(it) }
+
         return thunkFactory.thunkEnv(metas) { env ->
             val procedureArgValues = argThunks.map { it(env) }
-            procedure.call(env, procedureArgValues)
+            procedure.call(env.session, procedureArgValues)
         }
     }
 

--- a/lang/src/org/partiql/lang/eval/builtins/storedprocedure/BuiltinProcedures.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/storedprocedure/BuiltinProcedures.kt
@@ -1,7 +1,0 @@
-package org.partiql.lang.eval.builtins.storedprocedure
-
-import org.partiql.lang.eval.ExprFunction
-import org.partiql.lang.eval.ExprValueFactory
-
-internal fun createBuiltinProcedures(valueFactory: ExprValueFactory) : List<ExprFunction> =
-    listOf()

--- a/lang/src/org/partiql/lang/eval/builtins/storedprocedure/BuiltinProcedures.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/storedprocedure/BuiltinProcedures.kt
@@ -1,0 +1,7 @@
+package org.partiql.lang.eval.builtins.storedprocedure
+
+import org.partiql.lang.eval.ExprFunction
+import org.partiql.lang.eval.ExprValueFactory
+
+internal fun createBuiltinProcedures(valueFactory: ExprValueFactory) : List<ExprFunction> =
+    listOf()

--- a/lang/src/org/partiql/lang/eval/builtins/storedprocedure/StoredProcedure.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/storedprocedure/StoredProcedure.kt
@@ -1,0 +1,40 @@
+package org.partiql.lang.eval.builtins.storedprocedure
+
+import org.partiql.lang.eval.EvaluatingCompiler
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprFunction
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.Expression
+
+/**
+ * A typed version of a stored procedure signature. This signature includes the stored procedure's [name] and [arity].
+ */
+data class StoredProcedureSignature(val name: String, val arity: IntRange) {
+    constructor(name: String, arity: Int) : this(name, (arity..arity))
+}
+
+/**
+ * Represents a stored procedure that can be invoked.
+ *
+ * Stored procedures differ from functions (i.e. [ExprFunction]) in that:
+ * 1. stored procedures are allowed to have side-effects
+ * 2. stored procedures are only allowed at the top level of a query and cannot be used as an [Expression] (i.e. stored
+ *    procedures can only be called using `EXEC sproc 'arg1', 'arg2'` and cannot be called from queries such as
+ *    `SELECT * FROM (EXEC sproc 'arg1', 'arg2')`
+ */
+interface StoredProcedure {
+    /**
+     * [StoredProcedureSignature] representing the stored procedure's name and arity to be referenced in stored
+     * procedure calls.
+     */
+    val signature: StoredProcedureSignature
+
+    /**
+     * Invokes the stored procedure. Proper arity is checked by the [EvaluatingCompiler], but argument type checking
+     * is left to the implementation.
+     *
+     * @param session the calling environment session
+     * @param args argument list supplied to the stored procedure
+     */
+    fun call(session: EvaluationSession, args: List<ExprValue>): ExprValue
+}

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerExecTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerExecTests.kt
@@ -1,0 +1,302 @@
+package org.partiql.lang.eval
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.partiql.lang.CompilerPipeline
+import org.partiql.lang.errors.ErrorCode
+import org.partiql.lang.errors.Property
+import org.partiql.lang.errors.PropertyValueMap
+import org.partiql.lang.util.ArgumentsProviderBase
+import org.partiql.lang.util.isAnyUnknown
+import org.partiql.lang.util.softAssert
+import org.partiql.lang.util.to
+
+/**
+ * Similar class to [NullPropagatingExprFunction], but will output a stored procedure related error for invalid arity.
+ */
+abstract class NullPropagatingProcedure(
+    override val name: String,
+    override val arity: IntRange,
+    valueFactory: ExprValueFactory) : NullPropagatingExprFunction(name, arity, valueFactory) {
+
+    constructor(name: String, arity: Int, valueFactory: ExprValueFactory) : this(name, (arity..arity), valueFactory)
+
+    private fun arityErrorMessage(argSize: Int) = when {
+        arity.first == 1 && arity.last == 1 -> "$name takes a single argument, received: $argSize"
+        arity.first == arity.last           -> "$name takes exactly ${arity.first} arguments, received: $argSize"
+        else                                -> "$name takes between ${arity.first} and ${arity.last} arguments, received: $argSize"
+    }
+
+    fun checkSProcArity(args: List<ExprValue>) {
+        if (!arity.contains(args.size)) {
+            val errorContext = PropertyValueMap()
+            errorContext[Property.EXPECTED_ARITY_MIN] = arity.first
+            errorContext[Property.EXPECTED_ARITY_MAX] = arity.last
+
+            throw EvaluationException(arityErrorMessage(args.size),
+                                      ErrorCode.EVALUATOR_INCORRECT_NUMBER_OF_ARGUMENTS_TO_PROCEDURE_CALL,
+                                      errorContext,
+                                      internal = false)
+        }
+    }
+
+    override fun call(env: Environment, args: List<ExprValue>): ExprValue {
+        checkSProcArity(args)
+
+        return when {
+            args.isAnyUnknown() -> valueFactory.nullValue
+            else                -> eval(env, args)
+        }
+    }
+}
+
+private fun createWrongSProcErrorContext(arg: ExprValue, expectedArgTypes: String, procName: String): PropertyValueMap {
+    val errorContext = PropertyValueMap()
+    errorContext[Property.EXPECTED_ARGUMENT_TYPES] = expectedArgTypes
+    errorContext[Property.ACTUAL_ARGUMENT_TYPES] = arg.type.name
+    errorContext[Property.FUNCTION_NAME] = procName
+    return errorContext
+}
+
+/**
+ * Simple stored procedure that takes no arguments and outputs 0.
+ */
+private class ZeroArgProcedure(valueFactory: ExprValueFactory): NullPropagatingProcedure("zero_arg_procedure", 0, valueFactory) {
+    override fun eval(env: Environment, args: List<ExprValue>): ExprValue {
+        return valueFactory.newInt(0)
+    }
+}
+
+/**
+ * Simple stored procedure that takes no arguments and outputs -1. Used to show that added stored procedures of the
+ * same name will be overridden.
+ */
+private class OverridenZeroArgProcedure(valueFactory: ExprValueFactory): NullPropagatingProcedure("zero_arg_procedure", 0, valueFactory) {
+    override fun eval(env: Environment, args: List<ExprValue>): ExprValue {
+        return valueFactory.newInt(-1)
+    }
+}
+
+/**
+ * Simple stored procedure that takes one integer argument and outputs that argument back.
+ */
+class OneArgProcedure(valueFactory: ExprValueFactory): NullPropagatingProcedure("one_arg_procedure", 1, valueFactory) {
+    override fun eval(env: Environment, args: List<ExprValue>): ExprValue {
+        val arg = args.first()
+        if (arg.type != ExprValueType.INT) {
+            val errorContext = createWrongSProcErrorContext(arg, "INT", name)
+            throw EvaluationException("invalid first argument",
+                ErrorCode.EVALUATOR_INCORRECT_TYPE_OF_ARGUMENTS_TO_PROCEDURE_CALL,
+                errorContext,
+                internal = false)
+        }
+        return arg
+    }
+}
+
+/**
+ * Simple stored procedure that takes two integer arguments and outputs the args as a string separated by
+ * a space.
+ */
+private class TwoArgProcedure(valueFactory: ExprValueFactory): NullPropagatingProcedure("two_arg_procedure", 2, valueFactory) {
+    override fun eval(env: Environment, args: List<ExprValue>): ExprValue {
+        val arg1 = args.first()
+        if (arg1.type != ExprValueType.INT) {
+            val errorContext = createWrongSProcErrorContext(arg1, "INT", name)
+            throw EvaluationException("invalid first argument",
+                ErrorCode.EVALUATOR_INCORRECT_TYPE_OF_ARGUMENTS_TO_PROCEDURE_CALL,
+                errorContext,
+                internal = false)
+        }
+
+        val arg2 = args[1]
+        if (arg2.type != ExprValueType.INT) {
+            val errorContext = createWrongSProcErrorContext(arg2, "INT", name)
+            throw EvaluationException("invalid second argument",
+                ErrorCode.EVALUATOR_INCORRECT_TYPE_OF_ARGUMENTS_TO_PROCEDURE_CALL,
+                errorContext,
+                internal = false)
+        }
+        return valueFactory.newString("$arg1 $arg2")
+    }
+}
+
+/**
+ * Simple stored procedure that takes one string argument and checks if the binding (case-insensitive) is in the
+ * current environment. If so, returns the value associated with that binding. Otherwise, returns missing.
+ */
+private class OutputBindingProcedure(valueFactory: ExprValueFactory): NullPropagatingProcedure("output_binding", 1, valueFactory) {
+    override fun eval(env: Environment, args: List<ExprValue>): ExprValue {
+        val arg = args.first()
+        if (arg.type != ExprValueType.STRING) {
+            val errorContext = createWrongSProcErrorContext(arg, "STRING", name)
+            throw EvaluationException("invalid first argument",
+                ErrorCode.EVALUATOR_INCORRECT_TYPE_OF_ARGUMENTS_TO_PROCEDURE_CALL,
+                errorContext,
+                internal = false)
+        }
+        val bindingName = BindingName(arg.stringValue(), BindingCase.INSENSITIVE)
+        return when(val value = env.current[bindingName]) {
+            null -> valueFactory.missingValue
+            else -> value
+        }
+    }
+}
+
+class EvaluatingCompilerExecTests : EvaluatorTestBase() {
+    private val session = mapOf("A" to "[ { id : 1 } ]").toSession()
+
+    /**
+     * Custom [CompilerPipeline] w/ additional stored procedures
+     */
+    private val pipeline = CompilerPipeline.build(ion) {
+        addProcedure(OverridenZeroArgProcedure(valueFactory))
+        addProcedure(ZeroArgProcedure(valueFactory))
+        addProcedure(OneArgProcedure(valueFactory))
+        addProcedure(TwoArgProcedure(valueFactory))
+        addProcedure(OutputBindingProcedure(valueFactory))
+    }
+
+    /**
+     * Runs the given [query] with the provided [session] using the custom [CompilerPipeline] with additional stored
+     * procedures to query.
+     */
+    private fun evalSProc(query: String, session: EvaluationSession): ExprValue {
+        val e = pipeline.compile(query)
+        return e.eval(session)
+    }
+
+    /**
+     * Similar to [EvaluatorTestBase]'s [runTestCase], but evaluates using a [CompilerPipeline] with added stored
+     * procedures.
+     */
+    private fun runSProcTestCase(tc: EvaluatorTestCase, session: EvaluationSession) {
+        val queryExprValue = evalSProc(tc.sqlUnderTest, session)
+        val expectedExprValue = evalSProc(tc.expectedSql, session)
+
+        if(!expectedExprValue.exprEquals(queryExprValue)) {
+            println("Expected ionValue : ${expectedExprValue.ionValue}")
+            println("Actual ionValue   : ${queryExprValue.ionValue}")
+
+            fail("Expected and actual ExprValue instances are not equivalent")
+        }
+    }
+
+    /**
+     * Similar to [EvaluatorTestBase]'s [checkInputThrowingEvaluationException], but evaluates using a
+     * [CompilerPipeline] with added stored procedures.
+     */
+    private fun checkInputThrowingEvaluationExceptionSProc(tc: EvaluatorErrorTestCase, session: EvaluationSession) {
+        softAssert {
+            try {
+                val result = evalSProc(tc.sqlUnderTest, session = session).ionValue;
+                fail("Expected EvaluationException but there was no Exception.  " +
+                     "The unexpected result was: \n${result.toPrettyString()}")
+            }
+            catch (e: EvaluationException) {
+                if (tc.cause != null) assertThat(e).hasRootCauseExactlyInstanceOf(tc.cause.java)
+                checkErrorAndErrorContext(tc.errorCode, e, tc.expectErrorContextValues)
+            }
+            catch (e: Exception) {
+                fail("Expected EvaluationException but a different exception was thrown:\n\t  $e")
+            }
+        }
+    }
+
+    class ArgsProviderValid : ArgumentsProviderBase() {
+        override fun getParameters(): List<Any> = listOf(
+            // OverridenZeroArgProcedure w/ same name as ZeroArgProcedure overridden
+            EvaluatorTestCase(
+                "EXEC zero_arg_procedure",
+                "0"),
+            EvaluatorTestCase(
+                "EXEC one_arg_procedure 1",
+                "1"),
+            EvaluatorTestCase(
+                "EXEC two_arg_procedure 1, 2",
+                "'1 2'"),
+            EvaluatorTestCase(
+                "EXEC output_binding 'A'",
+                "[{'id':1}]"),
+            EvaluatorTestCase(
+                "EXEC output_binding 'B'",
+                "MISSING"))
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgsProviderValid::class)
+    fun validTests(tc: EvaluatorTestCase) = runSProcTestCase(tc, session)
+
+
+    class ArgsProviderError : ArgumentsProviderBase() {
+        override fun getParameters(): List<Any> = listOf(
+            // call function that is not a stored procedure
+            EvaluatorErrorTestCase(
+                "EXEC utcnow",
+                ErrorCode.EVALUATOR_NO_SUCH_PROCEDURE,
+                mapOf(
+                    Property.LINE_NUMBER to 1L,
+                    Property.COLUMN_NUMBER to 6L,
+                    Property.PROCEDURE_NAME to "utcnow")),
+            // call function that is not a stored procedure, w/ args
+            EvaluatorErrorTestCase(
+                "EXEC substring 0, 1, 'foo'",
+                ErrorCode.EVALUATOR_NO_SUCH_PROCEDURE,
+                mapOf(
+                    Property.LINE_NUMBER to 1L,
+                    Property.COLUMN_NUMBER to 6L,
+                    Property.PROCEDURE_NAME to "substring")),
+            // invalid # args to sproc (too many)
+            EvaluatorErrorTestCase(
+                "EXEC zero_arg_procedure 1",
+                ErrorCode.EVALUATOR_INCORRECT_NUMBER_OF_ARGUMENTS_TO_PROCEDURE_CALL,
+                mapOf(
+                    Property.LINE_NUMBER to 1L,
+                    Property.COLUMN_NUMBER to 6L,
+                    Property.EXPECTED_ARITY_MIN to 0,
+                    Property.EXPECTED_ARITY_MAX to 0)),
+            // invalid # args to sproc (too many)
+            EvaluatorErrorTestCase(
+                "EXEC two_arg_procedure 1 2 3",
+                ErrorCode.EVALUATOR_INCORRECT_NUMBER_OF_ARGUMENTS_TO_PROCEDURE_CALL,
+                mapOf(
+                    Property.LINE_NUMBER to 1L,
+                    Property.COLUMN_NUMBER to 6L,
+                    Property.EXPECTED_ARITY_MIN to 2,
+                    Property.EXPECTED_ARITY_MAX to 2)),
+            // invalid # args to sproc (too few)
+            EvaluatorErrorTestCase(
+                "EXEC one_arg_procedure",
+                ErrorCode.EVALUATOR_INCORRECT_NUMBER_OF_ARGUMENTS_TO_PROCEDURE_CALL,
+                mapOf(
+                    Property.LINE_NUMBER to 1L,
+                    Property.COLUMN_NUMBER to 6L,
+                    Property.EXPECTED_ARITY_MIN to 1,
+                    Property.EXPECTED_ARITY_MAX to 1)),
+            // invalid first arg type
+            EvaluatorErrorTestCase(
+                "EXEC one_arg_procedure 'foo'",
+                ErrorCode.EVALUATOR_INCORRECT_TYPE_OF_ARGUMENTS_TO_PROCEDURE_CALL,
+                mapOf(
+                    Property.LINE_NUMBER to 1L,
+                    Property.COLUMN_NUMBER to 6L,
+                    Property.EXPECTED_ARGUMENT_TYPES to "INT",
+                    Property.ACTUAL_ARGUMENT_TYPES to "STRING",
+                    Property.FUNCTION_NAME to "one_arg_procedure")),
+            // invalid second arg type
+            EvaluatorErrorTestCase(
+                "EXEC two_arg_procedure 1, 'two'",
+                ErrorCode.EVALUATOR_INCORRECT_TYPE_OF_ARGUMENTS_TO_PROCEDURE_CALL,
+                mapOf(
+                    Property.LINE_NUMBER to 1L,
+                    Property.COLUMN_NUMBER to 6L,
+                    Property.EXPECTED_ARGUMENT_TYPES to "INT",
+                    Property.ACTUAL_ARGUMENT_TYPES to "STRING",
+                    Property.FUNCTION_NAME to "two_arg_procedure"))
+        )
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgsProviderError::class)
+    fun errorTests(tc: EvaluatorErrorTestCase) = checkInputThrowingEvaluationExceptionSProc(tc, session)
+}


### PR DESCRIPTION
Implements evaluation of stored procedure calls with unnamed argument syntax defined in PartiQL spec issue #[17](https://github.com/partiql/partiql-spec/issues/17).

This should be reviewed **after** the parsing of stored procedure calls (#333) is merged into the `stored-procedures` feature branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
