### PR TITLE
cli: Add --output-format=PARTIQL_PRETTY for non-interactive use

### DIFF
--- a/cli/src/org/partiql/cli/Cli.kt
+++ b/cli/src/org/partiql/cli/Cli.kt
@@ -16,10 +16,11 @@ package org.partiql.cli
 
 import com.amazon.ion.*
 import com.amazon.ion.system.*
+import java.io.*
 import org.partiql.cli.OutputFormat.*
 import org.partiql.lang.*
 import org.partiql.lang.eval.*
-import java.io.*
+import org.partiql.lang.util.ConfigurableExprValueFormatter
 
 /**
  * TODO builder, kdoc
@@ -46,6 +47,9 @@ internal class Cli(private val valueFactory: ExprValueFactory,
                 ION_TEXT   -> valueFactory.ion.newTextWriter(output).use { printIon(it, result) }
                 ION_BINARY -> valueFactory.ion.newBinaryWriter(output).use { printIon(it, result) }
                 PARTIQL    -> OutputStreamWriter(output).use { it.write(result.toString()) }
+                PARTIQL_PRETTY -> OutputStreamWriter(output).use {
+                    ConfigurableExprValueFormatter.pretty.formatTo(result, it)
+                }
             }
         }
     }

--- a/cli/src/org/partiql/cli/main.kt
+++ b/cli/src/org/partiql/cli/main.kt
@@ -62,7 +62,7 @@ private val formatter = object : BuiltinHelpFormatter(120, 2) {
 }
 
 enum class OutputFormat {
-    ION_TEXT, ION_BINARY, PARTIQL
+    ION_TEXT, ION_BINARY, PARTIQL, PARTIQL_PRETTY
 }
 
 // opt parser options

--- a/cli/src/org/partiql/cli/main.kt
+++ b/cli/src/org/partiql/cli/main.kt
@@ -108,7 +108,7 @@ private val outputFormatOpt = optParser.acceptsAll(listOf("output-format", "of")
  *      * -q --query: PartiQL query
  *      * -i --input: input file, default STDIN
  *      * -o --output: output file, default STDOUT
- *      * -of --output-format: output format, ION_TEXT, ION_BINARY and PARTIQL (default)
+ *      * -of --output-format: ION_TEXT, ION_BINARY, PARTIQL (default), PARTIQL_PRETTY
  */
 fun main(args: Array<String>) = try {
     optParser.formatHelpWith(formatter)

--- a/docs/user/CLI.md
+++ b/docs/user/CLI.md
@@ -25,7 +25,7 @@ Option                                Description
 -i, --input <File>                    input file, requires the query option (default: stdin)
 -o, --output <File>                   output file, requires the query option (default: stdout)
 --of, --output-format <OutputFormat:  output format, requires the query option (default: PARTIQL)
-  (ION_TEXT|ION_BINARY|PARTIQL)>
+  (ION_TEXT|ION_BINARY|PARTIQL|PARTIQL_PRETTY)>
 -q, --query <String>                  PartiQL query, triggers non interactive mode
 ```
 


### PR DESCRIPTION
*Description of changes:*

The interactive REPL prints PartiQL results in a "pretty" format with
newlines and indentation. The non-interactive command line tool does
not. This adds --output-format=PARTIQL_PRETTY to print results in the
same format.

Example result without --output-format:

    <<{'employeeName': 'Bob Smith', 'projectName': 'AWS Redshift Spectrum querying'}, {'employeeName': 'Jane Smith', 'projectName': 'AWS Redshift security'}>>

Example result with --output-format=PARTIQL_PRETTY

    <<
      {
        'employeeName': 'Bob Smith',
        'projectName': 'AWS Redshift Spectrum querying'
      },
      {
        'employeeName': 'Jane Smith',
        'projectName': 'AWS Redshift security'
      }
    >>



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
