### PR TITLE
Fix to gradle to run on `ParameterizedTest`s

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ subprojects {
             events "failed"
             exceptionFormat "full"
         }
+        useJUnitPlatform()
     }
 
 

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 
     testImplementation 'org.jetbrains.kotlin:kotlin-test'
     testImplementation 'pl.pragmatists:JUnitParams:[1.0.0,1.1.0)'
+
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }
 
 jacocoTestReport {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 
     implementation 'org.jetbrains.kotlin:kotlin-test'
     implementation 'junit:junit:4.12'
+
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }
 
 jacocoTestReport {

--- a/pts/build.gradle
+++ b/pts/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:[3.11.0,3.12.0)'
     testImplementation project(':lang')
     testImplementation project(':testscript')
+
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }
 
 jacocoTestReport {

--- a/testscript/build.gradle
+++ b/testscript/build.gradle
@@ -17,11 +17,7 @@ dependencies {
 
     testImplementation 'com.amazon.ion:ion-kotlin-builder:1.0.1'
     
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.3.1"
-}
-
-test {
-    useJUnitPlatform()
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }
 
 compileKotlin {


### PR DESCRIPTION
Gradle was previously not running any of the `ParameterizedTest`s and possibly other JUnit5 tests.

Tested by running `./gradlew build` with a failing `ParameterizedTest` to ensure the test fails appropriately.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
