### PR TITLE
Adds comparison operators for DATE and TIME

### DIFF
--- a/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
@@ -154,6 +154,7 @@ operator fun ExprValue.compareTo(other: ExprValue): Int {
 
 /**
  * Checks if the two ExprValues are directly comparable.
+ * Directly comparable is used in the context of the `<`/`<=`/`>`/`>=` operators.
  */
 internal fun ExprValue.isDirectlyComparableTo(other: ExprValue): Boolean =
     when {

--- a/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
@@ -147,10 +147,21 @@ operator fun ExprValue.compareTo(other: ExprValue): Int {
     return when {
         type.isUnknown || other.type.isUnknown  ->
             throw EvaluationException("Null value cannot be compared: $this, $other", internal = false)
-        type.isDirectlyComparableTo(other.type) -> DEFAULT_COMPARATOR.compare(this, other)
-        else                                    -> errNoContext("Cannot compare values: $this, $other", internal = false)
+        isDirectlyComparableTo(other) -> DEFAULT_COMPARATOR.compare(this, other)
+        else                          -> errNoContext("Cannot compare values: $this, $other", internal = false)
     }
 }
+
+/**
+ * Checks if the two ExprValues are directly comparable.
+ */
+internal fun ExprValue.isDirectlyComparableTo(other: ExprValue): Boolean =
+    when {
+        // The ExprValue type for TIME and TIME WITH TIME ZONE is same
+        // and thus needs to be checked explicitly for the timezone values.
+        type == TIME && other.type == TIME -> timeValue().isDirectlyComparableTo(other.timeValue())
+        else -> type.isDirectlyComparableTo(other.type)
+    }
 
 /** Types that are cast to the [ExprValueType.isText] types by calling `IonValue.toString()`. */
 private val ION_TEXT_STRING_CAST_TYPES = setOf(BOOL, TIMESTAMP)

--- a/lang/src/org/partiql/lang/eval/NaturalExprValueComparators.kt
+++ b/lang/src/org/partiql/lang/eval/NaturalExprValueComparators.kt
@@ -32,6 +32,9 @@ import org.partiql.lang.util.*
  *    of precision or specific type.
  *      For `FLOAT` special values, `nan` comes before `-inf`, which comes before all normal
  *      numeric values, which is followed by `+inf`.
+ *  * `DATE` values follow and are compared by the date from earliest to latest.
+ *  * `TIME` values follow and are compared by the time of the day (point of time in a day of 24 hours)
+ *      from earliest to latest. Note that time without time zone is incomparable with time with time zone.
  *  * `TIMESTAMP` values follow and are compared by the point of time irrespective of precision and
  *    local UTC offset.
  *  * The [ExprValueType.isText] types come next ordered by their lexicographical ordering by
@@ -183,6 +186,26 @@ enum class NaturalExprValueComparators(private val nullOrder: NullOrder) : Compa
                     lVal.isZero() && rVal.isZero() -> return EQUAL // for negative zero
                     else -> return lVal.compareTo(rVal)
                 }
+            }
+        ) { return it }
+
+        // Date
+        ifCompared(
+            handle(lType == DATE, rType == DATE) {
+                val lVal = left.dateValue()
+                val rVal = right.dateValue()
+
+                return lVal.compareTo(rVal)
+            }
+        ) { return it }
+
+        // Time
+        ifCompared(
+            handle(lType == TIME, rType == TIME) {
+                val lVal = left.timeValue()
+                val rVal = right.timeValue()
+
+                return lVal.compareTo(rVal)
             }
         ) { return it }
 

--- a/lang/src/org/partiql/lang/eval/NaturalExprValueComparators.kt
+++ b/lang/src/org/partiql/lang/eval/NaturalExprValueComparators.kt
@@ -34,7 +34,8 @@ import org.partiql.lang.util.*
  *      numeric values, which is followed by `+inf`.
  *  * `DATE` values follow and are compared by the date from earliest to latest.
  *  * `TIME` values follow and are compared by the time of the day (point of time in a day of 24 hours)
