### PR TITLE
Fixes `TimestampTemporalAccessorTests` negative year

### DIFF
--- a/lang/test/org/partiql/lang/eval/builtins/TimestampExtensions.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/TimestampExtensions.kt
@@ -41,7 +41,7 @@ internal fun OffsetDateTime.toTimestamp(): com.amazon.ion.Timestamp =
                 this.offset.totalSeconds / 60)
 
 internal fun java.util.Random.nextTimestamp(): Timestamp {
-    val year = Math.abs(this.nextInt()) % 9999 + 1
+    val year = Math.abs(this.nextInt() % 9999) + 1
     val month = Math.abs(this.nextInt() % 12) + 1
 
     //Determine last day of month for randomly generated month & year (e.g. 28, 29, 30 or 31)
@@ -52,7 +52,7 @@ internal fun java.util.Random.nextTimestamp(): Timestamp {
     val minute = Math.abs(this.nextInt() % 60)
 
     val secondFraction = BigDecimal.valueOf(Math.abs(this.nextLong()) % 1000000000).div(BigDecimal.valueOf(1000000000L))
-    val seconds = BigDecimal.valueOf(Math.abs(this.nextInt()) % 59L).add(secondFraction).abs()
+    val seconds = BigDecimal.valueOf(Math.abs(this.nextInt() % 59L)).add(secondFraction).abs()
     //Note:  need to % 59L above because 59L + secondFraction can yield 60 seconds
 
     var offsetMinutes = this.nextInt() % (18 * 60)


### PR DESCRIPTION
Fixes #229.

This issue was kind of bugging me from a GH actions [build failure](https://github.com/partiql/partiql-lang-kotlin/runs/1560219706?check_suite_focus=true) from the other day.

The year needs to be an integer between 1 and 9999 inclusive. The [previous code](https://github.com/partiql/partiql-lang-kotlin/blob/de1fe32b1d535a9d56b3337b1de9c10780422745/lang/test/org/partiql/lang/eval/builtins/TimestampExtensions.kt#L44) would 
1. generate a random int
2. take the absolute value
3. modulo 9999
4. add 1

However, taking `abs(Int.MIN_VALUE) = Int.MIN_VALUE`, so the resulting year would be negative. The correct order of operations should be 
1. generate a random int
2. **modulo 9999**
3. **take the absolute value**
4. add 1

I also fixed this for the `seconds` argument.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
