### PR TITLE
Fixes parser for the top level tokens

### DIFF
--- a/lang/src/org/partiql/lang/errors/ErrorCode.kt
+++ b/lang/src/org/partiql/lang/errors/ErrorCode.kt
@@ -302,11 +302,6 @@ enum class ErrorCode(private val category: ErrorCategory,
         LOC_TOKEN,
         "No stored procedure provided"),
 
-    PARSE_EXEC_AT_UNEXPECTED_LOCATION(
-        ErrorCategory.PARSER,
-        LOC_TOKEN,
-        "EXEC call found at unexpected location"),
-
     PARSE_MALFORMED_JOIN(
         ErrorCategory.PARSER,
         LOC_TOKEN,

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -1740,6 +1740,8 @@ class ParserErrorsTest : TestBase() {
             Property.TOKEN_TYPE to TokenType.KEYWORD,
             Property.TOKEN_VALUE to ion.newSymbol("exec")))
 
+    // TODO: The token in the error message here should be "exec" instead of "undrop".
+    //  Check this issue for more details. https://github.com/partiql/partiql-lang-kotlin/issues/372
     @Test
     fun execAtUnexpectedLocationInExpression() = checkInputThrowingParserException(
         "SELECT * FROM (EXEC undrop 'foo')",

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -1327,6 +1327,26 @@ class ParserErrorsTest : TestBase() {
             Property.TOKEN_VALUE to ion.newSymbol("create")))
 
     @Test
