### PR TITLE
Merges DML and other changes made for DynamoDB

### DIFF
--- a/cli/src/org/partiql/cli/Runnable.kt
+++ b/cli/src/org/partiql/cli/Runnable.kt
@@ -12,10 +12,22 @@
  *  language governing permissions and limitations under the License.
  */
 
-package org.partiql.lang.syntax
+package org.partiql.cli
 
-/** Simple source line/column value. */
-data class SourcePosition(val line: Long, val column: Long) {
-    override fun toString(): String = "line $line, column $column"
+import com.amazon.ion.*
+import org.partiql.lang.eval.*
+
+internal abstract class SqlCommand {
+    abstract fun run()
+
+
+    protected fun writeResult(result: ExprValue, writer: IonWriter): Int {
+        var itemCount = 0
+        result.rangeOver().forEach {
+            it.ionValue.writeTo(writer)
+            itemCount++
+        }
+        writer.flush()
+        return itemCount
+    }
 }
-

--- a/cli/src/org/partiql/cli/stopwatch.kt
+++ b/cli/src/org/partiql/cli/stopwatch.kt
@@ -12,10 +12,14 @@
  *  language governing permissions and limitations under the License.
  */
 
-package org.partiql.lang.syntax
+package org.partiql.cli
 
-/** Simple source line/column value. */
-data class SourcePosition(val line: Long, val column: Long) {
-    override fun toString(): String = "line $line, column $column"
+import java.util.concurrent.*
+
+fun <T> timeIt(block: () -> T): Long {
+    val start = System.nanoTime()
+    block()
+    val end = System.nanoTime()
+
+    return TimeUnit.MILLISECONDS.convert(end - start, TimeUnit.NANOSECONDS)
 }
-

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -21,9 +21,10 @@
             // necessary to check the validity of these nodes during compilation or another phase.  In the future, we
             // should consider changing the modeling of these so such validity checks are not needed.
             (dml
-                (operation op::dml_op)
+                (operations ops::dml_op_list)
                 (from from::(? from_source))
-                (where where::(? expr)))
+                (where where::(? expr))
+                (returning returning::(? returning_expr)))
 
             // Data definition operations also cannot be composed with other `expr` nodes.
             (ddl op::ddl_op)
@@ -115,6 +116,7 @@
                 (where (? expr))
                 (group (? group_by))
                 (having (? expr))
+                (order (? order_by))
                 (limit (? expr))))
         // end of sum expr
 
@@ -199,6 +201,18 @@
         // <expr> [AS <symbol>]
         (product group_key expr::expr as_alias::(? symbol))
 
+        // ORDER BY <sort_spec>...
+        (product order_by sort_specs::(* sort_spec 1))
+
+        // <expr> [ASC | DESC] ?
+        (product sort_spec expr::expr ordering_spec::(? ordering_spec))
+
+        // Desired ordering spec: ASC or DESC
+        (sum ordering_spec
+            (asc)
+            (desc)
+        )
+
         // Indicates if variable lookup should be case-sensitive or not.
         (sum case_sensitivity (case_sensitive) (case_insensitive))
 
@@ -214,22 +228,31 @@
 
         // A Data Manipulation Operation.
         // TODO:  domain of `expr` is too broad for several elements below: https://github.com/partiql/partiql-lang-kotlin/issues/243
-        (sum dml_op
+        (product dml_op_list ops::(* dml_op 1))
 
+        (sum dml_op
             // `INSERT INTO <expr> <expr>`
             (insert target::expr values::expr)
 
-            // `INSERT INTO <expr> VALUE <expr> [AT <expr>]`
-            (insert_value target::expr value::expr index::(? expr))
+            // `INSERT INTO <expr> VALUE <expr> [AT <expr>]` [ON CONFLICT WHERE <expr> DO NOTHING]`
+            (insert_value target::expr value::expr index::(? expr) on_conflict::(? on_conflict))
 
             // `SET <assignment>...`
-            (set assignments::(* assignment 1))
+            (set assignment::assignment)
 
             // `REMOVE <expr>`
             (remove target::expr)
 
             // DELETE
-            (delete))
+            (delete)
+         )
+
+        // `ON CONFLICT WHERE <expr> <conflict_action>`
+        (product on_conflict expr::expr conflict_action::conflict_action)
+
+        // `CONFLICT_ACTION <action>`
+        (sum conflict_action
+            (do_nothing))
 
         // A data definition operation.
         (sum ddl_op
@@ -248,6 +271,25 @@
             (drop_index
                 (table identifier)
                 (keys identifier)))
+
+        // `RETURNING (<returning_elem> [, <returning_elem>]...)`
+        (product returning_expr elems::(* returning_elem 1))
+
+        // `<returning mapping> (<expr> [, <expr>]...)`
+        (product returning_elem mapping::returning_mapping column::column_component)
+
+        (sum column_component
+            (returning_wildcard)
+            (returning_column expr::expr)
+        )
+
+        // ( MODIFIED | ALL ) ( NEW | OLD )
+        (sum returning_mapping
+            (modified_new)
+            (modified_old)
+            (all_new)
+            (all_old)
+        )
 
         // `identifier` can be used for names that need to be looked up with a notion of case-sensitivity.
 

--- a/lang/src/org/partiql/lang/ast/IsIonLiteralMeta.kt
+++ b/lang/src/org/partiql/lang/ast/IsIonLiteralMeta.kt
@@ -12,10 +12,25 @@
  *  language governing permissions and limitations under the License.
  */
 
