### PR TITLE
Fixes leap year logic in SqlParserDateTimeTests's random date generator.

### DIFF
--- a/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserDateTimeTests.kt
@@ -207,9 +207,9 @@ class SqlParserDateTimeTests : SqlParserTestBase() {
         val month = nextInt(12) + 1
         val day = when (month) {
             in monthsWith31Days -> nextInt(31)
-            2 -> when (year % 4) {
-                0 -> nextInt(29)
-                else -> nextInt(28)
+            2 -> when ((year % 4 == 0 && year % 100 != 0) || (year % 400 == 0))  {
+                true -> nextInt(29)
+                false -> nextInt(28)
             }
             else -> nextInt(30)
         } + 1


### PR DESCRIPTION
Resolves #399 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
