### PR TITLE
Added Parser support for TIME literals

### DIFF
--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -96,6 +96,7 @@
 
             // Constructors for DateTime types
             (date year::int month::int day::int)
+            (time hour::int minute::int second::int nano::int precision::int tz_minutes::(? int))
 
             // Set operators
             (union setq::set_quantifier operands::(* expr 2))
@@ -357,6 +358,7 @@
             (blob_type)
             (clob_type)
             (date_type)
+            (time_type)
             (struct_type)
             (tuple_type)
             (list_type)

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -96,7 +96,7 @@
 
             // Constructors for DateTime types
             (date year::int month::int day::int)
-            (time hour::int minute::int second::int nano::int precision::int tz_minutes::(? int))
+            (lit_time value::time_value)
 
             // Set operators
             (union setq::set_quantifier operands::(* expr 2))
@@ -123,6 +123,9 @@
                 (order (? order_by))
                 (limit (? expr))))
         // end of sum expr
+
+        // Time
+        (product time_value hour::int minute::int second::int nano::int precision::int tz_minutes::(? int))
 
         // A "step" within a path expression; that is the components of the expression following the root.
         (sum path_step

--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -95,6 +95,7 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
                     is DropIndex         -> case { writeDropIndex(expr) }
                     is Parameter         -> case { writeParameter(expr)}
                     is DateTimeType.Date -> throw UnsupportedOperationException("DATE literals not supported by the V0 AST")
+                    is DateTimeType.Time -> throw UnsupportedOperationException("TIME literals not supported by the V0 AST")
                     is Exec              -> throw UnsupportedOperationException("EXEC clause not supported by the V0 AST")
                 }.toUnit()
             }

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -11,7 +11,7 @@ fun ExprNode.toAstStatement(): PartiqlAst.Statement {
     val node = this
     return when(node) {
         is Literal, is LiteralMissing, is VariableReference, is Parameter, is NAry, is CallAgg,
-        is Typed, is Path, is SimpleCase, is SearchedCase, is Select, is Struct, is DateTimeType.Date,
+        is Typed, is Path, is SimpleCase, is SearchedCase, is Select, is Struct, is DateTimeType,
         is Seq -> PartiqlAst.build { query(toAstExpr()) }
 
         is DataManipulation -> node.toAstDml()
@@ -35,7 +35,7 @@ private fun ExprNode.toAstDdl(): PartiqlAst.Statement {
     return PartiqlAst.build {
         when(thiz) {
             is Literal, is LiteralMissing, is VariableReference, is Parameter, is NAry, is CallAgg, is Typed,
-            is Path, is SimpleCase, is SearchedCase, is Select, is Struct, is Seq, is DateTimeType.Date,
+            is Path, is SimpleCase, is SearchedCase, is Select, is Struct, is Seq, is DateTimeType,
             is DataManipulation, is Exec -> error("Can't convert ${thiz.javaClass} to PartiqlAst.ddl")
 
             is CreateTable -> ddl(createTable(thiz.tableName), metas)
@@ -174,6 +174,14 @@ fun ExprNode.toAstExpr(): PartiqlAst.Expr {
             is DateTimeType -> {
                 when (node) {
                     is DateTimeType.Date -> date(node.year.toLong(), node.month.toLong(), node.day.toLong(), metas)
+                    is DateTimeType.Time -> time(
+                        node.hour.toLong(),
+                        node.minute.toLong(),
+                        node.second.toLong(),
+                        node.nano.toLong(),
+                        node.precision.toLong(),
+                        node.tz_minutes?.toLong()
+                    )
                 }
             }
         }
@@ -447,6 +455,7 @@ private fun DataType.toAstType(): PartiqlAst.Type {
             SqlDataType.SEXP -> sexpType(metas)
             SqlDataType.BAG -> bagType(metas)
             SqlDataType.DATE -> dateType(metas)
+            SqlDataType.TIME -> timeType(metas)
         }
     }
 }

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -174,13 +174,15 @@ fun ExprNode.toAstExpr(): PartiqlAst.Expr {
             is DateTimeType -> {
                 when (node) {
                     is DateTimeType.Date -> date(node.year.toLong(), node.month.toLong(), node.day.toLong(), metas)
-                    is DateTimeType.Time -> time(
-                        node.hour.toLong(),
-                        node.minute.toLong(),
-                        node.second.toLong(),
-                        node.nano.toLong(),
-                        node.precision.toLong(),
-                        node.tz_minutes?.toLong()
+                    is DateTimeType.Time -> litTime(
+                        timeValue(
+                            node.hour.toLong(),
+                            node.minute.toLong(),
+                            node.second.toLong(),
+                            node.nano.toLong(),
+                            node.precision.toLong(),
+                            node.tz_minutes?.toLong()
+                        )
                     )
                 }
             }

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -192,14 +192,14 @@ private class StatementTransformer(val ion: IonSystem) {
             )
             is Expr.Date ->
                 DateTimeType.Date(year.value.toInt(), month.value.toInt(), day.value.toInt(), metas)
-            is Expr.Time ->
+            is Expr.LitTime ->
                 DateTimeType.Time(
-                    hour.value.toInt(),
-                    minute.value.toInt(),
-                    second.value.toInt(),
-                    nano.value.toInt(),
-                    precision.value.toInt(),
-                    tzMinutes?.value?.toInt(),
+                    value.hour.value.toInt(),
+                    value.minute.value.toInt(),
+                    value.second.value.toInt(),
+                    value.nano.value.toInt(),
+                    value.precision.value.toInt(),
+                    value.tzMinutes?.value?.toInt(),
                     metas
                 )
         }

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -192,6 +192,16 @@ private class StatementTransformer(val ion: IonSystem) {
             )
             is Expr.Date ->
                 DateTimeType.Date(year.value.toInt(), month.value.toInt(), day.value.toInt(), metas)
+            is Expr.Time ->
+                DateTimeType.Time(
+                    hour.value.toInt(),
+                    minute.value.toInt(),
+                    second.value.toInt(),
+                    nano.value.toInt(),
+                    precision.value.toInt(),
+                    tzMinutes?.value?.toInt(),
+                    metas
+                )
         }
     }
 
@@ -320,6 +330,7 @@ private class StatementTransformer(val ion: IonSystem) {
             is Type.SexpType -> DataType(SqlDataType.SEXP, listOf(), metas)
             is Type.BagType -> DataType(SqlDataType.BAG, listOf(), metas)
             is Type.DateType -> DataType(SqlDataType.DATE, listOf(), metas)
+            is Type.TimeType -> DataType(SqlDataType.TIME, listOf(), metas)
         }
     }
 

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -109,6 +109,9 @@ sealed class ExprNode : AstNode(), HasMetas {
             is DateTimeType.Date -> {
                 copy(metas = metas)
             }
+            is DateTimeType.Time -> {
+                copy(metas = metas)
+            }
         }
     }
 }
