### PR TITLE
Adds support for parsing date literals

### DIFF
--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -95,7 +95,7 @@
             (sexp values::(* expr 0))
 
             // Constructors for DateTime types
-            (date date_string::symbol)
+            (date year::int month::int day::int)
 
             // Set operators
             (union setq::set_quantifier operands::(* expr 2))

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -94,6 +94,9 @@
             (list values::(* expr 0))
             (sexp values::(* expr 0))
 
+            // Constructors for DateTime types
+            (date date_string::symbol)
+
             // Set operators
             (union setq::set_quantifier operands::(* expr 2))
             (except setq::set_quantifier operands::(* expr 2))
@@ -353,6 +356,7 @@
             (symbol_type)
             (blob_type)
             (clob_type)
+            (date_type)
             (struct_type)
             (tuple_type)
             (list_type)

--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -94,6 +94,7 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
                     is DropTable         -> case { writeDropTable(expr) }
                     is DropIndex         -> case { writeDropIndex(expr) }
                     is Parameter         -> case { writeParameter(expr)}
+                    is DateTimeType.Date -> throw UnsupportedOperationException("DATE literals not supported by the V0 AST")
                     is Exec              -> throw UnsupportedOperationException("EXEC clause not supported by the V0 AST")
                 }.toUnit()
             }

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -173,7 +173,7 @@ fun ExprNode.toAstExpr(): PartiqlAst.Expr {
             // DateTime types
             is DateTimeType -> {
                 when (node) {
-                    is DateTimeType.Date -> date(node.dateString, metas)
+                    is DateTimeType.Date -> date(node.year.toLong(), node.month.toLong(), node.day.toLong(), metas)
                 }
             }
         }

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -190,6 +190,7 @@ private class StatementTransformer(val ion: IonSystem) {
                     limit = limit?.toExprNode(),
                     metas = metas
             )
+            is Expr.Date -> DateTimeType.Date(this.dateString.text, metas)
         }
     }
 
@@ -317,6 +318,7 @@ private class StatementTransformer(val ion: IonSystem) {
             is Type.ListType -> DataType(SqlDataType.LIST, listOf(), metas)
             is Type.SexpType -> DataType(SqlDataType.SEXP, listOf(), metas)
             is Type.BagType -> DataType(SqlDataType.BAG, listOf(), metas)
+            is Type.DateType -> DataType(SqlDataType.DATE, listOf(), metas)
         }
     }
 

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -190,7 +190,8 @@ private class StatementTransformer(val ion: IonSystem) {
                     limit = limit?.toExprNode(),
                     metas = metas
             )
-            is Expr.Date -> DateTimeType.Date(this.dateString.text, metas)
+            is Expr.Date ->
+                DateTimeType.Date(year.value.toInt(), month.value.toInt(), day.value.toInt(), metas)
         }
     }
 

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -969,10 +969,21 @@ enum class OrderingSpec {
 
 /**
  * The sealed class includes all the datetime types such as DATE, TIME, TIMESTAMP
+ * Note that the ast nodes corresponding to the DATE, TIME and TIMESTAMP here are different from the [Literal] nodes.
+ * You can create an Ion literal as [Timestamp] which will correspond to the [Literal] node and will have the type
+ * [SqlDataType.TIMESTAMP]. However that will be different from the
+ * `TIMESTAMP` here.
  * Note: TIME and TIMESTAMP are yet to be added.
  */
 sealed class DateTimeType : ExprNode() {
-    data class Date( val dateString: String, override val metas: MetaContainer ) : DateTimeType() {
+    /**
+     * AST Node corresponding to the DATE literal
+     */
+    data class Date(
+        val year: Int,
+        val month: Int,
+        val day: Int,
+        override val metas: MetaContainer ) : DateTimeType() {
         override val children: List<AstNode> = listOf()
     }
 }

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -106,6 +106,9 @@ sealed class ExprNode : AstNode(), HasMetas {
             is Exec            -> {
                 copy(metas = metas)
             }
+            is DateTimeType.Date -> {
+                copy(metas = metas)
+            }
         }
     }
 }