-package org.partiql.lang.syntax
+/*
 
-/** Simple source line/column value. */
-data class SourcePosition(val line: Long, val column: Long) {
-    override fun toString(): String = "line $line, column $column"
+ */
+package org.partiql.lang.ast
+
+import com.amazon.ion.*
+import org.partiql.lang.ast.*
+
+/**
+ * Meta node intended to be attached to an instance of [Literal] to indicate that it was
+ * designated as an `ionLiteral` in the parsed statement.
+ */
+class IsIonLiteralMeta private constructor(): Meta {
+    override val tag = TAG
+
+    companion object {
+        const val TAG = "\$is_ion_literal"
+
+        val instance = IsIonLiteralMeta()
+        val deserializer = MemoizedMetaDeserializer(TAG, instance)
+    }
 }
-

--- a/lang/src/org/partiql/lang/ast/SourceLocationMeta.kt
+++ b/lang/src/org/partiql/lang/ast/SourceLocationMeta.kt
@@ -20,18 +20,45 @@ import org.partiql.lang.util.*
 /**
  * Represents a specific location within a source file.
  */
-data class SourceLocationMeta(val lineNum: Long, val charOffset: Long) : Meta {
-    override fun toString() = "$lineNum:$charOffset"
+data class SourceLocationMeta(val lineNum: Long, val charOffset: Long, val length: Long = -1) : Meta {
+    override fun toString() = "$lineNum:$charOffset:${if(length > 0) length.toString() else "<unknown>"}"
 
     override val tag = TAG
+
+
 
     override fun serialize(writer: IonWriter) {
         IonWriterContext(writer).apply {
             struct {
                 int("line_num", lineNum)
                 int("char_offset", charOffset)
+                int("length", length)
             }
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SourceLocationMeta) return false
+
+        if (lineNum != other.lineNum) return false
+        if (charOffset != other.charOffset) return false
+
+        // if length is unknown or the other is unknown, ignore the length.
+        if(length > 0 && other.length > 0 && length != other.length) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = lineNum.hashCode()
+        result = 31 * result + charOffset.hashCode()
+
+        // if the length is unknown, ignore it.
+        if(length > 0) {
+            result = 31 * result + length.hashCode()
+        }
+        return result
     }
 
     companion object {
@@ -42,8 +69,9 @@ data class SourceLocationMeta(val lineNum: Long, val charOffset: Long) : Meta {
                 val struct = sexp.first().asIonStruct()
                 val lineNum = struct.field("line_num").longValue()
                 val charOffset = struct.field("char_offset").longValue()
+                val length = struct.field("length").longValue()
 
-                return SourceLocationMeta(lineNum, charOffset)
+                return SourceLocationMeta(lineNum, charOffset, length)
             }
         }
     }

--- a/lang/src/org/partiql/lang/ast/passes/AstVisitor.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstVisitor.kt
@@ -91,6 +91,15 @@ interface AstVisitor {
     fun visitDataManipulationOperation(dmlOp: DataManipulationOperation) {
         // Default implementation does nothing.
     }
+
+    /**
+     * Invoked by [AstWalker] for every instance of [OnConflict].
+     *
+     * The operation's children are visited after this method is invoked.
+     */
+    fun visitOnConflict(onConflict: OnConflict) {
+        // Default implementation does nothing.
+    }
 }
 
 /**
@@ -126,6 +135,10 @@ open class AstVisitorBase : AstVisitor {
     }
 
     override fun visitDataManipulationOperation(dmlOp: DataManipulationOperation) {
+        // Default implementation does nothing.
+    }
+
+    override fun visitOnConflict(onConflict: OnConflict) {
         // Default implementation does nothing.
     }
 }

--- a/lang/src/org/partiql/lang/ast/passes/StatementRedactor.kt
+++ b/lang/src/org/partiql/lang/ast/passes/StatementRedactor.kt
@@ -1,0 +1,319 @@
+package org.partiql.lang.ast.passes
+
+import com.amazon.ion.IonString
+import com.amazon.ion.system.IonSystemBuilder
+import org.partiql.lang.ast.*
+import org.partiql.lang.ast.NAryOp.*
+import org.partiql.lang.syntax.SqlParser
+
+/**
+ * This is a lambda function typed alias for caller side udf validation implementation
+ *
+ * There are two major components needed for implementation:
+ *     1. Which arguments are needed for [SafeFieldName] validation
+ *     2. Which arguments are needed for redaction should be returned
+ *
+ * For example, for a given function which argument number is static, func(a, b, c, d)
+ * We can validate whether arg[0] and arg[1] are [SafeFieldName], if yes, arg[2] and arg[3] will be redacted
+ */
+typealias UserDefinedFunctionRedactionLambda = (List<ExprNode>) -> List<ExprNode>
+
+private var safeFieldNames = emptySet<String>()
+
+private val parser = SqlParser(IonSystemBuilder.standard().build())
+
+const val INVALID_NUM_ARGS = "Invalid number of args in node"
+const val INPUT_AST_STATEMENT_MISMATCH = "Input ast should be the parsed result of the input statement"
+
+/**
+ * Return true if the input node has value in [safeFieldNames] or skip the redaction intentionally
+ */
+fun validateSafeFieldNames(node: ExprNode): Boolean {
+    if (safeFieldNames.isEmpty()) {
+        return false
+    }
+
+    return when (node) {
+        is NAry -> true // Skip redaction for NAry node
+        is VariableReference -> safeFieldNames.contains(node.id)
+        is Literal -> {
+            if (node.ionValue is IonString) {
+                val name = node.ionValue.stringValue()
+                safeFieldNames.contains(name)
+            } else { false }
+        }
+        is Path -> {
+            var hasKeyAttribute = false
+            node.components.map {
+                when (it) {
+                    is PathComponentExpr -> {
+                        if (it.expr is Literal && it.expr.ionValue is IonString) {
+                            val name = it.expr.ionValue.stringValue()
+                            hasKeyAttribute = hasKeyAttribute || safeFieldNames.contains(name)
+                        }
+                    }
+                    else -> { /* intentionally blank */ }
+                }
+            }
+            hasKeyAttribute
+        }
+        else -> {
+            throw IllegalArgumentException("Unexpected ExprNode type in StatementRedactor.validateSafeFieldNames: ${node.javaClass}")
+        }
+    }
+}
+
+/**
+ * Redact sensitive data [Literal] not assigned with [safeFieldNames] to "***(Redacted)" based on input [statement]
+ * and ast from default parser
+ *
+ * [safeFieldNames] is optional for fields not redacted
+ *     For example: `SELECT * FROM tb WHERE hashkey = 'a' AND attr = 16453643`
+ *     gets rewritten as `SELECT * FROM tb WHERE hashkey = 'a' AND attr = ***(Redacted)`
+ *     because hashkey is in [safeFieldNames]
+ * [userDefinedFunctionRedactionConfig] is optional for UDF function redaction, please check StatementRedactorTest.kt for more details
+ *
+ * Return redacted statement
+ */
+fun redact(statement: String,
+           providedSafeFieldNames: Set<String> = emptySet(),
+           userDefinedFunctionRedactionConfig: Map<String, UserDefinedFunctionRedactionLambda> = emptyMap()): String {
+    return redact(statement, parser.parseExprNode(statement), providedSafeFieldNames, userDefinedFunctionRedactionConfig)
+}
+
+/**
+ * Redact sensitive data [Literal] not assigned with [safeFieldNames] to "***(Redacted)" based on input [ast]
+ * and [ast] parsed from the same input [statement]
+ *
+ * [safeFieldNames] is optional for fields not redacted
+ *     For example: `SELECT * FROM tb WHERE hashkey = 'a' AND attr = 16453643`
+ *     gets rewritten as `SELECT * FROM tb WHERE hashkey = 'a' AND attr = ***(Redacted)`
+ *     because hashkey is in [safeFieldNames]
+ * [userDefinedFunctionRedactionConfig] is optional for UDF function redaction, please check StatementRedactorTest.kt for more details
+ *
+ * Return correct redacted statement only if the parsed results of input [statement] is the same as input [ast]
+ */
+fun redact(statement: String,
+           ast: ExprNode,
+           providedSafeFieldNames: Set<String> = emptySet(),
+           userDefinedFunctionRedactionConfig: Map<String, UserDefinedFunctionRedactionLambda> = emptyMap()): String {
+    safeFieldNames = providedSafeFieldNames
+
+    val statementRedactionRewriter = StatementRedactionRewriter(statement, ast, userDefinedFunctionRedactionConfig)
+    statementRedactionRewriter.rewriteExprNode()
+    return statementRedactionRewriter.getRedactedStatement()
+}
+
+/**
+ * Redact sensitive data [Literal] not assigned with [safeFieldNames] to "***(Redacted)"
+ *
+ * TODO: when migrating to PIG, please use PartiqlAst.Visitor and not PartiqlAst.VisitorTransform!"
+ */
+private class StatementRedactionRewriter(
+        private val statement: String,
+        node: ExprNode,
+        private val userDefinedFunctionRedactionConfig: Map<String, UserDefinedFunctionRedactionLambda>
+) : AstRewriterBase() {
+    private val root = node
+    private val sourceLocationMetaForRedaction = arrayListOf<SourceLocationMeta>()
+    private val maskPattern = "***(Redacted)"
+
+    fun rewriteExprNode(): ExprNode {
+        return super.rewriteExprNode(root)
+    }
+
+    override fun rewriteSelectWhere(node: ExprNode): ExprNode {
+        redactOnField(node)
+        return super.rewriteSelectWhere(node)
+    }
+
+    override fun rewriteDataManipulationWhere(node: ExprNode): ExprNode {
+        redactOnField(node)
+        return super.rewriteDataManipulationWhere(node)
+    }
+
+    override fun rewriteAssignment(node: Assignment): Assignment {
+        if (!validateSafeFieldNames(node.lvalue)) {
+            redactOnField(node.rvalue)
+        }
+        return super.rewriteAssignment(node)
+    }
+
+    override fun rewriteDataManipulationOperationInsertValueOp(node: InsertValueOp): DataManipulationOperation {
+        when (node.value) {
+            is Struct -> redactOnStructInInsertValueOp(node.value)
+            else -> redactOnField(node.value)
+        }
+        return super.rewriteDataManipulationOperationInsertValueOp(node)
+    }
+
+    private fun redactOnField(node: ExprNode) {
+        when (node) {
+            is NAry -> redactOnNAry(node)
+            is Literal -> redactOnLiteral(node)
+            is Seq -> redactOnSeq(node)
+            is Struct -> redactOnStruct(node)
+            is Typed -> redactOnTyped(node)
+            else -> { /* intentionally blank */ }
+        }
+    }
+
+    private fun redactOnNAry(node: NAry) {
+        val rewrittenArgs = node.args
+
+        when (node.op) {
+            AND, OR -> {
+                rewrittenArgs.forEach { redactOnField(it) }
+            }
+            EQ, NE, GT, GTE, LT, LTE, IN -> {
+                if (rewrittenArgs.size != 2) {
+                    throw IllegalArgumentException(INVALID_NUM_ARGS)
+                }
+                if (!validateSafeFieldNames(rewrittenArgs[0])) {
+                    redactOnField(rewrittenArgs[1])
+                }
+            }
+            ADD, SUB -> {
+                when (rewrittenArgs.size) {
+                    1 -> {
+                        redactOnField(rewrittenArgs[0])
+                    }
+                    2 -> {
+                        redactOnField(rewrittenArgs[0])
+                        redactOnField(rewrittenArgs[1])
+                    }
+                    else -> {
+                        throw IllegalArgumentException(INVALID_NUM_ARGS)
+                    }
+                }
+            }
+            MUL, DIV, MOD -> {
+                if (rewrittenArgs.size != 2) {
+                    throw IllegalArgumentException(INVALID_NUM_ARGS)
+                }
+                redactOnField(rewrittenArgs[0])
+                redactOnField(rewrittenArgs[1])
+            }
+            BETWEEN -> {
+                if (rewrittenArgs.size != 3) {
+                    throw IllegalArgumentException(INVALID_NUM_ARGS)
+                }
+                if (!validateSafeFieldNames(rewrittenArgs[0])) {
+                    redactOnField(rewrittenArgs[1])
+                    redactOnField(rewrittenArgs[2])
+                }
+            }
+            NOT -> {
+                if (rewrittenArgs.size != 1) {
+                    throw IllegalArgumentException(INVALID_NUM_ARGS)
+                }
+                val arg = rewrittenArgs[0]
+                when (arg) {
+                    is NAry -> redactOnNAry(arg)
+                    is Typed -> redactOnTyped(arg)
+                    else -> { /* intentionally blank */ }
+                }
+            }
+            CALL -> {
+                redactOnCall(rewrittenArgs)
+            }
+            else -> { /* intentionally blank */ }
+        }
+    }
+
+    private fun redactOnLiteral(literal: Literal) {
+        val sourceLocation = literal.metas.sourceLocation ?: throw NoSuchElementException("No SourceLocation meta data in Literal object $literal")
+        sourceLocationMetaForRedaction.add(sourceLocation)
+    }
+
+    private fun redactOnSeq(seq: Seq) {
+        seq.values.map {
+            redactOnField(it)
+        }
+    }
+
+    private fun redactOnStruct(struct: Struct) {
+        struct.fields.map {
+            if (it.name is Literal) {
+                redactOnLiteral(it.name)
+            }
+            redactOnField(it.expr)
+        }
+    }
+
+    private fun redactOnCall(args: List<ExprNode>) {
+        if (args.isEmpty()) {
+            return
+        }
+        if (args[0] !is VariableReference) {
+            return
+        }
+
+        val funcName = (args[0] as VariableReference).id
+
+        if (userDefinedFunctionRedactionConfig.isEmpty() || !userDefinedFunctionRedactionConfig.containsKey(funcName)) {
+            args.drop(0).map { redactOnField(it) }
+            return
+        }
+
+        /* Call is redacted based on function name */
+        val getArgsToRedact = userDefinedFunctionRedactionConfig[funcName]
+        val argsToRedact = getArgsToRedact?.invoke(args)
+        argsToRedact?.map { redactOnField(it) }
+    }
+
+    private fun redactOnTyped(typed: Typed) {
+        when(typed.op) {
+            TypedOp.IS -> {
+                if (typed.expr is VariableReference && !validateSafeFieldNames(typed.expr)) {
+                    val sourceLocation = typed.type.metas.sourceLocation ?: throw NoSuchElementException("No SourceLocation meta data in DataType object $typed")
+                    sourceLocationMetaForRedaction.add(sourceLocation)
+                }
+            }
+            else -> { /* intentionally blank */ }
+        }
+    }
+
+    /**
+     * For InsertValueOp, only first level of struct files could have key attribute
+     * For example, in struct { 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}
+     * 'hk' in 'attr': { 'hk': 'a' } will be redacted
+     */
+    private fun redactOnStructInInsertValueOp(struct: Struct) {
+        struct.fields.map {
+            if (it.name is Literal) {
+                if (!validateSafeFieldNames(it.name)) {
+                    redactOnField(it.expr)
+                }
+            } else { /* intentionally blank */ }
+        }
+    }
+
+    /**
+     * Redact the statement based on [redactedSourceLocationMeta]
+     * Convert the lineNum in SourceLocationMeta to the actual index in the single line
+     */
+    fun getRedactedStatement(): String {
+        val lines = statement.lines()
+        val totalCharactersInPreviousLines = IntArray(lines.size)
+        for (lineNum in 1 until lines.size) {
+            totalCharactersInPreviousLines[lineNum] = totalCharactersInPreviousLines[lineNum - 1] + lines[lineNum - 1].length + 1
+        }
+
+        val sb = StringBuilder(statement)
+        var offset = 0;
+        sourceLocationMetaForRedaction.sortWith(compareBy<SourceLocationMeta> { it.lineNum }.thenBy { it.charOffset })
+
+        sourceLocationMetaForRedaction.map {
+            val length = it.length.toInt()
+            val start = totalCharactersInPreviousLines[it.lineNum.toInt() - 1] + it.charOffset.toInt() - 1 + offset
+            if (start >= sb.length || start > sb.length - length) {
+                throw IllegalArgumentException(INPUT_AST_STATEMENT_MISMATCH)
+            }
+            sb.replace(start, start + length, maskPattern)
+            offset = offset + maskPattern.length - length
+        }
+
+        return sb.toString()
+    }
+}

--- a/lang/src/org/partiql/lang/errors/ErrorCode.kt
+++ b/lang/src/org/partiql/lang/errors/ErrorCode.kt
@@ -120,6 +120,26 @@ enum class ErrorCode(private val category: ErrorCategory,
         LOC_TOKEN,
         "expected WHEN clause in CASE"),
 
+    PARSE_EXPECTED_WHERE_CLAUSE(
+            ErrorCategory.PARSER,
+            LOC_TOKEN,
+            "expected WHERE clause"),
+
+    PARSE_EXPECTED_CONFLICT_ACTION(
+            ErrorCategory.PARSER,
+            LOC_TOKEN,
+            "expected <conflict action>"),
+
+    PARSE_EXPECTED_RETURNING_CLAUSE(
+            ErrorCategory.PARSER,
+            LOC_TOKEN,
+            "expected <returning mapping>"),
+
+    PARSE_UNSUPPORTED_RETURNING_CLAUSE_SYNTAX(
+            ErrorCategory.PARSER,
+            LOC_TOKEN,
+            "unsupported syntax in RETURNING clause"),
+
     PARSE_UNSUPPORTED_TOKEN(
         ErrorCategory.PARSER,
         LOC_TOKEN,

--- a/lang/src/org/partiql/lang/eval/like/PatternPart.kt
+++ b/lang/src/org/partiql/lang/eval/like/PatternPart.kt
@@ -18,7 +18,6 @@ internal sealed class PatternPart {
         override fun hashCode(): Int {
             return codepoints.contentHashCode()
         }
-
     }
 }
 

--- a/lang/src/org/partiql/lang/eval/visitors/GroupByPathExpressionVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/GroupByPathExpressionVisitorTransform.kt
@@ -107,6 +107,8 @@ class GroupByPathExpressionVisitorTransform(
 
         val having = node.having?.let { currentAndUnshadowedTransformer.transformExprSelect_having(node) }
 
+        val order = node.having?.let { currentAndUnshadowedTransformer.transformExprSelect_order(node) }
+
         val limit = node.limit?.let { unshadowedTransformer.transformExprSelect_limit(node) }
 
         val metas = unshadowedTransformer.transformExprSelect_metas(node)
@@ -120,6 +122,7 @@ class GroupByPathExpressionVisitorTransform(
                 where = where,
                 group = groupBy,
                 having = having,
+                order = order,
                 limit = limit,
                 metas = metas)
         }

--- a/lang/src/org/partiql/lang/eval/visitors/VisitorTransformBase.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/VisitorTransformBase.kt
@@ -28,6 +28,7 @@ abstract class VisitorTransformBase : PartiqlAst.VisitorTransform() {
         val having = transformExprSelect_having(node)
         val setq = transformExprSelect_setq(node)
         val project = transformExprSelect_project(node)
+        val order = node.having?.let { transformExprSelect_order(node) }
         val limit = transformExprSelect_limit(node)
         val metas = transformExprSelect_metas(node)
         return PartiqlAst.build {
@@ -39,6 +40,7 @@ abstract class VisitorTransformBase : PartiqlAst.VisitorTransform() {
                 where = where,
                 group = group,
                 having = having,
+                order = order,
                 limit = limit,
                 metas = metas)
         }
@@ -57,11 +59,17 @@ abstract class VisitorTransformBase : PartiqlAst.VisitorTransform() {
     fun transformDataManipulationEvaluationOrder(node: PartiqlAst.Statement.Dml): PartiqlAst.Statement {
         val from = node.from?.let { transformFromSource(it) }
         val where = node.where?.let { transformStatementDml_where(node) }
-        val dmlOperation = transformDmlOp(node.operation)
+        val dmlOperations = transformDmlOpList(node.operations)
+        val returning = node.returning?.let { transformReturningExpr(it) }
         val metas = transformMetas(node.metas)
 
         return PartiqlAst.build {
-            dml(dmlOperation, from, where, metas)
+            dml(
+                dmlOperations,
+                from,
+                where,
+                returning,
+                metas)
         }
     }
 }

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -259,6 +259,14 @@ internal val DATE_PART_KEYWORDS: Set<String> = DatePart.values()
     "tuple",
     "remove",
     "index",
+    "conflict",
+    "do",
+    "nothing",
+    "returning",
+    "modified",
+    "all",
+    "new",
+    "old",
     "let",
 
     // Ion type names
@@ -425,7 +433,13 @@ internal val DATE_PART_KEYWORDS: Set<String> = DatePart.values()
     listOf("outer", "cross", "join")    to ("outer_cross_join" to KEYWORD),
     listOf("full", "outer",
            "cross", "join")             to ("outer_cross_join" to KEYWORD),
-    listOf("insert", "into")            to ("insert_into" to KEYWORD)
+    listOf("insert", "into")            to ("insert_into" to KEYWORD),
+    listOf("on", "conflict")            to ("on_conflict" to KEYWORD),
+    listOf("do", "nothing")             to ("do_nothing" to KEYWORD),
+    listOf("modified", "old")           to ("modified_old" to KEYWORD),
+    listOf("modified", "new")           to ("modified_new" to KEYWORD),
+    listOf("all", "old")                to ("all_old" to KEYWORD),
+    listOf("all", "new")                to ("all_new" to KEYWORD)
 )
 
 @JvmField internal val MULTI_LEXEME_MIN_LENGTH = MULTI_LEXEME_TOKEN_MAP.keys.map { it.size }.min()!!

--- a/lang/src/org/partiql/lang/syntax/SourceSpan.kt
+++ b/lang/src/org/partiql/lang/syntax/SourceSpan.kt
@@ -1,0 +1,6 @@
+package org.partiql.lang.syntax
+
+/**
+ * Defines the location of a token and its length in bytes.
+ */
+data class SourceSpan(val line: Long, val column: Long, val length: Long)

--- a/lang/src/org/partiql/lang/syntax/SqlLexer.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlLexer.kt
@@ -370,7 +370,7 @@ class SqlLexer(private val ion: IonSystem) : Lexer {
                     }
                 }
 
-                delta(BACKTICK_CHARS, TERMINAL, LITERAL, ION_LITERAL, replacement = REPLACE_NOTHING, delegate = initialState)
+                delta(BACKTICK_CHARS, TERMINAL, TokenType.ION_LITERAL, LexType.ION_LITERAL, replacement = REPLACE_NOTHING, delegate = initialState)
             }
 
             delta(ALL_WHITESPACE_CHARS, START_AND_TERMINAL, null, WHITESPACE)
