### PR TITLE
Cherry-pick PR #398 to v0.1.6 branch and optimize test memory usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,14 @@ configure(subprojects.findAll { it.name != 'example' }) {
 
 subprojects {
 
+    tasks.withType(Test) {
+        maxHeapSize = "8g"
+        testLogging {
+            events "failed"
+            exceptionFormat "full"
+        }
+    }
+
 
     plugins.withId('java', { _ ->
 

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ configure(subprojects.findAll { it.name != 'example' }) {
 subprojects {
 
     tasks.withType(Test) {
-        maxHeapSize = "8g"
+        maxHeapSize = "4g"
         testLogging {
             events "failed"
             exceptionFormat "full"

--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -18,7 +18,8 @@ import com.amazon.ion.IonSexp
 import com.amazon.ion.IonSystem
 import org.partiql.lang.util.IonWriterContext
 import org.partiql.lang.util.case
-import java.lang.UnsupportedOperationException
+import org.partiql.lang.util.checkThreadInterrupted
+import kotlin.UnsupportedOperationException
 
 /**
  * The current version of the AST.  Update this once every time a new variant of the AST is created.
@@ -71,6 +72,7 @@ private fun IonWriterContext.writeAsTerm(metas: MetaContainer, block: IonWriterC
 
 private fun IonWriterContext.writeExprNode(expr: ExprNode): Unit =
     writeAsTerm(expr.metas) {
+            checkThreadInterrupted()
         sexp {
             when (expr) {
                 is Literal           -> case { writeLiteral(expr) }

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -26,27 +26,14 @@ sealed class AstNode : Iterable<AstNode> {
     /**
      * Returns all the children nodes.
      *
-     * This property is [deprecated](see https://github.com/partiql/partiql-lang-kotlin/issues/396).  Use
-     * one of the following PIG-generated classes to analyze AST nodes instead:
-     *
-     * - [org.partiql.lang.domains.PartiqlAst.Visitor]
-     * - [org.partiql.lang.domains.PartiqlAst.VisitorFold]
      */
-    @Deprecated("DO NOT USE - see kdoc, see https://github.com/partiql/partiql-lang-kotlin/issues/396")
     abstract val children: List<AstNode>
 
     /**
      * Depth first iterator over all nodes.
      *
      * While collecting child nodes, throws [InterruptedException] if the [Thread.interrupted] flag has been set.
-     *
-     * This property is [deprecated](see https://github.com/partiql/partiql-lang-kotlin/issues/396).  Use
-     * one of the following PIG-generated classes to analyze AST nodes instead:
-     *
-     * - [org.partiql.lang.domains.PartiqlAst.Visitor]
-     * - [org.partiql.lang.domains.PartiqlAst.VisitorFold]
      */
-    @Deprecated("DO NOT USE - see kdoc for alternatives")
     override operator fun iterator(): Iterator<AstNode> {
         val allNodes = mutableListOf<AstNode>()
 

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -24,19 +24,35 @@ import java.util.*
 sealed class AstNode : Iterable<AstNode> {
 
     /**
-     * returns all the children nodes.
+     * Returns all the children nodes.
+     *
+     * This property is [deprecated](see https://github.com/partiql/partiql-lang-kotlin/issues/396).  Use
+     * one of the following PIG-generated classes to analyze AST nodes instead:
+     *
+     * - [org.partiql.lang.domains.PartiqlAst.Visitor]
+     * - [org.partiql.lang.domains.PartiqlAst.VisitorFold]
      */
+    @Deprecated("DO NOT USE - see kdoc, see https://github.com/partiql/partiql-lang-kotlin/issues/396")
     abstract val children: List<AstNode>
 
     /**
      * Depth first iterator over all nodes.
+     *
+     * While collecting child nodes, throws [InterruptedException] if the [Thread.interrupted] flag has been set.
+     *
+     * This property is [deprecated](see https://github.com/partiql/partiql-lang-kotlin/issues/396).  Use
+     * one of the following PIG-generated classes to analyze AST nodes instead:
+     *
+     * - [org.partiql.lang.domains.PartiqlAst.Visitor]
+     * - [org.partiql.lang.domains.PartiqlAst.VisitorFold]
      */
+    @Deprecated("DO NOT USE - see kdoc for alternatives")
     override operator fun iterator(): Iterator<AstNode> {
         val allNodes = mutableListOf<AstNode>()
 
         fun depthFirstSequence(node: AstNode) {
             allNodes.add(node)
-            node.children.map { depthFirstSequence(it) }
+            node.children.interruptibleMap { depthFirstSequence(it) }
         }
 
         depthFirstSequence(this)

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -15,6 +15,7 @@
 package org.partiql.lang.ast.passes
 
 import org.partiql.lang.ast.*
+import org.partiql.lang.util.checkThreadInterrupted
 
 /**
  * Provides a minimal interface for an AST rewriter implementation.
@@ -27,10 +28,11 @@ public interface AstRewriter {
  * This is the base-class for an AST rewriter which simply makes an exact copy of the original AST.
  * Simple rewrites can be performed by inheritors.
  */
-public open class AstRewriterBase : AstRewriter {
+open class AstRewriterBase : AstRewriter {
 
-    override fun rewriteExprNode(node: ExprNode): ExprNode =
-        when (node) {
+    override fun rewriteExprNode(node: ExprNode): ExprNode {
+        checkThreadInterrupted()
+        return when (node) {
             is Literal           -> rewriteLiteral(node)
             is LiteralMissing    -> rewriteLiteralMissing(node)
             is VariableReference -> rewriteVariableReference(node)
@@ -45,6 +47,7 @@ public open class AstRewriterBase : AstRewriter {
             is Bag               -> rewriteBag(node)
             is Select            -> rewriteSelect(node)
         }
+    }
 
     open fun rewriteMetas(itemWithMetas: HasMetas): MetaContainer = itemWithMetas.metas
 

--- a/lang/src/org/partiql/lang/ast/passes/AstVisitor.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstVisitor.kt
@@ -27,7 +27,6 @@ import org.partiql.lang.ast.*
  *
  *  One `visit*` function is included for each base type in the AST.
  */
-@Deprecated("Use org.lang.partiql.domains.PartiqlAst.Visitor instead")
 interface AstVisitor {
     /**
      * Invoked by [AstWalker] for every instance of [ExprNode] encountered.

--- a/lang/src/org/partiql/lang/ast/passes/AstVisitor.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstVisitor.kt
@@ -27,7 +27,7 @@ import org.partiql.lang.ast.*
  *
  *  One `visit*` function is included for each base type in the AST.
  */
-@Deprecated("Use AstNode#iterator() or AstNode#children()")
+@Deprecated("Use org.lang.partiql.domains.PartiqlAst.Visitor instead")
 interface AstVisitor {
     /**
      * Invoked by [AstWalker] for every instance of [ExprNode] encountered.

--- a/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
@@ -20,11 +20,11 @@ import org.partiql.lang.util.*
 /**
  * Contains the logic necessary to walk every node in the AST and invokes methods of [AstVisitor] along the way.
  */
-@Deprecated("Use AstNode#iterator() or AstNode#children()")
-class AstWalker(private val visitor: AstVisitor) {
+open class AstWalker(private val visitor: AstVisitor) {
 
     fun walk(exprNode: ExprNode) {
-        exprNode.forEach { node -> 
+        exprNode.forEach { node ->
+            checkThreadInterrupted()
             when(node) {
                 is ExprNode -> visitor.visitExprNode(node)
                 is DataType -> visitor.visitDataType(node)
@@ -32,7 +32,7 @@ class AstWalker(private val visitor: AstVisitor) {
                 is FromSource -> visitor.visitFromSource(node)
                 is SelectListItem -> visitor.visitSelectListItem(node)
                 is SelectProjection -> visitor.visitSelectProjection(node)
-                    
+
             }
         }
     }

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -162,6 +162,10 @@ internal class EvaluatingCompiler(
 
     /**
      * Compiles an [ExprNode] tree to an [Expression].
+     *
+     * Checks [Thread.interrupted] before every expression and sub-expression is compiled
+     * and throws [InterruptedException] if [Thread.interrupted] it has been set in the
+     * hope that long running compilations may be aborted by the caller.
      */
     fun compile(originalAst: ExprNode): Expression {
 
@@ -227,7 +231,13 @@ internal class EvaluatingCompiler(
      */
     fun eval(ast: ExprNode, session: EvaluationSession): ExprValue = compile(ast).eval(session)
 
+    /**
+     * Compiles the specified [ExprNode] into a [ThunkEnv].
+     *
+     * This function will [InterruptedException] if [Thread.interrupted] has been set.
+     */
     private fun compileExprNode(expr: ExprNode): ThunkEnv {
+        checkThreadInterrupted()
         return when (expr) {
             is Literal           -> compileLiteral(expr)
             is LiteralMissing    -> compileLiteralMissing(expr)

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -656,12 +656,17 @@ class SqlParser(private val ion: IonSystem) : Parser {
     /**
      * Parses the given token list.
      *
+     * Throws [InterruptedException] if [Thread.interrupted] is set. This is the best place to do
+     * that for the parser because this is the main function called to parse an expression and so
+     * is called quite frequently during parsing by many parts of the parser.
+     *
      * @param precedence The precedence of the current expression parsing.
      *                   A negative value represents the "top-level" parsing.
      *
      * @return The parse tree for the given expression.
      */
     internal fun List<Token>.parseExpression(precedence: Int = -1): ParseNode {
+        checkThreadInterrupted()
         var expr = parseUnaryTerm()
         var rem = expr.remaining
 

--- a/lang/src/org/partiql/lang/util/ThreadInterruptUtils.kt
+++ b/lang/src/org/partiql/lang/util/ThreadInterruptUtils.kt
@@ -1,0 +1,30 @@
+package org.partiql.lang.util
+
+/** Throws [InterruptedException] if [Thread.interrupted] is set. */
+internal fun checkThreadInterrupted() {
+    if(Thread.interrupted()) {
+        throw InterruptedException()
+    }
+}
+
+/**
+ * Like a regular [map], but checks [Thread.interrupted] before each iteration and throws
+ * [InterruptedException] if it is set.
+ *
+ * This should be used instead of the regular [map] where there is a potential for a large
+ * number of items in the receiver [List] to allow long running operations to be aborted
+ * by the caller.
+ */
+internal inline fun <T, R> List<T>.interruptibleMap(crossinline block: (T) -> R): List<R> =
+    this.map { checkThreadInterrupted(); block(it) }
+
+/**
+ * Like a regular [fold], but checks [Thread.interrupted] before each iteration and throws
+ * [InterruptedException] if it is set.
+ *
+ * This should be used instead of the regular [fold] where there is a potential for a large
+ * number of items in the receiver [List] to allow long running operations to be aborted
+ * by the caller.
+ */
+internal inline fun <T, A> List<T>.interruptibleFold(initial: A, crossinline block: (A, T) -> A) =
+    this.fold(initial) { acc, curr -> checkThreadInterrupted(); block(acc, curr) }

--- a/lang/test/org/partiql/lang/ast/AstNodeTest.kt
+++ b/lang/test/org/partiql/lang/ast/AstNodeTest.kt
@@ -8,6 +8,7 @@ import org.junit.Assert.*
 import org.junit.runner.*
 import org.partiql.lang.syntax.*
 
+@Suppress("DEPRECATION")
 @RunWith(JUnitParamsRunner::class)
 class AstNodeTest {
     // This test builds some invalid AST nodes but since we are focusing on testing AstNode interface we only care

--- a/lang/test/org/partiql/lang/thread/EndlessExprNodeList.kt
+++ b/lang/test/org/partiql/lang/thread/EndlessExprNodeList.kt
@@ -1,0 +1,13 @@
+package org.partiql.lang.thread
+
+import org.partiql.lang.ast.ExprNode
+import org.partiql.lang.eval.ExprValue
+
+class EndlessExprNodeList(
+    override val size: Int,
+    private val exprNode: ExprNode
+) : AbstractList<ExprNode>() {
+
+    override fun get(index: Int): ExprNode = exprNode
+}
+

--- a/lang/test/org/partiql/lang/thread/EndlessTokenList.kt
+++ b/lang/test/org/partiql/lang/thread/EndlessTokenList.kt
@@ -1,0 +1,38 @@
+package org.partiql.lang.thread
+
+import com.amazon.ion.IonSystem
+import org.partiql.lang.syntax.SourcePosition
+import org.partiql.lang.syntax.Token
+import org.partiql.lang.syntax.TokenType
+
+/**
+ * A synthetic list of tokens containing [Int.MAX_VALUE] elements, in the format of `1 + 2 + 3...`
+ *
+ * This class is useful for testing the ability to abort [SqlParser] when parsing something really big.
+ */
+internal class EndlessTokenList(val ion: IonSystem, val startIndex: Int = 0) : AbstractList<Token>() {
+
+    override val size: Int
+        get() = Int.MAX_VALUE
+
+    override fun get(index: Int): Token {
+        val span = SourcePosition(index / 80L, index % 80L)
+
+        return when((startIndex + index) % 2) {
+            0 -> Token(
+                type = TokenType.LITERAL,
+                value = ion.newInt(startIndex + index),
+                position = span
+            )
+            1 -> Token(
+                TokenType.OPERATOR,
+                ion.newSymbol("+"),
+                span
+            )
+            else -> error("shouldn't happen")
+        }
+    }
+
+    override fun subList(fromIndex: Int, toIndex: Int): List<Token> =
+        EndlessTokenList(ion, startIndex + fromIndex)
+}

--- a/lang/test/org/partiql/lang/thread/ThreadInterruptedTests.kt
+++ b/lang/test/org/partiql/lang/thread/ThreadInterruptedTests.kt
@@ -42,12 +42,13 @@ const val WAIT_FOR_THREAD_TERMINATION_MS: Long = 1000
  */
 class ThreadInterruptedTests {
     private val ion = IonSystemBuilder.standard().build()
-    private val reallyBigNAry by lazy { makeBigExprNode(20000000) }
-    private val bigNAry by lazy { makeBigExprNode(10000000) }
+    private val reallyBigNAry = makeBigExprNode(20000000)
+    private val bigNAry = makeBigExprNode(10000000)
 
     private val bigSexpAst by lazy {
+        val nary = makeBigExprNode(1000000)
         @Suppress("DEPRECATION")
-        val sexp = AstSerializer.serialize(bigNAry, ion)
+        val sexp = AstSerializer.serialize(nary, ion)
         // format of sexp is:
         // (ast
         //    (version x)
@@ -61,11 +62,10 @@ class ThreadInterruptedTests {
         val variableA = VariableReference("a", CaseSensitivity.INSENSITIVE, ScopeQualifier.UNQUALIFIED, emptyMetas)
         return NAry(
             NAryOp.ADD,
-            (0..n).map { variableA },
+            EndlessExprNodeList(n, variableA),
             emptyMetas
         )
     }
-
 
     private fun testThreadInterrupt(block: () -> Unit) {
         val wasInterrupted = AtomicBoolean(false)

--- a/lang/test/org/partiql/lang/thread/ThreadInterruptedTests.kt
+++ b/lang/test/org/partiql/lang/thread/ThreadInterruptedTests.kt
@@ -1,0 +1,202 @@
+package org.partiql.lang.thread
+
+import com.amazon.ion.IonSexp
+import com.amazon.ion.system.IonSystemBuilder
+import org.junit.Test
+import org.partiql.lang.CompilerPipeline
+import org.partiql.lang.CompilerPipelineImpl
+import org.partiql.lang.StepContext
+import org.partiql.lang.ast.AstDeserializerImpl
+import org.partiql.lang.ast.AstSerializer
+import org.partiql.lang.ast.AstVersion
+import org.partiql.lang.ast.CaseSensitivity
+import org.partiql.lang.ast.Literal
+import org.partiql.lang.ast.NAry
+import org.partiql.lang.ast.NAryOp
+import org.partiql.lang.ast.ScopeQualifier
+import org.partiql.lang.ast.VariableReference
+import org.partiql.lang.ast.metaContainerOf
+import org.partiql.lang.ast.passes.AstRewriterBase
+import org.partiql.lang.ast.passes.AstVisitor
+import org.partiql.lang.ast.passes.AstWalker
+import org.partiql.lang.eval.CompileOptions
+import org.partiql.lang.syntax.SqlParser
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.test.assertTrue
+
+
+/** How long (in miilis) to wait after starting a thread to set the interrupted flag. */
+const val INTERRUPT_AFTER_MS: Long = 100
+
+/** How long (in millis) to wait for a thread to terminate after setting the interrupted flag. */
+const val WAIT_FOR_THREAD_TERMINATION_MS: Long = 1000
+
+/**
+ * At various locations in this codebase we check the state of [Thread.interrupted] and throw an
+ * [InterruptedException] if it is set.  This class contains one test for each of those locations.
+ * Each test spins up a background thread and tries to interrupt it.
+ *
+ * In order to ensure the these tests are deterministic, we use fairly low values for [INTERRUPT_AFTER_MS],
+ * a large value for [WAIT_FOR_THREAD_TERMINATION_MS] and pathologically large mock data.
+ */
+class ThreadInterruptedTests {
+    private val ion = IonSystemBuilder.standard().build()
+    private val reallyBigNAry by lazy { makeBigExprNode(20000000) }
+    private val bigNAry by lazy { makeBigExprNode(10000000) }
+
+    private val bigSexpAst by lazy {
+        @Suppress("DEPRECATION")
+        val sexp = AstSerializer.serialize(bigNAry, ion)
+        // format of sexp is:
+        // (ast
+        //    (version x)
+        //    (root y))
+        // Extract y:
+        (sexp[2] as IonSexp)[1] as IonSexp
+    }
+
+    private fun makeBigExprNode(n: Int): NAry {
+        val emptyMetas = metaContainerOf()
+        val variableA = VariableReference("a", CaseSensitivity.INSENSITIVE, ScopeQualifier.UNQUALIFIED, emptyMetas)
+        return NAry(
+            NAryOp.ADD,
+            (0..n).map { variableA },
+            emptyMetas
+        )
+    }
+
+
+    private fun testThreadInterrupt(block: () -> Unit) {
+        val wasInterrupted = AtomicBoolean(false)
+        val t = thread {
+            try {
+                block()
+            } catch(_: InterruptedException) {
+                wasInterrupted.set(true)
+            }
+        }
+
+        Thread.sleep(INTERRUPT_AFTER_MS)
+
+        t.interrupt()
+        t.join(WAIT_FOR_THREAD_TERMINATION_MS)
+        assertTrue(wasInterrupted.get(), "Thread should have been interrupted.")
+    }
+
+    @Test
+    fun parser() {
+        testThreadInterrupt {
+            val sqlParser = SqlParser(ion)
+            val endlessTokenList = EndlessTokenList(ion)
+            sqlParser.run {
+                endlessTokenList.parseExpression()
+            }
+        }
+    }
+
+    @Test
+    fun astChildIterator() {
+        // force lazy load
+        reallyBigNAry
+        testThreadInterrupt {
+            @Suppress("DEPRECATION")
+            reallyBigNAry.iterator()
+        }
+    }
+
+    @Test
+    fun astWalker() {
+        // force lazy load
+        reallyBigNAry
+        val walker = AstWalker(object : AstVisitor { })
+        testThreadInterrupt {
+            walker.walk(reallyBigNAry)
+        }
+    }
+
+    @Test
+    fun serialize() {
+        // force lazy load
+        bigNAry
+        testThreadInterrupt {
+            @Suppress("DEPRECATION")
+            AstSerializer.serialize(bigNAry, ion)
+        }
+    }
+
+    @Test
+    fun deserialize_validate() {
+        // force lazy load
+        bigSexpAst
+
+        val deserializer = AstDeserializerImpl(ion, emptyMap())
+        deserializer.astVersion = AstVersion.V1
+        testThreadInterrupt {
+            deserializer.validate(bigSexpAst)
+        }
+    }
+
+    @Test
+    fun deserialize_deserializeExprNode() {
+        // force lazy load
+        bigSexpAst
+
+        val deserializer = AstDeserializerImpl(ion, emptyMap())
+        deserializer.astVersion = AstVersion.V1
+
+        testThreadInterrupt {
+            deserializer.deserializeExprNode(bigSexpAst)
+        }
+    }
+
+    @Test
+    fun astRewriterBase() {
+        // force lazy load
+        reallyBigNAry
+
+        @Suppress("DEPRECATION")
+        val identityRewriter = AstRewriterBase()
+        testThreadInterrupt {
+            identityRewriter.rewriteExprNode(reallyBigNAry)
+        }
+    }
+
+    @Test
+    fun compilerPipeline() {
+        val numSteps = 10000000
+        val pipeline = CompilerPipeline.build(ion) {
+            repeat(numSteps) {
+                addPreprocessingStep { expr, _ ->
+                    // burns about 200ms on first run
+                    assert(factorial(Int.MAX_VALUE / 8) >= 0)
+                    expr
+                }
+            }
+        } as CompilerPipelineImpl
+
+        val expr = Literal(ion.newInt(42), metaContainerOf())
+        val context = StepContext(pipeline.valueFactory, CompileOptions.standard(), emptyMap())
+
+        testThreadInterrupt {
+            pipeline.executePreProcessingSteps(expr, context)
+        }
+    }
+}
+
+private fun factorial(num: Int): Long {
+    var result = 1L
+    for (i in 2..num) result *= i
+    return result
+}
+
+fun <T> time(message: String = "", block: () -> T): T {
+    val startTime = System.currentTimeMillis()
+
+    return block().also {
+        val endTime = System.currentTimeMillis()
+        val duration = endTime - startTime
+        val of = when(message.length) { 0 -> "" else -> " of $message"}
+        println("duration$of: $duration")
+    }
+}


### PR DESCRIPTION
Just like the title says, no new implementation, but there was changes to the unit tests:

For some reason I still don't fully understand, the tests added in PR #398 to the started consuming more than 4gb of RAM after being cherry-picked to the `v0.1.6` branch, which would cause the build fail since the JVM was limited to 4gb.  I tried increasing the RAM allocated to the JVM but wasn't able to get it to run correctly until 6gb and 7gb is the maximum amount of memory allowed by GitHub actions, which I know we will likely migrate to some day soon.  That was cutting it pretty close, so I was felt it was better to reduce memory consumption of the tests, so this PR includes changes that reduce the memory consumption of the tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
