### PR TITLE
Fixes group by for more than 2 nested path expressions.

### DIFF
--- a/lang/src/org/partiql/lang/eval/visitors/GroupByPathExpressionVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/GroupByPathExpressionVisitorTransform.kt
@@ -31,8 +31,9 @@ class GroupByPathExpressionVisitorTransform(
         /**
          * Determines if [gbi] is an expression of the type that should be replaced elsewhere in the query.
          *
-         * Since we are only concerned about SQL-92 compatibility here, we only replace path expressions that
-         * have a single component, i.e. `f.bar` but not `f.bar.bat`.  (The latter is not part of SQL-92.)
+         * As we support querying nested data, we are not just limited to SQL-92 compatibility (that have
+         * path expressions with single component, i.e. `foo.bar`) but also replace path expressions that
+         * have more than one component, i.e. `f.bar.bat`.
          */
         fun canBeSubstituted(groupKey: PartiqlAst.GroupKey): Boolean {
             val expr = groupKey.expr
@@ -42,7 +43,7 @@ class GroupByPathExpressionVisitorTransform(
             return when {
                 asName == null                                     -> throw IllegalStateException("GroupByItem.asName must be specified for this transform to work")
                 !asName.metas.containsKey(IsSyntheticNameMeta.TAG) ->
-                    // If this meta is not present it would indicate that the alias was explicitly specifed, which is
+                    // If this meta is not present it would indicate that the alias was explicitly specified, which is
                     // not allowed by SQL-92, so ignore.
                     false
 

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerGroupByTest.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerGroupByTest.kt
@@ -82,7 +82,7 @@ EvaluatingCompilerGroupByTest : EvaluatorTestBase() {
              { name: 'Joey', age: 25, manager: { name: 'John', address: { city: 'Seattle' } } },
              { name: 'Chandler', age: 27, manager: { name: 'Rocky', address: { city: 'Seattle' } } },
              { name: 'Ross', age: 22, manager: { 'name': 'Alex', address: { city: 'Chicago' } } }
-         ]"""
+        ]"""
      ).toSession()
 
     companion object {
@@ -728,7 +728,7 @@ EvaluatingCompilerGroupByTest : EvaluatorTestBase() {
             "SELECT VALUE (SELECT SUM(outerFromSource.col1) AS the_sum FROM <<1>>) FROM simple_1_col_1_group as outerFromSource",
             "<< << { 'the_sum': 1 } >>,  << { 'the_sum': 1 } >> >>"),
         EvaluatorTestCase(
-            "SELECT with nested GROUPBY",
+            "SELECT with GROUP BY path expression having more than 1 component.",
             "SELECT avg(age) as avg_employee_age, manager.address.city FROM employees GROUP BY manager.address.city",
             "<<{'avg_employee_age': 22, 'city': 'Chicago'}, {'avg_employee_age': 26, 'city': 'Seattle'}>>")
     )


### PR DESCRIPTION
Resolves #458 

*Description of changes:*
Removes check for `component's step.size != 1` in `GroupByPathExpressionVisitorTransform.kt`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