@@ -425,11 +425,13 @@ class SqlLexer(private val ion: IonSystem) : Lexer {
         val tracker = PositionTracker()
         var parameterCt = 0
         var currPos = tracker.position
+        var tokenCodePointCount = 0L
         var curr: State = INITIAL_STATE
         val buffer = StringBuilder()
 
 
         for (cp in codePoints) {
+            tokenCodePointCount++;
 
             fun errInvalidChar(): Nothing =
                 throw LexerException(errorCode = LEXER_INVALID_CHAR, errorContext = makePropertyBag(repr(cp), tracker))
@@ -515,6 +517,14 @@ class SqlLexer(private val ion: IonSystem) : Lexer {
                                         tokenType = FOR
                                         ion.newSymbol(lower)
                                     }
+                                    lower == "asc" -> {
+                                        tokenType = ASC
+                                        ion.newSymbol(lower)
+                                    }
+                                    lower == "desc" -> {
+                                        tokenType = DESC
+                                        ion.newSymbol(lower)
+                                    }
                                     lower in BOOLEAN_KEYWORDS -> {
                                         // literal boolean
                                         tokenType = LITERAL
@@ -537,7 +547,11 @@ class SqlLexer(private val ion: IonSystem) : Lexer {
                                 catch (e: NumberFormatException) {
                                     errInvalidLiteral(text)
                                 }
-                                ION_LITERAL -> try {
+
+                                else        -> errInvalidLiteral(text)
+                            }
+                            TokenType.ION_LITERAL -> {
+                                try {
                                     // anything wrapped by `` is considered as an ion literal, including invalid
                                     // ion so we need to handle the exception here for proper error reporting
                                     ion.singleValue(text)
@@ -545,19 +559,24 @@ class SqlLexer(private val ion: IonSystem) : Lexer {
                                 catch (e: IonException) {
                                     errInvalidIonLiteral(text, e)
                                 }
-                                else        -> errInvalidLiteral(text)
                             }
                             QUESTION_MARK -> {
                                 ion.newInt(++parameterCt)
                             }
                             else -> ion.newSymbol(text)
                         }.seal()
-                        tokens.addOrMerge(Token(tokenType, ionValue, currPos))
+
+                        tokens.addOrMerge(
+                            Token(
+                                type = tokenType,
+                                value = ionValue,
+                                span = SourceSpan(currPos.line, currPos.column, tokenCodePointCount)))
                     }
 
                     // get ready for next token
                     buffer.setLength(0)
                     currPos = tracker.position
+                    tokenCodePointCount = 0
                 }
             }
             val replacement = next.replacement
@@ -569,7 +588,12 @@ class SqlLexer(private val ion: IonSystem) : Lexer {
             }
 
             // if next state is the EOF marker add it to `tokens`.
-            if (next.stateType == END) tokens.add(Token(TokenType.EOF,ion.newSymbol("EOF"), currPos))
+            if (next.stateType == END) tokens.add(
+                Token(
+                    type = TokenType.EOF,
+                    value = ion.newSymbol("EOF"),
+                    span = SourceSpan(currPos.line, currPos.column, 0)))
+
             curr = next
         }
 
@@ -596,9 +620,10 @@ class SqlLexer(private val ion: IonSystem) : Lexer {
             val lexemeMapping = MULTI_LEXEME_TOKEN_MAP[keywords] ?: continue
 
             // at this point we found the candidate so we need to replace the suffix
-            var newPos = newToken.position
+            var newPos = newToken.span
             for (count in 1..prefixLength) {
-                newPos = removeAt(size - 1).position
+                newPos = removeAt(size - 1).span
+                // TODO: calculate length of multi-lexeme tokens correctly. We use the length of the first token for now
             }
 
             // create our new token

--- a/lang/src/org/partiql/lang/syntax/Token.kt
+++ b/lang/src/org/partiql/lang/syntax/Token.kt
@@ -23,7 +23,7 @@ import org.partiql.lang.syntax.TokenType.*
  */
 data class Token(val type: TokenType,
                  val value: IonValue? = null,
-                 val position: SourcePosition) {
+                 val span: SourceSpan) {
     val text: String?
         get() = value?.stringValue()
 

--- a/lang/src/org/partiql/lang/syntax/TokenType.kt
+++ b/lang/src/org/partiql/lang/syntax/TokenType.kt
@@ -29,6 +29,7 @@ enum class TokenType {
     OPERATOR,
     KEYWORD,
     LITERAL,
+    ION_LITERAL,
     // punctuation
     DOT,
     STAR,
@@ -43,6 +44,8 @@ enum class TokenType {
     BY,
     MISSING,
     NULL,
+    ASC,
+    DESC,
     // function specific
     TRIM_SPECIFICATION,
     DATE_PART,

--- a/lang/src/org/partiql/lang/util/TokenListExtensions.kt
+++ b/lang/src/org/partiql/lang/util/TokenListExtensions.kt
@@ -35,13 +35,13 @@ internal fun List<Token>.onlyEndOfStatement() =
  * Given an error context ([PropertyValueMap]) and a source position ([SourcePosition]) populate the given
  * error context with line and column information found in source position.
  */
-private fun populateLineAndColumn(errorContext: PropertyValueMap, sourcePosition: SourcePosition?): PropertyValueMap {
-    when (sourcePosition) {
+private fun populateLineAndColumn(errorContext: PropertyValueMap, sourceSpan: SourceSpan?): PropertyValueMap {
+    when (sourceSpan) {
         null -> {
             return errorContext
         }
         else -> {
-            val (line, col) = sourcePosition
+            val (line, col) = sourceSpan
             errorContext[Property.LINE_NUMBER] = line
             errorContext[Property.COLUMN_NUMBER] = col
             return errorContext
@@ -53,7 +53,7 @@ internal fun Token?.err(message: String, errorCode: ErrorCode, errorContext: Pro
     when (this) {
         null -> throw ParserException(errorCode = errorCode, errorContext = errorContext)
         else -> {
-            val pvmap = populateLineAndColumn(errorContext, this.position)
+            val pvmap = populateLineAndColumn(errorContext, this.span)
             pvmap[Property.TOKEN_TYPE] = type
             value?.let { pvmap[Property.TOKEN_VALUE] = it }
             throw ParserException(message, errorCode, pvmap)

--- a/lang/test/org/partiql/lang/ast/AstNodeTest.kt
+++ b/lang/test/org/partiql/lang/ast/AstNodeTest.kt
@@ -137,16 +137,16 @@ class AstNodeTest {
             "Select|SelectProjectionPivot|Literal|Literal|FromSourceExpr|Literal"),
         IteratorTestCase(
             "INSERT INTO foo VALUES (1)",
-            "DataManipulation|VariableReference|Seq|Seq|Literal|InsertOp|VariableReference|Seq|Seq|Literal"),
+            "DataManipulation|InsertOp|VariableReference|Seq|Seq|Literal|DmlOpList|InsertOp|VariableReference|Seq|Seq|Literal"),
         IteratorTestCase(
             "UPDATE foo SET x.y = bar WHERE n",
-            "DataManipulation|Assignment|Path|VariableReference|PathComponentExpr|Literal|VariableReference|FromSourceExpr|VariableReference|VariableReference|AssignmentOp|Assignment|Path|VariableReference|PathComponentExpr|Literal|VariableReference"),
+            "DataManipulation|AssignmentOp|Assignment|Path|VariableReference|PathComponentExpr|Literal|VariableReference|FromSourceExpr|VariableReference|VariableReference|DmlOpList|AssignmentOp|Assignment|Path|VariableReference|PathComponentExpr|Literal|VariableReference"),
         IteratorTestCase(
             "FROM x IN Y REMOVE p",
-            "DataManipulation|VariableReference|FromSourceExpr|NAry|VariableReference|VariableReference|RemoveOp|VariableReference"),
+            "DataManipulation|RemoveOp|VariableReference|FromSourceExpr|NAry|VariableReference|VariableReference|DmlOpList|RemoveOp|VariableReference"),
         IteratorTestCase(
             "DELETE FROM foo WHERE bar",
-            "DataManipulation|FromSourceExpr|VariableReference|VariableReference|DeleteOp"),
+            "DataManipulation|DeleteOp|FromSourceExpr|VariableReference|VariableReference|DmlOpList|DeleteOp"),
         IteratorTestCase(
             "CREATE TABLE foo",
             "CreateTable"),
@@ -275,7 +275,7 @@ class AstNodeTest {
         val from = FromSourceExpr(literal("2"), LetVariables())
 
         assertEquals(listOf(projection, from),
-                     Select(SetQuantifier.ALL, projection, from, null, null, null, null, null, emptyMeta).children)
+                     Select(SetQuantifier.ALL, projection, from, null, null, null, null, null, null, emptyMeta).children)
     }
 
     @Test
@@ -286,10 +286,11 @@ class AstNodeTest {
         val where = literal("3")
         val groupBy = GroupBy(GroupingStrategy.FULL, listOf())
         val having = literal("4")
+        val orderBy = OrderBy(listOf())
         val limit = literal("5")
 
-        assertEquals(listOf(projection, from, fromLet, where, groupBy, having, limit),
-                     Select(SetQuantifier.ALL, projection, from, fromLet, where, groupBy, having, limit, emptyMeta).children)
+        assertEquals(listOf(projection, from, fromLet, where, groupBy, having, orderBy, limit),
+                     Select(SetQuantifier.ALL, projection, from, fromLet, where, groupBy, having, orderBy, limit, emptyMeta).children)
     }
 
     @Test

--- a/lang/test/org/partiql/lang/ast/AstSerDeTests.kt
+++ b/lang/test/org/partiql/lang/ast/AstSerDeTests.kt
@@ -25,7 +25,7 @@ import org.junit.*
 class AstSerDeTests : TestBase() {
 
     fun parametersForSerDeMetas() = listOf(
-        Literal(ion.newInt(1), metaContainerOf(SourceLocationMeta(1, 1)))
+        Literal(ion.newInt(1), metaContainerOf(SourceLocationMeta(1, 1, 1)))
     )
 
     @Test

--- a/lang/test/org/partiql/lang/ast/IsIonLiteralMetaTest.kt
+++ b/lang/test/org/partiql/lang/ast/IsIonLiteralMetaTest.kt
@@ -1,3 +1,5 @@
+package org.partiql.lang.ast
+
 /*
  * Copyright 2019 Amazon.com, Inc. or its affiliates.  All rights reserved.
  *
@@ -12,10 +14,18 @@
  *  language governing permissions and limitations under the License.
  */
 
-package org.partiql.lang.syntax
+import com.amazon.ion.system.*
+import org.junit.*
+import org.partiql.lang.syntax.SqlParser
 
-/** Simple source line/column value. */
-data class SourcePosition(val line: Long, val column: Long) {
-    override fun toString(): String = "line $line, column $column"
+class IsIonLiteralMetaTest {
+
+    @Test
+    fun testIonLiteralMetaPreserved() {
+        val ion = IonSystemBuilder.standard().build()
+        val ionLiteral = SqlParser(ion).parseExprNode("`1.0`")
+        Assert.assertTrue(ionLiteral.metas.hasMeta(IsIonLiteralMeta.TAG))
+        val roundTrippedIonLiteral = ionLiteral.toAstStatement().toExprNode(ion)
+        Assert.assertTrue(roundTrippedIonLiteral.metas.hasMeta(IsIonLiteralMeta.TAG))
+    }
 }
-

--- a/lang/test/org/partiql/lang/ast/SourceLocationMetaTest.kt
+++ b/lang/test/org/partiql/lang/ast/SourceLocationMetaTest.kt
@@ -24,8 +24,8 @@ class SourceLocationMetaTest {
     fun test1() {
         val ion = IonSystemBuilder.standard().build()
 
-        val sl = SourceLocationMeta(1, 2)
-        val expected = ion.singleValue("{ line_num: 1, char_offset: 2 }")
+        val sl = SourceLocationMeta(1, 2, 3)
+        val expected = ion.singleValue("{ line_num: 1, char_offset: 2, length: 3 }")
 
         val dg = ion.newDatagram()
         val writer = ion.newWriter(dg)

--- a/lang/test/org/partiql/lang/ast/passes/AstWalkerTests.kt
+++ b/lang/test/org/partiql/lang/ast/passes/AstWalkerTests.kt
@@ -163,7 +163,11 @@ class AstWalkerTests {
             "?",
             "Parameter|"),
 
-        WalkerTestCase("MISSING", "LiteralMissing|")
+        WalkerTestCase("MISSING", "LiteralMissing|"),
+
+        WalkerTestCase("SELECT a FROM tb WHERE hk = 1 ORDER BY rk DESC", "Select|SelectProjectionList|SelectListItemExpr|VariableReference|FromSourceExpr|VariableReference|NAry|VariableReference|Literal|VariableReference|"),
+        WalkerTestCase("INSERT INTO foo VALUE 1 ON CONFLICT WHERE bar DO NOTHING", "DataManipulation|VariableReference|Literal|VariableReference|")
+
     )
 
 }

--- a/lang/test/org/partiql/lang/ast/passes/StatementRedactorTest.kt
+++ b/lang/test/org/partiql/lang/ast/passes/StatementRedactorTest.kt
@@ -1,0 +1,337 @@
+package org.partiql.lang.ast.passes
+
+import com.amazon.ion.IonString
+import junitparams.Parameters
+import org.junit.Test
+import org.partiql.lang.ast.ExprNode
+import org.partiql.lang.ast.Literal
+import org.partiql.lang.ast.Path
+import org.partiql.lang.ast.VariableReference
+import org.partiql.lang.syntax.SqlParserTestBase
+
+class StatementRedactorTest : SqlParserTestBase() {
+
+    /**
+     * Here is an example of user defined functions (UDF) with following signature:
+     *  begins_with(Path: ExprNode, Value: Literal)
+     *  contains(Path: ExprNode, Value: Literal)
+     *
+     * Callers are responsible for providing implementation of the UDF validation
+     * There are two major components:
+     *     1. Which arguments are needed for [SafeFieldName] validation
+     *     2. Which arguments are returned for redaction
+     */
+    private fun validateFuncContainsAndBeginsWith(args : List<ExprNode> ) : List<ExprNode> {
+        val path = args[1]
+        val value = args[2]
+        val argsToRedact = mutableListOf<ExprNode>()
+
+        if (path !is VariableReference && path !is Path) {
+            throw IllegalArgumentException("Unexpected type of argument path")
+        }
+        if (value !is Literal || value.ionValue !is IonString) {
+            throw IllegalArgumentException("Unexpected type of argument value")
+        }
+        if (!validateSafeFieldNames(path)) {
+            argsToRedact.add(value)
+        }
+
+        return argsToRedact
+    }
+
+    /**
+     * Return true if the parsed results of input [statement] is the same as input [ast]
+     */
+    private fun validateInputAstParsedFromInputStatement(statement: String, ast: ExprNode): Boolean {
+        return parser.parseExprNode(statement) == ast
+    }
+
+    data class RedactionTestCase(val originalStatement: String, val redactedStatement: String)
+
+    @Test
+    @Parameters
+    fun testRedactOnPositiveCases(tc: RedactionTestCase) {
+        val testSafeFieldNames = setOf("hk", "rk")
+        val testConfig = mapOf("contains" to ::validateFuncContainsAndBeginsWith, "begins_with" to ::validateFuncContainsAndBeginsWith)
+
+        val redactedStatement = redact(tc.originalStatement, testSafeFieldNames, testConfig)
+
+        assertEquals(tc.redactedStatement, redactedStatement)
+    }
+
+    fun parametersForTestRedactOnPositiveCases() = listOf(
+            // Typed
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk IS MISSING AND attr IS MISSING",
+                    "SELECT * FROM tb WHERE hk IS MISSING AND attr IS ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk IS NOT MISSING AND attr IS NOT MISSING",
+                    "SELECT * FROM tb WHERE hk IS NOT MISSING AND attr IS NOT ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS MISSING",
+                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS NUMERIC",
+                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS NOT NUMERIC",
+                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS STRING",
+                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS NOT STRING",
+                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS TUPLE",
+                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS NOT TUPLE",
+                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS STRUCT",
+                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS NOT STRUCT",
+                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS BOOLEAN",
+                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS NOT BOOLEAN",
+                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS LIST",
+                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS NOT LIST",
+                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS BLOB",
+                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS NOT BLOB",
+                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS NULL",
+                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE attr IS NOT NULL",
+                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+            // Call and Nested Call
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 1 AND begins_with(Attr, 'foo') AND begins_with(hk, 'foo')",
+                    "SELECT * FROM tb WHERE hk = 1 AND begins_with(Attr, ***(Redacted)) AND begins_with(hk, 'foo')"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 1 AND contains(Attr, 'foo') AND contains(hk, 'foo')",
+                    "SELECT * FROM tb WHERE hk = 1 AND contains(Attr, ***(Redacted)) AND contains(hk, 'foo')"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 1 AND arbitrary_udf(Attr, 'foo', arbitrary_udf(hk, 'foo'))",
+                    "SELECT * FROM tb WHERE hk = 1 AND arbitrary_udf(Attr, ***(Redacted), arbitrary_udf(hk, ***(Redacted)))"),
+            // Unary operator
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk IS MISSING AND attr = - 'literal'",
+                    "SELECT * FROM tb WHERE hk IS MISSING AND attr = - ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk IS MISSING AND attr = -+ -+ -+ non_literal",
+                    "SELECT * FROM tb WHERE hk IS MISSING AND attr = -+ -+ -+ non_literal"),
+            // Arithmetic operators are not redacted
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = 012-34-5678",
+                    "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = ***(Redacted)-***(Redacted)-***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = 012*34*5678",
+                    "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = ***(Redacted)****(Redacted)****(Redacted)"),
+            // In operator
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk IN (1, 3, 5) AND attr IN (2, 4, 6)",
+                    "SELECT * FROM tb WHERE hk IN (1, 3, 5) AND attr IN (***(Redacted), ***(Redacted), ***(Redacted))"),
+            // Between operator
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk BETWEEN 1 AND 2 AND attr BETWEEN 1 AND 2",
+                    "SELECT * FROM tb WHERE hk BETWEEN 1 AND 2 AND attr BETWEEN ***(Redacted) AND ***(Redacted)"),
+            // Comparison operators
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE (hk <> 1 or hk < 1 or hk <= 1 or hk > 1 or hk >=1 )",
+                    "SELECT * FROM tb WHERE (hk <> 1 or hk < 1 or hk <= 1 or hk > 1 or hk >=1 )"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 'a' and (attr1 <> 1 or attr2 < 1 or attr3 <= 1 or attr4 > 1 or attr5 >=1 )",
+                    "SELECT * FROM tb WHERE hk = 'a' and (attr1 <> ***(Redacted) or attr2 < ***(Redacted) or attr3 <= ***(Redacted) or attr4 > ***(Redacted) or attr5 >=***(Redacted) )"),
+            // String
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 'a' and attr = 'a'",
+                    "SELECT * FROM tb WHERE hk = 'a' and attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = '2016-02-15' and attr = '2016-02-15'",
+                    "SELECT * FROM tb WHERE hk = '2016-02-15' and attr = ***(Redacted)"),
+            // TODO: Fix metadata length for unicode
+//            RedactionTestCase(
+//                    "SELECT * FROM tb WHERE hk = '\uD83D\uDE01\uD83D\uDE1E\uD83D\uDE38\uD83D\uDE38' and attr = '\uD83D\uDE01\uD83D\uDE1E\uD83D\uDE38\uD83D\uDE38'",
+//                    "SELECT * FROM tb WHERE hk = '\uD83D\uDE01\uD83D\uDE1E\uD83D\uDE38\uD83D\uDE38' and attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = '話家身圧費谷料村能計税金' and attr = '話家身圧費谷料村能計税金'",
+                    "SELECT * FROM tb WHERE hk = '話家身圧費谷料村能計税金' and attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 'abcde\\u0832fgh' and attr = 'abcde\\u0832fgh'",
+                    "SELECT * FROM tb WHERE hk = 'abcde\\u0832fgh' and attr = ***(Redacted)"),
+            // Int
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE NOT hk = 1 AND NOT attr = 1",
+                    "SELECT * FROM tb WHERE NOT hk = 1 AND NOT attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE NOT hk = 0 AND NOT attr = 0",
+                    "SELECT * FROM tb WHERE NOT hk = 0 AND NOT attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = -0 AND attr = -0",
+                    "SELECT * FROM tb WHERE hk = -0 AND attr = -***(Redacted)"),
+            // Decimal
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 0.123 AND attr = 0.123",
+                    "SELECT * FROM tb WHERE hk = 0.123 AND attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = -0.123 AND attr = -0.123",
+                    "SELECT * FROM tb WHERE hk = -0.123 AND attr = -***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 0.000 AND attr = 0.000",
+                    "SELECT * FROM tb WHERE hk = 0.000 AND attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = -0.000 AND attr = -0.000",
+                    "SELECT * FROM tb WHERE hk = -0.000 AND attr = -***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 0.12e-4 AND attr = 0.12e-4",
+                    "SELECT * FROM tb WHERE hk = 0.12e-4 AND attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = -0.01200e5 AND attr = -0.01200e5",
+                    "SELECT * FROM tb WHERE hk = -0.01200e5 AND attr = -***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 0. AND attr = 0.",
+                    "SELECT * FROM tb WHERE hk = 0. AND attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 0E0 AND attr = 0E0",
+                    "SELECT * FROM tb WHERE hk = 0E0 AND attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 0E-0 AND attr = 0E-0",
+                    "SELECT * FROM tb WHERE hk = 0E-0 AND attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 0.0E1 AND attr = 0.0E1",
+                    "SELECT * FROM tb WHERE hk = 0.0E1 AND attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = -0E0 AND attr = -0E0",
+                    "SELECT * FROM tb WHERE hk = -0E0 AND attr = -***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = -0. AND attr = -0.",
+                    "SELECT * FROM tb WHERE hk = -0. AND attr = -***(Redacted)"),
+            // Boolean on non-key attr
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = TRUE AND attr = TRUE",
+                    "SELECT * FROM tb WHERE hk = TRUE AND attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = FALSE AND attr = FALSE",
+                    "SELECT * FROM tb WHERE hk = FALSE AND attr = ***(Redacted)"),
+            // NULL on non-key attr
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = NULL AND attr = NULL",
+                    "SELECT * FROM tb WHERE hk = NULL AND attr = ***(Redacted)"),
+            // Map on non-key attr
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 'a' AND attr = { 'hk' : 'value' }",
+                    "SELECT * FROM tb WHERE hk = 'a' AND attr = { ***(Redacted) : ***(Redacted) }"),
+            // List
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 'a' AND attr = [ 'value1', 'value2' ]",
+                    "SELECT * FROM tb WHERE hk = 'a' AND attr = [ ***(Redacted), ***(Redacted) ]"),
+            // Set
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 'a' AND attr = << 'value1', 'value2' >>",
+                    "SELECT * FROM tb WHERE hk = 'a' AND attr = << ***(Redacted), ***(Redacted) >>"),
+            // Space and new line preserved
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk =1    \n    AND attr =1",
+                    "SELECT * FROM tb WHERE hk =1    \n" +
+                            "    AND attr =***(Redacted)"),
+            RedactionTestCase(
+                    "SELECT * \n FROM tb \n WHERE hk =1 \n\r AND attr = 'asdfas \n\r df \n\r sa' AND hk = 2",
+                    "SELECT * \n FROM tb \n WHERE hk =1 \n\r AND attr = ***(Redacted) AND hk = 2"),
+            // Multiple Args cases
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 1 and rk = '1'",
+                    "SELECT * FROM tb WHERE hk = 1 and rk = '1'"),
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 'a' and (rk = 1 or (rk = 2 and attr = '1'))",
+                    "SELECT * FROM tb WHERE hk = 'a' and (rk = 1 or (rk = 2 and attr = ***(Redacted)))"),
+            // Nested Map
+            RedactionTestCase(
+                    "SELECT * FROM tb WHERE hk = 'a' AND attr = { 'name' : { 'name' : 'value' } }",
+                    "SELECT * FROM tb WHERE hk = 'a' AND attr = { ***(Redacted) : { ***(Redacted) : ***(Redacted) } }"),
+            // Insert Into
+            RedactionTestCase(
+                    "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': 'b' }",
+                    "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': ***(Redacted) }"),
+            RedactionTestCase(
+                    "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}",
+                    "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': { ***(Redacted): ***(Redacted) }}"),
+            RedactionTestCase(
+                    "INSERT INTO tb VALUE `{ 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}`",
+                    "INSERT INTO tb VALUE ***(Redacted)"),
+            RedactionTestCase(
+                    "INSERT INTO tb VALUE HK",
+                    "INSERT INTO tb VALUE HK"),
+            RedactionTestCase(
+                    "INSERT INTO tb VALUE hk",
+                    "INSERT INTO tb VALUE hk"),
+            RedactionTestCase(
+                    "INSERT INTO tb VALUE hk = 'a' and attr = 'a'",
+                    "INSERT INTO tb VALUE hk = 'a' and attr = ***(Redacted)"),
+            RedactionTestCase(
+                    "INSERT INTO tb VALUE MISSING",
+                    "INSERT INTO tb VALUE MISSING"),
+            RedactionTestCase(
+                    "INSERT INTO tb VALUE << 'value1', 'value2' >>",
+                    "INSERT INTO tb VALUE << ***(Redacted), ***(Redacted) >>"),
+            // Update Assignment
+            RedactionTestCase(
+                    "update nonExistentTable set foo = 'bar' where attr1='testValue'",
+                    "update nonExistentTable set foo = ***(Redacted) where attr1=***(Redacted)"),
+            RedactionTestCase(
+                    "UPDATE tb SET hk = 'b', rk = 2, attr = 2 WHERE hk = 'a' and rk = 1 and attr = 1",
+                    "UPDATE tb SET hk = 'b', rk = 2, attr = ***(Redacted) WHERE hk = 'a' and rk = 1 and attr = ***(Redacted)"),
+            // Delete
+            RedactionTestCase(
+                    "DELETE FROM tb WHERE hk = 'a' AND attr = 'b'",
+                    "DELETE FROM tb WHERE hk = 'a' AND attr = ***(Redacted)"),
+            // Path
+            RedactionTestCase(
+                    "SELECT ?, tb.a from tb where tb.hk = ? and tb.rk = 'eggs' and tb[*].bar = ? or tb[*].rk = 'foo'",
+                    "SELECT ?, tb.a from tb where tb.hk = ? and tb.rk = 'eggs' and tb[*].bar = ? or tb[*].rk = 'foo'")
+    )
+
+    @Test
+    fun testDefaultArguments() {
+        val originalStatement = "SELECT * FROM tb WHERE hk = 1 AND begins_with(Attr, 'foo', bar)"
+        val expectedRedactedStatement = "SELECT * FROM tb WHERE hk = ***(Redacted) AND begins_with(Attr, ***(Redacted), bar)"
+        val redactedStatement1 = redact(originalStatement, super.parser.parseExprNode(originalStatement))
+        assertEquals(expectedRedactedStatement, redactedStatement1)
+
+        val redactedStatement2 = redact(originalStatement, super.parser.parseExprNode(originalStatement), providedSafeFieldNames = emptySet())
+        assertEquals(expectedRedactedStatement, redactedStatement2)
+
+        val redactedStatement3 = redact(originalStatement, super.parser.parseExprNode(originalStatement), userDefinedFunctionRedactionConfig = emptyMap())
+        assertEquals(expectedRedactedStatement, redactedStatement3)
+    }
+
+    @Test
+    fun testInputStatementAstMismatch() {
+        val inputStatement = "SELECT * FROM tb WHERE nonKey = 'a'"
+        val inputAst = super.parser.parseExprNode("SELECT * FROM tb WHERE hk = 1 AND nonKey = 'a'")
+        assertFalse(validateInputAstParsedFromInputStatement(inputStatement, inputAst))
+
+        try {
+            redact(inputStatement, inputAst)
+            fail("Expected IllegalArgumentException but there was no Exception")
+        } catch (e: IllegalArgumentException) {
+            assertEquals(INPUT_AST_STATEMENT_MISMATCH, e.message)
+        } catch (e: Exception) {
+            fail("Expected EvaluationException but a different exception was thrown \n\t  $e")
+        }
+    }
+}

