### PR TITLE
Add offset parser

### DIFF
--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -207,7 +207,12 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
     }
 
     private fun IonWriterContext.writeSelect(expr: Select) {
-        val (setQuantifier, projection, from, fromLet, where, groupBy, having, orderBy, limit, _: MetaContainer) = expr
+        val (setQuantifier, projection, from, fromLet, where, groupBy, having, orderBy, limit, offset, _: MetaContainer) = expr
+
+        if (offset != null){
+            throw UnsupportedOperationException("OFFSET clause is not supported by the V0 AST")
+        }
+
         if (orderBy != null) {
             throw UnsupportedOperationException("ORDER BY clause is not supported by the V0 AST")
         }

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -160,6 +160,7 @@ fun ExprNode.toAstExpr(): PartiqlAst.Expr {
                     group = node.groupBy?.toAstGroupSpec(),
                     having = node.having?.toAstExpr(),
                     limit = node.limit?.toAstExpr(),
+                    offset = node.offset?.toAstExpr(),
                     metas = metas)
             is Struct -> struct(node.fields.map { exprPair(it.name.toAstExpr(), it.expr.toAstExpr()) }, metas)
             is Seq ->

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -190,6 +190,7 @@ private class StatementTransformer(val ion: IonSystem) {
                     having = having?.toExprNode(),
                     orderBy = order?.toOrderBy(),
                     limit = limit?.toExprNode(),
+                    offset = offset?.toExprNode(),
                     metas = metas
             )
             is Expr.Date ->

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -440,9 +440,10 @@ data class Select(
     val having: ExprNode? = null,
     val orderBy: OrderBy? = null,
     val limit: ExprNode? = null,
+    val offset: ExprNode? = null,
     override val metas: MetaContainer
 ) : ExprNode() {
-    override val children: List<AstNode> = listOfNotNull(projection, from, fromLet, where, groupBy, having, orderBy, limit)
+    override val children: List<AstNode> = listOfNotNull(projection, from, fromLet, where, groupBy, having, orderBy, limit, offset)
 }
 
 //********************************

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -154,7 +154,8 @@ open class AstRewriterBase : AstRewriter {
      * 5. `HAVING`
      * 6. *projection*
      * 7. `ORDER BY` (to be implemented)
-     * 8. `LIMIT`
+     * 8. `OFFSET`
+     * 9. `LIMIT`
      */
     protected open fun innerRewriteSelect(selectExpr: Select): Select {
         val from = rewriteFromSource(selectExpr.from)
@@ -164,6 +165,7 @@ open class AstRewriterBase : AstRewriter {
         val having = selectExpr.having?.let { rewriteSelectHaving(it) }
         val projection = rewriteSelectProjection(selectExpr.projection)
         val orderBy = selectExpr.orderBy?.let { rewriteOrderBy(it) }
+        val offset = selectExpr.offset?.let { rewriteSelectOffset(it) }
         val limit = selectExpr.limit?.let { rewriteSelectLimit(it) }
         val metas = rewriteSelectMetas(selectExpr)
 
@@ -177,6 +179,7 @@ open class AstRewriterBase : AstRewriter {
             having = having,
             orderBy = orderBy,
             limit = limit,
+            offset = offset,
             metas = metas)
     }
 
@@ -185,6 +188,8 @@ open class AstRewriterBase : AstRewriter {
     open fun rewriteSelectHaving(node: ExprNode): ExprNode = rewriteExprNode(node)
 
     open fun rewriteSelectLimit(node: ExprNode): ExprNode = rewriteExprNode(node)
+
+    open fun rewriteSelectOffset(node: ExprNode): ExprNode = rewriteExprNode(node)
 
     open fun rewriteSelectMetas(selectExpr: Select): MetaContainer = rewriteMetas(selectExpr)
 

--- a/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
@@ -88,7 +88,7 @@ open class AstWalker(private val visitor: AstVisitor) {
                     }
                 }
                 is Select       -> case {
-                    val (_, projection, from, fromLet, where, groupBy, having, orderBy, limit, _: MetaContainer) = expr
+                    val (_, projection, from, fromLet, where, groupBy, having, orderBy, limit, offset, _: MetaContainer) = expr
                     walkSelectProjection(projection)
                     walkFromSource(from)
                     walkExprNode(where)
@@ -107,6 +107,7 @@ open class AstWalker(private val visitor: AstVisitor) {
                         }
                     }
                     walkExprNode(limit)
+                    walkExprNode(offset)
                 }
                 is DataManipulation -> case {
                     val (dmlOperation, from, where, returning, _: MetaContainer) = expr

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -980,7 +980,7 @@ internal class EvaluatingCompiler(
             .union(pigGeneratedAst.fromLet?.let { fold.walkLet(pigGeneratedAst.fromLet, emptySet()) } ?: emptySet())
 
         return nestCompilationContext(ExpressionContext.NORMAL, emptySet()) {
-            val (setQuantifier, projection, from, fromLet, _, groupBy, having, _, limit, metas: MetaContainer) = selectExpr
+            val (setQuantifier, projection, from, fromLet, _, groupBy, having, _, limit, offset, metas: MetaContainer) = selectExpr
 
             val fromSourceThunks = compileFromSources(from)
             val letSourceThunks = fromLet?.let { compileLetSources(it) }

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -258,6 +258,7 @@ internal val DATE_PART_KEYWORDS: Set<String> = DatePart.values()
     "pivot",
     "unpivot",
     "limit",
+    "offset",
     "tuple",
     "remove",
     "index",

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -654,12 +654,12 @@ class SqlParser(private val ion: IonSystem) : Parser {
                     it.children[0].toExprNode()
                 }
 
-                val offsetExpr = unconsumedChildren.firstOrNull { it.type == OFFSET }?.let {
+                val limitExpr = unconsumedChildren.firstOrNull { it.type == LIMIT }?.let {
                     unconsumedChildren.remove(it)
                     it.children[0].toExprNode()
                 }
 
-                val limitExpr = unconsumedChildren.firstOrNull { it.type == LIMIT }?.let {
+                val offsetExpr = unconsumedChildren.firstOrNull { it.type == OFFSET }?.let {
                     unconsumedChildren.remove(it)
                     it.children[0].toExprNode()
                 }

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -89,6 +89,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
         GROUP_PARTIAL,
         HAVING,
         LIMIT,
+        OFFSET,
         PIVOT,
         UNPIVOT,
         CALL,
@@ -554,7 +555,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
 
                 // The second child of a SELECT_LIST is always an ARG_LIST containing the from clause.
 
-                // GROUP BY, GROUP PARTIAL BY, WHERE, HAVING and limit parse nodes each have distinct ParseNodeTypes
+                // GROUP BY, GROUP PARTIAL BY, WHERE, HAVING, LIMIT and OFFSET parse nodes each have distinct ParseNodeTypes
                 // and if present, exist in children, starting at the third position.
 
                 var setQuantifier = SetQuantifier.ALL
@@ -653,6 +654,11 @@ class SqlParser(private val ion: IonSystem) : Parser {
                     it.children[0].toExprNode()
                 }
 
+                val offsetExpr = unconsumedChildren.firstOrNull { it.type == OFFSET }?.let {
+                    unconsumedChildren.remove(it)
+                    it.children[0].toExprNode()
+                }
+
                 val limitExpr = unconsumedChildren.firstOrNull { it.type == LIMIT }?.let {
                     unconsumedChildren.remove(it)
                     it.children[0].toExprNode()
@@ -672,6 +678,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
                     having = havingExpr,
                     orderBy = orderBy,
                     limit = limitExpr,
+                    offset = offsetExpr,
                     metas = metas)
             }
             CREATE_TABLE -> {
@@ -1442,7 +1449,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
             rem = it.remaining
         }
 
-        // TODO support ORDER BY and LIMIT (and full select sub-clauses)
+        // TODO support ORDER BY, LIMIT and OFFSET (and full select sub-clauses)
 
         // TODO determine if DML l-value should be restricted to paths...
         // TODO support the FROM ... SELECT forms
@@ -2032,6 +2039,8 @@ class SqlParser(private val ion: IonSystem) : Parser {
         parseOptionalSingleExpressionClause(HAVING)
 
         parseOptionalSingleExpressionClause(LIMIT)
+
+        parseOptionalSingleExpressionClause(OFFSET)
 
         return ParseNode(selectType, null, children, rem)
     }

--- a/lang/test/org/partiql/lang/ast/AstNodeTest.kt
+++ b/lang/test/org/partiql/lang/ast/AstNodeTest.kt
@@ -275,7 +275,7 @@ class AstNodeTest {
         val from = FromSourceExpr(literal("2"), LetVariables())
 
         assertEquals(listOf(projection, from),
-                     Select(SetQuantifier.ALL, projection, from, null, null, null, null, null, null, emptyMeta).children)
+                     Select(SetQuantifier.ALL, projection, from, null, null, null, null, null, null, null, emptyMeta).children)
     }
 
     @Test
@@ -288,9 +288,10 @@ class AstNodeTest {
         val having = literal("4")
         val orderBy = OrderBy(listOf())
         val limit = literal("5")
+        val offset = literal("6")
 
-        assertEquals(listOf(projection, from, fromLet, where, groupBy, having, orderBy, limit),
-                     Select(SetQuantifier.ALL, projection, from, fromLet, where, groupBy, having, orderBy, limit, emptyMeta).children)
+        assertEquals(listOf(projection, from, fromLet, where, groupBy, having, orderBy, limit, offset),
+                     Select(SetQuantifier.ALL, projection, from, fromLet, where, groupBy, having, orderBy, limit, offset, emptyMeta).children)
     }
 
     @Test

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -809,6 +809,50 @@ class ParserErrorsTest : SqlParserTestBase() {
     }
 
     @Test
+    fun offsetBeforeLimit() {
+        checkInputThrowingParserException("SELECT a FROM tb OFFSET 5 LIMIT 10",
+            ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            mapOf(Property.LINE_NUMBER to 1L,
+                Property.COLUMN_NUMBER to 27L,
+                Property.TOKEN_TYPE to TokenType.KEYWORD,
+                Property.TOKEN_VALUE to ion.newSymbol("limit"))
+        )
+    }
+
+    @Test
+    fun limitOffsetBeforeOrderBy() {
+        checkInputThrowingParserException("SELECT a FROM tb LIMIT 10 OFFSET 5 ORDER BY b ASC",
+            ErrorCode.PARSE_UNEXPECTED_TOKEN,
+            mapOf(Property.LINE_NUMBER to 1L,
+                Property.COLUMN_NUMBER to 36L,
+                Property.TOKEN_TYPE to TokenType.KEYWORD,
+                Property.TOKEN_VALUE to ion.newSymbol("order"))
+        )
+    }
+
+    @Test
+    fun offsetMissingArgument() {
+        checkInputThrowingParserException("SELECT a FROM tb OFFSET",
+            ErrorCode.PARSE_UNEXPECTED_TERM,
+            mapOf(Property.LINE_NUMBER to 1L,
+                Property.COLUMN_NUMBER to 24L,
+                Property.TOKEN_TYPE to TokenType.EOF,
+                Property.TOKEN_VALUE to ion.newSymbol("EOF"))
+        )
+    }
+
+    @Test
+    fun offsetUnexpectedKeywordAsAttribute() {
+        checkInputThrowingParserException("SELECT a FROM tb OFFSET SELECT",
+            ErrorCode.PARSE_UNEXPECTED_TERM,
+            mapOf(Property.LINE_NUMBER to 1L,
+                Property.COLUMN_NUMBER to 31L,
+                Property.TOKEN_TYPE to TokenType.EOF,
+                Property.TOKEN_VALUE to ion.newSymbol("EOF"))
+        )
+    }
+
+    @Test
     fun onConflictUnexpectedTokenOnConflict() {
         checkInputThrowingParserException("INSERT INTO foo VALUE 1 ON_CONFLICT WHERE bar DO NOTHING",
                 ErrorCode.PARSE_UNEXPECTED_TOKEN,

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -15,8 +15,10 @@
 package org.partiql.lang.syntax
 
 import com.amazon.ion.Decimal
-import com.amazon.ion.IonInt
-import com.amazon.ionelement.api.*
+import com.amazon.ionelement.api.ionDecimal
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.ionString
+import com.amazon.ionelement.api.loadSingleElement
 import org.junit.Ignore
 import org.junit.Test
 import org.partiql.lang.ast.ExprNode

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3990,6 +3990,17 @@ class SqlParserTest : SqlParserTestBase() {
         )
     }
 
+    @Test
+    fun selectOrderbyLimitOffsetTest() = assertExpression("SELECT x FROM a ORDER BY y DESC LIMIT 10 OFFSET 5") {
+        select(
+            project = buildProject("x"),
+            from = scan(id("a")),
+            order = PartiqlAst.OrderBy(listOf(PartiqlAst.SortSpec(id("y"), PartiqlAst.OrderingSpec.Desc()))),
+            limit = buildLit("10"),
+            offset = buildLit("5")
+        )
+    }
+
     //****************************************
     // EXEC clause parsing
     //****************************************

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3951,7 +3951,7 @@ class SqlParserTest : SqlParserTestBase() {
     }
 
     //****************************************
-    // LET clause parsing
+    // OFFSET clause parsing
     //****************************************
 
     private fun buildProject(project: String) = PartiqlAst.build { projectList(projectExpr(id(project))) }
@@ -3959,7 +3959,7 @@ class SqlParserTest : SqlParserTestBase() {
     private fun buildLit(lit: String) = PartiqlAst.Expr.Lit(loadSingleElement(lit))
 
     @Test
-    fun selectLiimitTest() = assertExpression("SELECT x FROM a OFFSET 5") {
+    fun selectOffsetTest() = assertExpression("SELECT x FROM a OFFSET 5") {
         select(
             project = buildProject("x"),
             from = scan(id("a")),

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -15,9 +15,8 @@
 package org.partiql.lang.syntax
 
 import com.amazon.ion.Decimal
-import com.amazon.ionelement.api.ionDecimal
-import com.amazon.ionelement.api.ionInt
-import com.amazon.ionelement.api.ionString
+import com.amazon.ion.IonInt
+import com.amazon.ionelement.api.*
 import org.junit.Ignore
 import org.junit.Test
 import org.partiql.lang.ast.ExprNode
@@ -3948,6 +3947,44 @@ class SqlParserTest : SqlParserTestBase() {
             project = projectX,
             from = scan(id("table1")),
             fromLet = let(letBinding(call("foo", listOf(id("table1"))), "A"))
+        )
+    }
+
+    //****************************************
+    // LET clause parsing
+    //****************************************
+
+    private fun buildProject(project: String) = PartiqlAst.build { projectList(projectExpr(id(project))) }
+
+    private fun buildLit(lit: String) = PartiqlAst.Expr.Lit(loadSingleElement(lit))
+
+    @Test
+    fun selectLiimitTest() = assertExpression("SELECT x FROM a OFFSET 5") {
+        select(
+            project = buildProject("x"),
+            from = scan(id("a")),
+            offset = buildLit("5")
+        )
+    }
+
+    @Test
+    fun selectLimitOffsetTest() = assertExpression("SELECT x FROM a LIMIT 7 OFFSET 5") {
+        select(
+            project = buildProject("x"),
+            from = scan(id("a")),
+            limit = buildLit("7"),
+            offset = buildLit("5")
+        )
+    }
+
+    @Test
+    fun selectWhereLimitOffsetTest() = assertExpression("SELECT x FROM a WHERE y = 10 LIMIT 7 OFFSET 5") {
+        select(
+            project = buildProject("x"),
+            from = scan(id("a")),
+            where = PartiqlAst.Expr.Eq(listOf(id("y"), buildLit("10"))),
+            limit = buildLit("7"),
+            offset = buildLit("5")
         )
     }
 

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3991,7 +3991,7 @@ class SqlParserTest : SqlParserTestBase() {
     }
 
     @Test
-    fun selectOrderbyLimitOffsetTest() = assertExpression("SELECT x FROM a ORDER BY y desc LIMIT 10 OFFSET 5") {
+    fun selectOrderbyLimitOffsetTest() = assertExpression("SELECT x FROM a ORDER BY y DESC LIMIT 10 OFFSET 5") {
         select(
             project = buildProject("x"),
             from = scan(id("a")),

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3991,7 +3991,7 @@ class SqlParserTest : SqlParserTestBase() {
     }
 
     @Test
-    fun selectOrderbyLimitOffsetTest() = assertExpression("SELECT x FROM a ORDER BY y DESC LIMIT 10 OFFSET 5") {
+    fun selectOrderbyLimitOffsetTest() = assertExpression("SELECT x FROM a ORDER BY y desc LIMIT 10 OFFSET 5") {
         select(
             project = buildProject("x"),
             from = scan(id("a")),


### PR DESCRIPTION
*Issue #422, task 2: Implement `OFFSET` in lexer, parser, and `ExprNode` conversions*

*Description of changes:*
1. `ExprNode` representation of `OFFSET` 
2. Conversion between `PartiqlAst` and `ExprNode` for `OFFSET` 
3. V0 Ast Serliazation for `OFFSET` 
4. Parsing of `OFFSET` in Parser
4. Other minor changes to make code able to be compiled 
5. Test cases for `OFFSET` in Parser 