### PR TITLE
Add version number to CLI output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,11 +90,26 @@ subprojects {
 
     })
     plugins.withId('org.jetbrains.kotlin.jvm', { _ ->
+        def generatedVersionDir = "${buildDir}/generated-version"
 
         sourceSets {
             main.kotlin.srcDirs = ["src"]
             test.kotlin.srcDirs = ["test"]
+
+            main {
+                output.dir(generatedVersionDir, builtBy: 'generateVersionProperties')
+            }
         }
+        task generateVersionProperties {
+            doLast {
+                def propertiesFile = file "$generatedVersionDir/version.properties"
+                propertiesFile.parentFile.mkdirs()
+                def properties = new Properties()
+                properties.setProperty("version", version.toString())
+                propertiesFile.withWriter { properties.store(it, null) }
+            }
+        }
+        processResources.dependsOn generateVersionProperties
     })
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -97,19 +97,32 @@ subprojects {
             test.kotlin.srcDirs = ["test"]
 
             main {
-                output.dir(generatedVersionDir, builtBy: 'generateVersionProperties')
+                output.dir(generatedVersionDir, builtBy: 'generateVersionAndHashProperties')
             }
         }
-        task generateVersionProperties {
+
+        // generates a build properties file with the current PartiQL version and most recent commit hash
+        task generateVersionAndHashProperties {
             doLast {
-                def propertiesFile = file "$generatedVersionDir/version.properties"
+                def propertiesFile = file "$generatedVersionDir/partiql.properties"
                 propertiesFile.parentFile.mkdirs()
                 def properties = new Properties()
+
+                // get current PartiQL version
                 properties.setProperty("version", version.toString())
+
+                // get most recent short commit hash
+                def commitHash = new ByteArrayOutputStream()
+                exec {
+                    commandLine 'git', 'rev-parse', '--short', 'HEAD'
+                    standardOutput = commitHash
+                }
+                properties.setProperty("commit", commitHash.toString().trim())
+
                 propertiesFile.withWriter { properties.store(it, null) }
             }
         }
-        processResources.dependsOn generateVersionProperties
+        processResources.dependsOn generateVersionAndHashProperties
     })
 
 }

--- a/cli/src/org/partiql/cli/Repl.kt
+++ b/cli/src/org/partiql/cli/Repl.kt
@@ -18,12 +18,11 @@ import com.amazon.ion.system.*
 import com.amazon.ionelement.api.toIonValue
 import org.partiql.cli.ReplState.*
 import org.partiql.lang.*
-import org.partiql.lang.ast.*
-import org.partiql.lang.ast.passes.MetaStrippingRewriter
 import org.partiql.lang.eval.*
 import org.partiql.lang.syntax.*
 import org.partiql.lang.util.*
 import java.io.*
+import java.util.Properties
 import java.util.concurrent.*
 
 internal const val PROMPT_1 = "PartiQL> "
@@ -192,6 +191,17 @@ internal class Repl(private val valueFactory: ExprValueFactory,
         outputWriter.write("\n")
     }
 