--- a/lang/test/org/partiql/lang/eval/EvaluatorTestBase.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTestBase.kt
@@ -74,7 +74,8 @@ abstract class EvaluatorTestBase : TestBase() {
         fun serializeRoundTripEvalAndAssert(astVersion: AstVersion) {
             val sexpAST = AstSerializer.serialize(originalExprNode, astVersion, ion)
             val deserializedExprNode = deserializer.deserialize(sexpAST, astVersion)
-            assertEquals(originalExprNode, deserializedExprNode, "ExprNode deserialized from s-exp $astVersion AST must match the ExprNode returned by the parser")
+            assertEquals(MetaStrippingRewriter.stripMetas(originalExprNode), MetaStrippingRewriter.stripMetas(deserializedExprNode),
+                    "ExprNode deserialized from s-exp $astVersion AST must match the ExprNode returned by the parser")
 
             // This step should only fail if there is a bug in the equality check that causes two
             // dissimilar ASTs to be considered equal.

--- a/lang/test/org/partiql/lang/eval/builtins/FromUnixTimeFunctionTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/FromUnixTimeFunctionTest.kt
@@ -44,7 +44,7 @@ class FromUnixTimeFunctionTest : EvaluatorTestBase() {
                   Property.EXPECTED_ARITY_MAX to 1))
 
 
-    class FromUnixTimeTests : ArgumentsProviderBase() {
+    class FromUnixTimeCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
             // negative unix epochs output timestamp before last epoch
             FromUnixTimeTestCase("from_unixtime(-1)", "1969-12-31T23:59:59-00:00"),
@@ -59,6 +59,6 @@ class FromUnixTimeFunctionTest : EvaluatorTestBase() {
         )
     }
     @ParameterizedTest
-    @ArgumentsSource(FromUnixTimeTests::class)
+    @ArgumentsSource(FromUnixTimeCases::class)
     fun runNoArgTests(tc: FromUnixTimeTestCase) = assertEval(tc.unixTimestamp, tc.expected)
 }