- *      from earliest to latest. Note that time without time zone is incomparable with time with time zone.
+ *      from earliest to latest. Note that time without time zone is not directly comparable with time with time zone.
+ *      However, time without time zone value comes before time with time zone value when compared in the natural order.
  *  * `TIMESTAMP` values follow and are compared by the point of time irrespective of precision and
  *    local UTC offset.
  *  * The [ExprValueType.isText] types come next ordered by their lexicographical ordering by
@@ -205,7 +206,7 @@ enum class NaturalExprValueComparators(private val nullOrder: NullOrder) : Compa
                 val lVal = left.timeValue()
                 val rVal = right.timeValue()
 
-                return lVal.compareTo(rVal)
+                return lVal.naturalOrderCompareTo(rVal)
             }
         ) { return it }
 

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerDateTimeTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerDateTimeTests.kt
@@ -263,7 +263,7 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
 
     private class ArgumentsForComparison : ArgumentsProviderBase() {
         private fun case(query: String, expected: String) = ComparisonTestCase(query, expected)
-        private fun case(query: String) = ComparisonTestCase(query, null)
+        private fun errorCase(query: String) = ComparisonTestCase(query, null)
         override fun getParameters() = listOf(
             case("DATE '2012-02-29' > DATE '2012-02-28'", "true"),
             case("DATE '2012-02-29' < DATE '2013-02-28'", "true"),
@@ -283,11 +283,10 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
             case("CAST('12:12:12.123' AS TIME WITH TIME ZONE) = TIME WITH TIME ZONE '12:12:12.123'", "true"),
             case("CAST(TIME WITH TIME ZONE '12:12:12.123' AS TIME) = TIME '12:12:12.123'", "true"),
             // Following are the error cases.
-            case("TIME '12:12:13' < TIME WITH TIME ZONE '12:12:12.123'"),
-            case("TIME WITH TIME ZONE '12:12:13' < TIME '12:12:12.123'"),
-            case("TIME WITH TIME ZONE '12:12:13-08:00' < TIME '12:12:12.123-08:00'"),
-            case("TIME WITH TIME ZONE '12:12:13' > DATE '2012-02-29'")
-
+            errorCase("TIME '12:12:13' < TIME WITH TIME ZONE '12:12:12.123'"),
+            errorCase("TIME WITH TIME ZONE '12:12:13' < TIME '12:12:12.123'"),
+            errorCase("TIME WITH TIME ZONE '12:12:13-08:00' < TIME '12:12:12.123-08:00'"),
+            errorCase("TIME WITH TIME ZONE '12:12:13' > DATE '2012-02-29'")
         )
     }
 }

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerDateTimeTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerDateTimeTests.kt
@@ -239,7 +239,7 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(ArgumentsForComparison::class)
     fun testComparison(tc: ComparisonTestCase) {
-        when (tc.throws) {
+        when (tc.expected == null) {
             true ->
                 try {
                     voidEval(tc.query)
@@ -254,11 +254,16 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
         }
     }
 
-    data class ComparisonTestCase(val query: String, val expected: String?, val throws: Boolean)
+    /**
+     * [query] is the original query to be evaluated.
+     * [expected] is the expected value of the query.
+     * The [null] [expected] value indicates that the comparison test case throws an error.
+     */
+    data class ComparisonTestCase(val query: String, val expected: String?)
 
     private class ArgumentsForComparison : ArgumentsProviderBase() {
-        private fun case(query: String, expected: String) = ComparisonTestCase(query, expected, false)
-        private fun case(query: String, throws: Boolean) = ComparisonTestCase(query, null, throws)
+        private fun case(query: String, expected: String) = ComparisonTestCase(query, expected)
+        private fun case(query: String) = ComparisonTestCase(query, null)
         override fun getParameters() = listOf(
             case("DATE '2012-02-29' > DATE '2012-02-28'", "true"),
             case("DATE '2012-02-29' < DATE '2013-02-28'", "true"),
@@ -277,10 +282,11 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
             case("TIME WITH TIME ZONE '12:12:12.123-08:00' < TIME WITH TIME ZONE '12:12:12.123+00:00'", "false"),
             case("CAST('12:12:12.123' AS TIME WITH TIME ZONE) = TIME WITH TIME ZONE '12:12:12.123'", "true"),
             case("CAST(TIME WITH TIME ZONE '12:12:12.123' AS TIME) = TIME '12:12:12.123'", "true"),
-            case("TIME '12:12:13' < TIME WITH TIME ZONE '12:12:12.123'", throws = true),
-            case("TIME WITH TIME ZONE '12:12:13' < TIME '12:12:12.123'", throws = true),
-            case("TIME WITH TIME ZONE '12:12:13-08:00' < TIME '12:12:12.123-08:00'", throws = true),
-            case("TIME WITH TIME ZONE '12:12:13' > DATE '2012-02-29'", throws = true)
+            // Following are the error cases.
+            case("TIME '12:12:13' < TIME WITH TIME ZONE '12:12:12.123'"),
+            case("TIME WITH TIME ZONE '12:12:13' < TIME '12:12:12.123'"),
+            case("TIME WITH TIME ZONE '12:12:13-08:00' < TIME '12:12:12.123-08:00'"),
+            case("TIME WITH TIME ZONE '12:12:13' > DATE '2012-02-29'")
 
         )
     }

--- a/lang/test/org/partiql/lang/eval/NaturalExprValueComparatorsTest.kt
+++ b/lang/test/org/partiql/lang/eval/NaturalExprValueComparatorsTest.kt
@@ -82,6 +82,30 @@ class NaturalExprValueComparatorsTest : EvaluatorTestBase() {
             "`+inf`"
         ),
         listOf(
+            "DATE '1992-08-22'"
+        ),
+        listOf(
+            "DATE '2021-08-22'"
+        ),
+        listOf(
+            "TIME '12:12:12'",
+            "TIME '12:12:12.00'",
+            "TIME (2) '12:12:12.00009'",
+            "TIME (2) '12:12:12.00009+00:00'",
+            "TIME (2) '12:12:12.00009-08:00'"
+        ),
+        listOf(
+            "TIME '12:12:12.1'"
+        ),
+        listOf(
+            "TIME WITH TIME ZONE '12:12:12-08:00'",
+            "TIME WITH TIME ZONE '12:12:12.00-08:00'",
+            "TIME (2) WITH TIME ZONE '12:12:12.00009-08:00'"
+        ),
+        listOf(
+            "TIME WITH TIME ZONE '12:12:12.1-09:00'"
+        ),
+        listOf(
             "`2017T`",
             "`2017-01T`",
             "`2017-01-01T`",
@@ -364,7 +388,7 @@ class NaturalExprValueComparatorsTest : EvaluatorTestBase() {
     fun nonNullEqualityTests(equivalentPair: Pair<String, String>) {
         val (left, right) = equivalentPair
 
-        assertEval("$left = $right", "true")
+        assertExprEquals(valueFactory.newBoolean(true), eval("$left = $right"))
     }
 
     // null to non null pairs
@@ -385,6 +409,6 @@ class NaturalExprValueComparatorsTest : EvaluatorTestBase() {
     fun nullEqualityTests(equivalentPair: Pair<String, String>) {
         val (left, right) = equivalentPair
 
-        assertEval("$left = $right", "null")
+        assertExprEquals(valueFactory.nullValue, eval("$left = $right"))
     }
 }


### PR DESCRIPTION
Resolves #394 
Adds comparison operations for `DATE` and `TIME` `ExprValues`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