+    fun retrievePartiQLVersion(): String {
+        val versionProperties = Properties()
+        versionProperties.load(this.javaClass.getResourceAsStream("/version.properties"))
+        return versionProperties.getProperty("version")
+    }
+
+    private fun printVersionNumber() {
+        outputWriter.write("Using version: ${retrievePartiQLVersion()}")
+        outputWriter.write("\n")
+    }
+
     private fun printPrompt() {
         when {
             buffer.isEmpty() -> outputWriter.write(PROMPT_1)
@@ -268,6 +278,7 @@ internal class Repl(private val valueFactory: ExprValueFactory,
             state = when (state) {
                 INIT                      -> {
                     printWelcomeMessage()
+                    printVersionNumber()
                     READY
                 }
 

--- a/cli/src/org/partiql/cli/Repl.kt
+++ b/cli/src/org/partiql/cli/Repl.kt
@@ -29,7 +29,7 @@ internal const val PROMPT_1 = "PartiQL> "
 internal const val PROMPT_2 = "   | "
 internal const val BAR_1 = "===' "
 internal const val BAR_2 = "--- "
-internal const val WELCOME_MSG = "Welcome to the PartiQL REPL!" // TODO: extract version from gradle.build and append to message
+internal const val WELCOME_MSG = "Welcome to the PartiQL REPL!"
 
 private enum class ReplState {
     /** Initial state, first state as soon as you start the REPL */

--- a/cli/src/org/partiql/cli/Repl.kt
+++ b/cli/src/org/partiql/cli/Repl.kt
@@ -191,14 +191,14 @@ internal class Repl(private val valueFactory: ExprValueFactory,
         outputWriter.write("\n")
     }
 
-    fun retrievePartiQLVersion(): String {
-        val versionProperties = Properties()
-        versionProperties.load(this.javaClass.getResourceAsStream("/version.properties"))
-        return versionProperties.getProperty("version")
+    fun retrievePartiQLVersionAndHash(): String {
+        val properties = Properties()
+        properties.load(this.javaClass.getResourceAsStream("/partiql.properties"))
+        return "${properties.getProperty("version")}-${properties.getProperty("commit")}"
     }
 
     private fun printVersionNumber() {
-        outputWriter.write("Using version: ${retrievePartiQLVersion()}")
+        outputWriter.write("Using version: ${retrievePartiQLVersionAndHash()}")
         outputWriter.write("\n")
     }
 

--- a/cli/test/org/partiql/cli/ReplTest.kt
+++ b/cli/test/org/partiql/cli/ReplTest.kt
@@ -21,7 +21,6 @@ import org.junit.*
 import org.junit.Assert.*
 import org.partiql.lang.*
 import java.io.*
-import java.util.*
 import java.util.concurrent.*
 import kotlin.concurrent.*
 

--- a/cli/test/org/partiql/cli/ReplTest.kt
+++ b/cli/test/org/partiql/cli/ReplTest.kt
@@ -79,7 +79,7 @@ private class ReplTester(bindings: Bindings<ExprValue> = Bindings.empty()) {
 
     private val repl = Repl(valueFactory, input, output, parser, compiler, bindings, zeroTimer)
 
-    val partiqlVersion = repl.retrievePartiQLVersion()
+    val partiqlVersionAndHash = repl.retrievePartiQLVersionAndHash()
 
     private val actualReplPrompt = StringBuilder()
 
@@ -150,13 +150,13 @@ private class ReplTester(bindings: Bindings<ExprValue> = Bindings.empty()) {
 
 @Ignore("https://github.com/partiql/partiql-lang-kotlin/issues/266")
 class ReplTest {
-    private val partiqlVersion = ReplTester().partiqlVersion
+    private val partiqlVersionAndHash = ReplTester().partiqlVersionAndHash
 
     @Test
     fun singleQuery() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
-            #Using version: $partiqlVersion
+            #Using version: $partiqlVersionAndHash
             #PartiQL> 1+1
             #   | 
             #===' 
@@ -171,7 +171,7 @@ class ReplTest {
     fun querySemiColon() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
-            #Using version: $partiqlVersion
+            #Using version: $partiqlVersionAndHash
             #PartiQL> 1+1;
             #===' 
             #2
@@ -185,7 +185,7 @@ class ReplTest {
     fun multipleQuery() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
-            #Using version: $partiqlVersion
+            #Using version: $partiqlVersionAndHash
             #PartiQL> 1 + 1
             #   | 
             #===' 
@@ -207,7 +207,7 @@ class ReplTest {
     fun astWithoutMetas() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
-            #Using version: $partiqlVersion
+            #Using version: $partiqlVersionAndHash
             #PartiQL> 1 + 1
             #   | !!
             #===' 
@@ -236,7 +236,7 @@ class ReplTest {
     fun addToGlobalEnvAndQuery() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
-            #Using version: $partiqlVersion
+            #Using version: $partiqlVersionAndHash
             #PartiQL> !add_to_global_env {'myTable': <<{'a':1}, {'a': 2}>>}
             #   | 
             #===' 
@@ -279,7 +279,7 @@ class ReplTest {
 
         ReplTester(initialBindings).assertReplPrompt("""
             #Welcome to the PartiQL REPL!
-            #Using version: $partiqlVersion
+            #Using version: $partiqlVersionAndHash
             #PartiQL> !global_env
             #   | 
             #===' 
@@ -300,7 +300,7 @@ class ReplTest {
     fun dumpEmptyInitialEnv() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
-            #Using version: $partiqlVersion
+            #Using version: $partiqlVersionAndHash
             #PartiQL> !global_env
             #   | 
             #===' 
@@ -315,7 +315,7 @@ class ReplTest {
     fun dumpEnvAfterAltering() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
-            #Using version: $partiqlVersion
+            #Using version: $partiqlVersionAndHash
             #PartiQL> !add_to_global_env {'myTable': <<{'a':1}, {'a': 2}>>}
             #   | 
             #===' 
@@ -354,7 +354,7 @@ class ReplTest {
     fun listCommands() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
-            #Using version: $partiqlVersion
+            #Using version: $partiqlVersionAndHash
             #PartiQL> !list_commands
             #   | 
             #

--- a/cli/test/org/partiql/cli/ReplTest.kt
+++ b/cli/test/org/partiql/cli/ReplTest.kt
@@ -21,6 +21,7 @@ import org.junit.*
 import org.junit.Assert.*
 import org.partiql.lang.*
 import java.io.*
+import java.util.*
 import java.util.concurrent.*
 import kotlin.concurrent.*
 
@@ -78,6 +79,8 @@ private class ReplTester(bindings: Bindings<ExprValue> = Bindings.empty()) {
     }
 
     private val repl = Repl(valueFactory, input, output, parser, compiler, bindings, zeroTimer)
+
+    val partiqlVersion = repl.retrievePartiQLVersion()
 
     private val actualReplPrompt = StringBuilder()
 
@@ -148,11 +151,13 @@ private class ReplTester(bindings: Bindings<ExprValue> = Bindings.empty()) {
 
 @Ignore("https://github.com/partiql/partiql-lang-kotlin/issues/266")
 class ReplTest {
+    private val partiqlVersion = ReplTester().partiqlVersion
 
     @Test
     fun singleQuery() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
+            #Using version: $partiqlVersion
             #PartiQL> 1+1
             #   | 
             #===' 
@@ -167,6 +172,7 @@ class ReplTest {
     fun querySemiColon() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
+            #Using version: $partiqlVersion
             #PartiQL> 1+1;
             #===' 
             #2
@@ -180,6 +186,7 @@ class ReplTest {
     fun multipleQuery() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
+            #Using version: $partiqlVersion
             #PartiQL> 1 + 1
             #   | 
             #===' 
@@ -201,66 +208,24 @@ class ReplTest {
     fun astWithoutMetas() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
+            #Using version: $partiqlVersion
             #PartiQL> 1 + 1
             #   | !!
             #===' 
             #
             #(
-            #  plus
-            #  (
-            #    lit
-            #    1
-            #  )
-            #  (
-            #    lit
-            #    1
-            #  )
-            #)
-            #--- 
-            #OK!
-            #PartiQL> 
-        """.trimMargin("#"))
-    }
-
-    @Test
-    fun astWithMetas() {
-        ReplTester().assertReplPrompt("""
-            #Welcome to the PartiQL REPL!
-            #PartiQL> 1 + 1
-            #   | !?
-            #===' 
-            #
-            #(
-            #  meta
+            #  query
             #  (
             #    plus
             #    (
-            #      meta
-            #      (
-            #        lit
-            #        1
-            #      )
-            #      {
-            #        line:1,
-            #        column:1
-            #      }
+            #      lit
+            #      1
             #    )
             #    (
-            #      meta
-            #      (
-            #        lit
-            #        1
-            #      )
-            #      {
-            #        line:1,
-            #        column:5
-            #      }
+            #      lit
+            #      1
             #    )
             #  )
-            #  {
-            #    line:1,
-            #    column:3
-            #  }
             #)
             #--- 
             #OK!
@@ -272,6 +237,7 @@ class ReplTest {
     fun addToGlobalEnvAndQuery() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
+            #Using version: $partiqlVersion
             #PartiQL> !add_to_global_env {'myTable': <<{'a':1}, {'a': 2}>>}
             #   | 
             #===' 
@@ -314,6 +280,7 @@ class ReplTest {
 
         ReplTester(initialBindings).assertReplPrompt("""
             #Welcome to the PartiQL REPL!
+            #Using version: $partiqlVersion
             #PartiQL> !global_env
             #   | 
             #===' 
@@ -334,6 +301,7 @@ class ReplTest {
     fun dumpEmptyInitialEnv() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
+            #Using version: $partiqlVersion
             #PartiQL> !global_env
             #   | 
             #===' 
@@ -348,6 +316,7 @@ class ReplTest {
     fun dumpEnvAfterAltering() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
+            #Using version: $partiqlVersion
             #PartiQL> !add_to_global_env {'myTable': <<{'a':1}, {'a': 2}>>}
             #   | 
             #===' 
@@ -386,6 +355,7 @@ class ReplTest {
     fun listCommands() {
         ReplTester().assertReplPrompt("""
             #Welcome to the PartiQL REPL!
+            #Using version: $partiqlVersion
             #PartiQL> !list_commands
             #   | 
             #


### PR DESCRIPTION
Adds current PartiQL version number (from gradle) and the most recent commit hash to the CLI output.

Example output shown below:
```
Welcome to the PartiQL REPL!
Using version: 0.2.5-SNAPSHOT-6786c36
PartiQL> 1+1;
==='
2
---
OK!
```

This approach follows from this similar stackoverflow [answer](https://stackoverflow.com/a/50119235). Essentially, the root `build.gradle` file will output the `version` to a file in the Gradle build, which can be accessed as a resource by the CLI/REPL.

Retrieving the most recent commit hash follows this stackoverflow [answer](https://stackoverflow.com/a/35041457). We similarly store the commit hash to a Gradle build file.

Also, some existing REPL tests (previously ignored by #266) were updated to incorporate this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