@@ -965,6 +968,16 @@ enum class OrderingSpec {
 }
 
 /**
+ * The sealed class includes all the datetime types such as DATE, TIME, TIMESTAMP
+ * Note: TIME and TIMESTAMP are yet to be added.
+ */
+sealed class DateTimeType : ExprNode() {
+    data class Date( val dateString: String, override val metas: MetaContainer ) : DateTimeType() {
+        override val children: List<AstNode> = listOf()
+    }
+}
+
+/**
  * Indicates strategy for binding lookup within scopes.
  */
 enum class ScopeQualifier {
@@ -1000,6 +1013,7 @@ enum class SqlDataType(val typeName: String, val arityRange: IntRange) {
     TUPLE("tuple", 0..0), // PartiQL
     LIST("list", 0..0), // Ion
     SEXP("sexp", 0..0), // Ion
+    DATE("date", 0..0), // SQL-92
     BAG("bag", 0..0);  // PartiQL
 
     companion object {

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -441,7 +441,9 @@ open class AstRewriterBase : AstRewriter {
 
     open fun rewriteDate(node: DateTimeType.Date): DateTimeType.Date =
         DateTimeType.Date(
-            node.dateString,
+            node.year,
+            node.month,
+            node.day,
             rewriteMetas(node)
         )
 }

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -52,6 +52,7 @@ open class AstRewriterBase : AstRewriter {
             is DropTable         -> rewriteDropTable(node)
             is DropIndex         -> rewriteDropIndex(node)
             is Exec              -> rewriteExec(node)
+            is DateTimeType.Date -> rewriteDate(node)
         }
 
     open fun rewriteMetas(itemWithMetas: HasMetas): MetaContainer = itemWithMetas.metas
@@ -438,4 +439,9 @@ open class AstRewriterBase : AstRewriter {
             node.args.map { rewriteExprNode(it) },
             rewriteMetas(node))
 
+    open fun rewriteDate(node: DateTimeType.Date): DateTimeType.Date =
+        DateTimeType.Date(
+            node.dateString,
+            rewriteMetas(node)
+        )
 }

--- a/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
@@ -133,8 +133,8 @@ open class AstWalker(private val visitor: AstVisitor) {
                         walkExprNode(key)
                     }
                 }
-                is CreateTable, is DropTable, is DropIndex -> case { }
-                is Exec -> case { }
+                is CreateTable, is DropTable, is DropIndex,
+                is Exec, is DateTimeType.Date -> case { }
             }.toUnit()
         }
     }

--- a/lang/src/org/partiql/lang/errors/ErrorCode.kt
+++ b/lang/src/org/partiql/lang/errors/ErrorCode.kt
@@ -272,6 +272,11 @@ enum class ErrorCode(private val category: ErrorCategory,
         LOC_TOKEN,
         "invalid value used for type parameter"),
 
+    PARSE_INVALID_DATE_STRING(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "expected date string to be of the format YYYY-MM-DD"),
+
     PARSE_EMPTY_SELECT(
         ErrorCategory.PARSER,
         LOC_TOKEN,

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -283,7 +283,7 @@ internal class EvaluatingCompiler(
             is DropIndex,
             is DropTable -> compileDdl(expr)
             is Exec      -> compileExec(expr)
-
+            is DateTimeType.Date      -> TODO()
         }
     }
 

--- a/lang/src/org/partiql/lang/eval/ExprValueType.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueType.kt
@@ -190,6 +190,7 @@ enum class ExprValueType(val typeNames: List<String>,
                 SqlDataType.LIST              -> ExprValueType.LIST
                 SqlDataType.SEXP              -> ExprValueType.SEXP
                 SqlDataType.BAG               -> ExprValueType.BAG
+                SqlDataType.DATE              -> TODO()
             }
     }
 }

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -685,7 +685,8 @@ class SqlParser(private val ion: IonSystem) : Parser {
             }
             DATE -> {
                 val dateString = token!!.text!!
-                DateTimeType.Date(dateString, metas)
+                val (year, month, day) = dateString.split("-")
+                DateTimeType.Date(year.toInt(), month.toInt(), day.toInt(), metas)
             }
             else -> unsupported("Unsupported syntax for $type", PARSE_UNSUPPORTED_SYNTAX)
         }

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -13,6 +13,7 @@
  */
 
 package org.partiql.lang.errors
+import com.amazon.ion.Timestamp
 import org.partiql.lang.*
 import org.partiql.lang.syntax.SqlParser
 import org.partiql.lang.syntax.ParserException
@@ -1860,7 +1861,7 @@ class ParserErrorsTest : TestBase() {
             Property.COLUMN_NUMBER to 12L,
             Property.TOKEN_TYPE to TokenType.LEFT_PAREN,
             Property.TOKEN_VALUE to ion.newSymbol("(")))
-    
+
     @Test
     fun dropIndexWithParenthesisAtTail() = checkInputThrowingParserException(
         "DROP INDEX goo ON foo (bar)",
@@ -2066,4 +2067,94 @@ class ParserErrorsTest : TestBase() {
             Property.COLUMN_NUMBER to 21L,
             Property.TOKEN_TYPE to TokenType.IDENTIFIER,
             Property.TOKEN_VALUE to ion.newSymbol("undrop")))
