### PR TITLE
Add more parser error tests to validate top level tokens

### DIFF
--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -2646,6 +2646,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
      * in the query then it is invalid.
      * [level] is the current traversal level in the parse tree.
      * If [topLevelTokenSeen] is true, it means it has been encountered at least once before while traversing the parse tree.
+     * If [dmlListTokenSeen] is true, it means it has been encountered at least once before while traversing the parse tree.
      */
     private fun validateTopLevelNodes(node: ParseNode, level: Int, topLevelTokenSeen: Boolean, dmlListTokenSeen: Boolean) {
         val isTopLevelType = when (node.type.isDml) {
@@ -2671,9 +2672,10 @@ class SqlParser(private val ion: IonSystem) : Parser {
         }
         node.children.map {
             validateTopLevelNodes(
-                node = it, level = level + 1,
+                node = it,
+                level = level + 1,
                 topLevelTokenSeen = topLevelTokenSeen || isTopLevelType,
-                dmlListTokenSeen = node.type == DML_LIST
+                dmlListTokenSeen = dmlListTokenSeen || node.type == DML_LIST
             )
         }
     }

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -1581,6 +1581,26 @@ class ParserErrorsTest : TestBase() {
             Property.TOKEN_VALUE to ion.newSymbol("insert_into")))
 
     @Test
+    fun selectAndRemove() = checkInputThrowingParserException(
+        "SELECT REMOVE foo FROM bar",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 8L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("remove")))
+
+    @Test
+    fun selectAndRemove2() = checkInputThrowingParserException(
+        "SELECT * FROM REMOVE foo",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 15L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("remove")))
+
+    @Test
     fun updateWithDropIndex() = checkInputThrowingParserException(
         "UPDATE test SET x = DROP INDEX bar ON foo",
         ErrorCode.PARSE_UNEXPECTED_TERM,


### PR DESCRIPTION
This PR adds more parser error tests to validate the behavior for the top level tokens which was introduced with the PR #369.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
