### PR TITLE
Better SqlParserTestBase 

### DIFF
--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -43,6 +43,7 @@ abstract class SqlParserTestBase : TestBase() {
 
     /**
      * This method is used by test cases, to test with PIG AST, while the expected PIG AST is a PIG builder
+     * Refer to kdoc for `assertExpression(source: String, expectedPigAst: String)` to see the checks performed.
      */
     protected fun assertExpression(
         source: String,
@@ -55,6 +56,14 @@ abstract class SqlParserTestBase : TestBase() {
 
     /**
      * This method is used by test cases, to test with PIG AST, while the expected PIG AST is a string
+     * The following checks are performed:
+     *      1. Check equals for actual value and expected value in IonSexp format
+     *      2. Check equals for actual value and expected value in SexpElement format
+     *      3. Check equals for actual value and expected value after transformation: astStatment -> SexpElement -> astStatement
+     *      4. Check equals for actual value after round trip transformation: astStatement -> ExprNode -> astStatement
+     *      5. Check equals for actual value after round trip transformation: SexpElement -> astStatement -> SexpElement
+     *      6. Check equals for actual value after round trip transformation: astStatement -> SexpElement -> astStatement
+     *      7. Check equals for actual value after round trip transformation: ExprNode -> astStatement -> SexpElement -> astStatement -> ExprNode
      */
     protected fun assertExpression(
         source: String,
@@ -73,6 +82,7 @@ abstract class SqlParserTestBase : TestBase() {
 
     /**
      * This method is used by test cases, to test with PIG AST and V0 AST, where the expected PIG AST is a PIG builder
+     * Refer to kdoc for `assertExpression(source: String, expectedSexpAstV0: String, expectedPigAst: String)` to see the checks performed.
      */
     protected fun assertExpression(
         source: String,
@@ -86,6 +96,11 @@ abstract class SqlParserTestBase : TestBase() {
 
     /**
      * This method is used by test cases, to test with PIG AST and V0 AST, while the expected PIG AST is a string
+     * The following checks for V0 AST are performed:
+     *      1. Check equals for actual value and expected value after transformation: EpxrNode -> IonSexp
+     *      2. Check equals for actual value and expected value after transformation: IonSexp -> EpxrNode
+     *
+     * Refer to kdoc for `assertExpression(source: String, expectedPigAst: String)` to see the checks performed for PIG Ast.
      */
     protected fun assertExpression(
         source: String,
@@ -174,16 +189,16 @@ abstract class SqlParserTestBase : TestBase() {
 
     private fun assertRoundTripIonElementToPartiQlAst(actualElement: SexpElement, expectedElement: SexpElement) {
         // #1 We can transform the actual PartiqlAst element.
-        val transformedActualElement = PartiqlAst.transform(actualElement)
+        val transformedActualStatement = PartiqlAst.transform(actualElement)
 
         // #2 We can transform the expected PartiqlAst element.
-        val transformedExpectedElement = PartiqlAst.transform(expectedElement)
+        val transformedExpectedStatement = PartiqlAst.transform(expectedElement)
 
         // #3 The results of both transformations match.
-        assertEquals(transformedExpectedElement, transformedActualElement)
+        assertEquals(transformedExpectedStatement, transformedActualStatement)
 
         // #4 Re-transforming the actual PartiqlAst element and check if it matches the expected AST.
-        val reserializedActualElement = transformedActualElement.toIonElement()
+        val reserializedActualElement = transformedActualStatement.toIonElement()
         assertEquals(expectedElement, reserializedActualElement)
 
         // #5 Re-serializing the expected PartiqlAst element matches the expected AST.

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -86,9 +86,9 @@ abstract class SqlParserTestBase : TestBase() {
     ) {
         // Check for V0 Ast
         val actualExprNode = parse(source)
-        val expectedV0Ast = loadIonSexp(expectedV0Ast)
+        val expectedV0AstSexp = loadIonSexp(expectedV0Ast)
 
-        serializeAssert(AstVersion.V0, actualExprNode, expectedV0Ast, source)
+        serializeAssert(AstVersion.V0, actualExprNode, expectedV0AstSexp, source)
 
         // Check for PIG Ast
         assertExpression(source, expectedPigAst)
@@ -116,7 +116,7 @@ abstract class SqlParserTestBase : TestBase() {
     private fun unwrapQuery(statement: PartiqlAst.Statement) : SexpElement {
        return when (statement) {
            is PartiqlAst.Statement.Query -> statement.expr.toIonElement()
-           is PartiqlAst.Statement.Dml -> statement.toIonElement()
+           is PartiqlAst.Statement.Dml,
            is PartiqlAst.Statement.Ddl,
            is PartiqlAst.Statement.Exec -> statement.toIonElement()
         }
@@ -124,8 +124,7 @@ abstract class SqlParserTestBase : TestBase() {
 
     /**
      * Performs checks similar to that of [serializeAssert]. First checks that parsing the [source] query string to
-     * a [PartiqlAst] and to an IonValue Sexp equals the [expectedSexpAst]. Next checks that converting this IonValue
-     * Sexp to an ExprNode equals the [actualExprNode].
+     * a [PartiqlAst] and to an IonValue Sexp equals the [expectedIonSexp].
      */
     private fun checkEqualInIonSexp(actualExprNode: ExprNode, expectedIonSexp: IonSexp, source: String) {
         val actualStatment = actualExprNode.toAstStatement()

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -74,18 +74,14 @@ abstract class SqlParserTestBase : TestBase() {
         expectedV0Ast: String,
         expectedPigAst: String
     ) {
-        // Convert the query to ExprNode
+        // Check for V0 Ast
         val actualExprNode = parse(source)
-
         val expectedV0Ast = loadIonSexp(expectedV0Ast)
+
         serializeAssert(AstVersion.V0, actualExprNode, expectedV0Ast, source)
 
-        val expectedIonSexp = loadIonSexp(expectedPigAst)
-        checkEqualInIonSexp(actualExprNode, expectedIonSexp, source)
-
-        pigDomainAssert(actualExprNode, expectedIonSexp.toIonElement().asSexp())
-
-        pigExprNodeTransformAsserts(actualExprNode)
+        // Check for PIG Ast
+        assertExpression(source, expectedPigAst)
     }
 
     protected fun assertExpression(
@@ -94,6 +90,7 @@ abstract class SqlParserTestBase : TestBase() {
         expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
     ) {
         val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
+
         assertExpression(source, expectedSexpAstV0, expectedPigAst)
     }
 
@@ -196,6 +193,7 @@ abstract class SqlParserTestBase : TestBase() {
         val actualExprNodeNoMetas = MetaStrippingRewriter.stripMetas(actualExprNode)
         val actualStatement = actualExprNodeNoMetas.toAstStatement()
         val transformedActualExprNode = actualStatement.toExprNode(ion)
+
         assertEquals(actualExprNodeNoMetas, transformedActualExprNode)
     }
 

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -49,16 +49,9 @@ abstract class SqlParserTestBase : TestBase() {
         source: String,
         expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
     ) {
-        val actualExprNode = parse(source)
-
         val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
-        // Convert the query to ExprNode
 
-        val expectedIonSexp = loadIonSexp(expectedPigAst)
-        partiqlAssert(actualExprNode, expectedIonSexp, source)
-
-        pigDomainAssert(actualExprNode, expectedIonSexp.toIonElement().asSexp())
-        pigExprNodeTransformAsserts(actualExprNode)
+        assertExpression(source, expectedPigAst)
     }
 
     protected fun assertExpression(

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -61,7 +61,6 @@ abstract class SqlParserTestBase : TestBase() {
         pigExprNodeTransformAsserts(actualExprNode)
     }
 
-    // TODO: refactor the signature with pig builder
     protected fun assertExpression(
             source: String,
             expectedSexpAst: String

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -93,7 +93,7 @@ abstract class SqlParserTestBase : TestBase() {
     protected fun assertExpression(
         source: String,
         expectedV0Ast: String,
-        expectedPigAst: String = expectedV0Ast
+        expectedPigAst: String
     ) {
         // Convert the query to ExprNode
         val actualExprNode = parse(source)

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -68,7 +68,7 @@ abstract class SqlParserTestBase : TestBase() {
         val expectedElement = expectedIonSexp.toIonElement().asSexp()
 
         pigDomainAssert(actualExprNode, expectedElement)
-        roundTripPigAstToExprNode(actualExprNode)
+        assertRoundTripPigAstToExprNode(actualExprNode)
     }
 
     /**
@@ -196,7 +196,7 @@ abstract class SqlParserTestBase : TestBase() {
      *
      * Verify that the result matches the original without metas.
      */
-    private fun roundTripPigAstToExprNode(actualExprNode: ExprNode) {
+    private fun assertRoundTripPigAstToExprNode(actualExprNode: ExprNode) {
         val actualExprNodeNoMetas = MetaStrippingRewriter.stripMetas(actualExprNode)
         val actualStatement = actualExprNodeNoMetas.toAstStatement()
         val roundTripActualExprNode = actualStatement.toExprNode(ion)

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -51,10 +51,10 @@ abstract class SqlParserTestBase : TestBase() {
     ) {
         val actualExprNode = parse(source)
 
-        val expectedPartiQlAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
+        val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
         // Convert the query to ExprNode
 
-        val expectedIonSexp = loadIonSexp(expectedPartiQlAst)
+        val expectedIonSexp = loadIonSexp(expectedPigAst)
         partiqlAssert(actualExprNode, expectedIonSexp, source)
 
         pigDomainAssert(actualExprNode, expectedIonSexp.toIonElement().asSexp())
@@ -63,13 +63,14 @@ abstract class SqlParserTestBase : TestBase() {
 
     protected fun assertExpression(
             source: String,
-            expectedSexpAst: String
+            expectedPigAst: String
     ) {
         val actualExprNode = parse(source)
-        val expectedElement = loadSingleElement(
-            expectedSexpAst,
-            IonElementLoaderOptions(includeLocationMeta = false)
-        ).asSexp()
+        val expectedIonSexp = loadIonSexp(expectedPigAst)
+
+        partiqlAssert(actualExprNode, expectedIonSexp, source)
+
+        val expectedElement = expectedIonSexp.toIonElement().asSexp()
 
         pigDomainAssert(actualExprNode, expectedElement)
         pigExprNodeTransformAsserts(actualExprNode)

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -66,16 +66,12 @@ abstract class SqlParserTestBase : TestBase() {
             expectedSexpAst: String
     ) {
         val actualExprNode = parse(source)
-        val actualStatement = actualExprNode.toAstStatement()
         val expectedElement = loadSingleElement(
             expectedSexpAst,
             IonElementLoaderOptions(includeLocationMeta = false)
         ).asSexp()
 
-        val actualElement = unwrapQuery(actualStatement)
-
-        assertRoundTripIonElementToPartiQlAst(actualElement, expectedElement)
-        assertRoundTripPartiQlAstToExprNode(actualStatement, expectedElement, actualExprNode)
+        pigDomainAssert(actualExprNode, expectedElement)
         pigExprNodeTransformAsserts(actualExprNode)
     }
 

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -47,16 +47,7 @@ abstract class SqlParserTestBase : TestBase() {
 
     protected fun assertExpression(
         source: String,
-        expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
-    ) {
-        val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
-
-        assertExpression(source, expectedPigAst)
-    }
-
-    protected fun assertExpression(
-            source: String,
-            expectedPigAst: String
+        expectedPigAst: String
     ) {
         val actualExprNode = parse(source)
         val expectedIonSexp = loadIonSexp(expectedPigAst)
@@ -71,11 +62,11 @@ abstract class SqlParserTestBase : TestBase() {
 
     protected fun assertExpression(
         source: String,
-        expectedSexpAstV0: String,
         expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
     ) {
         val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
-        assertExpression(source, expectedSexpAstV0, expectedPigAst)
+
+        assertExpression(source, expectedPigAst)
     }
 
     protected fun assertExpression(
@@ -95,6 +86,15 @@ abstract class SqlParserTestBase : TestBase() {
         pigDomainAssert(actualExprNode, expectedIonSexp.toIonElement().asSexp())
 
         pigExprNodeTransformAsserts(actualExprNode)
+    }
+
+    protected fun assertExpression(
+        source: String,
+        expectedSexpAstV0: String,
+        expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
+    ) {
+        val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
+        assertExpression(source, expectedSexpAstV0, expectedPigAst)
     }
 
     private fun serializeAssert(astVersion: AstVersion, actualExprNode: ExprNode, expectedIonSexp: IonSexp, source: String) {

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -68,7 +68,7 @@ abstract class SqlParserTestBase : TestBase() {
         val expectedElement = expectedIonSexp.toIonElement().asSexp()
 
         pigDomainAssert(actualExprNode, expectedElement)
-        pigExprNodeTransformAsserts(actualExprNode)
+        roundTripPigAstToExprNode(actualExprNode)
     }
 
     /**
@@ -196,12 +196,12 @@ abstract class SqlParserTestBase : TestBase() {
      *
      * Verify that the result matches the original without metas.
      */
-    private fun pigExprNodeTransformAsserts(actualExprNode: ExprNode) {
+    private fun roundTripPigAstToExprNode(actualExprNode: ExprNode) {
         val actualExprNodeNoMetas = MetaStrippingRewriter.stripMetas(actualExprNode)
         val actualStatement = actualExprNodeNoMetas.toAstStatement()
-        val transformedActualExprNode = actualStatement.toExprNode(ion)
+        val roundTripActualExprNode = actualStatement.toExprNode(ion)
 
-        assertEquals(actualExprNodeNoMetas, transformedActualExprNode)
+        assertEquals(actualExprNodeNoMetas, roundTripActualExprNode)
     }
 
     private fun loadIonSexp(expectedSexpAst: String) = ion.singleValue(expectedSexpAst).asIonSexp()

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -16,19 +16,15 @@ package org.partiql.lang.syntax
 
 import com.amazon.ion.IonSexp
 import com.amazon.ionelement.api.IonElement
-import com.amazon.ionelement.api.IonElementLoaderOptions
 import com.amazon.ionelement.api.SexpElement
 import com.amazon.ionelement.api.toIonElement
-import com.amazon.ionelement.api.loadSingleElement
 import com.amazon.ionelement.api.toIonValue
 import org.partiql.lang.TestBase
 import org.partiql.lang.ast.AstDeserializerBuilder
 import org.partiql.lang.ast.AstSerializer
 import org.partiql.lang.ast.AstVersion
-import org.partiql.lang.ast.DataManipulation
 import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.ast.passes.MetaStrippingRewriter
-import org.partiql.lang.ast.toAstExpr
 import org.partiql.lang.ast.toAstStatement
 import org.partiql.lang.ast.toExprNode
 import org.partiql.lang.domains.PartiqlAst
@@ -45,6 +41,9 @@ abstract class SqlParserTestBase : TestBase() {
     protected fun parse(source: String): ExprNode = parser.parseExprNode(source)
     protected fun parseToAst(source: String): PartiqlAst.Statement = parser.parseAstStatement(source)
 
+    /**
+     * This method is used by test cases, to test with PIG AST, while the expected PIG AST is a PIG builder
+     */
     protected fun assertExpression(
         source: String,
         expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
@@ -54,6 +53,9 @@ abstract class SqlParserTestBase : TestBase() {
         assertExpression(source, expectedPigAst)
     }
 
+    /**
+     * This method is used by test cases, to test with PIG AST, while the expected PIG AST is a string
+     */
     protected fun assertExpression(
         source: String,
         expectedPigAst: String
@@ -69,6 +71,9 @@ abstract class SqlParserTestBase : TestBase() {
         pigExprNodeTransformAsserts(actualExprNode)
     }
 
+    /**
+     * This method is used by test cases, to test with PIG AST and V0 AST, where the expected PIG AST is a PIG builder
+     */
     protected fun assertExpression(
         source: String,
         expectedSexpAstV0: String,
@@ -79,6 +84,9 @@ abstract class SqlParserTestBase : TestBase() {
         assertExpression(source, expectedSexpAstV0, expectedPigAst)
     }
 
+    /**
+     * This method is used by test cases, to test with PIG AST and V0 AST, while the expected PIG AST is a string
+     */
     protected fun assertExpression(
         source: String,
         expectedV0Ast: String,

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -52,7 +52,7 @@ abstract class SqlParserTestBase : TestBase() {
         val actualExprNode = parse(source)
         val expectedIonSexp = loadIonSexp(expectedPigAst)
 
-        partiqlAssert(actualExprNode, expectedIonSexp, source)
+        checkEqualInIonSexp(actualExprNode, expectedIonSexp, source)
 
         val expectedElement = expectedIonSexp.toIonElement().asSexp()
 
@@ -81,7 +81,7 @@ abstract class SqlParserTestBase : TestBase() {
         serializeAssert(AstVersion.V0, actualExprNode, expectedV0Ast, source)
 
         val expectedIonSexp = loadIonSexp(expectedPigAst)
-        partiqlAssert(actualExprNode, expectedIonSexp, source)
+        checkEqualInIonSexp(actualExprNode, expectedIonSexp, source)
 
         pigDomainAssert(actualExprNode, expectedIonSexp.toIonElement().asSexp())
 
@@ -130,19 +130,12 @@ abstract class SqlParserTestBase : TestBase() {
      * a [PartiqlAst] and to an IonValue Sexp equals the [expectedSexpAst]. Next checks that converting this IonValue
      * Sexp to an ExprNode equals the [actualExprNode].
      */
-    private fun partiqlAssert(actualExprNode: ExprNode, expectedIonSexp: IonSexp, source: String) {
-        val actualStatment = parseToAst(source)
+    private fun checkEqualInIonSexp(actualExprNode: ExprNode, expectedIonSexp: IonSexp, source: String) {
+        val actualStatment = actualExprNode.toAstStatement()
         val actualElement = unwrapQuery(actualStatment)
         val actualIonSexp = actualElement.toIonElement().asAnyElement().toIonValue(ion)
 
         assertSexpEquals(expectedIonSexp, actualIonSexp, "AST, $source")
-
-        val exprNodeFromSexp = actualStatment.toExprNode(ion)
-
-        assertEquals(
-            "actual ExprNodes must match the expected PartiqlAst",
-            actualExprNode.stripMetas(),
-            exprNodeFromSexp.stripMetas())
     }
 
     private fun pigDomainAssert(actualExprNode: ExprNode, expectedSexpAst: SexpElement) {

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -47,6 +47,15 @@ abstract class SqlParserTestBase : TestBase() {
 
     protected fun assertExpression(
         source: String,
+        expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
+    ) {
+        val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
+
+        assertExpression(source, expectedPigAst)
+    }
+
+    protected fun assertExpression(
+        source: String,
         expectedPigAst: String
     ) {
         val actualExprNode = parse(source)
@@ -62,11 +71,12 @@ abstract class SqlParserTestBase : TestBase() {
 
     protected fun assertExpression(
         source: String,
+        expectedSexpAstV0: String,
         expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
     ) {
         val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
 
-        assertExpression(source, expectedPigAst)
+        assertExpression(source, expectedSexpAstV0, expectedPigAst)
     }
 
     protected fun assertExpression(
@@ -82,16 +92,6 @@ abstract class SqlParserTestBase : TestBase() {
 
         // Check for PIG Ast
         assertExpression(source, expectedPigAst)
-    }
-
-    protected fun assertExpression(
-        source: String,
-        expectedSexpAstV0: String,
-        expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
-    ) {
-        val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
-
-        assertExpression(source, expectedSexpAstV0, expectedPigAst)
     }
 
     private fun serializeAssert(astVersion: AstVersion, actualExprNode: ExprNode, expectedIonSexp: IonSexp, source: String) {


### PR DESCRIPTION
This PR aims to better the code in file 'SqlParserTestBase'. 

### Description of Changes: 
1. Changed variables name. e.g. originally, for actual values, some variables use `actual` or `parsed` as prefix, while some do not have prefix. Now change them into a uniform prefix `actual`. 
2. Removed unuseful code. 
3. Refactored the code in `assertExpression`. 