+    fun nestedRemove() = checkInputThrowingParserException(
+        "REMOVE REMOVE y",
+        ErrorCode.PARSE_INVALID_PATH_COMPONENT,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 8L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("remove")))
+
+    @Test
+    fun nestedInsertInto() = checkInputThrowingParserException(
+        "INSERT INTO foo VALUE INSERT INTO foo VALUE 1 AT bar",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 23L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("insert_into")))
+
+    @Test
     fun updateWithDropIndex() = checkInputThrowingParserException(
         "UPDATE test SET x = DROP INDEX bar ON foo",
         ErrorCode.PARSE_UNEXPECTED_TERM,

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -1252,9 +1252,49 @@ class ParserErrorsTest : TestBase() {
         ErrorCode.PARSE_UNEXPECTED_TERM,
         mapOf(
             Property.LINE_NUMBER to 1L,
-            Property.COLUMN_NUMBER to 35L,
-            Property.TOKEN_TYPE to TokenType.EOF,
-            Property.TOKEN_VALUE to ion.newSymbol("EOF")))
+            Property.COLUMN_NUMBER to 21L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("set")))
+
+    @Test
+    fun updateWithSetAndRemove() = checkInputThrowingParserException(
+        "UPDATE test SET x = REMOVE y",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 21L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("remove")))
+
+    @Test
+    fun updateWithSetAndInsert() = checkInputThrowingParserException(
+        "UPDATE test SET x = INSERT INTO foo VALUE 1",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 21L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("insert_into")))
+
+    @Test
+    fun updateWithSetAndDelete() = checkInputThrowingParserException(
+        "UPDATE test SET x = DELETE FROM y",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 21L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("delete")))
+
+    @Test
+    fun updateWithSetAndExec() = checkInputThrowingParserException(
+        "UPDATE test SET x = EXEC foo arg1, arg2",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 26L,
+            Property.TOKEN_TYPE to TokenType.IDENTIFIER,
+            Property.TOKEN_VALUE to ion.newSymbol("foo")))
 
     @Test
     fun updateFromList() = checkInputThrowingParserException(
@@ -1613,7 +1653,7 @@ class ParserErrorsTest : TestBase() {
     @Test
     fun execAtUnexpectedLocation() = checkInputThrowingParserException(
         "EXEC EXEC",
-        ErrorCode.PARSE_EXEC_AT_UNEXPECTED_LOCATION,
+        ErrorCode.PARSE_UNEXPECTED_TERM,
         mapOf(
             Property.LINE_NUMBER to 1L,
             Property.COLUMN_NUMBER to 6L,
@@ -1623,7 +1663,7 @@ class ParserErrorsTest : TestBase() {
     @Test
     fun execAtUnexpectedLocationAfterExec() = checkInputThrowingParserException(
         "EXEC foo EXEC",
-        ErrorCode.PARSE_EXEC_AT_UNEXPECTED_LOCATION,
+        ErrorCode.PARSE_UNEXPECTED_TERM,
         mapOf(
             Property.LINE_NUMBER to 1L,
             Property.COLUMN_NUMBER to 10L,
@@ -1633,10 +1673,10 @@ class ParserErrorsTest : TestBase() {
     @Test
     fun execAtUnexpectedLocationInExpression() = checkInputThrowingParserException(
         "SELECT * FROM (EXEC undrop 'foo')",
-        ErrorCode.PARSE_EXEC_AT_UNEXPECTED_LOCATION,
+        ErrorCode.PARSE_UNEXPECTED_TERM,
         mapOf(
             Property.LINE_NUMBER to 1L,
-            Property.COLUMN_NUMBER to 16L,
-            Property.TOKEN_TYPE to TokenType.KEYWORD,
-            Property.TOKEN_VALUE to ion.newSymbol("exec")))
+            Property.COLUMN_NUMBER to 21L,
+            Property.TOKEN_TYPE to TokenType.IDENTIFIER,
+            Property.TOKEN_VALUE to ion.newSymbol("undrop")))
 }

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -1257,7 +1257,7 @@ class ParserErrorsTest : TestBase() {
             Property.TOKEN_VALUE to ion.newSymbol("set")))
 
     @Test
-    fun updateWithSetAndRemove() = checkInputThrowingParserException(
+    fun updateWithRemove() = checkInputThrowingParserException(
         "UPDATE test SET x = REMOVE y",
         ErrorCode.PARSE_UNEXPECTED_TERM,
         mapOf(
@@ -1267,7 +1267,7 @@ class ParserErrorsTest : TestBase() {
             Property.TOKEN_VALUE to ion.newSymbol("remove")))
 
     @Test
-    fun updateWithSetAndInsert() = checkInputThrowingParserException(
+    fun updateWithInsert() = checkInputThrowingParserException(
         "UPDATE test SET x = INSERT INTO foo VALUE 1",
         ErrorCode.PARSE_UNEXPECTED_TERM,
         mapOf(
@@ -1277,7 +1277,7 @@ class ParserErrorsTest : TestBase() {
             Property.TOKEN_VALUE to ion.newSymbol("insert_into")))
 
     @Test
-    fun updateWithSetAndDelete() = checkInputThrowingParserException(
+    fun updateWithDelete() = checkInputThrowingParserException(
         "UPDATE test SET x = DELETE FROM y",
         ErrorCode.PARSE_UNEXPECTED_TERM,
         mapOf(
@@ -1287,7 +1287,7 @@ class ParserErrorsTest : TestBase() {
             Property.TOKEN_VALUE to ion.newSymbol("delete")))
 
     @Test
-    fun updateWithSetAndExec() = checkInputThrowingParserException(
+    fun updateWithExec() = checkInputThrowingParserException(
         "UPDATE test SET x = EXEC foo arg1, arg2",
         ErrorCode.PARSE_UNEXPECTED_TERM,
         mapOf(
@@ -1295,6 +1295,46 @@ class ParserErrorsTest : TestBase() {
             Property.COLUMN_NUMBER to 26L,
             Property.TOKEN_TYPE to TokenType.IDENTIFIER,
             Property.TOKEN_VALUE to ion.newSymbol("foo")))
+
+    @Test
+    fun updateWithCreateTable() = checkInputThrowingParserException(
+        "UPDATE test SET x = CREATE TABLE foo",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 21L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("create")))
+
+    @Test
+    fun updateWithDropTable() = checkInputThrowingParserException(
+        "UPDATE test SET x = DROP TABLE foo",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 21L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("drop")))
+
+    @Test
+    fun updateWithCreateIndex() = checkInputThrowingParserException(
+        "UPDATE test SET x = CREATE INDEX ON foo (x, y.z)",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 21L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("create")))
+
+    @Test
+    fun updateWithDropIndex() = checkInputThrowingParserException(
+        "UPDATE test SET x = DROP INDEX bar ON foo",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 21L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("drop")))
 
     @Test
     fun updateFromList() = checkInputThrowingParserException(
@@ -1345,6 +1385,16 @@ class ParserErrorsTest : TestBase() {
             Property.COLUMN_NUMBER to 17L,
             Property.TOKEN_TYPE to TokenType.OPERATOR,
             Property.TOKEN_VALUE to ion.newSymbol("-")))
+
+    @Test
+    fun nestedCreateTable() = checkInputThrowingParserException(
+        "CREATE TABLE CREATE TABLE foo",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 14L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("create")))
 
     @Test
     fun dropTableWithOperatorAfterIdentifier() = checkInputThrowingParserException(

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -1247,6 +1247,16 @@ class ParserErrorsTest : TestBase() {
             Property.TOKEN_VALUE to ion.newSymbol("EOF")))
 
     @Test
+    fun updateWithNestedSet() = checkInputThrowingParserException(
+        "UPDATE test SET x = SET test.y = 6",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 35L,
+            Property.TOKEN_TYPE to TokenType.EOF,
+            Property.TOKEN_VALUE to ion.newSymbol("EOF")))
+
+    @Test
     fun updateFromList() = checkInputThrowingParserException(
         "UPDATE x, y SET a = b",
         ErrorCode.PARSE_MISSING_OPERATION,

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -2636,6 +2636,32 @@ class SqlParserTest : SqlParserTestBase() {
         """
     )
 
+    @Test
+    fun fromWhereSetDml() = assertExpression(
+        "FROM x WHERE a = b SET k = 5",
+        """
+          (dml
+            (set
+              (assignment
+                (id k case_insensitive)
+                (lit 5)))
+            (from
+              (id x case_insensitive))
+            (where (= (id a case_insensitive) (id b case_insensitive)))
+          )
+        """,
+        """
+          (dml
+            (operation
+              (set
+                (assignment
+                  (id k (case_insensitive) (unqualified))
+                  (lit 5))))
+              (from (scan (id x (case_insensitive) (unqualified)) null null null))
+              (where (eq (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified))))
+          )
+        """
+    )
 
     @Test
     fun updateWhereDml() = assertExpression(

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -2637,33 +2637,6 @@ class SqlParserTest : SqlParserTestBase() {
     )
 
     @Test
-    fun fromWhereSetDml() = assertExpression(
-        "FROM x WHERE a = b SET k = 5",
-        """
-          (dml
-            (set
-              (assignment
-                (id k case_insensitive)
-                (lit 5)))
-            (from
-              (id x case_insensitive))
-            (where (= (id a case_insensitive) (id b case_insensitive)))
-          )
-        """,
-        """
-          (dml
-            (operation
-              (set
-                (assignment
-                  (id k (case_insensitive) (unqualified))
-                  (lit 5))))
-              (from (scan (id x (case_insensitive) (unqualified)) null null null))
-              (where (eq (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified))))
-          )
-        """
-    )
-
-    @Test
     fun updateWhereDml() = assertExpression(
         "UPDATE x SET k = 5, m = 6 WHERE a = b",
         """


### PR DESCRIPTION
Issue #363 

Fixes parser by traversing and validating the parse tree to ensure that the top level tokens are not present at the level(s) below. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