@@ -986,6 +989,29 @@ sealed class DateTimeType : ExprNode() {
         override val metas: MetaContainer ) : DateTimeType() {
         override val children: List<AstNode> = listOf()
     }
+
+    /**
+     * AST node representing the TIME literal.
+     *
+     * @param hour represents the hour value.
+     * @param minute represents the minute value.
+     * @param second represents the second value.
+     * @param nano represents the fractional part of the second upto the nano seconds' precision.
+     * @param precision is an optional parameter which, if specified, represents the precision of the fractional second.
+     * The default precision is 9 or nanosecond.
+     * @param tz_minutes is the optional time zone in minutes which can be specified with "WITH TIME ZONE".
+     * If [tz_minutes] is null, that means the time zone is undefined.
+     */
+    data class Time(
+        val hour: Int,
+        val minute: Int,
+        val second: Int,
+        val nano: Int,
+        val precision: Int = 9,
+        val tz_minutes: Int? = null,
+        override val metas: MetaContainer ) : DateTimeType() {
+        override val children: List<AstNode> = listOf()
+    }
 }
 
 /**
@@ -1025,6 +1051,7 @@ enum class SqlDataType(val typeName: String, val arityRange: IntRange) {
     LIST("list", 0..0), // Ion
     SEXP("sexp", 0..0), // Ion
     DATE("date", 0..0), // SQL-92
+    TIME("time", 0..0), // SQL-92
     BAG("bag", 0..0);  // PartiQL
 
     companion object {

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -986,7 +986,8 @@ sealed class DateTimeType : ExprNode() {
         val year: Int,
         val month: Int,
         val day: Int,
-        override val metas: MetaContainer ) : DateTimeType() {
+        override val metas: MetaContainer
+    ) : DateTimeType() {
         override val children: List<AstNode> = listOf()
     }
 
@@ -996,7 +997,7 @@ sealed class DateTimeType : ExprNode() {
      * @param hour represents the hour value.
      * @param minute represents the minute value.
      * @param second represents the second value.
-     * @param nano represents the fractional part of the second upto the nano seconds' precision.
+     * @param nano represents the fractional part of the second up to the nanoseconds' precision.
      * @param precision is an optional parameter which, if specified, represents the precision of the fractional second.
      * The default precision is 9 or nanosecond.
      * @param tz_minutes is the optional time zone in minutes which can be specified with "WITH TIME ZONE".
@@ -1009,7 +1010,8 @@ sealed class DateTimeType : ExprNode() {
         val nano: Int,
         val precision: Int = 9,
         val tz_minutes: Int? = null,
-        override val metas: MetaContainer ) : DateTimeType() {
+        override val metas: MetaContainer
+    ) : DateTimeType() {
         override val children: List<AstNode> = listOf()
     }
 }

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -53,6 +53,7 @@ open class AstRewriterBase : AstRewriter {
             is DropIndex         -> rewriteDropIndex(node)
             is Exec              -> rewriteExec(node)
             is DateTimeType.Date -> rewriteDate(node)
+            is DateTimeType.Time -> rewriteTime(node)
         }
 
     open fun rewriteMetas(itemWithMetas: HasMetas): MetaContainer = itemWithMetas.metas
@@ -444,6 +445,17 @@ open class AstRewriterBase : AstRewriter {
             node.year,
             node.month,
             node.day,
+            rewriteMetas(node)
+        )
+
+    open fun rewriteTime(node: DateTimeType.Time): DateTimeType.Time =
+        DateTimeType.Time(
+            node.hour,
+            node.minute,
+            node.second,
+            node.nano,
+            node.precision,
+            node.tz_minutes,
             rewriteMetas(node)
         )
 }

--- a/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
@@ -134,7 +134,7 @@ open class AstWalker(private val visitor: AstVisitor) {
                     }
                 }
                 is CreateTable, is DropTable, is DropIndex,
-                is Exec, is DateTimeType.Date -> case { }
+                is Exec, is DateTimeType -> case { }
             }.toUnit()
         }
     }

--- a/lang/src/org/partiql/lang/errors/ErrorCode.kt
+++ b/lang/src/org/partiql/lang/errors/ErrorCode.kt
@@ -272,10 +272,20 @@ enum class ErrorCode(private val category: ErrorCategory,
         LOC_TOKEN,
         "invalid value used for type parameter"),
 
+    PARSE_INVALID_PRECISION_FOR_TIME(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "invalid precision used for TIME type"),
+
     PARSE_INVALID_DATE_STRING(
         ErrorCategory.PARSER,
         LOC_TOKEN,
         "expected date string to be of the format YYYY-MM-DD"),
+
+    PARSE_INVALID_TIME_STRING(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "expected time string to be of the format HH:MM:SS[.dddd...][+|-HH:MM]"),
 
     PARSE_EMPTY_SELECT(
         ErrorCategory.PARSER,

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -284,6 +284,7 @@ internal class EvaluatingCompiler(
             is DropTable -> compileDdl(expr)
             is Exec      -> compileExec(expr)
             is DateTimeType.Date      -> TODO()
+            is DateTimeType.Time -> TODO()
         }
     }
 

--- a/lang/src/org/partiql/lang/eval/ExprValueType.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueType.kt
@@ -191,6 +191,7 @@ enum class ExprValueType(val typeNames: List<String>,
                 SqlDataType.SEXP              -> ExprValueType.SEXP
                 SqlDataType.BAG               -> ExprValueType.BAG
                 SqlDataType.DATE              -> TODO()
+                SqlDataType.TIME              -> TODO()
             }
     }
 }

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -14,34 +14,12 @@
 
 package org.partiql.lang.errors
 import com.amazon.ion.Timestamp
-import org.partiql.lang.*
-import org.partiql.lang.syntax.SqlParser
-import org.partiql.lang.syntax.ParserException
 import org.partiql.lang.syntax.TokenType
 import org.partiql.lang.util.*
 import org.junit.*
+import org.partiql.lang.syntax.SqlParserTestBase
 
-class ParserErrorsTest : TestBase() {
-
-    private val parser = SqlParser(ion)
-
-    private fun checkInputThrowingParserException(input: String,
-                                                  errorCode: ErrorCode,
-                                                  expectErrorContextValues: Map<Property, Any>) {
-
-        softAssert {
-            try {
-                parser.parseExprNode(input)
-                fail("Expected ParserException but there was no Exception")
-            }
-            catch (pex: ParserException) {
-                checkErrorAndErrorContext(errorCode, pex, expectErrorContextValues)
-            }
-            catch (ex: Exception) {
-                fail("Expected ParserException but a different exception was thrown \n\t  $ex")
-            }
-        }
-    }
+class ParserErrorsTest : SqlParserTestBase() {
 
     @Test
     fun expectedKeyword() {

--- a/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt
@@ -1,11 +1,20 @@
 package org.partiql.lang.syntax
 
+import com.amazon.ion.IonValue
 import junitparams.Parameters
 import org.junit.Test
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.domains.id
+import org.partiql.lang.errors.ErrorCode
+import org.partiql.lang.errors.Property
+import org.partiql.lang.util.softAssert
+import org.partiql.lang.util.to
+import java.time.Instant
+import java.time.ZoneOffset
 
 class SqlParserDateTimeTests : SqlParserTestBase() {
+
+    private val LOCAL_TIME_ZONE_OFFSET = (ZoneOffset.systemDefault().rules.getOffset(Instant.now()).totalSeconds / 60).toLong()
 
     data class DateTimeTestCase(val source: String, val block: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode)
 
@@ -25,6 +34,567 @@ class SqlParserDateTimeTests : SqlParserTestBase() {
                 project = projectList(projectExpr(date(2021, 3, 10))),
                 from = scan(id("foo"))
             )
+        },
+        DateTimeTestCase("TIME '02:30:59'") {
+            time(2, 30, 59, 0, 9, null)
+        },
+        DateTimeTestCase("TIME (3) '12:59:31'") {
+            time(12, 59, 31, 0, 3, null)
+        },
+        DateTimeTestCase("TIME '23:59:59.9999'") {
+            time(23, 59, 59, 999900000, 9, null)
+        },
+        DateTimeTestCase("TIME (7) '23:59:59.123456789'") {
+            time(23, 59, 59, 123456789, 7, null)
+        },
+        DateTimeTestCase("TIME (9) '23:59:59.123456789'") {
+            time(23, 59, 59, 123456789, 9, null)
+        },
+        DateTimeTestCase("TIME (0) '23:59:59.123456789'") {
+            time(23, 59, 59, 123456789, 0, null)
+        },
+        DateTimeTestCase("TIME (10) '23:59:59.123456789'") {
+            time(23, 59, 59, 123456789, 9, null)
+        },
+        DateTimeTestCase("TIME '02:30:59-05:30'") {
+            time(2, 30, 59, 0, 9, null)
+        },
+        DateTimeTestCase("TIME '02:30:59+05:30'") {
+            time(2, 30, 59, 0, 9, null)
+        },
+        DateTimeTestCase("TIME '02:30:59-14:39'") {
+            time(2, 30, 59, 0, 9, null)
+        },
+        DateTimeTestCase("TIME '02:30:59+00:00'") {
+            time(2, 30, 59, 0, 9, null)
+        },
+        DateTimeTestCase("TIME '02:30:59-00:00'") {
+            time(2, 30, 59, 0, 9, null)
+        },
+        DateTimeTestCase("TIME (3) '12:59:31+10:30'") {
+            time(12, 59, 31, 0, 3, null)
+        },
+        DateTimeTestCase("TIME (0) '00:00:00+00:00'") {
+            time(0, 0, 0, 0, 0, null)
+        },
+        DateTimeTestCase("TIME (0) '00:00:00-00:00'") {
+            time(0, 0, 0, 0, 0, null)
+        },
+        DateTimeTestCase("TIME '23:59:59.9999-11:59'") {
+            time(23, 59, 59, 999900000, 9, null)
+        },
+        DateTimeTestCase("TIME (7) '23:59:59.123456789+01:00'") {
+            time(23, 59, 59, 123456789, 7, null)
+        },
+        DateTimeTestCase("TIME (9) '23:59:59.123456789-14:50'") {
+            time(23, 59, 59, 123456789, 9, null)
+        },
+        DateTimeTestCase("TIME (0) '23:59:59.123456789-18:00'") {
+            time(23, 59, 59, 123456789, 0, null)
+        },
+        DateTimeTestCase("TIME (10) '23:59:59.123456789+18:00'") {
+            time(23, 59, 59, 123456789, 9, null)
+        },
+        DateTimeTestCase("TIME WITH TIME ZONE '02:30:59'") {
+            time(2, 30, 59, 0, 9, LOCAL_TIME_ZONE_OFFSET)
+        },
+        DateTimeTestCase("TIME (3) WITH TIME ZONE '12:59:31'") {
+            time(12, 59, 31, 0, 3, LOCAL_TIME_ZONE_OFFSET)
+        },
+        DateTimeTestCase("TIME WITH TIME ZONE '23:59:59.9999'") {
+            time(23, 59, 59, 999900000, 9, LOCAL_TIME_ZONE_OFFSET)
+        },
+        DateTimeTestCase("TIME (7) WITH TIME ZONE '23:59:59.123456789'") {
+            time(23, 59, 59, 123456789, 7, LOCAL_TIME_ZONE_OFFSET)
+        },
+        DateTimeTestCase("TIME (9) WITH TIME ZONE '23:59:59.123456789'") {
+            time(23, 59, 59, 123456789, 9, LOCAL_TIME_ZONE_OFFSET)
+        },
+        DateTimeTestCase("TIME (0) WITH TIME ZONE '23:59:59.123456789'") {
+            time(23, 59, 59, 123456789, 0, LOCAL_TIME_ZONE_OFFSET)
+        },
+        DateTimeTestCase("TIME (10) WITH TIME ZONE '23:59:59.123456789'") {
+            time(23, 59, 59, 123456789, 9, LOCAL_TIME_ZONE_OFFSET)
+        },
+        DateTimeTestCase("TIME (0) WITH TIME ZONE '00:00:00+00:00'") {
+            time(0, 0, 0, 0, 0, 0)
+        },
+        DateTimeTestCase("TIME (0) WITH TIME ZONE '00:00:00-00:00'") {
+            time(0, 0, 0, 0, 0, 0)
+        },
+        DateTimeTestCase("TIME WITH TIME ZONE '02:30:59-05:30'") {
+            time(2, 30, 59, 0, 9, -330)
+        },
+        DateTimeTestCase("TIME WITH TIME ZONE '02:30:59+05:30'") {
+            time(2, 30, 59, 0, 9, 330)
+        },
+        DateTimeTestCase("TIME WITH TIME ZONE '02:30:59-14:39'") {
+            time(2, 30, 59, 0, 9, -879)
+        },
+        DateTimeTestCase("TIME WITH TIME ZONE '23:59:59.9999-11:59'") {
+            time(23, 59, 59, 999900000, 9, -719)
+        },
+        DateTimeTestCase("TIME (7) WITH TIME ZONE '23:59:59.123456789+01:00'") {
+            time(23, 59, 59, 123456789, 7, 60)
+        },
+        DateTimeTestCase("TIME (9) WITH TIME ZONE '23:59:59.123456789-14:50'") {
+            time(23, 59, 59, 123456789, 9, -890)
+        },
+        DateTimeTestCase("TIME (0) WITH TIME ZONE '23:59:59.123456789-18:00'") {
+            time(23, 59, 59, 123456789, 0, -1080)
+        },
+        DateTimeTestCase("TIME (10) WITH TIME ZONE '23:59:59.123456789+18:00'") {
+            time(23, 59, 59, 123456789, 9, 1080)
         }
     )
+
+    private fun createErrorCaseForTime(source: String, errorCode: ErrorCode, line: Long, col: Long, tokenType: TokenType, tokenValue: IonValue): () -> Unit = {
+        checkInputThrowingParserException(
+            source,
+            errorCode,
+            mapOf(
+                Property.LINE_NUMBER to line,
+                Property.COLUMN_NUMBER to col,
+                Property.TOKEN_TYPE to tokenType,
+                Property.TOKEN_VALUE to tokenValue))
+    }
+
+    private fun createErrorCaseForTime(source: String, errorCode: ErrorCode, errorContext: Map<Property, Any>): () -> Unit = {
+        checkInputThrowingParserException(
+            source,
+            errorCode,
+            errorContext)
+    }
+
+    fun parametersForTimeParserErrorTests() = listOf(
+        createErrorCaseForTime(
+            source = "TIME",
+            line = 1L,
+            col = 5L,
+            errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            tokenType = TokenType.EOF,
+            tokenValue = ion.newSymbol("EOF")
+        ),
+        createErrorCaseForTime(
+            source = "TIME 123",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newInt(123)
+        ),
+        createErrorCaseForTime(
+            source = "TIME 'time_string'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("time_string")
+        ),
+        createErrorCaseForTime(
+            source = "TIME 123.23",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.singleValue("123.23")
+        ),
+        createErrorCaseForTime(
+            source = "TIME `2012-12-12`",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            tokenType = TokenType.ION_LITERAL,
+            tokenValue = ion.singleValue("2012-12-12")
+        ),
+        createErrorCaseForTime(
+            source = "TIME '2012-12-12'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("2012-12-12")
+        ),
+        createErrorCaseForTime(
+            source = "TIME '12'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("12")
+        ),
+        // This is a valid time string in PostgreSQL
+        createErrorCaseForTime(
+            source = "TIME '12:30'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("12:30")
+        ),
+        // This is a valid time string in PostgreSQL
+        createErrorCaseForTime(
+            source = "TIME '34:59'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("34:59")
+        ),
+        // This is a valid time string in PostgreSQL
+        createErrorCaseForTime(
+            source = "TIME '59.12345'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("59.12345")
+        ),
+        // This is a valid time string in PostgreSQL
+        createErrorCaseForTime(
+            source = "TIME '1:30:38'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("1:30:38")
+        ),
+        // This is a valid time string in PostgreSQL
+        createErrorCaseForTime(
+            source = "TIME '1:30:38'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("1:30:38")
+        ),
+        createErrorCaseForTime(
+            source = "TIME '12:59:61.0000'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("12:59:61.0000")
+        ),
+        createErrorCaseForTime(
+            source = "TIME '12.123:45.123:54.123'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("12.123:45.123:54.123")
+        ),
+        createErrorCaseForTime(
+            source = "TIME '-19:45:13'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("-19:45:13")
+        ),
+        createErrorCaseForTime(
+            source = "TIME '24:00:00'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("24:00:00")
+        ),
+        createErrorCaseForTime(
+            source = "TIME '23:59:59.99999 05:30'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("23:59:59.99999 05:30")
+        ),
+        createErrorCaseForTime(
+            source = "TIME '23:59:59+05:30.00'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("23:59:59+05:30.00")
+        ),
+        // TODO: Investing why the build failed in GH actions for these two tests.
+//        createErrorCaseForTime(
+//            source = "TIME '23:59:59+24:00'",
+//            line = 1L,
+//            col = 6L,
+//            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+//            tokenType = TokenType.LITERAL,
+//            tokenValue = ion.newString("23:59:59+24:00")
+//        ),
+//        createErrorCaseForTime(
+//            source = "TIME '23:59:59-24:00'",
+//            line = 1L,
+//            col = 6L,
+//            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+//            tokenType = TokenType.LITERAL,
+//            tokenValue = ion.newString("23:59:59-24:00")
+//        ),
+        // This is a valid time string in PostgreSQL
+        createErrorCaseForTime(
+            source = "TIME '08:59:59.99999 AM'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("08:59:59.99999 AM")
+        ),
+        // This is a valid time string in PostgreSQL
+        createErrorCaseForTime(
+            source = "TIME '08:59:59.99999 PM'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("08:59:59.99999 PM")
+        ),
+        createErrorCaseForTime(
+            source = "TIME ( '23:59:59.99999'",
+            line = 1L,
+            col = 8L,
+            errorCode = ErrorCode.PARSE_INVALID_PRECISION_FOR_TIME,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("23:59:59.99999")
+        ),
+        createErrorCaseForTime(
+            source = "TIME () '23:59:59.99999'",
+            line = 1L,
+            col = 7L,
+            errorCode = ErrorCode.PARSE_INVALID_PRECISION_FOR_TIME,
+            tokenType = TokenType.RIGHT_PAREN,
+            tokenValue = ion.newSymbol(")")
+        ),
+        createErrorCaseForTime(
+            source = "TIME [4] '23:59:59.99999'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            tokenType = TokenType.LEFT_BRACKET,
+            tokenValue = ion.newSymbol("[")
+        ),
+        createErrorCaseForTime(
+            source = "TIME {4} '23:59:59.99999'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            tokenType = TokenType.LEFT_CURLY,
+            tokenValue = ion.newSymbol("{")
+        ),
+        createErrorCaseForTime(
+            source = "TIME 4 '23:59:59.99999'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newInt(4)
+        ),
+        createErrorCaseForTime(
+            source = "TIME ('4') '23:59:59.99999'",
+            line = 1L,
+            col = 7L,
+            errorCode = ErrorCode.PARSE_INVALID_PRECISION_FOR_TIME,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("4")
+        ),
+        createErrorCaseForTime(
+            source = "TIME ('four') '23:59:59.99999'",
+            line = 1L,
+            col = 7L,
+            errorCode = ErrorCode.PARSE_INVALID_PRECISION_FOR_TIME,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("four")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE",
+            line = 1L,
+            col = 20L,
+            errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            tokenType = TokenType.EOF,
+            tokenValue = ion.newSymbol("EOF")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE '12:20'",
+            line = 1L,
+            col = 21L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("12:20")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE '34:59'",
+            line = 1L,
+            col = 21L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("34:59")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE '59.12345'",
+            line = 1L,
+            col = 21L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("59.12345")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE '12:20'",
+            line = 1L,
+            col = 21L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("12:20")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIMEZONE '23:59:59.99999'",
+            errorCode = ErrorCode.PARSE_EXPECTED_KEYWORD,
+            errorContext = mapOf(
+                Property.LINE_NUMBER to 1L,
+                Property.COLUMN_NUMBER to 11L,
+                Property.KEYWORD to "TIME",
+                Property.TOKEN_TYPE to TokenType.IDENTIFIER,
+                Property.TOKEN_VALUE to ion.newSymbol("TIMEZONE")
+            )
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH_TIME_ZONE '23:59:59.99999'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            tokenType = TokenType.IDENTIFIER,
+            tokenValue = ion.newSymbol("WITH_TIME_ZONE")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITHTIMEZONE '23:59:59.99999'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            tokenType = TokenType.IDENTIFIER,
+            tokenValue = ion.newSymbol("WITHTIMEZONE")
+        ),
+        // PartiQL doesn't support "WITHOUT TIME ZONE" yet. TIME '<time_string>' is in effect the same as TIME WITHOUT TIME ZONE '<time_string>'
+        createErrorCaseForTime(
+            source = "TIME WITHOUT TIME ZONE '23:59:59.99999'",
+            line = 1L,
+            col = 6L,
+            errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            tokenType = TokenType.IDENTIFIER,
+            tokenValue = ion.newSymbol("WITHOUT")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME PHONE '23:59:59.99999'",
+            errorCode = ErrorCode.PARSE_EXPECTED_KEYWORD,
+            errorContext = mapOf(
+                Property.LINE_NUMBER to 1L,
+                Property.COLUMN_NUMBER to 16L,
+                Property.KEYWORD to "ZONE",
+                Property.TOKEN_TYPE to TokenType.IDENTIFIER,
+                Property.TOKEN_VALUE to ion.newSymbol("PHONE")
+            )
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH (4) TIME ZONE '23:59:59.99999'",
+            errorCode = ErrorCode.PARSE_EXPECTED_KEYWORD,
+            errorContext = mapOf(
+                Property.LINE_NUMBER to 1L,
+                Property.COLUMN_NUMBER to 11L,
+                Property.KEYWORD to "TIME",
+                Property.TOKEN_TYPE to TokenType.LEFT_PAREN,
+                Property.TOKEN_VALUE to ion.newSymbol("(")
+            )
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME (4) ZONE '23:59:59.99999'",
+            errorCode = ErrorCode.PARSE_EXPECTED_KEYWORD,
+            errorContext = mapOf(
+                Property.LINE_NUMBER to 1L,
+                Property.COLUMN_NUMBER to 16L,
+                Property.KEYWORD to "ZONE",
+                Property.TOKEN_TYPE to TokenType.LEFT_PAREN,
+                Property.TOKEN_VALUE to ion.newSymbol("(")
+            )
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE (4) '23:59:59.99999'",
+            line = 1L,
+            col = 21L,
+            errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            tokenType = TokenType.LEFT_PAREN,
+            tokenValue = ion.newSymbol("(")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE 'time_string'",
+            line = 1L,
+            col = 21L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("time_string")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE '23:59:59+18:00.00'",
+            line = 1L,
+            col = 21L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("23:59:59+18:00.00")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE '23:59:59-18:00.00'",
+            line = 1L,
+            col = 21L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("23:59:59-18:00.00")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE '23:59:59+18:01'",
+            line = 1L,
+            col = 21L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("23:59:59+18:01")
+        ),
+        // time zone offset out of range
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE '23:59:59-18:01'",
+            line = 1L,
+            col = 21L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("23:59:59-18:01")
+        ),
+        // time zone offset out of range
+        createErrorCaseForTime(
+            source = "TIME ('4') WITH TIME ZONE '23:59:59-18:01'",
+            line = 1L,
+            col = 7L,
+            errorCode = ErrorCode.PARSE_INVALID_PRECISION_FOR_TIME,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("4")
+        ),
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE '23:59:59-18-01'",
+            line = 1L,
+            col = 21L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("23:59:59-18-01")
+        ),
+        // This is valid in PostgreSQL.
+        createErrorCaseForTime(
+            source = "TIME WITH TIME ZONE '23:59:59 PST'",
+            line = 1L,
+            col = 21L,
+            errorCode = ErrorCode.PARSE_INVALID_TIME_STRING,
+            tokenType = TokenType.LITERAL,
+            tokenValue = ion.newString("23:59:59 PST")
+        )
+    )
+
+    @Test
+    @Parameters
+    fun timeParserErrorTests(block: () -> Unit) = block()
+
 }

--- a/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt
@@ -36,115 +36,115 @@ class SqlParserDateTimeTests : SqlParserTestBase() {
             )
         },
         DateTimeTestCase("TIME '02:30:59'") {
-            time(2, 30, 59, 0, 9, null)
+            litTime(timeValue(2, 30, 59, 0, 9, null))
         },
         DateTimeTestCase("TIME (3) '12:59:31'") {
-            time(12, 59, 31, 0, 3, null)
+            litTime(timeValue(12, 59, 31, 0, 3, null))
         },
         DateTimeTestCase("TIME '23:59:59.9999'") {
-            time(23, 59, 59, 999900000, 9, null)
+            litTime(timeValue(23, 59, 59, 999900000, 9, null))
         },
         DateTimeTestCase("TIME (7) '23:59:59.123456789'") {
-            time(23, 59, 59, 123456789, 7, null)
+            litTime(timeValue(23, 59, 59, 123456789, 7, null))
         },
         DateTimeTestCase("TIME (9) '23:59:59.123456789'") {
-            time(23, 59, 59, 123456789, 9, null)
+            litTime(timeValue(23, 59, 59, 123456789, 9, null))
         },
         DateTimeTestCase("TIME (0) '23:59:59.123456789'") {
-            time(23, 59, 59, 123456789, 0, null)
+            litTime(timeValue(23, 59, 59, 123456789, 0, null))
         },
         DateTimeTestCase("TIME (10) '23:59:59.123456789'") {
-            time(23, 59, 59, 123456789, 9, null)
+            litTime(timeValue(23, 59, 59, 123456789, 9, null))
         },
         DateTimeTestCase("TIME '02:30:59-05:30'") {
-            time(2, 30, 59, 0, 9, null)
+            litTime(timeValue(2, 30, 59, 0, 9, null))
         },
         DateTimeTestCase("TIME '02:30:59+05:30'") {
-            time(2, 30, 59, 0, 9, null)
+            litTime(timeValue(2, 30, 59, 0, 9, null))
         },
         DateTimeTestCase("TIME '02:30:59-14:39'") {
-            time(2, 30, 59, 0, 9, null)
+            litTime(timeValue(2, 30, 59, 0, 9, null))
         },
         DateTimeTestCase("TIME '02:30:59+00:00'") {
-            time(2, 30, 59, 0, 9, null)
+            litTime(timeValue(2, 30, 59, 0, 9, null))
         },
         DateTimeTestCase("TIME '02:30:59-00:00'") {
-            time(2, 30, 59, 0, 9, null)
+            litTime(timeValue(2, 30, 59, 0, 9, null))
         },
         DateTimeTestCase("TIME (3) '12:59:31+10:30'") {
-            time(12, 59, 31, 0, 3, null)
+            litTime(timeValue(12, 59, 31, 0, 3, null))
         },
         DateTimeTestCase("TIME (0) '00:00:00+00:00'") {
-            time(0, 0, 0, 0, 0, null)
+            litTime(timeValue(0, 0, 0, 0, 0, null))
         },
         DateTimeTestCase("TIME (0) '00:00:00-00:00'") {
-            time(0, 0, 0, 0, 0, null)
+            litTime(timeValue(0, 0, 0, 0, 0, null))
         },
         DateTimeTestCase("TIME '23:59:59.9999-11:59'") {
-            time(23, 59, 59, 999900000, 9, null)
+            litTime(timeValue(23, 59, 59, 999900000, 9, null))
         },
         DateTimeTestCase("TIME (7) '23:59:59.123456789+01:00'") {
-            time(23, 59, 59, 123456789, 7, null)
+            litTime(timeValue(23, 59, 59, 123456789, 7, null))
         },
         DateTimeTestCase("TIME (9) '23:59:59.123456789-14:50'") {
-            time(23, 59, 59, 123456789, 9, null)
+            litTime(timeValue(23, 59, 59, 123456789, 9, null))
         },
         DateTimeTestCase("TIME (0) '23:59:59.123456789-18:00'") {
-            time(23, 59, 59, 123456789, 0, null)
+            litTime(timeValue(23, 59, 59, 123456789, 0, null))
         },
         DateTimeTestCase("TIME (10) '23:59:59.123456789+18:00'") {
-            time(23, 59, 59, 123456789, 9, null)
+            litTime(timeValue(23, 59, 59, 123456789, 9, null))
         },
         DateTimeTestCase("TIME WITH TIME ZONE '02:30:59'") {
-            time(2, 30, 59, 0, 9, LOCAL_TIME_ZONE_OFFSET)
+            litTime(timeValue(2, 30, 59, 0, 9, LOCAL_TIME_ZONE_OFFSET))
         },
         DateTimeTestCase("TIME (3) WITH TIME ZONE '12:59:31'") {
-            time(12, 59, 31, 0, 3, LOCAL_TIME_ZONE_OFFSET)
+            litTime(timeValue(12, 59, 31, 0, 3, LOCAL_TIME_ZONE_OFFSET))
         },
         DateTimeTestCase("TIME WITH TIME ZONE '23:59:59.9999'") {
-            time(23, 59, 59, 999900000, 9, LOCAL_TIME_ZONE_OFFSET)
+            litTime(timeValue(23, 59, 59, 999900000, 9, LOCAL_TIME_ZONE_OFFSET))
         },
         DateTimeTestCase("TIME (7) WITH TIME ZONE '23:59:59.123456789'") {
-            time(23, 59, 59, 123456789, 7, LOCAL_TIME_ZONE_OFFSET)
+            litTime(timeValue(23, 59, 59, 123456789, 7, LOCAL_TIME_ZONE_OFFSET))
         },
         DateTimeTestCase("TIME (9) WITH TIME ZONE '23:59:59.123456789'") {
-            time(23, 59, 59, 123456789, 9, LOCAL_TIME_ZONE_OFFSET)
+            litTime(timeValue(23, 59, 59, 123456789, 9, LOCAL_TIME_ZONE_OFFSET))
         },
         DateTimeTestCase("TIME (0) WITH TIME ZONE '23:59:59.123456789'") {
-            time(23, 59, 59, 123456789, 0, LOCAL_TIME_ZONE_OFFSET)
+            litTime(timeValue(23, 59, 59, 123456789, 0, LOCAL_TIME_ZONE_OFFSET))
         },
         DateTimeTestCase("TIME (10) WITH TIME ZONE '23:59:59.123456789'") {
-            time(23, 59, 59, 123456789, 9, LOCAL_TIME_ZONE_OFFSET)
+            litTime(timeValue(23, 59, 59, 123456789, 9, LOCAL_TIME_ZONE_OFFSET))
         },
         DateTimeTestCase("TIME (0) WITH TIME ZONE '00:00:00+00:00'") {
-            time(0, 0, 0, 0, 0, 0)
+            litTime(timeValue(0, 0, 0, 0, 0, 0))
         },
         DateTimeTestCase("TIME (0) WITH TIME ZONE '00:00:00-00:00'") {
-            time(0, 0, 0, 0, 0, 0)
+            litTime(timeValue(0, 0, 0, 0, 0, 0))
         },
         DateTimeTestCase("TIME WITH TIME ZONE '02:30:59-05:30'") {
-            time(2, 30, 59, 0, 9, -330)
+            litTime(timeValue(2, 30, 59, 0, 9, -330))
         },
         DateTimeTestCase("TIME WITH TIME ZONE '02:30:59+05:30'") {
-            time(2, 30, 59, 0, 9, 330)
+            litTime(timeValue(2, 30, 59, 0, 9, 330))
         },
         DateTimeTestCase("TIME WITH TIME ZONE '02:30:59-14:39'") {
-            time(2, 30, 59, 0, 9, -879)
+            litTime(timeValue(2, 30, 59, 0, 9, -879))
         },
         DateTimeTestCase("TIME WITH TIME ZONE '23:59:59.9999-11:59'") {
-            time(23, 59, 59, 999900000, 9, -719)
+            litTime(timeValue(23, 59, 59, 999900000, 9, -719))
         },
         DateTimeTestCase("TIME (7) WITH TIME ZONE '23:59:59.123456789+01:00'") {
-            time(23, 59, 59, 123456789, 7, 60)
+            litTime(timeValue(23, 59, 59, 123456789, 7, 60))
         },
         DateTimeTestCase("TIME (9) WITH TIME ZONE '23:59:59.123456789-14:50'") {
-            time(23, 59, 59, 123456789, 9, -890)
+            litTime(timeValue(23, 59, 59, 123456789, 9, -890))
         },
         DateTimeTestCase("TIME (0) WITH TIME ZONE '23:59:59.123456789-18:00'") {
-            time(23, 59, 59, 123456789, 0, -1080)
+            litTime(timeValue(23, 59, 59, 123456789, 0, -1080))
         },
         DateTimeTestCase("TIME (10) WITH TIME ZONE '23:59:59.123456789+18:00'") {
-            time(23, 59, 59, 123456789, 9, 1080)
+            litTime(timeValue(23, 59, 59, 123456789, 9, 1080))
         }
     )
 

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -32,8 +32,11 @@ import org.partiql.lang.ast.toAstExpr
 import org.partiql.lang.ast.toAstStatement
 import org.partiql.lang.ast.toExprNode
 import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.errors.ErrorCode
+import org.partiql.lang.errors.Property
 import org.partiql.lang.util.asIonSexp
 import org.partiql.lang.util.filterMetaNodes
+import org.partiql.lang.util.softAssert
 import org.partiql.pig.runtime.toIonElement
 
 abstract class SqlParserTestBase : TestBase() {
@@ -218,4 +221,21 @@ abstract class SqlParserTestBase : TestBase() {
     private fun loadIonSexp(expectedSexpAst: String) = ion.singleValue(expectedSexpAst).asIonSexp()
     private fun ExprNode.stripMetas() = MetaStrippingRewriter.stripMetas(this)
 
+    protected fun checkInputThrowingParserException(input: String,
+                                                  errorCode: ErrorCode,
+                                                  expectErrorContextValues: Map<Property, Any>) {
+
+        softAssert {
+            try {
+                parser.parseExprNode(input)
+                fail("Expected ParserException but there was no Exception")
+            }
+            catch (pex: ParserException) {
+                checkErrorAndErrorContext(errorCode, pex, expectErrorContextValues)
+            }
+            catch (ex: Exception) {
+                fail("Expected ParserException but a different exception was thrown \n\t  $ex")
+            }
+        }
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Extends `SqlParser` to support `TIME` literals.
* Supports parsing optional `precision` and optional TIME ZONE specifier `WITH TIME ZONE` for `TIME` literals.
* Adds tests covering positive and negative cases for `TIME` literals.
*  Uses `LocalTime` and `OffsetTime` java classes for parsing and validating `TIME` strings.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