--- a/lang/test/org/partiql/lang/eval/builtins/UnixTimestampFunctionTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/UnixTimestampFunctionTest.kt
@@ -37,7 +37,7 @@ class UnixTimestampFunctionTest : EvaluatorTestBase() {
                   Property.EXPECTED_ARITY_MAX to 1))
 
 
-    class NoArgsTests : ArgumentsProviderBase() {
+    class NoArgsCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
             // unix_timestamp no args, now = 0
             UnixTimestampNoArgTestCase(numMillis = 0, expected = "0"),
@@ -52,7 +52,7 @@ class UnixTimestampFunctionTest : EvaluatorTestBase() {
         )
     }
     @ParameterizedTest
-    @ArgumentsSource(NoArgsTests::class)
+    @ArgumentsSource(NoArgsCases::class)
     fun runNoArgTests(tc: UnixTimestampNoArgTestCase) =
         assertEval(
             "unix_timestamp()",
@@ -60,7 +60,7 @@ class UnixTimestampFunctionTest : EvaluatorTestBase() {
             session = EvaluationSession.build { now(Timestamp.forMillis(tc.numMillis, 0)) })
 
 
-    class OneArgTests : ArgumentsProviderBase() {
+    class OneArgCases : ArgumentsProviderBase() {
         private val epoch2020 = "1577836800"
         private val epoch2020Decimal = "1577836800."
 
@@ -85,6 +85,6 @@ class UnixTimestampFunctionTest : EvaluatorTestBase() {
         )
     }
     @ParameterizedTest
-    @ArgumentsSource(OneArgTests::class)
+    @ArgumentsSource(OneArgCases::class)
     fun runOneArgTests(tc: UnixTimestampOneArgTestCase) = assertEval(tc.timestamp, tc.expected)
 }

--- a/lang/test/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransformTests.kt
@@ -82,7 +82,7 @@ class AggregateSupportVisitorTransformTests : VisitorTransformTestBase() {
         }
     }
 
