### PR TITLE
Cherry picks "Fix bug causing multiple nested `not`s to parse very slowly (#436)" for v0.1.7 release

### DIFF
--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -747,41 +747,39 @@ class SqlParser(private val ion: IonSystem) : Parser {
         return expr
     }
 
-    private fun List<Token>.parseUnaryTerm(): ParseNode =
-        when (head?.isUnaryOperator) {
+    private fun List<Token>.parseUnaryTerm(): ParseNode {
+        return when (head?.isUnaryOperator) {
             true -> {
                 val op = head!!
-
-                val term = tail.parseUnaryTerm()
-                var expr: ParseNode? = null
+                fun makeUnaryParseNode(term: ParseNode) =
+                    ParseNode(UNARY, op, listOf(term), term.remaining)
 
                 // constant fold unary plus/minus into constant literals
                 when (op.keywordText) {
-                    "+" -> when {
-                        term.isNumericLiteral -> {
-                            // unary plus is a NO-OP
-                            expr = term
+                    "+" -> {
+                        val term = tail.parseUnaryTerm()
+                        when {
+                            // unary plus is a no-op on numeric literals.
+                            term.isNumericLiteral -> term
+                            else -> makeUnaryParseNode(term)
                         }
                     }
-                    "-" -> when {
-                        term.isNumericLiteral -> {
-                            val num = -term.numberValue()
-                            expr = ParseNode(ATOM,
-                                             term.token!!.copy(value = num.ionValue(ion)),
-                                             emptyList(),
-                                             term.remaining)
+                    "-" -> {
+                        val term = tail.parseUnaryTerm()
+                        when {
+                            // for numbers, drop the minus sign but also negate the value
+                            term.isNumericLiteral ->
+                                term.copy(token = term.token!!.copy(value = (-term.numberValue()).ionValue(ion)))
+                            else -> makeUnaryParseNode(term)
                         }
                     }
-                    "not" -> {
-                        val children = tail.parseExpression(op.prefixPrecedence)
-                        expr = ParseNode(UNARY, op, listOf(children), children.remaining)
-                    }
+                    else -> makeUnaryParseNode(tail.parseExpression(op.prefixPrecedence))
                 }
-
-                expr ?: ParseNode(UNARY, op, listOf(term), term.remaining)
             }
             else -> parsePathTerm()
         }
+    }
+
 
     private fun List<Token>.parsePathTerm(): ParseNode {
         val term = parseTerm()

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -15,6 +15,7 @@
 package org.partiql.lang.syntax
 
 import org.junit.*
+import kotlin.concurrent.thread
 
 /**
  * Originally just meant to test the parser, this class now tests several different things because
@@ -3655,5 +3656,36 @@ class SqlParserTest : SqlParserTestBase() {
         val withoutSemicolon = parse("(1+1)")
 
         assertEquals(withoutSemicolon, withSemicolon)
+    }
+
+    @Test
+    fun manyNestedNotPerformanceRegressionTest() {
+        val startTime = System.currentTimeMillis()
+        val t = thread {
+            parse(
+                """
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not 
+                not not not not not not not not not not not not not not not not not not not not not not not not false
+                """)
+        }
+        val maxParseTime: Long = 5000
+        t.join(maxParseTime)
+        t.interrupt()
+
+        assertTrue(
+            "parsing many nested unary nots should take less than $maxParseTime",
+            System.currentTimeMillis() - startTime < maxParseTime)
     }
 }


### PR DESCRIPTION
Refactors `SqlParser.parseUnaryTerm` so it does not attempt to
needlessly re-parse every sub-expression of the `not` unary operator.
This effect was cumulative, so that multiple nestings of `not` would
become pathologically slow.

(cherry picked from commit 6de9ca0d42b18d72c3f81bf62c6a9faa0cc1d033)

This will be for the v0.1.7 release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
