### PR TITLE
Change ION_TEXT output format to put each top-level ion value on a newline

### DIFF
--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -120,4 +120,12 @@ class CliTest {
 
         assertEquals("<<\n  {\n    'a': 1,\n    'b': 2\n  }\n>>", actual)
     }
+
+    @Test
+    fun withIonTextOutput() {
+        val subject = makeCli("SELECT * FROM input_data", "{a: 1} {b: 1}", outputFormat = OutputFormat.ION_TEXT)
+        val actual = subject.runAndOutput()
+
+        assertEquals("{a:1}\n{b:1}\n", actual)
+    }
 }


### PR DESCRIPTION
**Issue #, if available:**

Fixes #207 

**Description of changes:**

Causes all top-level ion values to be delimited by a newline when using the ION_TEXT output format, and the full output is terminated by a newline.

----
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