-    class NonSubqueryTests : ArgumentsProviderBase() {
+    class NonSubqueryCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
             // one aggregate transform
             AggSupportTestCase(
@@ -112,7 +112,7 @@ class AggregateSupportVisitorTransformTests : VisitorTransformTestBase() {
     }
 
     @ParameterizedTest
-    @ArgumentsSource(NonSubqueryTests::class)
+    @ArgumentsSource(NonSubqueryCases::class)
     fun testNonSubquery(tc: AggSupportTestCase) {
         val select = tc.query.parseAndTransformQuery()
 

--- a/lang/test/org/partiql/lang/eval/visitors/VisitorTransformTestBase.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/VisitorTransformTestBase.kt
@@ -14,10 +14,10 @@
 
 package org.partiql.lang.eval.visitors
 
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.partiql.lang.ast.toAstStatement
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.SqlParserTestBase
+import org.junit.jupiter.api.fail
 
 /** Provides some basic functionality for parameterized testing implementation of [PartiqlAst.VisitorTransform]. */
 abstract class VisitorTransformTestBase : SqlParserTestBase() {
@@ -67,5 +67,13 @@ abstract class VisitorTransformTestBase : SqlParserTestBase() {
         }
 
         assertEquals("The expected AST must match the transformed AST", expectedAst, actualExprNode)
+    }
+
+    private fun <T> assertDoesNotThrow(message: String, block: () -> T): T {
+        try {
+            return block()
+        } catch (e: Throwable) {
+            fail("Expected block to not throw but it threw: $message", e)
+        }
     }
 }

--- a/lang/test/org/partiql/lang/syntax/SqlLexerTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlLexerTest.kt
@@ -22,12 +22,13 @@ import java.util.*
 class SqlLexerTest : TestBase() {
     val lexer = SqlLexer(ion)
 
-    fun token(type: TokenType, lit: String?, line: Long, column: Long): Token {
+    // TODO: remove default value on [length] and specify the correct value for all invocations of this function
+    fun token(type: TokenType, lit: String?, line: Long, column: Long, length: Long): Token {
         val value = when (lit) {
             null -> null
             else -> ion.singleValue(lit)
         }
-        return Token(type, value, SourcePosition(line, column))
+        return Token(type, value, SourceSpan(line, column, length))
     }
 
     fun tokenize(text: String): Pair<Token, List<Token>> {
@@ -35,157 +36,161 @@ class SqlLexerTest : TestBase() {
         return Pair(tokens[tokens.size - 1], tokens.dropLast(1))
     }
 
-    fun assertTokens(text: String, vararg tokens: Token) {
-        val expected = listOf(*tokens)
-        val (eofToken, actual) = tokenize(text)
+    fun assertTokens(text: String, vararg expectedTokens: Token) {
+        val expected = listOf(*expectedTokens)
+        val (eofToken, actualTokens) = tokenize(text)
 
-        assertEquals(expected, actual)
+        assertEquals("Expected and actualTokens number of tokens must match", expected.size, actualTokens.size)
+        expectedTokens.zip(actualTokens).forEachIndexed { idx, (expected, actual) ->
+            assertEquals("Token at position $idx must match", expected, actual)
+        }
         assertEquals(TokenType.EOF, eofToken.type)
     }
 
     @Test
     fun punctuation() = assertTokens(
         "()[]{}:,.*<<>>;",
-        token(LEFT_PAREN, "'('", 1, 1),
-        token(RIGHT_PAREN, "')'", 1, 2),
-        token(LEFT_BRACKET, "'['", 1, 3),
-        token(RIGHT_BRACKET, "']'", 1, 4),
-        token(LEFT_CURLY, "'{'", 1, 5),
-        token(RIGHT_CURLY, "'}'", 1, 6),
-        token(COLON, "':'", 1, 7),
-        token(COMMA, "','", 1, 8),
-        token(DOT, "'.'", 1, 9),
-        token(STAR, "'*'", 1, 10),
-        token(LEFT_DOUBLE_ANGLE_BRACKET, "'<<'", 1, 11),
-        token(RIGHT_DOUBLE_ANGLE_BRACKET, "'>>'", 1, 13),
-        token(SEMICOLON, "';'", 1, 15)
+        token(LEFT_PAREN, "'('", 1, 1, 1),
+        token(RIGHT_PAREN, "')'", 1, 2, 1),
+        token(LEFT_BRACKET, "'['", 1, 3, 1),
+        token(RIGHT_BRACKET, "']'", 1, 4, 1),
+        token(LEFT_CURLY, "'{'", 1, 5, 1),
+        token(RIGHT_CURLY, "'}'", 1, 6, 1),
+        token(COLON, "':'", 1, 7, 1),
+        token(COMMA, "','", 1, 8, 1),
+        token(DOT, "'.'", 1, 9, 1),
+        token(STAR, "'*'", 1, 10, 1),
+        token(LEFT_DOUBLE_ANGLE_BRACKET, "'<<'", 1, 11, 2),
+        token(RIGHT_DOUBLE_ANGLE_BRACKET, "'>>'", 1, 13, 2),
+        token(SEMICOLON, "';'", 1, 15, 1)
     )
 
     @Test
     fun keywordsThatHaveTheirOwnTokenTypes() = assertTokens(
         "AS AT FOR",
-            token(AS, "as", 1, 1),
-            token(AT, "at", 1, 4),
-            token(FOR, "for", 1, 7)
+            token(AS, "as", 1, 1, 2),
+            token(AT, "at", 1, 4, 2),
+            token(FOR, "for", 1, 7, 3)
     )
 
     @Test
     fun whitespaceAndIdentifiers() = assertTokens(
         "ab\r\n_bc_  \r\r \$cd\$\n\r\tde1",
-        token(IDENTIFIER, "ab", 1, 1),
-        token(IDENTIFIER, "_bc_", 2, 1),
-        token(IDENTIFIER, "\$cd\$", 4, 2),
-        token(IDENTIFIER, "de1", 6, 2)
+        token(IDENTIFIER, "ab", 1, 1, 2),
+        token(IDENTIFIER, "_bc_", 2, 1, 4),
+        token(IDENTIFIER, "\$cd\$", 4, 2, 4),
+        token(IDENTIFIER, "de1", 6, 2, 3)
     )
+
     @Test
     fun whitespaceAndQuotedIdentifiers() = assertTokens(
         "\"ab\"\r\n\"_bc_\"  \r\r \"\$cd\$\"\n\r\t\"de1\"",
-        token(QUOTED_IDENTIFIER, "ab", 1, 1),
-        token(QUOTED_IDENTIFIER, "_bc_", 2, 1),
-        token(QUOTED_IDENTIFIER, "\$cd\$", 4, 2),
-        token(QUOTED_IDENTIFIER, "de1", 6, 2)
+        token(QUOTED_IDENTIFIER, "ab", 1, 1, 4),
+        token(QUOTED_IDENTIFIER, "_bc_", 2, 1, 6),
+        token(QUOTED_IDENTIFIER, "\$cd\$", 4, 2, 6),
+        token(QUOTED_IDENTIFIER, "de1", 6, 2, 5)
     )
 
     @Test
     fun inlineCommentAtEnd() = assertTokens(
         "ab\n--Ignore Me",
-        token(IDENTIFIER, "ab", 1, 1)
+        token(IDENTIFIER, "ab", 1, 1, 2)
     )
 
     @Test
     fun inlineCommentAtEndNoContent() = assertTokens(
         "ab--",
-        token(IDENTIFIER, "ab", 1, 1)
+        token(IDENTIFIER, "ab", 1, 1, 2)
     )
 
     @Test
     fun blockCommentAtStart() = assertTokens(
         "/*Ignore Me*/ab",
-        token(IDENTIFIER, "ab", 1, 14)
+        token(IDENTIFIER, "ab", 1, 14, 2)
     )
 
     @Test
     fun blockCommentAtEnd() = assertTokens(
         "ab\n/*Ignore Me*/",
-        token(IDENTIFIER, "ab", 1, 1)
+        token(IDENTIFIER, "ab", 1, 1, 2)
     )
 
     @Test
     fun booleans() = assertTokens(
         "true false truefalse",
-        token(LITERAL, "true", 1, 1),
-        token(LITERAL, "false", 1, 6),
-        token(IDENTIFIER, "truefalse", 1, 12)
+        token(LITERAL, "true", 1, 1, 4),
+        token(LITERAL, "false", 1, 6, 5),
+        token(IDENTIFIER, "truefalse", 1, 12, 9)
     )
 
     @Test
     fun nullAndMissing() = assertTokens(
         "null Null MISSING `null`",
-        token(NULL, "null", 1, 1),
-        token(NULL, "null", 1, 6),
-        token(MISSING, "null", 1, 11),
-        token(LITERAL, "null", 1, 19)
+        token(NULL, "null", 1, 1, 4),
+        token(NULL, "null", 1, 6, 4),
+        token(MISSING, "null", 1, 11, 7),
+        token(ION_LITERAL, "null", 1, 19, 6)
     )
 
     @Test
     fun numbers() = assertTokens(
         "500 600. 0.1 . .1 0000 0.00e0 1e+1",
-        token(LITERAL, "500", 1, 1),
-        token(LITERAL, "600d0", 1, 5),
-        token(LITERAL, "1d-1", 1, 10),
-        token(DOT, "'.'", 1, 14),
-        token(LITERAL, "1d-1", 1, 16),
-        token(LITERAL, "0", 1, 19),
-        token(LITERAL, "0d-2", 1, 24),
-        token(LITERAL, "1d1", 1, 31)
+        token(LITERAL, "500", 1, 1, 3),
+        token(LITERAL, "600d0", 1, 5, 4),
+        token(LITERAL, "1d-1", 1, 10, 3),
+        token(DOT, "'.'", 1, 14, 1),
+        token(LITERAL, "1d-1", 1, 16, 2),
+        token(LITERAL, "0", 1, 19, 4),
+        token(LITERAL, "0d-2", 1, 24, 6),
+        token(LITERAL, "1d1", 1, 31, 4)
     )
 
     @Test
     fun signedNumbers() = assertTokens(
         "+500 -600. -0.1 . +.1 -0000 +0.00e0 -+-1e+1",
-        token(OPERATOR, "'+'", 1, 1),
-        token(LITERAL, "500", 1, 2),
-        token(OPERATOR, "'-'", 1, 6),
-        token(LITERAL, "600d0", 1, 7),
-        token(OPERATOR, "'-'", 1, 12),
-        token(LITERAL, "1d-1", 1, 13),
-        token(DOT, "'.'", 1, 17),
-        token(OPERATOR, "'+'", 1, 19),
-        token(LITERAL, "1d-1", 1, 20),
-        token(OPERATOR, "'-'", 1, 23),
-        token(LITERAL, "0", 1, 24),
-        token(OPERATOR, "'+'", 1, 29),
-        token(LITERAL, "0d-2", 1, 30),
-        token(OPERATOR, "'-'", 1, 37),
-        token(OPERATOR, "'+'", 1, 38),
-        token(OPERATOR, "'-'", 1, 39),
-        token(LITERAL, "1d1", 1, 40)
+        token(OPERATOR, "'+'", 1, 1, 1),
+        token(LITERAL, "500", 1, 2, 3),
+        token(OPERATOR, "'-'", 1, 6, 1),
+        token(LITERAL, "600d0", 1, 7, 4),
+        token(OPERATOR, "'-'", 1, 12, 1),
+        token(LITERAL, "1d-1", 1, 13, 3),
+        token(DOT, "'.'", 1, 17, 1),
+        token(OPERATOR, "'+'", 1, 19, 1),
+        token(LITERAL, "1d-1", 1, 20, 2),
+        token(OPERATOR, "'-'", 1, 23, 1),
+        token(LITERAL, "0", 1, 24, 4),
+        token(OPERATOR, "'+'", 1, 29, 1),
+        token(LITERAL, "0d-2", 1, 30, 6),
+        token(OPERATOR, "'-'", 1, 37, 1),
+        token(OPERATOR, "'+'", 1, 38, 1),
+        token(OPERATOR, "'-'", 1, 39, 1),
+        token(LITERAL, "1d1", 1, 40, 4)
     )
 
     @Test
     fun quotedIon() = assertTokens(
         "`1e0` `{a:5}` `/*`*/\"`\"` `//`\n'''`'''` `{{ +AB//A== }}` `{{ \"not a comment //\" }}`",
-        token(LITERAL, "1e0", 1, 1),
-        token(LITERAL, "{a:5}", 1, 7),
-        token(LITERAL, "\"`\"", 1, 15),
-        token(LITERAL, "\"`\"", 1, 26),
-        token(LITERAL, "{{ +AB//A== }}", 2, 10),
-        token(LITERAL, "{{ \"not a comment //\" }}", 2, 27)
+        token(ION_LITERAL, "1e0", 1, 1, 5),
+        token(ION_LITERAL, "{a:5}", 1, 7, 7),
+        token(ION_LITERAL, "\"`\"", 1, 15, 10),
+        token(ION_LITERAL, "\"`\"", 1, 26, 13),
+        token(ION_LITERAL, "{{ +AB//A== }}", 2, 10, 16),
+        token(ION_LITERAL, "{{ \"not a comment //\" }}", 2, 27, 26)
     )
 
 
     @Test
     fun quotedStrings() = assertTokens(
         "'1e0' '{''a'':5}'",
-        token(LITERAL, "\"1e0\"", 1, 1),
-        token(LITERAL, "\"{'a':5}\"", 1, 7)
+        token(LITERAL, "\"1e0\"", 1, 1, 5),
+        token(LITERAL, "\"{'a':5}\"", 1, 7, 11)
     )
 
     @Test
     fun quotedIdentifiers() = assertTokens(
         "\"1e0\" \"{\"\"a\"\":5}\"",
-        token(QUOTED_IDENTIFIER, "'1e0'", 1, 1),
-        token(QUOTED_IDENTIFIER, "'{\"a\":5}'", 1, 7)
+        token(QUOTED_IDENTIFIER, "'1e0'", 1, 1, 5),
+        token(QUOTED_IDENTIFIER, "'{\"a\":5}'", 1, 7, 11)
     )
 
     @Test
@@ -199,11 +204,11 @@ class SqlLexerTest : TestBase() {
                 in KEYWORDS -> KEYWORD
                 else -> OPERATOR
             }
-            expected.add(token(type, "'$op'", 1, buf.length + 1L))
+            expected.add(token(type, "'$op'", 1, buf.length + 1L, op.length.toLong()))
             buf.append(op)
             // make sure we have a token between things to avoid hitting multi-lexeme
             // tokens by mistake
-            expected.add(token(LITERAL, "1", 1, buf.length + 2L))
+            expected.add(token(LITERAL, "1", 1, buf.length + 2L, 1))
             buf.append(" 1 ")
         }
         assertTokens(buf.toString(), *expected.toTypedArray())
@@ -212,19 +217,19 @@ class SqlLexerTest : TestBase() {
     @Test
     fun multiLexemeOperators() = assertTokens(
         "UNION ALL IS NOT union_all is_not",
-        token(OPERATOR, "union_all", 1, 1),
-        token(OPERATOR, "is_not", 1, 11),
-        token(IDENTIFIER, "union_all", 1, 18),
-        token(IDENTIFIER, "is_not", 1, 28)
+        token(OPERATOR, "union_all", 1, 1, 5),
+        token(OPERATOR, "is_not", 1, 11, 2),
+        token(IDENTIFIER, "union_all", 1, 18, 9),
+        token(IDENTIFIER, "is_not", 1, 28, 6)
     )
 
     @Test
     fun multiLexemeKeywords() = assertTokens(
         "CHARACTER VARYING DoUblE PrEcision double_precision character_varying",
-        token(KEYWORD, "character_varying", 1, 1),
-        token(KEYWORD, "double_precision", 1, 19),
-        token(IDENTIFIER, "double_precision", 1, 36),
-        token(IDENTIFIER, "character_varying", 1, 53)
+        token(KEYWORD, "character_varying", 1, 1, 9),
+        token(KEYWORD, "double_precision", 1, 19, 6),
+        token(IDENTIFIER, "double_precision", 1, 36, 16),
+        token(IDENTIFIER, "character_varying", 1, 53, 17)
     )
 
     @Test
@@ -232,151 +237,151 @@ class SqlLexerTest : TestBase() {
         "cRoSs Join left join left left Inner joiN RIGHT JOIN RIGHT OUTER JOIN LEFT OUTER JOIN" +
         "\nFULL join OUTER JOIN FULL OUTER JOIN" +
         "\nCROSS CROSS JOIN JOIN",
-        token(KEYWORD, "cross_join", 1, 1),
-        token(KEYWORD, "left_join", 1, 12),
-        token(KEYWORD, "left", 1, 22),
-        token(KEYWORD, "left", 1, 27),
-        token(KEYWORD, "inner_join", 1, 32),
-        token(KEYWORD, "right_join", 1, 43),
-        token(KEYWORD, "right_join", 1, 54),
-        token(KEYWORD, "left_join", 1, 71),
-        token(KEYWORD, "outer_join", 2, 1),
-        token(KEYWORD, "outer_join", 2, 11),
-        token(KEYWORD, "outer_join", 2, 22),
-        token(KEYWORD, "cross", 3, 1),
-        token(KEYWORD, "cross_join", 3, 7),
-        token(KEYWORD, "join", 3, 18)
+        token(KEYWORD, "cross_join", 1, 1, 5),
+        token(KEYWORD, "left_join", 1, 12, 4),
+        token(KEYWORD, "left", 1, 22, 4),
+        token(KEYWORD, "left", 1, 27, 4),
+        token(KEYWORD, "inner_join", 1, 32, 5),
+        token(KEYWORD, "right_join", 1, 43, 5),
+        token(KEYWORD, "right_join", 1, 54, 5),
+        token(KEYWORD, "left_join", 1, 71, 4),
+        token(KEYWORD, "outer_join", 2, 1, 4),
+        token(KEYWORD, "outer_join", 2, 11, 5),
+        token(KEYWORD, "outer_join", 2, 22, 4),
+        token(KEYWORD, "cross", 3, 1, 5),
+        token(KEYWORD, "cross_join", 3, 7, 5),
+        token(KEYWORD, "join", 3, 18, 4)
     )
 
     @Test
     fun functionKeywordNames() = assertTokens(
             "SUBSTRING",
-            token(KEYWORD, "substring", 1, 1)
+            token(KEYWORD, "substring", 1, 1, 9)
     )
 
     @Test
     fun boolType() = assertTokens(
         "BOOL",
-        token(KEYWORD, "boolean", 1, 1)
+        token(KEYWORD, "boolean", 1, 1, 4)
     )
     @Test
     fun smallintType() = assertTokens(
         "SMALLINT",
-        token(KEYWORD, "smallint", 1, 1)
+        token(KEYWORD, "smallint", 1, 1, 8)
     )
 
     @Test
     fun intType() = assertTokens(
         "INT",
-        token(KEYWORD, "integer", 1, 1)
+        token(KEYWORD, "integer", 1, 1, 3)
     )
 
     @Test
     fun integerType() = assertTokens(
         "INTEGER",
-        token(KEYWORD, "integer", 1, 1)
+        token(KEYWORD, "integer", 1, 1, 7)
     )
 
     @Test
     fun floatType() = assertTokens(
         "FLOAT",
-        token(KEYWORD, "float", 1, 1)
+        token(KEYWORD, "float", 1, 1, 5)
     )
 
     @Test
     fun realType() = assertTokens(
         "REAL",
-        token(KEYWORD, "real", 1, 1)
+        token(KEYWORD, "real", 1, 1, 4)
     )
 
     @Test
     fun doublePrecisionType() = assertTokens(
         "DOUBLE PRECISION",
-        token(KEYWORD, "double_precision", 1, 1)
+        token(KEYWORD, "double_precision", 1, 1, 6)
     )
 
     @Test
     fun decimalType() = assertTokens(
         "DECIMAL",
-        token(KEYWORD, "decimal", 1, 1)
+        token(KEYWORD, "decimal", 1, 1, 7)
     )
 
     @Test
     fun numericType() = assertTokens(
         "NUMERIC",
-        token(KEYWORD, "numeric", 1, 1)
+        token(KEYWORD, "numeric", 1, 1, 7)
     )
 
     @Test
     fun timestampType() = assertTokens(
         "TIMESTAMP",
-        token(KEYWORD, "timestamp", 1, 1)
+        token(KEYWORD, "timestamp", 1, 1, 9)
     )
 
     @Test
     fun characterType() = assertTokens(
         "CHARACTER",
-        token(KEYWORD, "character", 1, 1)
+        token(KEYWORD, "character", 1, 1, 9)
     )
 
     @Test
     fun charType() = assertTokens(
         "CHAR",
-        token(KEYWORD, "character", 1, 1)
+        token(KEYWORD, "character", 1, 1, 4)
     )
 
     @Test
     fun varcharType() = assertTokens(
         "VARCHAR",
-        token(KEYWORD, "character_varying", 1, 1)
+        token(KEYWORD, "character_varying", 1, 1, 7)
     )
 
     @Test
     fun characterVaryingType() = assertTokens(
         "CHARACTER VARYING",
-        token(KEYWORD, "character_varying", 1, 1)
+        token(KEYWORD, "character_varying", 1, 1, 9)
     )
 
     @Test
     fun stringType() = assertTokens(
         "STRING",
-        token(KEYWORD, "string", 1, 1)
+        token(KEYWORD, "string", 1, 1, 6)
     )
 
     @Test
     fun symbolType() = assertTokens(
         "SYMBOL",
-        token(KEYWORD, "symbol", 1, 1)
+        token(KEYWORD, "symbol", 1, 1, 6)
     )
 
     @Test
     fun clobType() = assertTokens(
         "CLOB",
-        token(KEYWORD, "clob", 1, 1)
+        token(KEYWORD, "clob", 1, 1, 4)
     )
 
     @Test
     fun blobType() = assertTokens(
         "BLOB",
-        token(KEYWORD, "blob", 1, 1)
+        token(KEYWORD, "blob", 1, 1, 4)
     )
 
     @Test
     fun structType() = assertTokens(
         "STRUCT",
-        token(KEYWORD, "struct", 1, 1)
+        token(KEYWORD, "struct", 1, 1, 6)
     )
 
     @Test
     fun listType() = assertTokens(
         "LIST",
-        token(KEYWORD, "list", 1, 1)
+        token(KEYWORD, "list", 1, 1, 4)
     )
 
     @Test
     fun sexpType() = assertTokens(
         "SEXP",
-        token(KEYWORD, "sexp", 1, 1)
+        token(KEYWORD, "sexp", 1, 1, 4)
     )
 
     @Test(expected = LexerException::class)

--- a/testscript/pts/test-scripts/group-by/simple-group-by.sqlts
+++ b/testscript/pts/test-scripts/group-by/simple-group-by.sqlts
@@ -461,13 +461,13 @@ test::{
 test::{
     id: 'group by with aliased group expression and having',
     statement: '''
-        SELECT modified
+        SELECT changed
         FROM sales_report
-        GROUP BY rep || '_modified' as modified
-        HAVING modified = 'Meg_modified'
+        GROUP BY rep || '_changed' as changed
+        HAVING changed = 'Meg_changed'
     ''',
     expected: (success (bag
-        { modified: "Meg_modified" }
+        { changed: "Meg_changed" }
     ))
 }
 
@@ -504,11 +504,11 @@ test::{
     statement: '''
         SELECT rep
         FROM sales_report
-        GROUP BY rep || '_modified' as rep --Note: "rep" shadows sales_report.rep
-        HAVING rep = 'Meg_modified'
+        GROUP BY rep || '_changed' as rep --Note: "rep" shadows sales_report.rep
+        HAVING rep = 'Meg_changed'
     ''',
     expected: (success (bag
-        { rep: "Meg_modified" }
+        { rep: "Meg_changed" }
     ))
 }
 


### PR DESCRIPTION
This includes:

- Parser support for:
    - ORDER BY
    - Multiple operations per DML statement (i.e. FROM x SET k = 5, REMOVE t)
    - RETURNING clause
    - ON CONFLICT clause for INSERT statement
- Introduces a new PartiQL statement redactor, suitable for removing customer data
from queries, allowing them to be logged.

Contributors include: Louis Chu, Lewis Bruck, Dhruva Batni, and Ben Wood.  Code
reviews provided by the PartiQL Team.

Commit subject lines below:

- dynamodb-dev Bugfix: Allow unary arithmetic operator
- Support non Struct node in statement and fix StringIndexOutOfBoundsException
- Bugfix: condition in validateSafeFieldNames
- Modify exception message to kotlin style
- Implement PartiQL query redaction
- Add SourcePosition.length & SourceLocationmeta.length
- Cherry pick 'Stop treating date parts as if they are string literals (#317)'
- Add RETURNING clause support
- Add new ION_LITERAL token type
- Multiple DML operations per statement
- Fix ON CONFLICT parsing
- Add conditional check for insert
- Add negative test case for ORDER BY support
- Implemented order by support

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
