### PR TITLE
gradle: fix test target for cli, examples, pts

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id 'io.gitlab.arturbosch.detekt'
     id 'application'
 }
 
@@ -35,10 +34,7 @@ dependencies {
     implementation 'net.sf.jopt-simple:jopt-simple:[5.0,6.0)'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
-    testImplementation 'org.jetbrains.kotlin:kotlin-test'
-    testImplementation 'pl.pragmatists:JUnitParams:[1.0.0,1.1.0)'
-
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
 }
 
 jacocoTestReport {

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -112,4 +112,13 @@ class CliTest {
 
         assertEquals("<<{'a': 1}>>", actual)
     }
+
+    @Test
+    fun withPartiQLPrettyOutput() {
+        val subject = makeCli("SELECT * FROM input_data", "{a: 1, b: 2}",
+            outputFormat = OutputFormat.PARTIQL_PRETTY)
+        val actual = subject.runAndOutput()
+
+        assertEquals("<<\n  {\n    'a': 1,\n    'b': 2\n  }\n>>", actual)
+    }
 }

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -115,8 +115,7 @@ class CliTest {
 
     @Test
     fun withPartiQLPrettyOutput() {
-        val subject = makeCli("SELECT * FROM input_data", "{a: 1, b: 2}",
-            outputFormat = OutputFormat.PARTIQL_PRETTY)
+        val subject = makeCli("SELECT * FROM input_data", "{a: 1, b: 2}", outputFormat = OutputFormat.PARTIQL_PRETTY)
         val actual = subject.runAndOutput()
 
         assertEquals("<<\n  {\n    'a': 1,\n    'b': 2\n  }\n>>", actual)

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -25,14 +25,11 @@ application {
 
 dependencies {
     implementation project(":lang")
-
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.11.554'
     implementation 'com.amazonaws:aws-java-sdk-s3control:1.11.554'
 
-    implementation 'org.jetbrains.kotlin:kotlin-test'
-    implementation 'junit:junit:4.12'
-
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
 }
 
 jacocoTestReport {

--- a/examples/src/kotlin/org/partiql/examples/CsvExprValueExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/CsvExprValueExample.kt
@@ -1,7 +1,5 @@
 package org.partiql.examples
 
-import org.junit.*
-import org.junit.Assert.*
 import com.amazon.ion.*
 import com.amazon.ion.system.*
 import org.partiql.examples.util.Example

--- a/examples/src/kotlin/org/partiql/examples/CustomFunctionsExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/CustomFunctionsExample.kt
@@ -1,12 +1,10 @@
 package org.partiql.examples
 
-import org.junit.*
 import com.amazon.ion.system.*
 import org.partiql.examples.util.Example
 import org.partiql.lang.*
 import org.partiql.lang.eval.*
 import java.io.PrintStream
-import kotlin.test.*
 
 /** A simple fibonacci calculator. */
 private fun calcFib(n: Long): Long = when (n) {

--- a/examples/src/kotlin/org/partiql/examples/ParserErrorExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/ParserErrorExample.kt
@@ -1,7 +1,5 @@
 package org.partiql.examples
 
-import org.junit.*
-import kotlin.test.*
 import com.amazon.ion.*
 import com.amazon.ion.system.*
 import org.partiql.examples.util.Example
@@ -28,7 +26,7 @@ class ParserErrorExample(out: PrintStream) : Example(out) {
         print("Invalid PartiQL query:", invalidQuery)
         parser.parseExprNode(invalidQuery)
 
-        fail("ParserException was not thrown")
+        throw Exception("ParserException was not thrown")
     } catch (e: ParserException) {
         val errorContext = e.errorContext!!
 

--- a/examples/src/kotlin/org/partiql/examples/ParserExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/ParserExample.kt
@@ -6,7 +6,6 @@ import org.partiql.lang.ast.*
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.*
 import java.io.PrintStream
-import java.util.Objects
 
 /**
  * Demonstrates the use of [SqlParser] and [PartiqlAst].

--- a/examples/src/kotlin/org/partiql/examples/ParserExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/ParserExample.kt
@@ -1,12 +1,12 @@
 package org.partiql.examples
 
-import kotlin.test.*
 import com.amazon.ion.system.*
 import org.partiql.examples.util.Example
 import org.partiql.lang.ast.*
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.*
 import java.io.PrintStream
+import java.util.Objects
 
 /**
  * Demonstrates the use of [SqlParser] and [PartiqlAst].
@@ -45,7 +45,9 @@ class ParserExample(out: PrintStream) : Example(out) {
         // version of the s-expression form to an instance of [ExprNode].
         val deserializedAst = serializedAst.toExprNode(ion)
         // Verify that we have the correct AST.
-        assertEquals(originalAst, deserializedAst)
+        if (originalAst != deserializedAst) {
+            throw Exception("expected AST to be equal")
+        }
 
         // Here we show how to parse a query directly to a PartiqlAst statement
         val statement = parser.parseAstStatement(query)
@@ -55,6 +57,8 @@ class ParserExample(out: PrintStream) : Example(out) {
         // and back into a PartiqlAst statement
         val roundTrippedStatement = PartiqlAst.transform(elements) as PartiqlAst.Statement
         // Verify that we have the original Partiql Ast statement
-        assertEquals(statement, roundTrippedStatement)
+        if (statement != roundTrippedStatement) {
+            throw Exception("Expected statements to be the same")
+        }
     }
 }

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     testImplementation 'pl.pragmatists:JUnitParams:[1.0.0,1.1.0)'
     testImplementation 'org.assertj:assertj-core:[3.11.0,3.12.0)'
 
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'
 }

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -48,17 +48,12 @@ dependencies {
     api 'org.partiql:partiql-ir-generator-runtime:0.3.0'
 
     // test-time dependencies
-    testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testImplementation 'pl.pragmatists:JUnitParams:[1.0.0,1.1.0)'
     testImplementation 'org.assertj:assertj-core:[3.11.0,3.12.0)'
 
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'
-    // PTS
-    testImplementation project(':testscript')
 }
 
 task generatePigDomains {

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -26,7 +26,6 @@ plugins {
     id 'maven-publish'
     id 'org.jetbrains.dokka' version '0.9.18'
     id 'org.jetbrains.kotlin.jvm'
-    id 'io.gitlab.arturbosch.detekt'
     id 'signing'
 }
 

--- a/pts/build.gradle
+++ b/pts/build.gradle
@@ -35,14 +35,9 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 
     // test-time dependencies
-    testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
-    testImplementation 'org.jetbrains.kotlin:kotlin-test'
-    testImplementation 'pl.pragmatists:JUnitParams:[1.0.0,1.1.0)'
-    testImplementation 'org.assertj:assertj-core:[3.11.0,3.12.0)'
     testImplementation project(':lang')
     testImplementation project(':testscript')
-
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
 }
 
 jacocoTestReport {

--- a/pts/build.gradle
+++ b/pts/build.gradle
@@ -16,7 +16,6 @@
 
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id 'io.gitlab.arturbosch.detekt'
 }
 
 group = 'org.partiql.lang'

--- a/testscript/build.gradle
+++ b/testscript/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
-    id 'io.gitlab.arturbosch.detekt'
 }
 
 dependencies {


### PR DESCRIPTION
*Description of changes:*

The following gradle targets were not running any of the unit tests
contained in their directories due to incorrect test dependencies. It
appears these projects all use JUnit 5 "vintage" tests, so need that
engine as a test dependency.

    :cli:test
    :examples:test
    :pts:test

CliTest: Add test for the PARTIQL_PRETTY output format added in commit
91750026f1. This was how I discovered this issue.

examples: Remove tests from the implementation dependencies.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
