### PR TITLE
Cherry picks "Use LazyThreadSafteyMode.PUBLICATION instead of NONE (#433)" for v0.2.7 release

### DIFF
--- a/lang/src/org/partiql/lang/eval/Bindings.kt
+++ b/lang/src/org/partiql/lang/eval/Bindings.kt
@@ -51,7 +51,7 @@ fun CaseSensitivity.toBindingCase(): BindingCase = when(this) {
  * Encapsulates the data necessary to perform a binding lookup.
  */
 data class BindingName(val name: String, val bindingCase: BindingCase) {
-    val loweredName: String by lazy(LazyThreadSafetyMode.NONE) { name.toLowerCase() }
+    val loweredName: String by lazy(LazyThreadSafetyMode.PUBLICATION) { name.toLowerCase() }
     /**
      * Compares [name] to [otherName] using the rules specified by [bindingCase].
      */

--- a/lang/src/org/partiql/lang/eval/ExprValueFactory.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueFactory.kt
@@ -253,9 +253,9 @@ private abstract class ScalarExprValue : BaseExprValue(), Scalar {
 
     abstract fun ionValueFun(): IonValue
 
-    // LazyThreadSafetyMode.NONE is ok here because the worst that can happen is that [ionValueFun] is invoked
+    // LazyThreadSafetyMode.PUBLICATION is ok here because the worst that can happen is that [ionValueFun] is invoked
     // from multiple threads.  This should be ok because [IonSystem] is thread-safe.
-    override val ionValue by lazy(LazyThreadSafetyMode.NONE) { ionValueFun().seal() }
+    override val ionValue by lazy(LazyThreadSafetyMode.PUBLICATION) { ionValueFun().seal() }
 }
 
 /** A base class for the `true` boolean value, intended to be memoized. */

--- a/testscript/src/org/partiql/testscript/compiler/Compiler.kt
+++ b/testscript/src/org/partiql/testscript/compiler/Compiler.kt
@@ -107,7 +107,7 @@ class Compiler(val ion: IonSystem) {
             val dirPath = File(node.scriptLocation.inputName).parent
             val file = File("$dirPath/${node.environmentRelativeFilePath}")
             
-            val lazyDatagram = lazy(LazyThreadSafetyMode.NONE) { ion.loader.load(file) }
+            val lazyDatagram = lazy(LazyThreadSafetyMode.PUBLICATION) { ion.loader.load(file) }
 
             when {
                 !file.exists() -> {


### PR DESCRIPTION
LazyThreadSafetyMode.NONE literally means that accessing
the lazy value from multiple threads can cause an NPE.

Unfortunately, we assumed NONE would be implemented such
that a lazy value could be initialized by multiple
threads without throwing an NPE, with race conditions
only possibly occurring inside the initializer block.
However, that is actually the behavior is for
LazyThreadSafeteyMode.PUBLICATION.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

(cherry picked from commit eef183c7853f8f8561f7ee487ab13f179ec0dbf9)

This will be for the v0.2.7 release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