+
+    @Test
+    fun invalidTypeIntForDateString() = checkInputThrowingParserException(
+        "DATE 2012",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 6L,
+            Property.TOKEN_TYPE to TokenType.LITERAL,
+            Property.TOKEN_VALUE to ion.newInt(2012)))
+
+    @Test
+    fun invalidTypeIntForDateString2() = checkInputThrowingParserException(
+        "DATE 2012-08-28",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 6L,
+            Property.TOKEN_TYPE to TokenType.LITERAL,
+            Property.TOKEN_VALUE to ion.newInt(2012)))
+
+    @Test
+    fun invalidTypeTimestampForDateString() = checkInputThrowingParserException(
+        "DATE `2012-08-28`",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 6L,
+            Property.TOKEN_TYPE to TokenType.ION_LITERAL,
+            Property.TOKEN_VALUE to ion.newTimestamp(Timestamp.forDay(2012, 8, 28))))
+
+    @Test
+    fun invalidDateStringFormat() = checkInputThrowingParserException(
+        "DATE 'date_string'",
+        ErrorCode.PARSE_INVALID_DATE_STRING,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 6L,
+            Property.TOKEN_TYPE to TokenType.LITERAL,
+            Property.TOKEN_VALUE to ion.newString("date_string")))
+
+    @Test
+    fun invalidDateStringFormatMissingDashes() = checkInputThrowingParserException(
+        "DATE '20210310'",
+        ErrorCode.PARSE_INVALID_DATE_STRING,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 6L,
+            Property.TOKEN_TYPE to TokenType.LITERAL,
+            Property.TOKEN_VALUE to ion.newString("20210310")))
+
+    @Test
+    fun invalidDateStringFormatUnexpectedColons() = checkInputThrowingParserException(
+        "DATE '2021:03:10'",
+        ErrorCode.PARSE_INVALID_DATE_STRING,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 6L,
+            Property.TOKEN_TYPE to TokenType.LITERAL,
+            Property.TOKEN_VALUE to ion.newString("2021:03:10")))
+
+    @Test
+    fun invalidDateStringFormatInvalidDate() = checkInputThrowingParserException(
+        "DATE '2021-02-29'",
+        ErrorCode.PARSE_INVALID_DATE_STRING,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 6L,
+            Property.TOKEN_TYPE to TokenType.LITERAL,
+            Property.TOKEN_VALUE to ion.newString("2021-02-29")))
+
+    @Test
+    fun invalidDateStringFormatMMDDYYYY() = checkInputThrowingParserException(
+        "DATE '03-10-2021'",
+        ErrorCode.PARSE_INVALID_DATE_STRING,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 6L,
+            Property.TOKEN_TYPE to TokenType.LITERAL,
+            Property.TOKEN_VALUE to ion.newString("03-10-2021")))
+
+    @Test
+    fun invalidDateStringFormatDDMMYYYY() = checkInputThrowingParserException(
+        "DATE '10-03-2021'",
+        ErrorCode.PARSE_INVALID_DATE_STRING,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 6L,
+            Property.TOKEN_TYPE to TokenType.LITERAL,
+            Property.TOKEN_VALUE to ion.newString("10-03-2021")))
 }

--- a/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt
@@ -15,14 +15,14 @@ class SqlParserDateTimeTests : SqlParserTestBase() {
 
     fun parametersForDateLiteralTests() = listOf(
         DateTimeTestCase("DATE '2012-02-29'") {
-            date("2012-02-29")
+            date(2012, 2, 29)
         },
         DateTimeTestCase("DATE'1992-11-30'") {
-            date("1992-11-30")
+            date(1992, 11, 30)
         },
         DateTimeTestCase("SELECT DATE '2021-03-10' FROM foo") {
             select(
-                project = projectList(projectExpr(date("2021-03-10"))),
+                project = projectList(projectExpr(date(2021, 3, 10))),
                 from = scan(id("foo"))
             )
         }

--- a/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt
@@ -1,0 +1,30 @@
+package org.partiql.lang.syntax
+
+import junitparams.Parameters
+import org.junit.Test
+import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.id
+
+class SqlParserDateTimeTests : SqlParserTestBase() {
+
+    data class DateTimeTestCase(val source: String, val block: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode)
+
+    @Test
+    @Parameters
+    fun dateLiteralTests(tc: DateTimeTestCase) = assertExpression(tc.source, tc.block)
+
+    fun parametersForDateLiteralTests() = listOf(
+        DateTimeTestCase("DATE '2012-02-29'") {
+            date("2012-02-29")
+        },
+        DateTimeTestCase("DATE'1992-11-30'") {
+            date("1992-11-30")
+        },
+        DateTimeTestCase("SELECT DATE '2021-03-10' FROM foo") {
+            select(
+                project = projectList(projectExpr(date("2021-03-10"))),
+                from = scan(id("foo"))
+            )
+        }
+    )
+}


### PR DESCRIPTION

*Description of changes:*
Adds support for parsing parsing date literals. Syntax for the date literal is `DATE 'YYYY-MM-DD'`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
