### PR TITLE
Fix to aggregate being used in subquery binding error

### DIFF
--- a/lang/src/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransform.kt
@@ -18,73 +18,46 @@ import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.metaContainerOf
 import org.partiql.lang.ast.AggregateCallSiteListMeta
 import org.partiql.lang.ast.AggregateRegisterIdMeta
-import org.partiql.lang.ast.SelectProjectionValue
 import org.partiql.lang.domains.PartiqlAst
 
 /**
  * Allocates registerIds to all aggregate call-sites, storing the allocated registerId in an instance of
  * [AggregateRegisterIdMeta].
  *
- * Also collects a list of all aggregate functions used in the `SELECT` list of the current query (excluding subqueries)
+ * Also collects a list of all aggregate functions used in the `SELECT` of the current query (excluding subqueries)
  * and stores them in an instance of [AggregateCallSiteListMeta] on the [PartiqlAst.Expr.Select] instance.
  */
 
-class AggregateSupportVisitorTransform : PartiqlAst.VisitorTransform() {
+class AggregateSupportVisitorTransform : VisitorTransformBase() {
     private val aggregateCallSites = ArrayList<PartiqlAst.Expr.CallAgg>()
 
-    inner class RegisterIdAdderSubVisitorTransform : PartiqlAst.VisitorTransform() {
-        /**
-         * Nests another [AggregateSupportVisitorTransform] within this transform
-         * in order to avoid exposing [aggregateCallSites] to subqueries.
-         */
-        override fun transformExprSelect(node: PartiqlAst.Expr.Select): PartiqlAst.Expr =
-            AggregateSupportVisitorTransform().transformExpr(node)
-
-        override fun transformExprCallAgg(node: PartiqlAst.Expr.CallAgg): PartiqlAst.Expr {
-            aggregateCallSites.add(node)
-
-            return PartiqlAst.build {
-                callAgg_(
-                    setq = node.setq,
-                    funcName = node.funcName,
-                    arg = transformExpr(node.arg),
-                    metas = transformMetas(node.metas) + metaContainerOf(AggregateRegisterIdMeta.TAG to AggregateRegisterIdMeta(aggregateCallSites.size - 1))
-                )
-            }
-        }
+    /**
+     * Nests another [AggregateSupportVisitorTransform] within this transform to avoid operating on
+     * [aggregateCallSites] of a nested `SELECT`.
+     */
+    override fun transformExprSelect(node: PartiqlAst.Expr.Select): PartiqlAst.Expr {
+        return AggregateSupportVisitorTransform().transformExprSelectEvaluationOrder(node)
     }
 
-    private val registerIdAdder = RegisterIdAdderSubVisitorTransform()
-
-    /**
-     * Applies the [registerIdAdder] only to expressions in select list items.
-     */
-    override fun transformProjectItemProjectExpr(node: PartiqlAst.ProjectItem.ProjectExpr): PartiqlAst.ProjectItem =
-        PartiqlAst.build {
-            projectExpr_(
-                expr = registerIdAdder.transformExpr(node.expr),
-                asAlias = node.asAlias,
-                metas = node.metas
-            )
+    override fun transformExprCallAgg(node: PartiqlAst.Expr.CallAgg): PartiqlAst.Expr {
+        val transformedCallAgg = PartiqlAst.build {
+            callAgg_(
+                setq = node.setq,
+                funcName = node.funcName,
+                arg = transformExpr(node.arg),
+                metas = transformMetas(node.metas) + metaContainerOf(AggregateRegisterIdMeta.TAG to AggregateRegisterIdMeta(aggregateCallSites.size)))
         }
-
-    /**
-     * Applies a new instance of [AggregateSupportVisitorTransform]
-     * to [SelectProjectionValue] nodes so that a different instance of [aggregateCallSites] is used.
-     */
-    override fun transformProjectionProjectValue(node: PartiqlAst.Projection.ProjectValue): PartiqlAst.Projection =
-        PartiqlAst.build {
-            projectValue(
-                value = AggregateSupportVisitorTransform().transformExpr(node.value),
-                metas = node.metas
-            )
+        aggregateCallSites.add(transformedCallAgg)
+        return transformedCallAgg
     }
 
-    override fun transformExprSelect_having(node: PartiqlAst.Expr.Select): PartiqlAst.Expr? =
-        node.having?.let { registerIdAdder.transformExpr(it) }
-
+    /**
+     * Applies a new instance of [AggregateSupportVisitorTransform] to [PartiqlAst.Projection.ProjectValue] nodes so
+     * that a different instance of [aggregateCallSites] is used.
+     */
+    override fun transformProjectionProjectValue_value(node: PartiqlAst.Projection.ProjectValue): PartiqlAst.Expr =
+        AggregateSupportVisitorTransform().transformExpr(node.value)
 
     override fun transformExprSelect_metas(node: PartiqlAst.Expr.Select): MetaContainer =
         transformMetas(node.metas) + metaContainerOf(AggregateCallSiteListMeta.TAG to AggregateCallSiteListMeta(aggregateCallSites.toList()))
-
 }

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerTests.kt
@@ -1771,4 +1771,40 @@ class EvaluatingCompilerTests : EvaluatorTestBase() {
             FROM << { 'year': 1968, 'month': 4, 'day': 3, 'hour': 12, 'minute': 31, 'second': 59 }>> AS x
             """,
             "<<[1968, 4, 3, 12, 31, 59]>>")
+
+    @Test
+    fun aggregateInSubqueryOfSelect() =
+        assertEvalExprValue(
+            """
+            SELECT foo.cnt
+            FROM
+                (SELECT COUNT(*) AS cnt 
+                FROM [1, 2, 3])
+            AS foo
+            """,
+            "<< { 'cnt': 3 } >>")
+
+    @Test
+    fun aggregateInSubqueryOfSelectValue() =
+        assertEvalExprValue(
+            """
+            SELECT VALUE foo.cnt
+            FROM
+                (SELECT COUNT(*) AS cnt 
+                FROM [1, 2, 3])
+            AS foo
+            """,
+            "<< 3 >>")
+
+    @Test
+    fun aggregateWithAliasingInSubqueryOfSelectValue() =
+        assertEvalExprValue(
+            """
+            SELECT VALUE foo.cnt
+            FROM
+                (SELECT COUNT(baz.bar) AS cnt 
+                FROM << { 'bar': 1 }, { 'bar': 2 } >> AS baz)
+            AS foo
+            """,
+            "<< 2 >>")
 }

--- a/lang/test/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransformTests.kt
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.eval.visitors
+
+import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.metaContainerOf
+import org.junit.Test
+import org.partiql.lang.ast.AggregateCallSiteListMeta
+import org.partiql.lang.ast.AggregateRegisterIdMeta
+import org.partiql.lang.ast.SourceLocationMeta
+import org.partiql.lang.ast.toAstStatement
+import org.partiql.lang.domains.PartiqlAst
+
+class AggregateSupportVisitorTransformTests : VisitorTransformTestBase() {
+    private val transformer = AggregateSupportVisitorTransform()
+
+    /**
+     * Simple helper for testing that parses [this] SFW query, transforms it using [AggregateSupportVisitorTransform],
+     * and returns the transformed query as [PartiqlAst.Expr.Select].
+     */
+    private fun String.parseAndTransformQuery() : PartiqlAst.Expr.Select {
+        val query = this
+        val statement = super.parser.parseExprNode(query).toAstStatement()
+        val transformedNode = (transformer).transformStatement(statement) as PartiqlAst.Statement.Query
+        return (transformedNode.expr) as PartiqlAst.Expr.Select
+    }
+
+    /**
+     * Simple helper for testing to create a [MetaContainer] with [AggregateCallSiteListMeta] mapping to a list of
+     * [PartiqlAst.Expr.CallAgg]s.
+     *
+     * Each of the created [PartiqlAst.Expr.CallAgg]s uses the function name provided by [callAggs]'s first argument
+     * and [AggregateRegisterIdMeta] passed as the second argument of the pair.
+     */
+    private fun createCallAggMetas(callAggs: List<Pair<String, Int>>): MetaContainer =
+        metaContainerOf(AggregateCallSiteListMeta.TAG to AggregateCallSiteListMeta(
+            callAggs.map { callAgg ->
+                PartiqlAst.build {
+                    callAgg(
+                        setq = all(),
+                        funcName = callAgg.first,
+                        arg = lit(ionInt(1)),
+                        metas = metaContainerOf(AggregateRegisterIdMeta.TAG to AggregateRegisterIdMeta(callAgg.second)))
+                }
+            }))
+
+    /**
+     * Simple helper for testing to remove the [SourceLocationMeta] from [this] [MetaContainer].
+     */
+    private fun MetaContainer.removeSourceLocation() : MetaContainer = this.minus(SourceLocationMeta.TAG)
+
+    /**
+     * Checks that [expected] and [actual] have the same metas (i.e. [AggregateCallSiteListMeta])
+     * (excluding source location).
+     */
+    private fun assertSameCallAggMetas(expected: MetaContainer, actual: MetaContainer) {
+        val expectedAggCalls = (expected[AggregateCallSiteListMeta.TAG] as AggregateCallSiteListMeta).aggregateCallSites
+        val actualAggCalls = (actual[AggregateCallSiteListMeta.TAG] as AggregateCallSiteListMeta).aggregateCallSites
+        expectedAggCalls.zip(actualAggCalls).forEach { (e, a) ->
+            assertEquals(e, a)
+
+            // check that these metas have the same [AggregateRegisterIdMeta]
+            assertEquals(e.metas, a.metas.removeSourceLocation())
+        }
+    }
+
+    @Test
+    fun `one aggregate transform`() {
+        val query = "SELECT COUNT(1) FROM foo"
+        val select = query.parseAndTransformQuery()
+
+        val actualMetas = select.metas
+        val expectedMetas = createCallAggMetas(listOf(Pair("count", 0)))
+
+        assertSameCallAggMetas(expectedMetas, actualMetas)
+    }
+
+    @Test
+    fun `one aggregate in HAVING transform`() {
+        val query = "SELECT 1 FROM foo GROUP BY bar HAVING SUM(1) > 0"
+        val select = query.parseAndTransformQuery()
+
+        val actualMetas = select.metas
+        val expectedMetas = createCallAggMetas(listOf(Pair("sum", 0)))
+
+        assertSameCallAggMetas(expectedMetas, actualMetas)
+    }
+
+    @Test
+    fun `one aggregate and one aggregate in HAVING transform`() {
+        val query = "SELECT COUNT(1) FROM foo GROUP BY bar HAVING SUM(1) > 0"
+        val select = query.parseAndTransformQuery()
+
+        val actualMetas = select.metas
+        val expectedMetas = createCallAggMetas(listOf(Pair("sum", 0), Pair("count", 1)))
+
+        assertSameCallAggMetas(expectedMetas, actualMetas)
+    }
+
+    @Test
+    fun `SELECT VALUE one aggregate and HAVING transform`() {
+        val query = "SELECT VALUE COUNT(1) FROM foo GROUP BY bar HAVING SUM(1) > 0"
+        val select = query.parseAndTransformQuery()
+
+        val actualMetas = select.metas
+        val expectedMetas = createCallAggMetas(listOf(Pair("sum", 0)))
+
+        assertSameCallAggMetas(expectedMetas, actualMetas)
+    }
+
+    @Test
+    fun `SELECT VALUE aggregate transform`() {
+        val query = "SELECT VALUE COUNT(1) FROM foo"
+        val select = query.parseAndTransformQuery()
+
+        val actualMetas = select.metas
+        val expectedMetas = createCallAggMetas(emptyList())
+
+        assertSameCallAggMetas(expectedMetas, actualMetas)
+    }
+
+    @Test
+    fun `SELECT VALUE with SELECT VALUE subquery aggregate transform`() {
+        val query = "SELECT VALUE (SELECT VALUE COUNT(1) FROM foo) FROM foo"
+
+        // outer SELECT VALUE has no aggregate call sites
+        val outerSelect = query.parseAndTransformQuery()
+        val outerActualMetas = outerSelect.metas
+        val outerExpectedMetas = createCallAggMetas(emptyList())
+
+        assertSameCallAggMetas(outerExpectedMetas, outerActualMetas)
+
+        // inner SELECT VALUE has no aggregate call sites
+        val innerSelect = (outerSelect.project as PartiqlAst.Projection.ProjectValue).value as PartiqlAst.Expr.Select
+        val innerActualMetas = innerSelect.metas
+        val innerExpectedMetas = createCallAggMetas(emptyList())
+
+        assertSameCallAggMetas(innerExpectedMetas, innerActualMetas)
+    }
+
+    @Test
+    fun `SELECT VALUE with subquery aggregate transform`() {
+        val query = "SELECT VALUE (SELECT COUNT(1) FROM foo) FROM foo"
+
+        // outer SELECT VALUE has no aggregate call sites
+        val outerSelect = query.parseAndTransformQuery()
+        val outerActualMetas = outerSelect.metas
+        val outerExpectedMetas = createCallAggMetas(emptyList())
+
+        assertSameCallAggMetas(outerExpectedMetas, outerActualMetas)
+
+        // inner SELECT query has 1 aggregate call
+        val innerSelect = (outerSelect.project as PartiqlAst.Projection.ProjectValue).value as PartiqlAst.Expr.Select
+        val innerActualMetas = innerSelect.metas
+        val innerExpectedMetas = createCallAggMetas(listOf(Pair("count", 0)))
+
+        assertSameCallAggMetas(innerExpectedMetas, innerActualMetas)
+    }
+
+    @Test
+    fun `multiple aggregates transform`() {
+        val query = "SELECT COUNT(1), SUM(1), AVG(1) FROM foo"
+        val select = query.parseAndTransformQuery()
+
+        val actualMetas = select.metas
+        val expectedMetas = createCallAggMetas(listOf(Pair("count", 0), Pair("sum", 1), Pair("avg", 2)))
+
+        assertSameCallAggMetas(expectedMetas, actualMetas)
+    }
+
+    @Test
+    fun `FROM clause subquery aggregate transform`() {
+        val query = "SELECT 1 FROM (SELECT COUNT(1), SUM(1) FROM foo)"
+
+        // outer query has no aggregate calls
+        val outerSelect = query.parseAndTransformQuery()
+        val outerActualMetas = outerSelect.metas
+        val outerExpectedMetas = createCallAggMetas(emptyList())
+
+        assertSameCallAggMetas(outerExpectedMetas, outerActualMetas)
+
+        // inner query has 2 aggregate calls
+        val innerSelect = (outerSelect.from as PartiqlAst.FromSource.Scan).expr as PartiqlAst.Expr.Select
+        val innerActualMetas = innerSelect.metas
+        val innerExpectedMetas = createCallAggMetas(listOf(Pair("count", 0), Pair("sum", 1)))
+
+        assertSameCallAggMetas(innerExpectedMetas, innerActualMetas)
+    }
+
+    @Test
+    fun `FROM clause subquery aggregate transform with HAVING`() {
+        val query = "SELECT 1 FROM (SELECT COUNT(1), SUM(1) FROM foo) GROUP BY bar HAVING SUM(1) > 0"
+
+        // outer query has 1 aggregate call
+        val outerSelect = query.parseAndTransformQuery()
+        val outerActualMetas = outerSelect.metas
+        val outerExpectedMetas = createCallAggMetas(listOf(Pair("sum", 0)))
+
+        assertSameCallAggMetas(outerExpectedMetas, outerActualMetas)
+
+        // inner query has 2 aggregate calls
+        val innerSelect = (outerSelect.from as PartiqlAst.FromSource.Scan).expr as PartiqlAst.Expr.Select
+        val innerActualMetas = innerSelect.metas
+        val innerExpectedMetas = createCallAggMetas(listOf(Pair("count", 0), Pair("sum", 1)))
+
+        assertSameCallAggMetas(innerExpectedMetas, innerActualMetas)
+    }
+
+    @Test
+    fun `FROM clause subsubquery aggregate transform`() {
+        val query = "SELECT 1 FROM (SELECT COUNT(1), SUM(1) FROM (SELECT AVG(1) FROM foo))"
+
+        // outer query has no aggregate calls
+        val outerSelect = query.parseAndTransformQuery()
+        val outerActualMetas = outerSelect.metas
+        val outerExpectedMetas = createCallAggMetas(emptyList())
+
+        assertSameCallAggMetas(outerExpectedMetas, outerActualMetas)
+
+        // inner query has 2 aggregate calls
+        val innerSelect = (outerSelect.from as PartiqlAst.FromSource.Scan).expr as PartiqlAst.Expr.Select
+        val innerActualMetas = innerSelect.metas
+        val innerExpectedMetas = createCallAggMetas(listOf(Pair("count", 0), Pair("sum", 1)))
+
+        assertSameCallAggMetas(innerExpectedMetas, innerActualMetas)
+
+        // innermost query has 1 aggregate calls
+        val innermostSelect = (innerSelect.from as PartiqlAst.FromSource.Scan).expr as PartiqlAst.Expr.Select
+        val innermostActualMetas = innermostSelect.metas
+        val innermostExpectedMetas = createCallAggMetas(listOf(Pair("avg", 0)))
+
+        assertSameCallAggMetas(innermostExpectedMetas, innermostActualMetas)
+    }
+
+    @Test
+    fun `SELECT VALUE subquery aggregate transform`() {
+        val query = "SELECT VALUE AVG(1) FROM (SELECT COUNT(1), SUM(1) FROM foo)"
+
+        // outer SELECT VALUE isn't included as an aggregate call site
+        val outerSelect = query.parseAndTransformQuery()
+        val outerActualMetas = outerSelect.metas
+        val outerExpectedMetas = createCallAggMetas(emptyList())
+
+        assertSameCallAggMetas(outerExpectedMetas, outerActualMetas)
+
+        // inner query has 2 aggregate calls
+        val innerSelect = (outerSelect.from as PartiqlAst.FromSource.Scan).expr as PartiqlAst.Expr.Select
+        val innerActualMetas = innerSelect.metas
+        val innerExpectedMetas = createCallAggMetas(listOf(Pair("count", 0), Pair("sum", 1)))
+
+        assertSameCallAggMetas(innerExpectedMetas, innerActualMetas)
+    }
+
+    @Test
+    fun `SELECT clause subquery aggregate transform`() {
+        val query = "SELECT AVG(1), (SELECT COUNT(1), SUM(1) FROM foo) FROM foo"
+
+        // outer query has 1 aggregate call
+        val outerSelect = query.parseAndTransformQuery()
+        val outerActualMetas = outerSelect.metas
+        val outerExpectedMetas = createCallAggMetas(listOf(Pair("avg", 0)))
+
+        assertSameCallAggMetas(outerExpectedMetas, outerActualMetas)
+
+        // inner select query's second item has 2 aggregate calls
+        val innerSelectList = (outerSelect.project as PartiqlAst.Projection.ProjectList).projectItems
+        val innerSelect = (innerSelectList[1] as PartiqlAst.ProjectItem.ProjectExpr).expr as PartiqlAst.Expr.Select
+        val innerActualMetas = innerSelect.metas
+        val innerExpectedMetas = createCallAggMetas(listOf(Pair("count", 0), Pair("sum", 1)))
+
+        assertSameCallAggMetas(innerExpectedMetas, innerActualMetas)
+    }
+}


### PR DESCRIPTION
Fixes #212.

The cause appears to be from the `AggregateSupport(Rewriter/VisitorTransform)`, which at a high level, populates a meta containing information about the query's aggregation functions. 

It was not correctly excluding subqueries when creating a list of aggregates. So in a query with aggregates in a subquery such as `SELECT 1 FROM (SELECT COUNT(1) FROM foo)`, the outer `SELECT`'s metas would contain the subquery's aggregate metas. Because of this, the wrong evaluation path was taken in the `EvaluatingCompiler`:https://github.com/partiql/partiql-lang-kotlin/blob/de1fe32b1d535a9d56b3337b1de9c10780422745/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt#L972

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
