### PR TITLE
Further revise thread interrupt tests

### DIFF
--- a/lang/test/org/partiql/lang/thread/EndlessList.kt
+++ b/lang/test/org/partiql/lang/thread/EndlessList.kt
@@ -1,0 +1,1 @@
+package org.partiql.lang.thread


### PR DESCRIPTION
Build failure example: https://github.com/partiql/partiql-lang-kotlin/runs/2531805409

I think that inside the loop of `factorial`, one of the multiplications would overflow to zero, and all subsequent multiplications would then be zero, and the JVM's JIT was detecting this and eliding the loop, making `factorial` return instantly and allowing all of the compiler steps to finish before the thread was interrupted.  Anyway, this can't happen with `fibonacci`, so I switched the "CPU eater" to `fibonacci` instead.

Also changes the following:

- Removes unused `time` function.
- Also, remove more laziness that I missed previously and isn't needed anymore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
