### PR TITLE
Reduce memory usage of Thread.interrupted() tests

### DIFF
--- a/lang/test/org/partiql/lang/thread/EndlessList.kt
+++ b/lang/test/org/partiql/lang/thread/EndlessList.kt
@@ -1,0 +1,1 @@
+package org.partiql.lang.thread

--- a/lang/test/org/partiql/lang/thread/EndlessList.kt
+++ b/lang/test/org/partiql/lang/thread/EndlessList.kt
@@ -1,1 +1,0 @@
-package org.partiql.lang.thread


### PR DESCRIPTION
For some reason I still don't fully understand, the tests added in PR #398 to the started consuming more than 4gb of RAM after being cherry-picked to the `v0.1.6` branch, which would cause the build fail since the JVM was limited to 4gb.  I tried increasing the RAM allocated to the JVM but wasn't able to get it to run correctly until 6gb and 7gb is the maximum amount of memory allowed by GitHub actions, which I know we will likely migrate to some day soon.  That was cutting it pretty close, so I was felt it was better to reduce memory consumption of the tests in that branch and decided to apply a similar fix to `master` in this PR. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
