### PR TITLE
CSVJavaExample.java: Fix unchecked warning

### DIFF
--- a/examples/src/java/org/partiql/examples/CSVJavaExample.java
+++ b/examples/src/java/org/partiql/examples/CSVJavaExample.java
@@ -69,7 +69,7 @@ public class CSVJavaExample extends Example {
 
         @NotNull
         @Override
-        public Bindings getBindings() {
+        public Bindings<ExprValue> getBindings() {
             return Bindings.ofMap(rowValues());
         }
 


### PR DESCRIPTION
*Description of changes:*

Add <ExprValue> to getBindings return type to fix the following
javac unchecked warning:

```
examples/src/java/org/partiql/examples/CSVJavaExample.java:72:
warning: [unchecked] getBindings() in CsvRowExprValue implements
getBindings() in ExprValue
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
