### PR TITLE
Add regression test for multi-codepoint LIKE patterns

### DIFF
--- a/lang/test/org/partiql/lang/eval/LikePredicateTest.kt
+++ b/lang/test/org/partiql/lang/eval/LikePredicateTest.kt
@@ -40,6 +40,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         ]
         """).toSession()
 
+
     @Test
     fun emptyTextUnderscorePattern() = assertEval("""SELECT * FROM `[true]` as a WHERE '' LIKE '_'  """, "[]", animals)
 
@@ -628,4 +629,8 @@ class LikePredicateTest : EvaluatorTestBase() {
                                                    NodeMetadata(1, 56)) {
         voidEval("SELECT * FROM `[{name:1, type:\"a\"}]` as a WHERE a.name LIKE a.type ")
     }
+
+    /** Regression test for: https://github.com/partiql/partiql-lang-kotlin/issues/32 */
+    @Test
+    fun multiCodepointPattern() = assertEval("'😍' LIKE '😍'", "true")
 }


### PR DESCRIPTION
#32 appears to have been inadvertently fixed by #286.  Inadvertent yes, but still a good thing. :)

This PR simply adds a regression test for it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
