### PR TITLE
Deprecate `ExprNode` in `Parser`

### DIFF
--- a/examples/src/kotlin/org/partiql/examples/ParserErrorExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/ParserErrorExample.kt
@@ -24,7 +24,7 @@ class ParserErrorExample(out: PrintStream) : Example(out) {
         // Attempt to parse a query with invalid syntax.
         val invalidQuery = "SELECT 1 + "
         print("Invalid PartiQL query:", invalidQuery)
-        parser.parseExprNode(invalidQuery)
+        parser.parseAstStatement(invalidQuery)
 
         throw Exception("ParserException was not thrown")
     } catch (e: ParserException) {

--- a/examples/src/kotlin/org/partiql/examples/ParserExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/ParserExample.kt
@@ -2,7 +2,6 @@ package org.partiql.examples
 
 import com.amazon.ion.system.*
 import org.partiql.examples.util.Example
-import org.partiql.lang.ast.*
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.*
 import java.io.PrintStream
@@ -20,43 +19,28 @@ class ParserExample(out: PrintStream) : Example(out) {
         // An instance of [SqlParser].
         val parser: Parser = SqlParser(ion)
 
+        // A query in string format
         val query = "SELECT exampleField FROM exampleTable WHERE anotherField > 10"
         print("PartiQL query", query)
 
-        // Use the SqlParser instance to parse the example query.  This is very simple.
-        val originalAst = parser.parseExprNode(query)
+        // Use the SqlParser instance to parse the example query and get the AST as a PartiqlAst Statement.
+        val ast = parser.parseAstStatement(query)
 
-        // Now the originalAst can be inspected, transformed and/or serialized as needed.
-        // For now we're just going to serialize and deserialize it.
+        // We can transform the AST into SexpElement form to pretty print
+        val elements = ast.toIonElement()
 
-        // Convert the ExprNode AST to the Ion s-expression form.
-        val serializedAst = originalAst.toAstStatement()
+        // Create an IonWriter to print the AST
+        val astString = StringBuilder()
+        val ionWriter = IonTextWriterBuilder.minimal().withPrettyPrinting().build(astString)
 
-        // Create an IonWriter for printing of the PartiqlAst
-        val partiqlAstString = StringBuilder()
-        val ionWriter = IonTextWriterBuilder.minimal().withPrettyPrinting().build(partiqlAstString)
+        // Now use the IonWriter to write the SexpElement AST into the StringBuilder and pretty print it
+        elements.writeTo(ionWriter)
+        print("Serialized AST", astString.toString())
 
-        // Now we can convert the Ion s-expression form into an Ion value to pretty print
-        serializedAst.toIonElement().writeTo(ionWriter)
-        print("Serialized AST", partiqlAstString.toString())
-
-        // Re-constitute the serialized AST.  The toExprNode will convert from any supported
-        // version of the s-expression form to an instance of [ExprNode].
-        val deserializedAst = serializedAst.toExprNode(ion)
-        // Verify that we have the correct AST.
-        if (originalAst != deserializedAst) {
-            throw Exception("expected AST to be equal")
-        }
-
-        // Here we show how to parse a query directly to a PartiqlAst statement
-        val statement = parser.parseAstStatement(query)
-
-        // We can easily convert the PartiqlAst statement into an Ion s-expression
-        val elements = statement.toIonElement()
-        // and back into a PartiqlAst statement
+        // We can also convert the SexpElement AST back into a PartiqlAst statement
         val roundTrippedStatement = PartiqlAst.transform(elements) as PartiqlAst.Statement
         // Verify that we have the original Partiql Ast statement
-        if (statement != roundTrippedStatement) {
+        if (ast != roundTrippedStatement) {
             throw Exception("Expected statements to be the same")
         }
     }

--- a/examples/src/kotlin/org/partiql/examples/PreventJoinVistor.kt
+++ b/examples/src/kotlin/org/partiql/examples/PreventJoinVistor.kt
@@ -2,7 +2,7 @@ package org.partiql.examples
 
 import com.amazon.ion.system.*
 import org.partiql.examples.util.Example
-import org.partiql.lang.ast.*
+import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.*
 import java.io.PrintStream
 
@@ -20,11 +20,12 @@ class PreventJoinVisitorExample(out: PrintStream) : Example(out) {
     private val parser = SqlParser(ion)
 
     private fun hasJoins(sql: String): Boolean = try {
-        val ast = parser.parseExprNode(sql)
-
-        if(ast.any { it is FromSourceJoin }) {
-            throw InvalidAstException("JOINs are prevented")
-        }
+        val ast = parser.parseAstStatement(sql)
+        object : PartiqlAst.Visitor(){
+            override fun visitFromSourceJoin(node: PartiqlAst.FromSource.Join) {
+                throw InvalidAstException("JOINs are prevented")
+            }
+        }.walkStatement(ast)
 
         false
     } catch (e: InvalidAstException) {

--- a/examples/src/kotlin/org/partiql/examples/PreventJoinVistor.kt
+++ b/examples/src/kotlin/org/partiql/examples/PreventJoinVistor.kt
@@ -21,7 +21,7 @@ class PreventJoinVisitorExample(out: PrintStream) : Example(out) {
 
     private fun hasJoins(sql: String): Boolean = try {
         val ast = parser.parseExprNode(sql)
-        
+
         if(ast.any { it is FromSourceJoin }) {
             throw InvalidAstException("JOINs are prevented")
         }

--- a/lang/jmh/org/partiql/jmh/PartiQLBenchmark.kt
+++ b/lang/jmh/org/partiql/jmh/PartiQLBenchmark.kt
@@ -54,10 +54,12 @@ open class PartiQLBenchmark {
                 } 
             }
         """.trimIndent()
+        // TODO: replace `parseExprNode` with `ParseStatement` once evaluator deprecates `ExprNode`
         val bindings = pipeline.compile(parser.parseExprNode(data)).eval(EvaluationSession.standard()).bindings
         val session = EvaluationSession.build { globals(bindings) }
 
         val query = "SELECT * FROM hr.employeesNestScalars"
+        // TODO: replace `parseExprNode` with `ParseStatement` once evaluator deprecates `ExprNode`
         val exprNode = parser.parseExprNode(query)
         val expression = pipeline.compile(exprNode)
     }
@@ -68,6 +70,7 @@ open class PartiQLBenchmark {
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     fun testPartiQLParser(state: MyState, blackhole: Blackhole) {
+        // TODO: replace `parseExprNode` with `ParseStatement` once evaluator deprecates `ExprNode`
         val expr = state.parser.parseExprNode(state.query)
         blackhole.consume(expr)
     }

--- a/lang/src/org/partiql/lang/CompilerPipeline.kt
+++ b/lang/src/org/partiql/lang/CompilerPipeline.kt
@@ -193,6 +193,7 @@ internal class CompilerPipelineImpl(
     private val compiler = EvaluatingCompiler(valueFactory, functions, procedures, compileOptions)
 
     override fun compile(query: String): Expression {
+        // TODO: replace `parseExprNode` with `ParseStatement` once evaluator deprecates `ExprNode`
         return compile(parser.parseExprNode(query))
     }
 

--- a/lang/src/org/partiql/lang/ast/AstDeserialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstDeserialization.kt
@@ -210,7 +210,9 @@ private enum class NodeTag(val definition: TagDefinition) {
 
     //Only valid as path components...
     CASE_INSENSITIVE(TagDefinition("case_insensitive", 0, 1)),
-    CASE_SENSITIVE(TagDefinition("case_sensitive", 0, 1));
+    CASE_SENSITIVE(TagDefinition("case_sensitive", 0, 1)),
+
+    IDENTIFIER(TagDefinition("identifier", 2, 2));
 
     companion object {
         private val tagLookup = values().map { Pair(it.definition.tagText, it) }.toMap()
@@ -417,7 +419,8 @@ internal class AstDeserializerInternal(
                 NodeTag.VALUE,
                 NodeTag.WHEN,
                 NodeTag.ELSE,
-                NodeTag.TYPE -> errInvalidContext(nodeTag)
+                NodeTag.TYPE,
+                NodeTag.IDENTIFIER -> errInvalidContext(nodeTag)
             }
         }
     }
@@ -673,10 +676,10 @@ internal class AstDeserializerInternal(
                 CreateTable(tableName, metas)
             }
             NodeTag.INDEX -> {
-                val tableName = args[0].stringValue() ?: err("Table name must be specified")
+                val tableId = deserializeIdentifier(args[0].asIonSexp().drop(1))
                 val children = args.drop(1).toListOfIonSexp().map { Pair(it.nodeTag, it) }.toMap()
                 val keys = children[NodeTag.KEYS]?.args?.deserializeAllExprNodes() ?: err("Index definition expects keys")
-                CreateIndex(tableName, keys, metas)
+                CreateIndex(tableId, keys, metas)
             }
             else -> errInvalidContext(target.nodeTag)
         }
@@ -686,22 +689,25 @@ internal class AstDeserializerInternal(
         targetArgs: List<IonValue>,
         metas: MetaContainer
     ): DropTable {
-        val tableName = targetArgs[0].stringValue() ?: err("Table name must be specified")
-        return DropTable(tableName, metas)
+        val tableId = deserializeIdentifier(targetArgs[0].asIonSexp().drop(1))
+        return DropTable(tableId, metas)
     }
 
     private fun deserializeDropIndexV0(
         targetArgs: List<IonValue>,
         metas: MetaContainer
     ): DropIndex {
-        val tableName = targetArgs[0].stringValue() ?: err("Table name must be specified")
-        val id = deserializeExprNode(targetArgs[1].asIonSexp()) as VariableReference
-        return DropIndex(tableName, id, metas)
+        val tableId = deserializeIdentifier(targetArgs[0].asIonSexp().drop(1))
+        val indexId = deserializeIdentifier(targetArgs[1].asIonSexp().drop(1))
+        return DropIndex(tableId, indexId, metas)
     }
 
-    private fun deserializeIdentifier(targetArgs: List<IonValue>): Pair<String, CaseSensitivity> {
-        return (targetArgs[0].stringValue() ?: err("Identifier deserialization: expecting string value, got ${targetArgs[0]}")) to
-            CaseSensitivity.fromSymbol(targetArgs[1].asIonSexp().tagText)
+    private fun deserializeIdentifier(targetArgs: List<IonValue>): Identifier {
+        return Identifier(
+            targetArgs[0].stringValue() ?: err("Identifier deserialization: expecting string value, got ${targetArgs[0]}"),
+            CaseSensitivity.fromSymbol(targetArgs[1].asIonSexp().tagText),
+            emptyMetaContainer
+        )
     }
 
     private fun deserializeTypedIs(

--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -743,7 +743,7 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
                 symbol(null)
                 sexp {
                     symbol("index")
-                    symbol(expr.tableName)
+                    writeIdentifier(expr.tableId.id, expr.tableId.case)
                     sexp {
                         symbol("keys")
                         expr.keys.forEach {
@@ -771,7 +771,7 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
         when (astVersion) {
             AstVersion.V0 -> {
                 symbol("drop_table")
-                symbol(expr.tableName)
+                writeIdentifier(expr.tableId.id, expr.tableId.case)
             }
         }
     }
@@ -780,8 +780,8 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
         when (astVersion) {
             AstVersion.V0 -> {
                 symbol("drop_index")
-                symbol(expr.tableName)
-                writeExprNode(expr.identifier)
+                writeIdentifier(expr.tableId.id, expr.tableId.case)
+                writeIdentifier(expr.indexId.id, expr.indexId.case)
             }
         }
     }

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -40,17 +40,27 @@ private fun ExprNode.toAstDdl(): PartiqlAst.Statement {
             is DataManipulation, is Exec -> error("Can't convert ${thiz.javaClass} to PartiqlAst.ddl")
 
             is CreateTable -> ddl(createTable(thiz.tableName), metas)
-            is CreateIndex -> ddl(createIndex(identifier(thiz.tableName, caseSensitive()), thiz.keys.map { it.toAstExpr() }), metas)
+            is CreateIndex ->
+                ddl(
+                    createIndex(
+                        identifier(thiz.tableId.id, thiz.tableId.case.toAstCaseSensitivity()),
+                        thiz.keys.map { it.toAstExpr() }
+                    ),
+                    metas)
             is DropIndex ->
                 ddl(
                     dropIndex(
                         // case-sensitivity of table names cannot be represented with ExprNode.
-                        identifier(thiz.tableName, caseSensitive()),
-                        identifier(thiz.identifier.id, thiz.identifier.case.toAstCaseSensitivity())),
+                        identifier(thiz.tableId.id, thiz.tableId.case.toAstCaseSensitivity()),
+                        identifier(thiz.indexId.id, thiz.indexId.case.toAstCaseSensitivity())),
                     metas)
             is DropTable ->
                 // case-sensitivity of table names cannot be represented with ExprNode.
-                ddl(dropTable(identifier(thiz.tableName, caseSensitive())), metas)
+                ddl(
+                    dropTable(
+                        identifier(thiz.tableId.id, thiz.tableId.case.toAstCaseSensitivity())
+                    ),
+                    metas)
         }
     }
 }

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -186,7 +186,8 @@ fun ExprNode.toAstExpr(): PartiqlAst.Expr {
                             node.precision.toLong(),
                             node.with_time_zone,
                             node.tz_minutes?.toLong()
-                        )
+                        ),
+                        metas
                     )
                 }
             }

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -429,15 +429,33 @@ private class StatementTransformer(val ion: IonSystem) {
         val metas = this.metas.toPartiQlMetaContainer()
         return when(op) {
             is DdlOp.CreateTable -> CreateTable(op.tableName.text, metas)
-            is DdlOp.DropTable -> DropTable(op.tableName.name.text, metas)
-            is DdlOp.CreateIndex -> CreateIndex(op.indexName.name.text, op.fields.map { it.toExprNode() }, metas)
+            is DdlOp.DropTable ->
+                DropTable(
+                    tableId = Identifier(
+                        id = op.tableName.name.text,
+                        case = op.tableName.case.toCaseSensitivity(),
+                        metas = emptyMetaContainer
+                    ),
+                    metas = metas)
+            is DdlOp.CreateIndex ->
+                CreateIndex(
+                    tableId = Identifier(
+                        id = op.indexName.name.text,
+                        case = op.indexName.case.toCaseSensitivity(),
+                        metas = emptyMetaContainer
+                    ),
+                    keys = op.fields.map { it.toExprNode() },
+                    metas = metas)
             is DdlOp.DropIndex ->
                 DropIndex(
-                    tableName = op.table.name.text,
-                    identifier = VariableReference(
+                    tableId = Identifier(
+                        id = op.table.name.text,
+                        case = op.table.case.toCaseSensitivity(),
+                        metas = emptyMetaContainer
+                    ),
+                    indexId = Identifier(
                         id = op.keys.name.text,
                         case = op.keys.case.toCaseSensitivity(),
-                        scopeQualifier = org.partiql.lang.ast.ScopeQualifier.UNQUALIFIED,
                         metas = emptyMetaContainer
                     ),
                     metas = metas)

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -229,7 +229,7 @@ private class StatementTransformer(val ion: IonSystem) {
         }
     }
 
-    private fun PartiqlAst.FromSource.toFromSource(): org.partiql.lang.ast.FromSource {
+    private fun PartiqlAst.FromSource.toFromSource(): FromSource {
         val metas = this.metas.toPartiQlMetaContainer()
         return when (this) {
             is PartiqlAst.FromSource.Scan ->

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -196,6 +196,15 @@ data class VariableReference(
 }
 
 /**
+ * an Identifier, which can be used for names that need to be looked up with a notion of case-sensitivity.
+ */
+data class Identifier(
+    val id: String,
+    val case: CaseSensitivity,
+    override val metas: MetaContainer
+) : HasMetas
+
+/**
  * Represents a dynamic parameter with ordinal position for a variable to be provided
  * by the evaluation environment.
  */
@@ -477,7 +486,7 @@ data class CreateTable(
  * @param keys The expressions that extract the keys from the target to be applied to the index.
  */
 data class CreateIndex(
-    val tableName: String,
+    val tableId: Identifier,
     val keys: List<ExprNode>,
     override val metas: MetaContainer
 ) : ExprNode() {
@@ -488,7 +497,7 @@ data class CreateIndex(
  * Represents a `DROP TABLE...` statement.
  */
 data class DropTable(
-    val tableName: String,
+    val tableId: Identifier,
     override val metas: MetaContainer
 ) : ExprNode() {
     override val children: List<AstNode> get() = emptyList()
@@ -496,16 +505,10 @@ data class DropTable(
 
 /**
  * Represents a `DROP INDEX $index_identifier ON $table_name` statement.
- *
- * TODO:  [identifier] should not be modeled as a [VariableReference] since it is not actually
- * a reference to a variable.  It actually a reference to an index identifier, which doesn't have
- * the same semantics--for instance identifier only exists within a scope that is limited to its
- * table and should not be resolved in the same way a variable does.  We should create a new
- * [AstNode] named `Identifier` which has `id` and `case` properties.
  */
 data class DropIndex(
-    val tableName: String,
-    val identifier: VariableReference,
+    val tableId: Identifier,
+    val indexId: Identifier,
     override val metas: MetaContainer
 ) : ExprNode() {
     override val children: List<AstNode> get() = emptyList()

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -429,17 +429,17 @@ open class AstRewriterBase : AstRewriter {
 
     open fun rewriteCreateIndex(node: CreateIndex): CreateIndex =
         CreateIndex(
-            node.tableName,
+            rewriteIdentifier(node.tableId),
             node.keys.map { rewriteExprNode(it) },
             rewriteMetas(node))
 
     open fun rewriteDropTable(node: DropTable): DropTable =
-        DropTable(node.tableName, rewriteMetas(node))
+        DropTable(rewriteIdentifier(node.tableId), rewriteMetas(node))
 
     open fun rewriteDropIndex(node: DropIndex): DropIndex =
         DropIndex(
-            node.tableName,
-            rewriteVariableReference(node.identifier) as VariableReference,
+            rewriteIdentifier(node.tableId),
+            rewriteIdentifier(node.indexId),
             rewriteMetas(node))
 
     open fun rewriteExec(node: Exec): Exec =
@@ -466,5 +466,12 @@ open class AstRewriterBase : AstRewriter {
             node.with_time_zone,
             node.tz_minutes,
             rewriteMetas(node)
+        )
+
+    open fun rewriteIdentifier(identifier: Identifier): Identifier =
+        Identifier(
+            identifier.id,
+            identifier.case,
+            rewriteMetas(identifier)
         )
 }

--- a/lang/src/org/partiql/lang/ast/passes/StatementRedactor.kt
+++ b/lang/src/org/partiql/lang/ast/passes/StatementRedactor.kt
@@ -2,10 +2,8 @@ package org.partiql.lang.ast.passes
 
 import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionelement.api.StringElement
-import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.ast.sourceLocation
-import org.partiql.lang.ast.toAstStatement
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.SqlParser
 
@@ -71,7 +69,7 @@ fun skipRedaction(node: PartiqlAst.Expr, safeFieldNames: Set<String>): Boolean {
 fun redact(statement: String,
            providedSafeFieldNames: Set<String> = emptySet(),
            userDefinedFunctionRedactionConfig: Map<String, UserDefinedFunctionRedactionLambda> = emptyMap()): String {
-    return redact(statement, parser.parseExprNode(statement), providedSafeFieldNames, userDefinedFunctionRedactionConfig)
+    return redact(statement, parser.parseAstStatement(statement), providedSafeFieldNames, userDefinedFunctionRedactionConfig)
 }
 
 /**
@@ -88,11 +86,10 @@ fun redact(statement: String,
  * arguments are to be redacted. For an example, please check StatementRedactorTest.kt for more details.
  */
 fun redact(statement: String,
-           ast: ExprNode,
+           partiqlAst: PartiqlAst.Statement,
            providedSafeFieldNames: Set<String> = emptySet(),
            userDefinedFunctionRedactionConfig: Map<String, UserDefinedFunctionRedactionLambda> = emptyMap()): String {
 
-    val partiqlAst = ast.toAstStatement()
     val statementRedactionVisitor = StatementRedactionVisitor(statement, providedSafeFieldNames, userDefinedFunctionRedactionConfig)
     statementRedactionVisitor.walkStatement(partiqlAst)
     return statementRedactionVisitor.getRedactedStatement()

--- a/lang/src/org/partiql/lang/ast/passes/StatementRedactor.kt
+++ b/lang/src/org/partiql/lang/ast/passes/StatementRedactor.kt
@@ -289,7 +289,7 @@ private class StatementRedactionVisitor(
                     if (!skipRedaction(it.first, safeFieldNames)) {
                         redactExpr(it.second)
                     }
-                else { /* intentionally blank */ }
+                    else { /* intentionally blank */ }
             }
         }
     }
@@ -299,23 +299,23 @@ private class StatementRedactionVisitor(
     // TODO: other NAry ops that not modeled (LIKE, INTERSECT, INTERSECT_ALL, EXCEPT, EXCEPT_ALL, UNION, UNION_ALL)
     private fun PartiqlAst.Expr.isNAry(): Boolean {
         return this is PartiqlAst.Expr.And
-            || this is PartiqlAst.Expr.Or
-            || this is PartiqlAst.Expr.Not
-            || this is PartiqlAst.Expr.Eq
-            || this is PartiqlAst.Expr.Ne
-            || this is PartiqlAst.Expr.Gt
-            || this is PartiqlAst.Expr.Gte
-            || this is PartiqlAst.Expr.Lt
-            || this is PartiqlAst.Expr.Lte
-            || this is PartiqlAst.Expr.InCollection
-            || this is PartiqlAst.Expr.Plus
-            || this is PartiqlAst.Expr.Minus
-            || this is PartiqlAst.Expr.Times
-            || this is PartiqlAst.Expr.Divide
-            || this is PartiqlAst.Expr.Modulo
-            || this is PartiqlAst.Expr.Concat
-            || this is PartiqlAst.Expr.Between
-            || this is PartiqlAst.Expr.Call
+                || this is PartiqlAst.Expr.Or
+                || this is PartiqlAst.Expr.Not
+                || this is PartiqlAst.Expr.Eq
+                || this is PartiqlAst.Expr.Ne
+                || this is PartiqlAst.Expr.Gt
+                || this is PartiqlAst.Expr.Gte
+                || this is PartiqlAst.Expr.Lt
+                || this is PartiqlAst.Expr.Lte
+                || this is PartiqlAst.Expr.InCollection
+                || this is PartiqlAst.Expr.Plus
+                || this is PartiqlAst.Expr.Minus
+                || this is PartiqlAst.Expr.Times
+                || this is PartiqlAst.Expr.Divide
+                || this is PartiqlAst.Expr.Modulo
+                || this is PartiqlAst.Expr.Concat
+                || this is PartiqlAst.Expr.Between
+                || this is PartiqlAst.Expr.Call
 
     }
 }

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -242,6 +242,7 @@ internal class EvaluatingCompiler(
     @Deprecated("Please use CompilerPipeline instead")
     fun compile(source: String): Expression {
         val parser = SqlParser(valueFactory.ion)
+        // TODO: replace `parseExprNode` with `ParseStatement` once evaluator deprecates `ExprNode`
         val ast = parser.parseExprNode(source)
         return compile(ast)
     }

--- a/lang/src/org/partiql/lang/syntax/Parser.kt
+++ b/lang/src/org/partiql/lang/syntax/Parser.kt
@@ -24,9 +24,11 @@ import org.partiql.lang.domains.PartiqlAst
  * Implementations must be thread-safe.
  */
 interface Parser {
-    fun parseExprNode(source: String): ExprNode
     fun parseAstStatement(source: String): PartiqlAst.Statement
 
-    @Deprecated("Please use parseExprNode() instead--the return value can be deserialized to backward-compatible IonSexp.")
+    @Deprecated("Please use parseAstStatement() instead--ExprNode is deprecated.")
+    fun parseExprNode(source: String): ExprNode
+
+    @Deprecated("Please use parseAstStatement() instead--the return value can be deserialized to backward-compatible IonSexp.")
     fun parse(source: String): IonSexp
 }

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -15,6 +15,7 @@
 package org.partiql.lang.syntax
 
 import com.amazon.ion.*
+import com.amazon.ionelement.api.*
 import org.partiql.lang.ast.*
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.errors.ErrorCode
@@ -29,6 +30,7 @@ import org.partiql.lang.syntax.SqlParser.ParseType.*
 import org.partiql.lang.syntax.TokenType.*
 import org.partiql.lang.syntax.TokenType.KEYWORD
 import org.partiql.lang.util.*
+import org.partiql.pig.runtime.SymbolPrimitive
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter.*
 import java.time.*
@@ -42,8 +44,6 @@ import java.time.temporal.Temporal
  * as the abstract syntax tree.
  */
 class SqlParser(private val ion: IonSystem) : Parser {
-
-    private val trueValue: IonBool = ion.newBool(true)
 
     internal enum class AliasSupportType(val supportsAs: Boolean, val supportsAt: Boolean, val supportsBy: Boolean) {
         NONE(supportsAs = false, supportsAt = false, supportsBy = false),
@@ -164,7 +164,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
         }
 
         fun deriveExpected(expectedType1: TokenType, expectedType2: TokenType): Pair<ParseNode, Token> =
-             if (expectedType1 != this.remaining.head?.type && expectedType2 != this.remaining.head?.type) {
+            if (expectedType1 != this.remaining.head?.type && expectedType2 != this.remaining.head?.type) {
                 val pvmap = PropertyValueMap()
                 pvmap[EXPECTED_TOKEN_TYPE_1_OF_2] = expectedType1
                 pvmap[EXPECTED_TOKEN_TYPE_2_OF_2] = expectedType2
@@ -198,326 +198,673 @@ class SqlParser(private val ion: IonSystem) : Parser {
 
     private fun Token.toSourceLocation() = SourceLocationMeta(span.line, span.column, span.length)
 
-    private fun Token?.toSourceLocationMetaContainer(): MetaContainer =
-        if(this == null) {
-            metaContainerOf()
+    private fun Token?.toSourceLocationMetaContainer(): IonElementMetaContainer =
+        if (this == null) {
+            emptyMetaContainer()
         } else {
-            metaContainerOf(this.toSourceLocation())
+            val sourceLocation = toSourceLocation()
+            metaContainerOf(Pair(sourceLocation.tag, sourceLocation))
         }
-
-    private fun ParseNode.toSymbolicName(): SymbolicName {
-        if(token == null) {
-            errMalformedParseTree("Expected ParseNode to have a token")
-        }
-        when (token.type) {
-            LITERAL, ION_LITERAL, IDENTIFIER, QUOTED_IDENTIFIER -> {
-                val tokenText = token.text ?: errMalformedParseTree("Expected ParseNode.token to have text")
-                return SymbolicName(tokenText, token.toSourceLocationMetaContainer())
-            }
-            else                                 -> {
-                errMalformedParseTree("TokenType.${token.type} cannot be converted to a SymbolicName")
-            }
-        }
-     }
 
     private fun ParseNode.malformedIfNotEmpty(unconsumedChildren: List<ParseNode>) {
-        if (!unconsumedChildren.isEmpty()) {
+        if (unconsumedChildren.isNotEmpty()) {
             errMalformedParseTree("Unprocessed components remaining")
         }
     }
 
     //***************************************
-    // toExprNode
+    // toAstStatement
     //***************************************
-    private fun ParseNode.toExprNode(): ExprNode {
-        val metas = token.toSourceLocationMetaContainer()
+    private fun ParseNode.toAstStatement(): PartiqlAst.Statement {
         return when (type) {
-            ATOM -> when (token?.type) {
-                LITERAL, NULL, TRIM_SPECIFICATION, DATE_PART -> {
-                    Literal(token.value!!, metas)
-                }
-                ION_LITERAL -> {
-                    Literal(token.value!!, metas.add(IsIonLiteralMeta.instance))
-                }
-                MISSING                                      -> {
-                    LiteralMissing(metas)
-                }
-                QUOTED_IDENTIFIER                            -> {
-                    VariableReference(
-                        token.text!!,
-                        CaseSensitivity.SENSITIVE,
-                        metas = metas)
-                }
-                IDENTIFIER                                   -> {
-                    VariableReference(
-                        token.text!!,
-                        CaseSensitivity.INSENSITIVE,
-                        metas = metas)
-                }
-                else                                         -> {
-                    errMalformedParseTree("Unsupported atom token type ${token?.type}")
-                }
-            }
-            LIST -> {
-                Seq(SeqType.LIST, children.map { it.toExprNode() }, metas)
-            }
-            BAG -> {
-                Seq(SeqType.BAG, children.map { it.toExprNode() }, metas)
-            }
-            STRUCT -> {
-                val fields = children.map {
-                    if (it.type != MEMBER) {
-                        errMalformedParseTree("Expected MEMBER node as direct descendant of a STRUCT node but instead found ${it.type}")
-                    }
-                    if (it.children.size != 2) {
-                        errMalformedParseTree("Expected MEMBER node to have 2 children but found ${it.children.size}")
-                    }
-                    val keyExpr = it.children[0].toExprNode()
-                    val valueExpr = it.children[1].toExprNode()
-                    StructField(keyExpr, valueExpr)
-            }
-                Struct(fields, metas)
-            }
-            UNARY, BINARY, TERNARY -> {
-                when(token!!.text) {
-                    "is" -> {
-                        Typed(
-                            TypedOp.IS,
-                            children[0].toExprNode(),
-                            children[1].toDataType(),
-                            metas)
-                    }
-                    "is_not" -> {
-                         NAry(
-                             NAryOp.NOT,
-                             listOf(Typed(TypedOp.IS, children[0].toExprNode(), children[1].toDataType(), metas)),
-                             metas.add(LegacyLogicalNotMeta.instance))
-                    }
-                    else -> {
+            ATOM, LIST, BAG, STRUCT, UNARY, BINARY, TERNARY, CAST, CALL, CALL_AGG,
+            CALL_DISTINCT_AGG, CALL_AGG_WILDCARD, PATH, PARAMETER, CASE, SELECT_LIST,
+            SELECT_VALUE, PIVOT, DATE, TIME, TIME_WITH_TIME_ZONE -> PartiqlAst.build { query(toAstExpr(), getMetas()) }
 
-                        val (opName, wrapInNot) = when (token.text) {
-                            "not_between" -> Pair("between", true)
-                            "not_like" -> Pair("like", true)
-                            "not_in" -> Pair("in", true)
-                            else -> Pair(token.text!!, false)
+            FROM, INSERT, INSERT_VALUE, SET, UPDATE, REMOVE, DELETE, DML_LIST -> toAstDml()
+
+            CREATE_TABLE, DROP_TABLE, CREATE_INDEX, DROP_INDEX -> toAstDdl()
+            
+            EXEC -> toAstExec()
+
+            else -> unsupported("Unsupported syntax for $type", PARSE_UNSUPPORTED_SYNTAX)
+        }
+    }
+
+    private fun ParseNode.toAstExpr(): PartiqlAst.Expr {
+        checkThreadInterrupted()
+        val metas = getMetas()
+
+        return PartiqlAst.build {
+            when (type) {
+                ATOM -> when (token?.type){
+                    LITERAL, NULL, TRIM_SPECIFICATION, DATE_PART -> lit(token.value!!.toIonElement(), metas)
+                    ION_LITERAL -> lit(token.value!!.toIonElement(), metas + metaToIonMetaContainer(IsIonLiteralMeta.instance))
+                    MISSING -> missing(metas)
+                    QUOTED_IDENTIFIER -> id(token.text!!, caseSensitive(), unqualified(), metas)
+                    IDENTIFIER -> id(token.text!!, caseInsensitive(), unqualified(), metas)
+                    else -> errMalformedParseTree("Unsupported atom token type ${token?.type}")
+                }
+                LIST -> list(children.map { it.toAstExpr() }, metas)
+                BAG -> bag(children.map { it.toAstExpr() }, metas)
+                STRUCT -> {
+                    val fields = children.map {
+                        if (it.type != MEMBER) {
+                            errMalformedParseTree("Expected MEMBER node as direct descendant of a STRUCT node but instead found ${it.type}")
                         }
-
-                        when (opName) {
-                            "@"  -> {
-                                val childNode = children[0]
-                                val childToken = childNode.token ?: errMalformedParseTree("@ node does not have a token")
-                                when(childToken.type) {
-                                    QUOTED_IDENTIFIER                            -> {
-                                        VariableReference(
-                                            childNode.token.text!!,
-                                            CaseSensitivity.SENSITIVE,
-                                            ScopeQualifier.LEXICAL,
-                                            childToken.toSourceLocationMetaContainer())
-                                    }
-                                    IDENTIFIER                                   -> {
-                                        VariableReference(
-                                            childNode.token.text!!,
-                                            CaseSensitivity.INSENSITIVE,
-                                            ScopeQualifier.LEXICAL,
-                                            childToken.toSourceLocationMetaContainer())
-                                    }
-                                    else                                         -> {
-                                        errMalformedParseTree("Unexpected child node token type of @ operator node ${childToken}")
-                                    }
-                                }
-                            }
-                            else -> {
-                                val op = NAryOp.forSymbol(opName) ?: errMalformedParseTree("Unsupported operator: $opName")
-
-                                val exprNode = NAry(op, children.map { it.toExprNode() }, metas)
-                                if (!wrapInNot) {
-                                    exprNode
-                                } else {
-                                    NAry(
-                                        NAryOp.NOT,
-                                        listOf(exprNode),
-                                        metas.add(LegacyLogicalNotMeta.instance))
-                                }
-                            }
+                        if (it.children.size != 2) {
+                            errMalformedParseTree("Expected MEMBER node to have 2 children but found ${it.children.size}")
                         }
+                        val keyExpr = it.children[0].toAstExpr()
+                        val valueExpr = it.children[1].toAstExpr()
+                        PartiqlAst.ExprPair(keyExpr, valueExpr)
                     }
+                    struct(fields, metas)
                 }
-
-            }
-            CAST -> {
-                val funcExpr = children[0].toExprNode()
-                val dataType = children[1].toDataType()
-                Typed(TypedOp.CAST, funcExpr, dataType, metas)
-            }
-            CALL -> {
-                val funcName = token?.text!!.toLowerCase()
-
-                when (funcName) {
-                    "sexp", "list", "bag" -> {
-                        // special case--list/sexp/bag "functions" are intrinsic to the literal form
-                        val seqType = SeqType.values().firstOrNull { it.typeName == funcName }
-                            ?: errMalformedParseTree("Cannot construct Seq node for functional call")
-                        Seq(seqType,  children.map { it.toExprNode()}, metas)
-                    }
-                    else -> {
-                        // Note:  we are forcing all function name lookups to be case insensitive here...
-                        // This seems like the right thing to do because that is consistent with the
-                        // previous behavior.
-                        val funcExpr =
-                            VariableReference(
-                                funcName,
-                                CaseSensitivity.INSENSITIVE,
-                                metas = metaContainerOf())
-                        NAry(NAryOp.CALL, listOf(funcExpr) + children.map { it.toExprNode() }, metas)
-                    }
-                }
-            }
-            EXEC -> {
-                val procedureName = SymbolicName(token?.text!!.toLowerCase(), token.toSourceLocationMetaContainer())
-                Exec(procedureName, children.map { it.toExprNode() }, metas)
-            }
-            CALL_AGG -> {
-                val funcExpr =
-                    VariableReference(
-                        token?.text!!.toLowerCase(),
-                        CaseSensitivity.INSENSITIVE,
-                        metas = metaContainerOf())
-
-                CallAgg(funcExpr, SetQuantifier.ALL, children.first().toExprNode(), metas)
-            }
-            CALL_DISTINCT_AGG -> {
-                val funcExpr =
-                    VariableReference(
-                        token?.text!!.toLowerCase(),
-                        CaseSensitivity.INSENSITIVE,
-                        metas = metaContainerOf())
-
-                CallAgg(funcExpr, SetQuantifier.DISTINCT, children.first().toExprNode(), metas)
-            }
-            CALL_AGG_WILDCARD -> {
-                if(token!!.type != KEYWORD || token.keywordText != "count") {
-                    errMalformedParseTree("only COUNT can be used with a wildcard")
-                }
-                val countStar = createCountStar(ion, metas)
-                countStar
-            }
-            PATH -> {
-                val rootExpr = children[0].toExprNode()
-                val pathComponents = children.drop(1).map {
-                    when(it.type) {
-                        PATH_DOT -> {
-                            if(it.children.size != 1) {
-                                errMalformedParseTree("Unexpected number of child elements in PATH_DOT ParseNode")
-                            }
-                            val atomParseNode = it.children.first()
-                            val atomMetas = atomParseNode.token.toSourceLocationMetaContainer()
-                            when(atomParseNode.type) {
-                                CASE_SENSITIVE_ATOM, CASE_INSENSITIVE_ATOM -> {
-                                    val sensitivity = if(atomParseNode.type  == CASE_SENSITIVE_ATOM)
-                                        CaseSensitivity.SENSITIVE
-                                    else {
-                                        CaseSensitivity.INSENSITIVE
-                                    }
-                                    PathComponentExpr(
-                                        Literal(
-                                            ion.newString(atomParseNode.token?.text!!),
-                                            atomMetas),
-                                        sensitivity)
-                                }
-                                PATH_UNPIVOT -> {
-                                    PathComponentUnpivot(atomMetas)
-                                }
-                                else -> errMalformedParseTree("Unsupported child path node of PATH_DOT")
-                            }
-                        }
-                        PATH_SQB -> {
-                            if(it.children.size != 1) {
-                                errMalformedParseTree("Unexpected number of child elements in PATH_SQB ParseNode")
-                            }
-                            val child = it.children.first()
-                            val childMetas = child.token.toSourceLocationMetaContainer()
-                            if(child.type == PATH_WILDCARD) {
-                                PathComponentWildcard(childMetas)
-                            } else {
-                                PathComponentExpr(child.toExprNode(), CaseSensitivity.SENSITIVE)
-                            }
-                        }
+                UNARY, BINARY, TERNARY -> {
+                    when (token!!.text) {
+                        "is" -> isType(children[0].toAstExpr(), children[1].toAstType(), metas)
+                        "is_not" -> not(
+                            isType(children[0].toAstExpr(), children[1].toAstType(), metas),
+                            metas + metaToIonMetaContainer(LegacyLogicalNotMeta.instance)
+                        )
                         else -> {
-                            errMalformedParseTree("Unsupported path component: ${it.type}")
-                        }
-                    }//.copy(token.toSourceLocationMetaContainer())
-                }
-                Path(rootExpr, pathComponents, metas)
-            }
-            PARAMETER -> {
-                Parameter(token!!.value!!.asIonInt().intValue(), metas)
-            }
-            CASE -> {
-                when (children.size) {
-                    // Searched CASE
-                    1 -> {
-                        val branches = ArrayList<SearchedCaseWhen>()
-                        var elseExpr: ExprNode? = null
-                        children[0].children.forEach {
-                            when(it.type) {
-                                WHEN -> branches.add(
-                                    SearchedCaseWhen(
-                                        it.children[0].toExprNode(),
-                                        it.children[1].toExprNode()))
+                            val (opName, wrapInNot) = when (token.text) {
+                                "not_between" -> Pair("between", true)
+                                "not_like" -> Pair("like", true)
+                                "not_in" -> Pair("in", true)
+                                else -> Pair(token.text!!, false)
+                            }
 
-                                ELSE -> elseExpr = it.children[0].toExprNode()
-                                else -> errMalformedParseTree("CASE clause must be WHEN or ELSE")
+                            when (opName) {
+                                "@"  -> {
+                                    val childNode = children[0]
+                                    val childToken = childNode.token
+                                        ?: errMalformedParseTree("@ node does not have a token")
+                                    when (childToken.type) {
+                                        QUOTED_IDENTIFIER -> id(childToken.text!!, caseSensitive(), localsFirst(), childNode.getMetas())
+                                        IDENTIFIER -> id(childToken.text!!, caseInsensitive(), localsFirst(), childNode.getMetas())
+                                        else -> errMalformedParseTree("Unexpected child node token type of @ operator node $childToken")
+                                    }
+                                }
+                                else -> {
+                                    val op = NAryOp.forSymbol(opName)
+                                        ?: errMalformedParseTree("Unsupported operator: $opName")
+                                    val args = children.map { it.toAstExpr() }
+                                    val node = op.toAstExpr(args, metas)
+
+                                    if (wrapInNot) {
+                                        not(node, metas + metaToIonMetaContainer(LegacyLogicalNotMeta.instance))
+                                    } else {
+                                        node
+                                    }
+                                }
                             }
                         }
-
-                        SearchedCase(branches, elseExpr, metas)
                     }
-                    // Simple CASE
-                    2 -> {
-                        val valueExpr = children[0].toExprNode()
-                        val branches = ArrayList<SimpleCaseWhen>()
-                        var elseExpr: ExprNode? = null
-                        children[1].children.forEach {
-                            when(it.type) {
-                                WHEN -> branches.add(
-                                    SimpleCaseWhen(
-                                        it.children[0].toExprNode(),
-                                        it.children[1].toExprNode()))
-
-                                ELSE -> elseExpr = it.children[0].toExprNode()
-                                else -> errMalformedParseTree("CASE clause must be WHEN or ELSE")
-                            }
-                        }
-
-                        SimpleCase(valueExpr, branches, elseExpr, metas)
-                    }
-                    else -> errMalformedParseTree("CASE must be searched or simple")
                 }
-            }
-            FROM -> {
-                // The first child is the operation, the second child is the from list,
-                // each child following is an optional clause (e.g. ORDER BY)
+                CAST -> cast(children[0].toAstExpr(), children[1].toAstType(), metas)
+                CALL -> {
+                    when (val funcName = token?.text!!.toLowerCase()) {
+                        // special case--list/sexp/bag "functions" are intrinsic to the literal form
+                        "sexp" -> sexp(children.map { it.toAstExpr()}, metas)
+                        "list" -> list(children.map { it.toAstExpr()}, metas)
+                        "bag" -> bag(children.map { it.toAstExpr()}, metas)
+                        else -> {
+                            // Note:  we are forcing all function name lookups to be case-insensitive here...
+                            // This seems like the right thing to do because that is consistent with the
+                            // previous behavior.
+                            val funcExpr = id(funcName, caseInsensitive(), unqualified())
+                            NAryOp.CALL.toAstExpr(listOf(funcExpr) + children.map { it.toAstExpr() }, metas)
+                        }
+                    }
+                }
+                CALL_AGG -> {
+                    val funcName = SymbolPrimitive(token?.text!!.toLowerCase(), emptyMetaContainer())
+                    callAgg_(all(), funcName, children[0].toAstExpr(), metas)
+                }
+                CALL_DISTINCT_AGG -> {
+                    val funcName = SymbolPrimitive(token?.text!!.toLowerCase(), emptyMetaContainer())
+                    callAgg_(distinct(), funcName, children[0].toAstExpr(), metas)
+                }
+                CALL_AGG_WILDCARD -> {
+                    if(token!!.type != KEYWORD || token.keywordText != "count") {
+                        errMalformedParseTree("only COUNT can be used with a wildcard")
+                    }
+                    // Should only get the [SourceLocationMeta] if present, not any other metas.
+                    val srcLocationMetaOnly = metas[SourceLocationMeta.TAG]
+                        ?.let { metaToIonMetaContainer(it as Meta) } ?: emptyMetaContainer()
+                    val lit = lit(ionInt(1), srcLocationMetaOnly)
+                    val symbolicPrimitive = SymbolPrimitive("count", srcLocationMetaOnly)
+                    callAgg_(all(), symbolicPrimitive, lit, metas + metaToIonMetaContainer(IsCountStarMeta.instance))
+                }
+                PATH -> {
+                    val rootExpr = children[0].toAstExpr()
+                    val pathComponents = children.drop(1).map {
+                        when(it.type) {
+                            PATH_DOT -> {
+                                if(it.children.size != 1) {
+                                    errMalformedParseTree("Unexpected number of child elements in PATH_DOT ParseNode")
+                                }
+                                val atomParseNode = it.children[0]
+                                val atomMetas = atomParseNode.getMetas()
+                                when (atomParseNode.type) {
+                                    CASE_SENSITIVE_ATOM, CASE_INSENSITIVE_ATOM -> {
+                                        val lit = lit(ionString(atomParseNode.token?.text!!), atomMetas)
+                                        val caseSensitivity = if (atomParseNode.type  == CASE_SENSITIVE_ATOM) caseSensitive() else caseInsensitive()
+                                        pathExpr(lit, caseSensitivity)
+                                    }
+                                    PATH_UNPIVOT -> pathUnpivot(atomMetas)
+                                    else -> errMalformedParseTree("Unsupported child path node of PATH_DOT")
+                                }
+                            }
+                            PATH_SQB -> {
+                                if(it.children.size != 1) {
+                                    errMalformedParseTree("Unexpected number of child elements in PATH_SQB ParseNode")
+                                }
+                                val child = it.children[0]
+                                val childMetas = child.getMetas()
+                                if (child.type == PATH_WILDCARD) pathWildcard(childMetas) else pathExpr(child.toAstExpr(), caseSensitive())
+                            }
+                            else -> errMalformedParseTree("Unsupported path component: ${it.type}")
+                        }
+                    }
+                    path(rootExpr, pathComponents, metas)
+                }
+                PARAMETER -> parameter(token!!.value!!.longValue(), metas)
+                CASE -> {
+                    val branches = ArrayList<PartiqlAst.ExprPair>()
+                    val cases = exprPairList(branches)
+                    var elseExpr: PartiqlAst.Expr? = null
 
-                val operation = children[0].toExprNode()
-                val fromSource = children[1].also {
-                    if (it.type != FROM_CLAUSE) {
-                        errMalformedParseTree("Invalid second child of FROM")
+                    fun ParseNode.addCases() = children.forEach {
+                        when(it.type) {
+                            WHEN -> branches.add(exprPair(it.children[0].toAstExpr(), it.children[1].toAstExpr()))
+                            ELSE -> elseExpr = it.children[0].toAstExpr()
+                            else -> errMalformedParseTree("CASE clause must be WHEN or ELSE")
+                        }
                     }
 
-                    if (it.children.size != 1) {
+                    when (children.size) {
+                        // Searched CASE
+                        1 -> {
+                            children[0].addCases()
+                            searchedCase(cases, elseExpr, metas)
+                        }
+                        // Simple CASE
+                        2 -> {
+                            val valueExpr = children[0].toAstExpr()
+                            children[1].addCases()
+                            simpleCase(valueExpr, cases, elseExpr, metas)
+                        }
+                        else -> errMalformedParseTree("CASE must be searched or simple")
+                    }
+                }
+                SELECT_LIST, SELECT_VALUE, PIVOT -> {
+                    // The first child of a SELECT_LIST parse node can be either DISTINCT or ARG_LIST.
+                    // If it is ARG_LIST, the children of that node are the select items and the SetQuantifier is ALL
+                    // If it is DISTINCT, the SetQuantifier is DISTINCT and there should be one child node, an ARG_LIST
+                    // containing the select items.
+
+                    // The second child of a SELECT_LIST is always an ARG_LIST containing the from clause.
+
+                    // GROUP BY, GROUP PARTIAL BY, WHERE, HAVING, LIMIT and OFFSET parse nodes each have distinct ParseNodeTypes
+                    // and if present, exist in children, starting at the third position.
+
+                    // If the query parsed was a `SELECT DISTINCT ...`, children[0] is of type DISTINCT and its
+                    // children are the actual select list.
+                    val setQuantifier = if (children[0].type == DISTINCT) distinct() else null
+                    val selectList = if (children[0].type == DISTINCT) children[0].children[0] else children[0]
+
+                    val fromList = children[1]
+                    if (fromList.type != FROM_CLAUSE) {
+                        errMalformedParseTree("Invalid second child of SELECT_LIST")
+                    }
+
+                    if (fromList.children.size != 1) {
                         errMalformedParseTree("Invalid FROM clause children length")
                     }
-                }.children[0].toFromSource()
 
+                    // We will remove items from this collection as we consume them.
+                    // If any unconsumed children remain, we've missed something and should throw an exception.
+                    val unconsumedChildren = children.drop(2).toMutableList()
+
+                    val projection = when (type) {
+                        SELECT_LIST -> {
+                            // We deal with ProjectStar first
+                            val childNodes = selectList.children
+                            if (childNodes.any { it.type == PROJECT_ALL && it.children.isEmpty() }) {
+                                if (childNodes.size > 1) error("More than one select item when SELECT * was present.")
+                                projectStar(childNodes[0].getMetas())
+                            } else {
+                                val selectListItems = childNodes.map {
+                                    when (it.type) {
+                                        PROJECT_ALL -> projectAll(it.children[0].toAstExpr())
+                                        else -> {
+                                            val (asAliasSymbol, parseNode) = it.unwrapAsAlias()
+                                            projectExpr_(parseNode.toAstExpr(), asAliasSymbol)
+                                        }
+                                    }
+                                }
+                                projectList(selectListItems)
+                            }
+                        }
+                        SELECT_VALUE -> projectValue(selectList.toAstExpr())
+                        PIVOT -> {
+                            val member = children[0]
+                            val asExpr = member.children[0].toAstExpr()
+                            val atExpr = member.children[1].toAstExpr()
+                            projectPivot(asExpr, atExpr)
+                        }
+                        else -> throw IllegalStateException("This can never happen!")
+                    }
+
+                    val fromSource = fromList.children[0].toFromSource()
+
+                    val fromLet = unconsumedChildren.firstOrNull { it.type == LET }?.let {
+                        unconsumedChildren.remove(it)
+                        it.toLetSource()
+                    }
+
+                    val whereExpr = unconsumedChildren.firstOrNull { it.type == WHERE }?.let {
+                        unconsumedChildren.remove(it)
+                        it.children[0].toAstExpr()
+                    }
+
+                    val groupBy = unconsumedChildren.firstOrNull { it.type == GROUP || it.type == GROUP_PARTIAL }?.let {
+                        unconsumedChildren.remove(it)
+                        val groupingStrategy = when (it.type) {
+                            GROUP -> groupFull()
+                            else -> groupPartial()
+                        }
+                        val groupAsName = if (it.children.size > 1) it.children[1].toSymbolicName() else null
+                        val keyList = it.children[0].children.map {
+                            val (alias, groupByItemNode) = it.unwrapAsAlias()
+                            groupKey_(groupByItemNode.toAstExpr(), alias)
+                        }
+
+                        groupBy_(
+                            groupingStrategy,
+                            groupKeyList(keyList),
+                            groupAsName
+                        )
+                    }
+
+                    val havingExpr = unconsumedChildren.firstOrNull { it.type == HAVING }?.let {
+                        unconsumedChildren.remove(it)
+                        it.children[0].toAstExpr()
+                    }
+
+                    val orderBy = unconsumedChildren.firstOrNull { it.type == ORDER_BY }?.let {
+                        unconsumedChildren.remove(it)
+                        orderBy(
+                            it.children[0].children.map {
+                                when (it.children.size) {
+                                    1 -> sortSpec(it.children[0].toAstExpr(), asc())
+                                    2 -> sortSpec(it.children[0].toAstExpr(), it.children[1].toOrderingSpec())
+                                    else -> errMalformedParseTree("Invalid ordering expressions syntax")
+                                }
+                            }
+                        )
+                    }
+
+                    val limitExpr = unconsumedChildren.firstOrNull { it.type == LIMIT }?.let {
+                        unconsumedChildren.remove(it)
+                        it.children[0].toAstExpr()
+                    }
+
+                    val offsetExpr = unconsumedChildren.firstOrNull { it.type == OFFSET }?.let {
+                        unconsumedChildren.remove(it)
+                        it.children[0].toAstExpr()
+                    }
+
+                    malformedIfNotEmpty(unconsumedChildren)
+
+                    select(
+                        setq = setQuantifier,
+                        project = projection,
+                        from = fromSource,
+                        fromLet = fromLet,
+                        where = whereExpr,
+                        group = groupBy,
+                        having = havingExpr,
+                        order = orderBy,
+                        limit = limitExpr,
+                        offset = offsetExpr,
+                        metas = metas
+                    )
+                }
+                DATE -> {
+                    val dateString = token!!.text!!
+                    val (year, month, day) = dateString.split("-")
+                    date(year.toLong(), month.toLong(), day.toLong(), metas)
+                }
+                TIME -> {
+                    val timeString = token!!.text!!
+                    val precision = children[0].token!!.value!!.numberValue().toLong()
+                    val time = LocalTime.parse(timeString, ISO_TIME)
+                    litTime(
+                        timeValue(time.hour.toLong(), time.minute.toLong(), time.second.toLong(), time.nano.toLong(), precision, false, null),
+                        metas
+                    )
+                }
+                TIME_WITH_TIME_ZONE -> {
+                    val timeString = token!!.text!!
+                    val precision = children[0].token!!.value!!.longValue()
+                    try {
+                        val time = OffsetTime.parse(timeString)
+                        litTime(
+                            timeValue(time.hour.toLong(), time.minute.toLong(), time.second.toLong(), time.nano.toLong(), precision, true, (time.offset.totalSeconds/60).toLong()),
+                            metas
+                        )
+                    } catch (e: DateTimeParseException) {
+                        // In case time zone not explicitly specified
+                        val time = LocalTime.parse(timeString)
+                        litTime(
+                            timeValue(time.hour.toLong(), time.minute.toLong(), time.second.toLong(), time.nano.toLong(), precision, true, null),
+                            metas
+                        )
+                    }
+                }
+                else -> error("Can't transform ParseType.$type to a PartiqlAst.expr }")
+            }
+        }
+    }
+
+    private fun ParseNode.toAstDml(): PartiqlAst.Statement.Dml {
+        val metas = getMetas()
+
+        return PartiqlAst.build {
+            when (type) {
+                FROM -> {
+                    // The first child is the operation, the second child is the from list,
+                    // each child following is an optional clause (e.g. ORDER BY)
+                    val operation = children[0].toAstDml()
+                    val fromSource = children[1].also {
+                        if (it.type != FROM_CLAUSE) {
+                            errMalformedParseTree("Invalid second child of FROM")
+                        }
+
+                        if (it.children.size != 1) {
+                            errMalformedParseTree("Invalid FROM clause children length")
+                        }
+                    }.children[0].toFromSource()
+
+                    // We will remove items from this collection as we consume them.
+                    // If any unconsumed children remain, we've missed something and should throw an exception.
+                    val unconsumedChildren = children.drop(2).toMutableList()
+
+                    val where = unconsumedChildren.firstOrNull { it.type == WHERE }?.let {
+                        unconsumedChildren.remove(it)
+                        it.children[0].toAstExpr()
+                    }
+                    val returning = unconsumedChildren.firstOrNull { it.type == RETURNING }?.let {
+                        unconsumedChildren.remove(it)
+                        it.toReturningExpr()
+                    }
+
+                    // Throw an exception if any unconsumed children remain
+                    malformedIfNotEmpty(unconsumedChildren)
+
+                    operation.copy(from = fromSource, where = where, returning = returning, metas = metas)
+                }
+                INSERT, INSERT_VALUE -> {
+                    val insertReturning = toInsertReturning()
+                    dml(
+                        dmlOpList(insertReturning.ops),
+                        returning = insertReturning.returning,
+                        metas = metas
+                    )
+                }
+                SET, UPDATE, REMOVE, DELETE -> dml(
+                    dmlOpList(toDmlOperation()),
+                    metas = metas
+                )
+                DML_LIST -> {
+                    val dmlOps = children.flatMap { it.toDmlOperation() }
+                    dml(
+                        dmlOpList(dmlOps),
+                        metas = metas
+                    )
+                }
+                else -> error("Can't transform ParseType.$type to PartiqlAst.Statement.Dml }")
+            }
+        }
+    }
+
+    private fun ParseNode.toAstDdl(): PartiqlAst.Statement.Ddl {
+        val metas = getMetas()
+
+        return PartiqlAst.build {
+            when (type) {
+                CREATE_TABLE -> ddl(
+                    createTable(children[0].token!!.text!!),
+                    metas
+                )
+                DROP_TABLE -> ddl(
+                    dropTable(children[0].toIdentifier()),
+                    metas
+                )
+                CREATE_INDEX -> ddl(
+                    createIndex(
+                        children[0].toIdentifier(),
+                        children[1].children.map { it.toAstExpr() }
+                    ),
+                    metas
+                )
+                DROP_INDEX -> ddl(
+                    dropIndex(children[1].toIdentifier(), children[0].toIdentifier()),
+                    metas
+                )
+                else -> error("Can't convert ParseType.$type to PartiqlAst.Statement.Ddl")
+            }
+        }
+    }
+
+    private fun ParseNode.toAstExec(): PartiqlAst.Statement.Exec {
+        val metas = getMetas()
+
+        return PartiqlAst.build {
+            when (type) {
+                EXEC -> exec_(
+                    SymbolPrimitive(token?.text!!.toLowerCase(), emptyMetaContainer()),
+                    children.map { it.toAstExpr() },
+                    metas
+                )
+                else -> error("Can't convert ParseType.$type to PartiqlAst.Statement.Exec")
+            }
+        }
+    }
+
+    private fun ParseNode.toAstType(): PartiqlAst.Type {
+        if (type != TYPE) {
+            errMalformedParseTree("Expected ParseType.TYPE instead of $type")
+        }
+
+        val sqlDataType = SqlDataType.forTypeName(token!!.keywordText!!)
+            ?: errMalformedParseTree("Invalid DataType: ${token.keywordText!!}")
+        val metas = getMetas()
+        val args = children.mapNotNull { it.token?.value?.longValue() }
+        val arg1 = args.getOrNull(0)
+        val arg2 = args.getOrNull(1)
+
+        return PartiqlAst.build {
+            when (sqlDataType) {
+                SqlDataType.MISSING -> missingType(metas)
+                SqlDataType.NULL -> nullType(metas)
+                SqlDataType.BOOLEAN -> booleanType(metas)
+                SqlDataType.SMALLINT -> smallintType(metas)
+                SqlDataType.INTEGER -> integerType(metas)
+                SqlDataType.FLOAT -> floatType(arg1, metas)
+                SqlDataType.REAL -> realType(metas)
+                SqlDataType.DOUBLE_PRECISION -> doublePrecisionType(metas)
+                SqlDataType.DECIMAL -> decimalType(arg1, arg2, metas)
+                SqlDataType.NUMERIC -> numericType(arg1, arg2, metas)
+                SqlDataType.TIMESTAMP -> timestampType(metas)
+                SqlDataType.CHARACTER -> characterType(arg1, metas)
+                SqlDataType.CHARACTER_VARYING -> characterVaryingType(arg1, metas)
+                SqlDataType.STRING -> stringType(metas)
+                SqlDataType.SYMBOL -> symbolType(metas)
+                SqlDataType.CLOB -> clobType(metas)
+                SqlDataType.BLOB -> blobType(metas)
+                SqlDataType.STRUCT -> structType(metas)
+                SqlDataType.TUPLE -> tupleType(metas)
+                SqlDataType.LIST -> listType(metas)
+                SqlDataType.SEXP -> sexpType(metas)
+                SqlDataType.BAG -> bagType(metas)
+                SqlDataType.DATE -> dateType(metas)
+                SqlDataType.TIME -> timeType(arg1, metas)
+                SqlDataType.TIME_WITH_TIME_ZONE -> timeWithTimeZoneType(arg1, metas)
+            }
+        }
+    }
+
+    private fun NAryOp.toAstExpr(args: List<PartiqlAst.Expr>, metas: IonElementMetaContainer): PartiqlAst.Expr {
+        return PartiqlAst.build {
+            when (this@toAstExpr) {
+                NAryOp.ADD -> plus(args, metas)
+                NAryOp.SUB -> minus(args, metas)
+                NAryOp.MUL -> times(args, metas)
+                NAryOp.DIV -> divide(args, metas)
+                NAryOp.MOD -> modulo(args, metas)
+                NAryOp.EQ -> eq(args, metas)
+                NAryOp.LT -> lt(args, metas)
+                NAryOp.LTE -> lte(args, metas)
+                NAryOp.GT -> gt(args, metas)
+                NAryOp.GTE -> gte(args, metas)
+                NAryOp.NE -> ne(args, metas)
+                NAryOp.LIKE -> like(args[0], args[1], args.getOrNull(2), metas)
+                NAryOp.BETWEEN -> between(args[0], args[1], args[2], metas)
+                NAryOp.NOT -> not(args[0], metas)
+                NAryOp.IN -> inCollection(args, metas)
+                NAryOp.AND -> and(args, metas)
+                NAryOp.OR -> or(args, metas)
+                NAryOp.STRING_CONCAT -> concat(args, metas)
+                NAryOp.CALL -> {
+                    val idArg = args.first() as? PartiqlAst.Expr.Id
+                        ?: error("First argument of call should be a VariableReference")
+                    // the above error message says "VariableReference" and not PartiqlAst.expr.id because it would
+                    // have been converted from a VariableReference when [args] was being built.
+
+                    // TODO:  we are losing case-sensitivity of the function name here.  Do we care?
+                    call(idArg.name.text, args.drop(1), metas)
+                }
+                NAryOp.INTERSECT -> intersect(distinct(), args, metas)
+                NAryOp.INTERSECT_ALL -> intersect(all(), args, metas)
+                NAryOp.EXCEPT -> except(distinct(), args, metas)
+                NAryOp.EXCEPT_ALL -> except(all(), args, metas)
+                NAryOp.UNION -> union(distinct(), args, metas)
+                NAryOp.UNION_ALL -> union(all(), args, metas)
+            }
+        }
+    }
+
+    private fun ParseNode.toFromSource(): PartiqlAst.FromSource {
+        val metas = getMetas()
+
+        return PartiqlAst.build {
+            when (type) {
+                FROM_SOURCE_JOIN -> {
+                    val isCrossJoin = token?.keywordText?.contains("cross") ?: false
+                    if (!isCrossJoin && children.size != 3) {
+                        errMalformedParseTree("Incorrect number of clauses provided to JOIN")
+                    }
+                    val jt = when (token?.keywordText) {
+                        "inner_join", "join", "cross_join" -> inner()
+                        "left_join", "left_cross_join" -> left()
+                        "right_join", "right_cross_join" -> right()
+                        "outer_join", "outer_cross_join" -> full()
+                        else -> errMalformedParseTree("Unsupported syntax for ${this@toFromSource.type}")
+                    }
+                    join(
+                        jt,
+                        children[0].toFromSource(),
+                        children[1].unwrapAliasesAndUnpivot(),
+                        if (isCrossJoin) null else children[2].toAstExpr(),
+                        if (isCrossJoin) metas + metaToIonMetaContainer(IsImplictJoinMeta.instance) else metas
+                    )
+                }
+                else -> unwrapAliasesAndUnpivot()
+            }
+        }
+    }
+
+    private fun ParseNode.unwrapAliasesAndUnpivot(): PartiqlAst.FromSource {
+        val (aliases, unwrappedParseNode) = unwrapAliases()
+
+        return PartiqlAst.build {
+            when (unwrappedParseNode.type) {
+                UNPIVOT -> unpivot_(
+                    unwrappedParseNode.children[0].toAstExpr(),
+                    aliases.asName,
+                    aliases.atName,
+                    aliases.byName,
+                    unwrappedParseNode.getMetas()
+                )
+                else -> {
+                    val expr = unwrappedParseNode.toAstExpr()
+                    scan_(expr, aliases.asName, aliases.atName, aliases.byName, expr.metas)
+                }
+            }
+        }
+    }
+
+    private fun ParseNode.unwrapAliases(
+        variables: LetVariables = LetVariables()
+    ): Pair<LetVariables, ParseNode> {
+        val metas = getMetas()
+
+        return when (type) {
+            AS_ALIAS -> {
+                if(variables.asName != null) error("Invalid parse tree: AS_ALIAS encountered more than once in FROM source")
+                children[0].unwrapAliases(variables.copy(asName = SymbolPrimitive(token!!.text!!, metas)))
+            }
+            AT_ALIAS -> {
+                if(variables.atName != null) error("Invalid parse tree: AT_ALIAS encountered more than once in FROM source")
+                children[0].unwrapAliases(variables.copy(atName = SymbolPrimitive(token!!.text!!, metas)))
+            }
+            BY_ALIAS -> {
+                if(variables.byName != null) error("Invalid parse tree: BY_ALIAS encountered more than once in FROM source")
+                children[0].unwrapAliases(variables.copy(byName = SymbolPrimitive(token!!.text!!, metas)))
+            }
+            else -> Pair(variables, this)
+        }
+    }
+
+    private fun ParseNode.toReturningExpr(): PartiqlAst.ReturningExpr =
+        PartiqlAst.build {
+            returningExpr(
+                children[0].children.map {
+                    returningElem(
+                        it.children[0].toReturningMapping(),
+                        it.children[1].toColumnComponent(it.getMetas())
+                    )
+                }
+            )
+        }
+
+    private fun ParseNode.toReturningMapping(): PartiqlAst.ReturningMapping {
+        if(type != RETURNING_MAPPING) {
+            errMalformedParseTree("Expected ParseType.RETURNING_MAPPING instead of $type")
+        }
+        return PartiqlAst.build {
+            when (token?.keywordText) {
+                "modified_old" -> modifiedOld()
+                "modified_new" -> modifiedNew()
+                "all_old" -> allOld()
+                "all_new" -> allNew()
+                else -> errMalformedParseTree("Invalid ReturningMapping parsing")
+            }
+        }
+    }
+
+    private fun ParseNode.toInsertReturning(): InsertReturning =
+        when (type) {
+            INSERT -> {
+                val ops = listOf(PartiqlAst.DmlOp.Insert(children[0].toAstExpr(), children[1].toAstExpr()))
                 // We will remove items from this collection as we consume them.
                 // If any unconsumed children remain, we've missed something and should throw an exception.
                 val unconsumedChildren = children.drop(2).toMutableList()
-
-                val where = unconsumedChildren.firstOrNull { it.type == WHERE }?.let {
-                    unconsumedChildren.remove(it)
-                    it.children[0].toExprNode()
-                }
-
                 val returning = unconsumedChildren.firstOrNull { it.type == RETURNING }?.let {
                     unconsumedChildren.remove(it)
                     it.toReturningExpr()
@@ -526,510 +873,201 @@ class SqlParser(private val ion: IonSystem) : Parser {
                 // Throw an exception if any unconsumed children remain
                 malformedIfNotEmpty(unconsumedChildren)
 
-                when (operation) {
-                    is DataManipulation -> {
-                        operation.copy(from = fromSource, where = where, returning = returning, metas = metas)
-                    }
-                    else -> {
-                        errMalformedParseTree("Unsupported operation for FROM expression")
-                    }
-                }
-            }
-            INSERT, INSERT_VALUE -> {
-                val insertReturning = this.toInsertReturning()
-                DataManipulation(DmlOpList(insertReturning.ops), returning = insertReturning.returning, metas = metas)
-            }
-            SET, UPDATE, REMOVE, DELETE -> {
-                DataManipulation(DmlOpList(this.toDmlOperation()), metas = metas)
-            }
-            DML_LIST -> {
-                val dmlops = children.flatMap { it.toDmlOperation() }.toList()
-                DataManipulation(DmlOpList(dmlops), metas = metas)
-            }
-
-            SELECT_LIST, SELECT_VALUE, PIVOT -> {
-                // The first child of a SELECT_LIST parse node and be either DISTINCT or ARG_LIST.
-                // If it is ARG_LIST, the children of that node are the select items and the SetQuantifier is ALL
-                // If it is DISTINCT, the SetQuantifier is DISTINCT and there should be one child node, an ARG_LIST
-                // containing the select items.
-
-                // The second child of a SELECT_LIST is always an ARG_LIST containing the from clause.
-
-                // GROUP BY, GROUP PARTIAL BY, WHERE, HAVING, LIMIT and OFFSET parse nodes each have distinct ParseNodeTypes
-                // and if present, exist in children, starting at the third position.
-
-                var setQuantifier = SetQuantifier.ALL
-                var selectList = children[0]
-                val fromList = children[1]
-
-                // We will remove items from this collection as we consume them.
-                // If any unconsumed children remain, we've missed something and should throw an exception.
-                val unconsumedChildren = children.drop(2).toMutableList()
-
-                // If the query parsed was a `SELECT DISTINCT ...`, children[0] is of type DISTINCT and its
-                // children are the actual select list.
-                if(selectList.type == DISTINCT) {
-                    selectList = selectList.children[0]
-                    setQuantifier = SetQuantifier.DISTINCT
-                }
-
-                val projection = when(type) {
-                    SELECT_LIST -> {
-                        val selectListItems = selectList.children.map { it.toSelectListItem() }
-                        SelectProjectionList(selectListItems)
-                    }
-                    SELECT_VALUE -> {
-                        SelectProjectionValue(selectList.toExprNode())
-                    }
-                    PIVOT -> {
-                        val member = children[0]
-                        val asExpr = member.children[0].toExprNode()
-                        val atExpr = member.children[1].toExprNode()
-                        SelectProjectionPivot(asExpr, atExpr)
-                    }
-                    else -> {
-                        throw IllegalStateException("This can never happen!")
-                    }
-                }
-
-                if (fromList.type != FROM_CLAUSE) {
-                    errMalformedParseTree("Invalid second child of SELECT_LIST")
-                }
-
-                if (fromList.children.size != 1) {
-                    errMalformedParseTree("Invalid FROM clause children length")
-                }
-
-                val fromSource = fromList.children[0].toFromSource()
-
-                val fromLet = unconsumedChildren.firstOrNull { it.type == LET }?.let {
-                    unconsumedChildren.remove(it)
-                    it.toLetSource()
-                }
-
-                val whereExpr = unconsumedChildren.firstOrNull { it.type == WHERE }?.let {
-                    unconsumedChildren.remove(it)
-                    it.children[0].toExprNode()
-                }
-
-                val orderBy = unconsumedChildren.firstOrNull { it.type == ORDER_BY }?.let {
-                    unconsumedChildren.remove(it)
-                    OrderBy(
-                        it.children[0].children.map {
-                            when (it.children.size) {
-                                1 -> SortSpec(it.children[0].toExprNode(), OrderingSpec.ASC)
-                                2 -> SortSpec(it.children[0].toExprNode(), it.children[1].toOrderingSpec())
-                                else -> errMalformedParseTree("Invalid ordering expressions syntax")
-                            }
-                        }
-                    )
-                }
-
-                val groupBy = unconsumedChildren.firstOrNull { it.type == GROUP || it.type == GROUP_PARTIAL }?.let {
-                    unconsumedChildren.remove(it)
-                    val groupingStrategy = when(it.type) {
-                        GROUP -> GroupingStrategy.FULL
-                        else -> GroupingStrategy.PARTIAL
-                    }
-
-                    val groupAsName = if(it.children.size > 1) {
-                        it.children[1].toSymbolicName()
-                    } else {
-                        null
-                    }
-
-                    GroupBy(
-                        groupingStrategy,
-                        it.children[0].children.map {
-                            val (alias, groupByItemNode) = it.unwrapAsAlias()
-                            GroupByItem(
-                                groupByItemNode.toExprNode(),
-                                alias)
-                        },
-                        groupAsName)
-                }
-
-                val havingExpr = unconsumedChildren.firstOrNull { it.type == HAVING }?.let {
-                    unconsumedChildren.remove(it)
-                    it.children[0].toExprNode()
-                }
-
-                val limitExpr = unconsumedChildren.firstOrNull { it.type == LIMIT }?.let {
-                    unconsumedChildren.remove(it)
-                    it.children[0].toExprNode()
-                }
-
-                val offsetExpr = unconsumedChildren.firstOrNull { it.type == OFFSET }?.let {
-                    unconsumedChildren.remove(it)
-                    it.children[0].toExprNode()
-                }
-
-                if(!unconsumedChildren.isEmpty()) {
-                    errMalformedParseTree("Unprocessed query components remaining")
-                }
-
-                Select(
-                    setQuantifier = setQuantifier,
-                    projection = projection,
-                    from = fromSource,
-                    fromLet = fromLet,
-                    where = whereExpr,
-                    groupBy = groupBy,
-                    having = havingExpr,
-                    orderBy = orderBy,
-                    limit = limitExpr,
-                    offset = offsetExpr,
-                    metas = metas)
-            }
-            CREATE_TABLE -> {
-                val name = children.first().token!!.text!!
-                CreateTable(name, metas = metas)
-            }
-            DROP_TABLE -> {
-                val name = children.first().token!!.text!!
-                DropTable(name, metas = metas)
-            }
-            CREATE_INDEX -> {
-                val tableName = children[0].token!!.text!!
-                val keys = children[1].children.map { it.toExprNode() }
-                CreateIndex(tableName, keys, metas = metas)
-            }
-            DROP_INDEX -> {
-                val identifier = children[0].toExprNode() as VariableReference
-                val tableName = children[1].token!!.text!!
-                DropIndex(tableName, identifier, metas = metas)
-            }
-            DATE -> {
-                val dateString = token!!.text!!
-                val (year, month, day) = dateString.split("-")
-                DateTimeType.Date(year.toInt(), month.toInt(), day.toInt(), metas)
-            }
-            TIME -> {
-                val timeString = token!!.text!!
-                val precision = children[0].token!!.value!!.numberValue().toInt()
-                val time = LocalTime.parse(timeString, DateTimeFormatter.ISO_TIME)
-                DateTimeType.Time(time.hour, time.minute, time.second, time.nano, precision, false, null, metas)
-            }
-            TIME_WITH_TIME_ZONE -> {
-                val timeString = token!!.text!!
-                val precision = children[0].token?.value?.numberValue()?.toInt()
-                try {
-                    val time = OffsetTime.parse(timeString)
-                    DateTimeType.Time(time.hour, time.minute, time.second, time.nano, precision!!, true, time.offset.totalSeconds/60, metas)
-                } catch (e: DateTimeParseException) {
-                    // In case time zone not explicitly specified
-                    val time = LocalTime.parse(timeString)
-                    DateTimeType.Time(time.hour, time.minute, time.second, time.nano, precision!!, true, null, metas)
-                }
-            }
-            else -> unsupported("Unsupported syntax for $type", PARSE_UNSUPPORTED_SYNTAX)
-        }
-    }
-
-    private fun ParseNode.toDmlOperation(): List<DataManipulationOperation> =
-        when(type) {
-            INSERT -> {
-                listOf(InsertOp(children[0].toExprNode(), children[1].toExprNode()))
+                InsertReturning(ops, returning)
             }
             INSERT_VALUE -> {
-                fun getOnConflictExprNode(onConflictChildren: List<ParseNode>) : OnConflict {
-                    onConflictChildren.getOrNull(0)?.let {
-                        val condition = it.toExprNode()
-                        onConflictChildren.getOrNull(1)?.let {
-                            if (CONFLICT_ACTION == it.type && "do_nothing" == it.token?.keywordText) {
-                                return OnConflict(condition, ConflictAction.DO_NOTHING)
+                fun getOnConflict(onConflictChildren: List<ParseNode>): PartiqlAst.OnConflict {
+                    onConflictChildren.getOrNull(0)?.let { firstNode ->
+                        val condition = firstNode.toAstExpr()
+                        onConflictChildren.getOrNull(1)?.let { secondNode ->
+                            if (CONFLICT_ACTION == secondNode.type && "do_nothing" == secondNode.token?.keywordText) {
+                                return PartiqlAst.build { onConflict(condition, doNothing()) }
                             }
                         }
                     }
                     errMalformedParseTree("invalid ON CONFLICT syntax")
                 }
 
-                val lvalue = children[0].toExprNode()
-                val value = children[1].toExprNode()
+                val lvalue = children[0].toAstExpr()
+                val value = children[1].toAstExpr()
 
                 // We will remove items from this collection as we consume them.
                 // If any unconsumed children remain, we've missed something and should throw an exception.
                 val unconsumedChildren = children.drop(2).toMutableList()
 
                 // Handle AT clause
-                val position = unconsumedChildren.firstOrNull {it.type != ON_CONFLICT && it.type != RETURNING }?.let {
+                val position = unconsumedChildren.firstOrNull { it.type != ON_CONFLICT && it.type != RETURNING }?.let {
                     unconsumedChildren.remove(it)
-                    it.toExprNode()
+                    it.toAstExpr()
                 }
 
-                val onConflict = unconsumedChildren.firstOrNull {it.type == ON_CONFLICT}?.let {
+                val onConflict = unconsumedChildren.firstOrNull { it.type == ON_CONFLICT }?.let {
                     unconsumedChildren.remove(it)
-                    getOnConflictExprNode(it.children)
+                    getOnConflict(it.children)
+                }
+
+                val ops = listOf(PartiqlAst.build { insertValue(lvalue, value, position, onConflict) })
+                val returning = unconsumedChildren.firstOrNull { it.type == RETURNING }?.let {
+                    unconsumedChildren.remove(it)
+                    it.toReturningExpr()
                 }
 
                 // Throw an exception if any unconsumed children remain
                 malformedIfNotEmpty(unconsumedChildren)
 
-                listOf(InsertValueOp(lvalue, value, position=position, onConflict=onConflict))
-            }
-            SET, UPDATE -> {
-                val assignments =
-                        children
-                                .map { AssignmentOp(Assignment(it.children[0].toExprNode(), it.children[1].toExprNode())) }
-                                .toList()
-                assignments
-            }
-            REMOVE -> {
-                listOf(RemoveOp(children[0].toExprNode()))
-            }
-            DELETE -> {
-                listOf(DeleteOp())
+                InsertReturning(ops, returning)
             }
             else -> unsupported("Unsupported syntax for $type", PARSE_UNSUPPORTED_SYNTAX)
         }
 
-    private fun ParseNode.toInsertReturning(): InsertReturning =
-            when(type) {
-                INSERT -> {
-                    val ops = listOf(InsertOp(children[0].toExprNode(), children[1].toExprNode()))
-                    // We will remove items from this collection as we consume them.
-                    // If any unconsumed children remain, we've missed something and should throw an exception.
-                    val unconsumedChildren = children.drop(2).toMutableList()
-                    val returning = unconsumedChildren.firstOrNull { it.type == RETURNING }?.let {
-                        unconsumedChildren.remove(it)
-                        it.toReturningExpr()
-                    }
+    private fun ParseNode.toColumnComponent(metas: IonElementMetaContainer): PartiqlAst.ColumnComponent =
+        PartiqlAst.build {
+            when (type) {
+                RETURNING_WILDCARD -> returningWildcard(metas)
+                else -> returningColumn(this@toColumnComponent.toAstExpr())
+            }
+        }
 
-                    // Throw an exception if any unconsumed children remain
-                    malformedIfNotEmpty(unconsumedChildren)
+    private fun ParseNode.toDmlOperation(): List<PartiqlAst.DmlOp> =
+        when (type) {
+            INSERT -> {
+                listOf(PartiqlAst.build { insert(children[0].toAstExpr(), children[1].toAstExpr()) })
+            }
+            INSERT_VALUE -> {
+                val lvalue = children[0].toAstExpr()
+                val value = children[1].toAstExpr()
 
-                    InsertReturning(ops, returning)
+                // We will remove items from this collection as we consume them.
+                // If any unconsumed children remain, we've missed something and should throw an exception.
+                val unconsumedChildren = children.drop(2).toMutableList()
+
+                // Handle AT clause
+                val position = unconsumedChildren.firstOrNull { it.type != ON_CONFLICT && it.type != RETURNING }?.let {
+                    unconsumedChildren.remove(it)
+                    it.toAstExpr()
                 }
-                INSERT_VALUE -> {
-                    fun getOnConflictExprNode(onConflictChildren: List<ParseNode>): OnConflict {
-                        onConflictChildren.getOrNull(0)?.let {
-                            val condition = it.toExprNode()
-                            onConflictChildren.getOrNull(1)?.let {
-                                if (CONFLICT_ACTION == it.type && "do_nothing" == it.token?.keywordText) {
-                                    return OnConflict(condition, ConflictAction.DO_NOTHING)
-                                }
+
+                val onConflict = unconsumedChildren.firstOrNull { it.type == ON_CONFLICT }?.let {
+                    unconsumedChildren.remove(it)
+                    val onConflictChildren = it.children
+                    onConflictChildren.getOrNull(0)?.let {
+                        val condition = it.toAstExpr()
+                        onConflictChildren.getOrNull(1)?.let {
+                            if (CONFLICT_ACTION == it.type && "do_nothing" == it.token?.keywordText) {
+                                PartiqlAst.build { onConflict(condition, doNothing()) }
                             }
                         }
-                        errMalformedParseTree("invalid ON CONFLICT syntax")
                     }
-
-                    val lvalue = children[0].toExprNode()
-                    val value = children[1].toExprNode()
-
-                    // We will remove items from this collection as we consume them.
-                    // If any unconsumed children remain, we've missed something and should throw an exception.
-                    val unconsumedChildren = children.drop(2).toMutableList()
-
-                    // Handle AT clause
-                    val position = unconsumedChildren.firstOrNull { it.type != ON_CONFLICT && it.type != RETURNING }?.let {
-                        unconsumedChildren.remove(it)
-                        it.toExprNode()
-                    }
-
-                    val onConflict = unconsumedChildren.firstOrNull { it.type == ON_CONFLICT }?.let {
-                        unconsumedChildren.remove(it)
-                        getOnConflictExprNode(it.children)
-                    }
-
-                    val ops = listOf(InsertValueOp(lvalue, value, position = position, onConflict = onConflict))
-
-                    val returning = unconsumedChildren.firstOrNull { it.type == RETURNING }?.let {
-                        unconsumedChildren.remove(it)
-                        it.toReturningExpr()
-                    }
-
-                    // Throw an exception if any unconsumed children remain
-                    malformedIfNotEmpty(unconsumedChildren)
-
-                    InsertReturning(ops, returning)
+                    errMalformedParseTree("invalid ON CONFLICT syntax")
                 }
-                else -> unsupported("Unsupported syntax for $type", PARSE_UNSUPPORTED_SYNTAX)
+
+                // Throw an exception if any unconsumed children remain
+                malformedIfNotEmpty(unconsumedChildren)
+
+                listOf(PartiqlAst.build { insertValue(lvalue, value, position, onConflict) })
             }
+            SET, UPDATE -> children.map {
+                PartiqlAst.build {
+                    set(
+                        assignment(
+                            it.children[0].toAstExpr(),
+                            it.children[1].toAstExpr()
+                        )
+                    )
+                }
+            }
+            REMOVE -> listOf(PartiqlAst.build { remove(children[0].toAstExpr()) })
+            DELETE -> listOf(PartiqlAst.build { delete() })
+            else -> unsupported("Unsupported syntax for $type", PARSE_UNSUPPORTED_SYNTAX)
+        }
 
-    private data class AsAlias(val name: SymbolicName?, val node: ParseNode)
-
-    /**
-     * Unwraps select list items that have been wrapped in an annotating node containing the `AS <alias>`,
-     * if present.
-     */
     private fun ParseNode.unwrapAsAlias(): AsAlias =
-        if(type == AS_ALIAS) {
-            AsAlias(SymbolicName(token!!.text!!, token.toSourceLocationMetaContainer()), children[0])
+        if (type == AS_ALIAS) {
+            AsAlias(SymbolPrimitive(token!!.text!!, getMetas()), children[0])
         } else {
             AsAlias(null, this)
         }
 
-    private fun ParseNode.toSelectListItem(): SelectListItem {
-        val metas = token.toSourceLocationMetaContainer()
-        return when (type) {
-            PROJECT_ALL -> {
-                if (children.isEmpty()) {
-                    SelectListItemStar(metas)
-                }
-                else {
-                    val expr = children[0].toExprNode()
-                    SelectListItemProjectAll(expr)
-                }
+    private fun ParseNode.toIdentifier(): PartiqlAst.Identifier {
+        if (type != ATOM){
+            errMalformedParseTree("Cannot transform ParseNode type: $type to identifier")
+        }
 
-            }
-            else        -> {
-                val (asAliasSymbol, parseNode) = unwrapAsAlias()
-                SelectListItemExpr(parseNode.toExprNode(), asAliasSymbol)
+        val metas = getMetas()
+
+        return PartiqlAst.build {
+            when (token?.type){
+                QUOTED_IDENTIFIER -> identifier(token.text!!, caseSensitive(), metas)
+                IDENTIFIER -> identifier(token.text!!, caseInsensitive(), metas)
+                else -> errMalformedParseTree("Cannot transform atom token type ${token?.type} to identifier")
             }
         }
     }
 
-    private fun ParseNode.unwrapAliases(
-        variables: LetVariables = LetVariables()
-    ): Pair<LetVariables, ParseNode> {
-
-        val metas = token.toSourceLocationMetaContainer()
-        return when (type) {
-            AS_ALIAS -> {
-                if(variables.asName != null) error("Invalid parse tree: AS_ALIAS encountered more than once in FROM source")
-                children[0].unwrapAliases(variables.copy(asName = SymbolicName(token!!.text!!, metas)))
-            }
-            AT_ALIAS -> {
-                if(variables.atName != null) error("Invalid parse tree: AT_ALIAS encountered more than once in FROM source")
-                children[0].unwrapAliases(variables.copy(atName = SymbolicName(token!!.text!!, metas)))
-            }
-            BY_ALIAS -> {
-                if(variables.byName != null) error("Invalid parse tree: BY_ALIAS encountered more than once in FROM source")
-                children[0].unwrapAliases(variables.copy(byName = SymbolicName(token!!.text!!, metas)))
-            }
-            else -> {
-                return Pair(variables, this)
-            }
-        }
-    }
-
-    private fun ParseNode.toFromSource(): FromSource {
-        val head = this
-        if (head.type == FROM_SOURCE_JOIN) {
-            val isCrossJoin = head.token?.keywordText?.contains("cross") ?: false
-            if (!isCrossJoin && head.children.size != 3) {
-                head.errMalformedParseTree("Incorrect number of clauses provided to JOIN")
-            }
-
-            val joinTokenType = head.token?.keywordText
-            val joinOp = when (joinTokenType) {
-                "inner_join", "join", "cross_join" -> JoinOp.INNER
-                "left_join", "left_cross_join" -> JoinOp.LEFT
-                "right_join", "right_cross_join" -> JoinOp.RIGHT
-                "outer_join", "outer_cross_join" -> JoinOp.OUTER
-                else -> {
-                    head.errMalformedParseTree("Unsupported syntax for ${head.type}")
-                }
-            }
-
-            val condition = when {
-                isCrossJoin -> Literal(trueValue, metaContainerOf())
-                else -> head.children[2].toExprNode()
-            }
-
-            return FromSourceJoin(joinOp,
-                    head.children[0].toFromSource(),
-                    head.children[1].unwrapAliasesAndUnpivot(),
-                    condition,
-                    token.toSourceLocationMetaContainer().let {
-                    when {
-                            isCrossJoin -> it.add(IsImplictJoinMeta.instance)
-                            else        -> it
-                        }
-                    }
-            )
-        }
-        return head.unwrapAliasesAndUnpivot()
-    }
-
-    private fun ParseNode.toLetSource(): LetSource {
-        val letBindings = this.children.map { it.toLetBinding() }
-        return LetSource(letBindings)
-    }
-
-    private fun ParseNode.toLetBinding(): LetBinding {
-        val (asAliasSymbol, parseNode) = unwrapAsAlias()
-        if (asAliasSymbol == null) {
-            this.errMalformedParseTree("Unsupported syntax for ${this.type}")
-        }
-        else {
-            return LetBinding(parseNode.toExprNode(), asAliasSymbol)
-        }
-    }
-
-    private fun ParseNode.unwrapAliasesAndUnpivot(): FromSource {
-        val (aliases, unwrappedParseNode) = unwrapAliases()
-        return when(unwrappedParseNode.type) {
-            UNPIVOT -> {
-                val expr = unwrappedParseNode.children[0].toExprNode()
-                FromSourceUnpivot(
-                    expr,
-                    aliases,
-                    unwrappedParseNode.token.toSourceLocationMetaContainer())
-            }
-            else    -> {
-                FromSourceExpr(unwrappedParseNode.toExprNode(), aliases)
-            }
-        }
-    }
-
-    private fun ParseNode.toDataType(): DataType {
-        if(type != TYPE) {
-            errMalformedParseTree("Expected ParseType.TYPE instead of $type")
-        }
-        val sqlDataType = SqlDataType.forTypeName(token!!.keywordText!!)
-        if(sqlDataType == null) {
-            errMalformedParseTree("Invalid DataType: ${token.keywordText!!}")
-        }
-
-        return DataType(
-            sqlDataType,
-            children.mapNotNull { it.token?.value?.longValue() },
-            metas = token.toSourceLocationMetaContainer())
-    }
-
-    private fun ParseNode.toOrderingSpec(): OrderingSpec {
-        if(type != ORDERING_SPEC) {
+    private fun ParseNode.toOrderingSpec(): PartiqlAst.OrderingSpec {
+        if (type != ORDERING_SPEC) {
             errMalformedParseTree("Expected ParseType.ORDERING_SPEC instead of $type")
         }
-        return when (token?.type) {
-            ASC -> OrderingSpec.ASC
-            DESC -> OrderingSpec.DESC
-            else -> errMalformedParseTree("Invalid ordering spec parsing")
-        }
-    }
-
-    private fun ParseNode.toReturningExpr(): ReturningExpr {
-        val metas = token.toSourceLocationMetaContainer()
-        return ReturningExpr(
-            this.children[0].children.map { re ->
-                ReturningElem(
-                    re.children[0].toReturningMapping(),
-                    re.children[1].toColumnComponent(metas)
-                )
+        return PartiqlAst.build {
+            when (token?.type) {
+                ASC -> asc()
+                DESC -> desc()
+                else -> errMalformedParseTree("Invalid ordering spec parsing")
             }
-        )
-    }
-
-    private fun ParseNode.toReturningMapping(): ReturningMapping {
-        if(type != RETURNING_MAPPING) {
-            errMalformedParseTree("Expected ParseType.RETURNING_MAPPING instead of $type")
-        }
-        return when (token?.keywordText) {
-            "modified_old" -> ReturningMapping.MODIFIED_OLD
-            "modified_new" -> ReturningMapping.MODIFIED_NEW
-            "all_old" -> ReturningMapping.ALL_OLD
-            "all_new" -> ReturningMapping.ALL_NEW
-            else -> errMalformedParseTree("Invalid ReturningMapping parsing")
         }
     }
 
-    private fun ParseNode.toColumnComponent(metas: MetaContainer): ColumnComponent {
-        return when (this.type) {
-            RETURNING_WILDCARD -> ReturningWildcard(metas)
-            else -> ReturningColumn(this.toExprNode())
+    private fun ParseNode.toSymbolicName(): SymbolPrimitive {
+        if (token == null) {
+            errMalformedParseTree("Expected ParseNode to have a token")
+        }
+        when (token.type) {
+            LITERAL, ION_LITERAL, IDENTIFIER, QUOTED_IDENTIFIER -> {
+                val tokenText = token.text ?: errMalformedParseTree("Expected ParseNode.token to have text")
+                return SymbolPrimitive(tokenText, getMetas())
+            }
+            else -> errMalformedParseTree("TokenType.${token.type} cannot be converted to a SymbolicPrimitive")
         }
     }
+
+    private fun ParseNode.toLetSource(): PartiqlAst.Let {
+        return PartiqlAst.build {
+            let(children.map { it.toLetBinding() })
+        }
+    }
+
+    private fun ParseNode.toLetBinding(): PartiqlAst.LetBinding {
+        val (asAliasSymbol, parseNode) = unwrapAsAlias()
+        if (asAliasSymbol == null) {
+            errMalformedParseTree("Unsupported syntax for $type")
+        }
+        return PartiqlAst.build {
+            letBinding(parseNode.toAstExpr(), asAliasSymbol.text, asAliasSymbol.metas)
+        }
+    }
+
+    private fun ParseNode.getMetas(): IonElementMetaContainer =
+        token.toSourceLocationMetaContainer()
+
+    private fun metaToIonMetaContainer(meta: Meta): IonElementMetaContainer =
+        metaContainerOf(Pair(meta.tag, meta))
+
+    private data class LetVariables(
+        val asName: SymbolPrimitive? = null,
+        val atName: SymbolPrimitive? = null,
+        val byName: SymbolPrimitive? = null
+    )
+
+    private data class InsertReturning(
+        val ops: List<PartiqlAst.DmlOp>,
+        val returning: PartiqlAst.ReturningExpr? = null
+    )
+
+    private data class AsAlias(
+        val name: SymbolPrimitive?,
+        val node: ParseNode
+    )
+
 
     /**********************************************************************************************
      * Parse logic below this line.
@@ -1232,7 +1270,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
 
     private fun List<Token>.parseTerm(): ParseNode = when (head?.type) {
         OPERATOR -> when (head?.keywordText) {
-        // the lexical scope operator is **only** allowed with identifiers
+            // the lexical scope operator is **only** allowed with identifiers
             "@" -> when (tail.head?.type) {
                 IDENTIFIER, QUOTED_IDENTIFIER -> ParseNode(
                     UNARY,
@@ -1283,9 +1321,9 @@ class SqlParser(private val ion: IonSystem) : Parser {
             ).deriveExpected(RIGHT_PAREN)
             when (group.children.size) {
                 0 -> tail.err("Expression group cannot be empty", PARSE_EXPECTED_EXPRESSION)
-            // expression grouping
+                // expression grouping
                 1 -> group.children[0].copy(remaining = group.remaining)
-            // row value constructor--which aliases to list constructor in PartiQL
+                // row value constructor--which aliases to list constructor in PartiQL
                 else -> group.copy(type = LIST)
             }
         }
@@ -1391,33 +1429,33 @@ class SqlParser(private val ion: IonSystem) : Parser {
 
             else -> ParseNode(TYPE, head, emptyList(), tail)
         }
-        // Check for the optional "WITH TIME ZONE" specifier for TIME and validate the value of precision.
-        // Note that this needs to be checked explicitly as the keywordtext for "TIME WITH TIME ZONE" consists of multiple words.
-        .let {
-            if (typeName == "time") {
-                // Check for the range of valid values for precision
-                it.children.firstOrNull()?.also { precision ->
-                    if (precision.token?.value == null || !precision.token.value.isUnsignedInteger ||
-                        precision.token.value.longValue() < 0 || precision.token.value.longValue() > MAX_PRECISION_FOR_TIME
-                    ) {
-                        precision.token.err(
-                            "Expected integer value between 0 and 9 for precision",
-                            PARSE_INVALID_PRECISION_FOR_TIME
-                        )
+            // Check for the optional "WITH TIME ZONE" specifier for TIME and validate the value of precision.
+            // Note that this needs to be checked explicitly as the keywordtext for "TIME WITH TIME ZONE" consists of multiple words.
+            .let {
+                if (typeName == "time") {
+                    // Check for the range of valid values for precision
+                    it.children.firstOrNull()?.also { precision ->
+                        if (precision.token?.value == null || !precision.token.value.isUnsignedInteger ||
+                            precision.token.value.longValue() < 0 || precision.token.value.longValue() > MAX_PRECISION_FOR_TIME
+                        ) {
+                            precision.token.err(
+                                "Expected integer value between 0 and 9 for precision",
+                                PARSE_INVALID_PRECISION_FOR_TIME
+                            )
+                        }
                     }
+                    val (remainingAfterOptionalTimeZone, isTimeZoneSpecified) = it.remaining.checkForOptionalTimeZone()
+                    val newToken = if (isTimeZoneSpecified) {
+                        it.token!!.copy(value = ion.singleValue(SqlDataType.TIME_WITH_TIME_ZONE.typeName))
+                    } else {
+                        it.token
+                    }
+                    it.copy(token = newToken, remaining = remainingAfterOptionalTimeZone)
                 }
-                val (remainingAfterOptionalTimeZone, isTimeZoneSpecified) = it.remaining.checkForOptionalTimeZone()
-                val newToken = if (isTimeZoneSpecified) {
-                    it.token!!.copy(value = ion.singleValue(SqlDataType.TIME_WITH_TIME_ZONE.typeName))
-                } else {
-                    it.token
+                else {
+                    it
                 }
-                it.copy(token = newToken, remaining = remainingAfterOptionalTimeZone)
             }
-            else {
-                it
-            }
-        }
 
         if (typeNode.children.size !in typeArity) {
             val pvmap = PropertyValueMap()
@@ -1719,7 +1757,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
 
                 val asterisk = list.children.firstOrNull { it.type == ParseType.PROJECT_ALL && it.children.isEmpty() }
                 if(asterisk != null
-                   && list.children.size > 1) {
+                    && list.children.size > 1) {
                     asterisk.token.err(
                         "Other expressions may not be present in the select list when '*' is used without dot notation.",
                         ErrorCode.PARSE_ASTERISK_IS_NOT_ALONE_IN_SELECT_LIST)
@@ -2157,7 +2195,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
         }
 
         return rem.parseArgList(aliasSupportType = NONE, mode = NORMAL_ARG_LIST)
-                  .copy(type = EXEC, token = procedureName)
+            .copy(type = EXEC, token = procedureName)
     }
 
     /**
@@ -2189,7 +2227,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
         }
 
         val (positionExpr: ParseNode, expectedToken: Token) = stringExpr.remaining.parseExpression()
-                .deriveExpected(if(parseSql92Syntax) FOR else COMMA, RIGHT_PAREN)
+            .deriveExpected(if(parseSql92Syntax) FOR else COMMA, RIGHT_PAREN)
 
         if (expectedToken.type == RIGHT_PAREN) {
             return ParseNode(
@@ -2203,9 +2241,9 @@ class SqlParser(private val ion: IonSystem) : Parser {
         rem = positionExpr.remaining
         val lengthExpr = rem.parseExpression().deriveExpected(RIGHT_PAREN)
         return ParseNode(ParseType.CALL,
-                name,
-                listOf(stringExpr, positionExpr, lengthExpr),
-                lengthExpr.remaining)
+            name,
+            listOf(stringExpr, positionExpr, lengthExpr),
+            lengthExpr.remaining)
 
     }
 
@@ -2288,7 +2326,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
      */
     private fun List<Token>.parseExtract(name: Token): ParseNode {
         if (head?.type != LEFT_PAREN) err("Expected $LEFT_PAREN",
-                                          PARSE_EXPECTED_LEFT_PAREN_BUILTIN_FUNCTION_CALL)
+            PARSE_EXPECTED_LEFT_PAREN_BUILTIN_FUNCTION_CALL)
 
         val datePart = this.tail.parseDatePart().deriveExpectedKeyword("from")
         val rem = datePart.remaining
@@ -2437,7 +2475,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
         // The source span here is just the filler value and does not reflect the actual source location of the precision
         // as it does not exists in case the precision is unspecified.
         val precisionOfValue =  precision.token ?:
-            Token(LITERAL, ion.newInt(getPrecisionFromTimeString(timeString)), timeStringToken.span)
+        Token(LITERAL, ion.newInt(getPrecisionFromTimeString(timeString)), timeStringToken.span)
 
         return ParseNode(
             if (withTimeZone) TIME_WITH_TIME_ZONE else TIME,
@@ -2566,7 +2604,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
         }
     }
 
-        private fun List<Token>.parseOrderByArgList(): ParseNode {
+    private fun List<Token>.parseOrderByArgList(): ParseNode {
         return parseDelimitedList(parseCommaDelim) {
             var rem = this
 
@@ -2594,10 +2632,10 @@ class SqlParser(private val ion: IonSystem) : Parser {
             "unpivot" -> {
                 val actualChild = rem.tail.parseExpression(precedence)
                 ParseNode(
-                        UNPIVOT,
-                        rem.head,
-                        listOf(actualChild),
-                        actualChild.remaining
+                    UNPIVOT,
+                    rem.head,
+                    listOf(actualChild),
+                    actualChild.remaining
                 )
             }
             else -> {
@@ -2708,9 +2746,9 @@ class SqlParser(private val ion: IonSystem) : Parser {
     }
 
     private fun List<Token>.parseArgList(
-            aliasSupportType: AliasSupportType,
-            mode: ArgListMode,
-            precedence: Int = -1
+        aliasSupportType: AliasSupportType,
+        mode: ArgListMode,
+        precedence: Int = -1
     ): ParseNode {
         val parseDelim = parseCommaDelim
 
@@ -2837,7 +2875,7 @@ class SqlParser(private val ion: IonSystem) : Parser {
 
     private fun ParseNode.throwTopLevelParserError(): Nothing =
         token?.err("Keyword ${token.text} only expected at the top level in the query", PARSE_UNEXPECTED_TERM)
-        ?: throw ParserException("Keyword ${token?.text} only expected at the top level in the query", PARSE_UNEXPECTED_TERM, PropertyValueMap())
+            ?: throw ParserException("Keyword ${token?.text} only expected at the top level in the query", PARSE_UNEXPECTED_TERM, PropertyValueMap())
 
     /**
      * Validates tree to make sure that the top level tokens are not found below the top level.
@@ -2882,27 +2920,30 @@ class SqlParser(private val ion: IonSystem) : Parser {
     }
 
     /** Entry point into the parser. */
+    @Deprecated("`ExprNode` is deprecated. Please use `parseAstStatement` instead. ")
     override fun parseExprNode(source: String): ExprNode {
+        return parseAstStatement(source).toExprNode(ion)
+    }
+
+    /**
+     * Parse given source node as a PartiqlAst.Statement
+     */
+    override fun parseAstStatement(source: String): PartiqlAst.Statement {
         val tokens = SqlLexer(ion).tokenize(source)
         val node = tokens.parseExpression()
         val rem = node.remaining
         if (!rem.onlyEndOfStatement()) {
             when (rem.head?.type) {
                 SEMICOLON -> rem.tail.err("Unexpected token after semicolon. (Only one query is allowed.)",
-                                          PARSE_UNEXPECTED_TOKEN)
+                    PARSE_UNEXPECTED_TOKEN)
                 else      -> rem.err("Unexpected token after expression", PARSE_UNEXPECTED_TOKEN)
             }
         }
 
         validateTopLevelNodes(node = node, level = 0, topLevelTokenSeen = false, dmlListTokenSeen = false)
 
-        return node.toExprNode()
+        return node.toAstStatement()
     }
-
-    /**
-     * Parse given source node as a PartiqlAst.Statement
-     */
-    override fun parseAstStatement(source: String): PartiqlAst.Statement = parseExprNode(source).toAstStatement()
 
     override fun parse(source: String): IonSexp =
         AstSerializer.serialize(parseExprNode(source), AstVersion.V0, ion)

--- a/lang/test/org/partiql/lang/ast/passes/StatementRedactorTest.kt
+++ b/lang/test/org/partiql/lang/ast/passes/StatementRedactorTest.kt
@@ -57,257 +57,257 @@ class StatementRedactorTest : SqlParserTestBase() {
     }
 
     fun parametersForTestRedactOnPositiveCases() = listOf(
-            // Typed
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk IS MISSING AND attr IS MISSING",
-                    "SELECT * FROM tb WHERE hk IS MISSING AND attr IS ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk IS NOT MISSING AND attr IS NOT MISSING",
-                    "SELECT * FROM tb WHERE hk IS NOT MISSING AND attr IS NOT ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS MISSING",
-                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS NUMERIC",
-                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS NOT NUMERIC",
-                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS STRING",
-                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS NOT STRING",
-                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS TUPLE",
-                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS NOT TUPLE",
-                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS STRUCT",
-                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS NOT STRUCT",
-                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS BOOLEAN",
-                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS NOT BOOLEAN",
-                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS LIST",
-                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS NOT LIST",
-                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS BLOB",
-                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS NOT BLOB",
-                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS NULL",
-                    "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE attr IS NOT NULL",
-                    "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
-            // Call and Nested Call
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 1 AND begins_with(Attr, 'foo') AND begins_with(hk, 'foo')",
-                    "SELECT * FROM tb WHERE hk = 1 AND begins_with(Attr, ***(Redacted)) AND begins_with(hk, 'foo')"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 1 AND contains(Attr, 'foo') AND contains(hk, 'foo')",
-                    "SELECT * FROM tb WHERE hk = 1 AND contains(Attr, ***(Redacted)) AND contains(hk, 'foo')"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 1 AND arbitrary_udf(Attr, 'foo', arbitrary_udf(hk, 'foo'))",
-                    "SELECT * FROM tb WHERE hk = 1 AND arbitrary_udf(Attr, ***(Redacted), arbitrary_udf(hk, ***(Redacted)))"),
-            // Unary operator
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk IS MISSING AND attr = - 'literal'",
-                    "SELECT * FROM tb WHERE hk IS MISSING AND attr = - ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk IS MISSING AND attr = -+ -+ -+ non_literal",
-                    "SELECT * FROM tb WHERE hk IS MISSING AND attr = -+ -+ -+ non_literal"),
-            // Arithmetic operators are not redacted
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = 012-34-5678",
-                    "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = ***(Redacted)-***(Redacted)-***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = 012*34*5678",
-                    "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = ***(Redacted)****(Redacted)****(Redacted)"),
-            // Concat operator
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 'abc' || '123' AND ssn = 'abc' || '123' || 'xyz'",
-                    "SELECT * FROM tb WHERE hk = 'abc' || '123' AND ssn = ***(Redacted) || ***(Redacted) || ***(Redacted)"),
-            // In operator
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk IN (1, 3, 5) AND attr IN (2, 4, 6)",
-                    "SELECT * FROM tb WHERE hk IN (1, 3, 5) AND attr IN (***(Redacted), ***(Redacted), ***(Redacted))"),
-            // Between operator
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk BETWEEN 1 AND 2 AND attr BETWEEN 1 AND 2",
-                    "SELECT * FROM tb WHERE hk BETWEEN 1 AND 2 AND attr BETWEEN ***(Redacted) AND ***(Redacted)"),
-            // Comparison operators
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE (hk <> 1 or hk < 1 or hk <= 1 or hk > 1 or hk >=1 )",
-                    "SELECT * FROM tb WHERE (hk <> 1 or hk < 1 or hk <= 1 or hk > 1 or hk >=1 )"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 'a' and (attr1 <> 1 or attr2 < 1 or attr3 <= 1 or attr4 > 1 or attr5 >=1 )",
-                    "SELECT * FROM tb WHERE hk = 'a' and (attr1 <> ***(Redacted) or attr2 < ***(Redacted) or attr3 <= ***(Redacted) or attr4 > ***(Redacted) or attr5 >=***(Redacted) )"),
-            // String
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 'a' and attr = 'a'",
-                    "SELECT * FROM tb WHERE hk = 'a' and attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = '2016-02-15' and attr = '2016-02-15'",
-                    "SELECT * FROM tb WHERE hk = '2016-02-15' and attr = ***(Redacted)"),
-            // TODO: Fix metadata length for unicode
+        // Typed
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk IS MISSING AND attr IS MISSING",
+            "SELECT * FROM tb WHERE hk IS MISSING AND attr IS ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk IS NOT MISSING AND attr IS NOT MISSING",
+            "SELECT * FROM tb WHERE hk IS NOT MISSING AND attr IS NOT ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS MISSING",
+            "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS NUMERIC",
+            "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS NOT NUMERIC",
+            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS STRING",
+            "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS NOT STRING",
+            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS TUPLE",
+            "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS NOT TUPLE",
+            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS STRUCT",
+            "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS NOT STRUCT",
+            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS BOOLEAN",
+            "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS NOT BOOLEAN",
+            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS LIST",
+            "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS NOT LIST",
+            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS BLOB",
+            "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS NOT BLOB",
+            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS NULL",
+            "SELECT * FROM tb WHERE attr IS ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE attr IS NOT NULL",
+            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"),
+        // Call and Nested Call
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 1 AND begins_with(Attr, 'foo') AND begins_with(hk, 'foo')",
+            "SELECT * FROM tb WHERE hk = 1 AND begins_with(Attr, ***(Redacted)) AND begins_with(hk, 'foo')"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 1 AND contains(Attr, 'foo') AND contains(hk, 'foo')",
+            "SELECT * FROM tb WHERE hk = 1 AND contains(Attr, ***(Redacted)) AND contains(hk, 'foo')"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 1 AND arbitrary_udf(Attr, 'foo', arbitrary_udf(hk, 'foo'))",
+            "SELECT * FROM tb WHERE hk = 1 AND arbitrary_udf(Attr, ***(Redacted), arbitrary_udf(hk, ***(Redacted)))"),
+        // Unary operator
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk IS MISSING AND attr = - 'literal'",
+            "SELECT * FROM tb WHERE hk IS MISSING AND attr = - ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk IS MISSING AND attr = -+ -+ -+ non_literal",
+            "SELECT * FROM tb WHERE hk IS MISSING AND attr = -+ -+ -+ non_literal"),
+        // Arithmetic operators are not redacted
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = 012-34-5678",
+            "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = ***(Redacted)-***(Redacted)-***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = 012*34*5678",
+            "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = ***(Redacted)****(Redacted)****(Redacted)"),
+        // Concat operator
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 'abc' || '123' AND ssn = 'abc' || '123' || 'xyz'",
+            "SELECT * FROM tb WHERE hk = 'abc' || '123' AND ssn = ***(Redacted) || ***(Redacted) || ***(Redacted)"),
+        // In operator
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk IN (1, 3, 5) AND attr IN (2, 4, 6)",
+            "SELECT * FROM tb WHERE hk IN (1, 3, 5) AND attr IN (***(Redacted), ***(Redacted), ***(Redacted))"),
+        // Between operator
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk BETWEEN 1 AND 2 AND attr BETWEEN 1 AND 2",
+            "SELECT * FROM tb WHERE hk BETWEEN 1 AND 2 AND attr BETWEEN ***(Redacted) AND ***(Redacted)"),
+        // Comparison operators
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE (hk <> 1 or hk < 1 or hk <= 1 or hk > 1 or hk >=1 )",
+            "SELECT * FROM tb WHERE (hk <> 1 or hk < 1 or hk <= 1 or hk > 1 or hk >=1 )"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 'a' and (attr1 <> 1 or attr2 < 1 or attr3 <= 1 or attr4 > 1 or attr5 >=1 )",
+            "SELECT * FROM tb WHERE hk = 'a' and (attr1 <> ***(Redacted) or attr2 < ***(Redacted) or attr3 <= ***(Redacted) or attr4 > ***(Redacted) or attr5 >=***(Redacted) )"),
+        // String
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 'a' and attr = 'a'",
+            "SELECT * FROM tb WHERE hk = 'a' and attr = ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = '2016-02-15' and attr = '2016-02-15'",
+            "SELECT * FROM tb WHERE hk = '2016-02-15' and attr = ***(Redacted)"),
+        // TODO: Fix metadata length for unicode
 //            RedactionTestCase(
 //                    "SELECT * FROM tb WHERE hk = '\uD83D\uDE01\uD83D\uDE1E\uD83D\uDE38\uD83D\uDE38' and attr = '\uD83D\uDE01\uD83D\uDE1E\uD83D\uDE38\uD83D\uDE38'",
 //                    "SELECT * FROM tb WHERE hk = '\uD83D\uDE01\uD83D\uDE1E\uD83D\uDE38\uD83D\uDE38' and attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = '話家身圧費谷料村能計税金' and attr = '話家身圧費谷料村能計税金'",
-                    "SELECT * FROM tb WHERE hk = '話家身圧費谷料村能計税金' and attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 'abcde\\u0832fgh' and attr = 'abcde\\u0832fgh'",
-                    "SELECT * FROM tb WHERE hk = 'abcde\\u0832fgh' and attr = ***(Redacted)"),
-            // Int
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE NOT hk = 1 AND NOT attr = 1",
-                    "SELECT * FROM tb WHERE NOT hk = 1 AND NOT attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE NOT hk = 0 AND NOT attr = 0",
-                    "SELECT * FROM tb WHERE NOT hk = 0 AND NOT attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = -0 AND attr = -0",
-                    "SELECT * FROM tb WHERE hk = -0 AND attr = -***(Redacted)"),
-            // Decimal
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 0.123 AND attr = 0.123",
-                    "SELECT * FROM tb WHERE hk = 0.123 AND attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = -0.123 AND attr = -0.123",
-                    "SELECT * FROM tb WHERE hk = -0.123 AND attr = -***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 0.000 AND attr = 0.000",
-                    "SELECT * FROM tb WHERE hk = 0.000 AND attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = -0.000 AND attr = -0.000",
-                    "SELECT * FROM tb WHERE hk = -0.000 AND attr = -***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 0.12e-4 AND attr = 0.12e-4",
-                    "SELECT * FROM tb WHERE hk = 0.12e-4 AND attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = -0.01200e5 AND attr = -0.01200e5",
-                    "SELECT * FROM tb WHERE hk = -0.01200e5 AND attr = -***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 0. AND attr = 0.",
-                    "SELECT * FROM tb WHERE hk = 0. AND attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 0E0 AND attr = 0E0",
-                    "SELECT * FROM tb WHERE hk = 0E0 AND attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 0E-0 AND attr = 0E-0",
-                    "SELECT * FROM tb WHERE hk = 0E-0 AND attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 0.0E1 AND attr = 0.0E1",
-                    "SELECT * FROM tb WHERE hk = 0.0E1 AND attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = -0E0 AND attr = -0E0",
-                    "SELECT * FROM tb WHERE hk = -0E0 AND attr = -***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = -0. AND attr = -0.",
-                    "SELECT * FROM tb WHERE hk = -0. AND attr = -***(Redacted)"),
-            // Boolean on non-key attr
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = TRUE AND attr = TRUE",
-                    "SELECT * FROM tb WHERE hk = TRUE AND attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = FALSE AND attr = FALSE",
-                    "SELECT * FROM tb WHERE hk = FALSE AND attr = ***(Redacted)"),
-            // NULL on non-key attr
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = NULL AND attr = NULL",
-                    "SELECT * FROM tb WHERE hk = NULL AND attr = ***(Redacted)"),
-            // Map on non-key attr
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 'a' AND attr = { 'hk' : 'value' }",
-                    "SELECT * FROM tb WHERE hk = 'a' AND attr = { ***(Redacted) : ***(Redacted) }"),
-            // List
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 'a' AND attr = [ 'value1', 'value2' ]",
-                    "SELECT * FROM tb WHERE hk = 'a' AND attr = [ ***(Redacted), ***(Redacted) ]"),
-            // Set
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 'a' AND attr = << 'value1', 'value2' >>",
-                    "SELECT * FROM tb WHERE hk = 'a' AND attr = << ***(Redacted), ***(Redacted) >>"),
-            // Space and new line preserved
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk =1    \n    AND attr =1",
-                    "SELECT * FROM tb WHERE hk =1    \n" +
-                            "    AND attr =***(Redacted)"),
-            RedactionTestCase(
-                    "SELECT * \n FROM tb \n WHERE hk =1 \n\r AND attr = 'asdfas \n\r df \n\r sa' AND hk = 2",
-                    "SELECT * \n FROM tb \n WHERE hk =1 \n\r AND attr = ***(Redacted) AND hk = 2"),
-            // Multiple Args cases
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 1 and rk = '1'",
-                    "SELECT * FROM tb WHERE hk = 1 and rk = '1'"),
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 'a' and (rk = 1 or (rk = 2 and attr = '1'))",
-                    "SELECT * FROM tb WHERE hk = 'a' and (rk = 1 or (rk = 2 and attr = ***(Redacted)))"),
-            // Nested Map
-            RedactionTestCase(
-                    "SELECT * FROM tb WHERE hk = 'a' AND attr = { 'name' : { 'name' : 'value' } }",
-                    "SELECT * FROM tb WHERE hk = 'a' AND attr = { ***(Redacted) : { ***(Redacted) : ***(Redacted) } }"),
-            // Insert Into
-            RedactionTestCase(
-                    "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': 'b' }",
-                    "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': ***(Redacted) }"),
-            RedactionTestCase(
-                    "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}",
-                    "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': { ***(Redacted): ***(Redacted) }}"),
-            RedactionTestCase(
-                    "INSERT INTO tb VALUE `{ 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}`",
-                    "INSERT INTO tb VALUE ***(Redacted)"),
-            RedactionTestCase(
-                    "INSERT INTO tb VALUE HK",
-                    "INSERT INTO tb VALUE HK"),
-            RedactionTestCase(
-                    "INSERT INTO tb VALUE hk",
-                    "INSERT INTO tb VALUE hk"),
-            RedactionTestCase(
-                    "INSERT INTO tb VALUE hk = 'a' and attr = 'a'",
-                    "INSERT INTO tb VALUE hk = 'a' and attr = ***(Redacted)"),
-            RedactionTestCase(
-                    "INSERT INTO tb VALUE MISSING",
-                    "INSERT INTO tb VALUE MISSING"),
-            RedactionTestCase(
-                    "INSERT INTO tb VALUE << 'value1', 'value2' >>",
-                    "INSERT INTO tb VALUE << ***(Redacted), ***(Redacted) >>"),
-            // Update Assignment
-            RedactionTestCase(
-                    "update nonExistentTable set foo = 'bar' where attr1='testValue'",
-                    "update nonExistentTable set foo = ***(Redacted) where attr1=***(Redacted)"),
-            RedactionTestCase(
-                    "UPDATE tb SET hk = 'b', rk = 2, attr = 2 WHERE hk = 'a' and rk = 1 and attr = 1",
-                    "UPDATE tb SET hk = 'b', rk = 2, attr = ***(Redacted) WHERE hk = 'a' and rk = 1 and attr = ***(Redacted)"),
-            // Delete
-            RedactionTestCase(
-                    "DELETE FROM tb WHERE hk = 'a' AND attr = 'b'",
-                    "DELETE FROM tb WHERE hk = 'a' AND attr = ***(Redacted)"),
-            // Path
-            RedactionTestCase(
-                    "SELECT ?, tb.a from tb where tb.hk = ? and tb.rk = 'eggs' and tb[*].bar = ? or tb[*].rk = 'foo'",
-                    "SELECT ?, tb.a from tb where tb.hk = ? and tb.rk = 'eggs' and tb[*].bar = ? or tb[*].rk = 'foo'"),
-            // Parameter
-            RedactionTestCase(
-                    "SELECT ?, tb.a from tb where ? = 'foo' and ? = ? and ?.rk = 'eggs' and ?[*].bar = ? or ?[*].rk = 'foo'",
-                    "SELECT ?, tb.a from tb where ? = 'foo' and ? = ? and ?.rk = 'eggs' and ?[*].bar = ? or ?[*].rk = 'foo'")
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = '話家身圧費谷料村能計税金' and attr = '話家身圧費谷料村能計税金'",
+            "SELECT * FROM tb WHERE hk = '話家身圧費谷料村能計税金' and attr = ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 'abcde\\u0832fgh' and attr = 'abcde\\u0832fgh'",
+            "SELECT * FROM tb WHERE hk = 'abcde\\u0832fgh' and attr = ***(Redacted)"),
+        // Int
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE NOT hk = 1 AND NOT attr = 1",
+            "SELECT * FROM tb WHERE NOT hk = 1 AND NOT attr = ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE NOT hk = 0 AND NOT attr = 0",
+            "SELECT * FROM tb WHERE NOT hk = 0 AND NOT attr = ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = -0 AND attr = -0",
+            "SELECT * FROM tb WHERE hk = -0 AND attr = -***(Redacted)"),
+        // Decimal
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 0.123 AND attr = 0.123",
+            "SELECT * FROM tb WHERE hk = 0.123 AND attr = ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = -0.123 AND attr = -0.123",
+            "SELECT * FROM tb WHERE hk = -0.123 AND attr = -***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 0.000 AND attr = 0.000",
+            "SELECT * FROM tb WHERE hk = 0.000 AND attr = ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = -0.000 AND attr = -0.000",
+            "SELECT * FROM tb WHERE hk = -0.000 AND attr = -***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 0.12e-4 AND attr = 0.12e-4",
+            "SELECT * FROM tb WHERE hk = 0.12e-4 AND attr = ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = -0.01200e5 AND attr = -0.01200e5",
+            "SELECT * FROM tb WHERE hk = -0.01200e5 AND attr = -***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 0. AND attr = 0.",
+            "SELECT * FROM tb WHERE hk = 0. AND attr = ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 0E0 AND attr = 0E0",
+            "SELECT * FROM tb WHERE hk = 0E0 AND attr = ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 0E-0 AND attr = 0E-0",
+            "SELECT * FROM tb WHERE hk = 0E-0 AND attr = ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 0.0E1 AND attr = 0.0E1",
+            "SELECT * FROM tb WHERE hk = 0.0E1 AND attr = ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = -0E0 AND attr = -0E0",
+            "SELECT * FROM tb WHERE hk = -0E0 AND attr = -***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = -0. AND attr = -0.",
+            "SELECT * FROM tb WHERE hk = -0. AND attr = -***(Redacted)"),
+        // Boolean on non-key attr
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = TRUE AND attr = TRUE",
+            "SELECT * FROM tb WHERE hk = TRUE AND attr = ***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = FALSE AND attr = FALSE",
+            "SELECT * FROM tb WHERE hk = FALSE AND attr = ***(Redacted)"),
+        // NULL on non-key attr
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = NULL AND attr = NULL",
+            "SELECT * FROM tb WHERE hk = NULL AND attr = ***(Redacted)"),
+        // Map on non-key attr
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 'a' AND attr = { 'hk' : 'value' }",
+            "SELECT * FROM tb WHERE hk = 'a' AND attr = { ***(Redacted) : ***(Redacted) }"),
+        // List
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 'a' AND attr = [ 'value1', 'value2' ]",
+            "SELECT * FROM tb WHERE hk = 'a' AND attr = [ ***(Redacted), ***(Redacted) ]"),
+        // Set
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 'a' AND attr = << 'value1', 'value2' >>",
+            "SELECT * FROM tb WHERE hk = 'a' AND attr = << ***(Redacted), ***(Redacted) >>"),
+        // Space and new line preserved
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk =1    \n    AND attr =1",
+            "SELECT * FROM tb WHERE hk =1    \n" +
+                    "    AND attr =***(Redacted)"),
+        RedactionTestCase(
+            "SELECT * \n FROM tb \n WHERE hk =1 \n\r AND attr = 'asdfas \n\r df \n\r sa' AND hk = 2",
+            "SELECT * \n FROM tb \n WHERE hk =1 \n\r AND attr = ***(Redacted) AND hk = 2"),
+        // Multiple Args cases
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 1 and rk = '1'",
+            "SELECT * FROM tb WHERE hk = 1 and rk = '1'"),
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 'a' and (rk = 1 or (rk = 2 and attr = '1'))",
+            "SELECT * FROM tb WHERE hk = 'a' and (rk = 1 or (rk = 2 and attr = ***(Redacted)))"),
+        // Nested Map
+        RedactionTestCase(
+            "SELECT * FROM tb WHERE hk = 'a' AND attr = { 'name' : { 'name' : 'value' } }",
+            "SELECT * FROM tb WHERE hk = 'a' AND attr = { ***(Redacted) : { ***(Redacted) : ***(Redacted) } }"),
+        // Insert Into
+        RedactionTestCase(
+            "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': 'b' }",
+            "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': ***(Redacted) }"),
+        RedactionTestCase(
+            "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}",
+            "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': { ***(Redacted): ***(Redacted) }}"),
+        RedactionTestCase(
+            "INSERT INTO tb VALUE `{ 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}`",
+            "INSERT INTO tb VALUE ***(Redacted)"),
+        RedactionTestCase(
+            "INSERT INTO tb VALUE HK",
+            "INSERT INTO tb VALUE HK"),
+        RedactionTestCase(
+            "INSERT INTO tb VALUE hk",
+            "INSERT INTO tb VALUE hk"),
+        RedactionTestCase(
+            "INSERT INTO tb VALUE hk = 'a' and attr = 'a'",
+            "INSERT INTO tb VALUE hk = 'a' and attr = ***(Redacted)"),
+        RedactionTestCase(
+            "INSERT INTO tb VALUE MISSING",
+            "INSERT INTO tb VALUE MISSING"),
+        RedactionTestCase(
+            "INSERT INTO tb VALUE << 'value1', 'value2' >>",
+            "INSERT INTO tb VALUE << ***(Redacted), ***(Redacted) >>"),
+        // Update Assignment
+        RedactionTestCase(
+            "update nonExistentTable set foo = 'bar' where attr1='testValue'",
+            "update nonExistentTable set foo = ***(Redacted) where attr1=***(Redacted)"),
+        RedactionTestCase(
+            "UPDATE tb SET hk = 'b', rk = 2, attr = 2 WHERE hk = 'a' and rk = 1 and attr = 1",
+            "UPDATE tb SET hk = 'b', rk = 2, attr = ***(Redacted) WHERE hk = 'a' and rk = 1 and attr = ***(Redacted)"),
+        // Delete
+        RedactionTestCase(
+            "DELETE FROM tb WHERE hk = 'a' AND attr = 'b'",
+            "DELETE FROM tb WHERE hk = 'a' AND attr = ***(Redacted)"),
+        // Path
+        RedactionTestCase(
+            "SELECT ?, tb.a from tb where tb.hk = ? and tb.rk = 'eggs' and tb[*].bar = ? or tb[*].rk = 'foo'",
+            "SELECT ?, tb.a from tb where tb.hk = ? and tb.rk = 'eggs' and tb[*].bar = ? or tb[*].rk = 'foo'"),
+        // Parameter
+        RedactionTestCase(
+            "SELECT ?, tb.a from tb where ? = 'foo' and ? = ? and ?.rk = 'eggs' and ?[*].bar = ? or ?[*].rk = 'foo'",
+            "SELECT ?, tb.a from tb where ? = 'foo' and ? = ? and ?.rk = 'eggs' and ?[*].bar = ? or ?[*].rk = 'foo'")
     )
 
     @Test

--- a/lang/test/org/partiql/lang/ast/passes/StatementRedactorTest.kt
+++ b/lang/test/org/partiql/lang/ast/passes/StatementRedactorTest.kt
@@ -3,7 +3,6 @@ package org.partiql.lang.ast.passes
 import com.amazon.ionelement.api.StringElement
 import junitparams.Parameters
 import org.junit.Test
-import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.SqlParserTestBase
 
@@ -14,8 +13,8 @@ class StatementRedactorTest : SqlParserTestBase() {
 
     /**
      * Here is an example of user defined functions (UDF) with following signature:
-     *  begins_with(Path: ExprNode, Value: Literal)
-     *  contains(Path: ExprNode, Value: Literal)
+     *  begins_with(Path: PartiqlAst.Expr.Id or PartiqlAst.Expr.Path, Value: PartiqlAst.Expr.Lit)
+     *  contains(Path: PartiqlAst.Expr or PartiqlAst.Expr.Path, Value: PartiqlAst.Expr.Lit)
      *
      * Callers are responsible for determining which [args] are to be redacted.
      * There are two major components:
@@ -43,8 +42,8 @@ class StatementRedactorTest : SqlParserTestBase() {
     /**
      * Return true if the parsed results of input [statement] is the same as input [ast]
      */
-    private fun validateInputAstParsedFromInputStatement(statement: String, ast: ExprNode): Boolean {
-        return parser.parseExprNode(statement) == ast
+    private fun validateInputAstParsedFromInputStatement(statement: String, ast: PartiqlAst.Statement): Boolean {
+        return parser.parseAstStatement(statement) == ast
     }
 
     @Test
@@ -314,20 +313,20 @@ class StatementRedactorTest : SqlParserTestBase() {
     fun testDefaultArguments() {
         val originalStatement = "SELECT * FROM tb WHERE hk = 1 AND begins_with(Attr, 'foo', bar)"
         val expectedRedactedStatement = "SELECT * FROM tb WHERE hk = ***(Redacted) AND begins_with(Attr, ***(Redacted), bar)"
-        val redactedStatement1 = redact(originalStatement, super.parser.parseExprNode(originalStatement))
+        val redactedStatement1 = redact(originalStatement, super.parser.parseAstStatement(originalStatement))
         assertEquals(expectedRedactedStatement, redactedStatement1)
 
-        val redactedStatement2 = redact(originalStatement, super.parser.parseExprNode(originalStatement), providedSafeFieldNames = emptySet())
+        val redactedStatement2 = redact(originalStatement, super.parser.parseAstStatement(originalStatement), providedSafeFieldNames = emptySet())
         assertEquals(expectedRedactedStatement, redactedStatement2)
 
-        val redactedStatement3 = redact(originalStatement, super.parser.parseExprNode(originalStatement), userDefinedFunctionRedactionConfig = emptyMap())
+        val redactedStatement3 = redact(originalStatement, super.parser.parseAstStatement(originalStatement), userDefinedFunctionRedactionConfig = emptyMap())
         assertEquals(expectedRedactedStatement, redactedStatement3)
     }
 
     @Test
     fun testInputStatementAstMismatch() {
         val inputStatement = "SELECT * FROM tb WHERE nonKey = 'a'"
-        val inputAst = super.parser.parseExprNode("SELECT * FROM tb WHERE hk = 1 AND nonKey = 'a'")
+        val inputAst = super.parser.parseAstStatement("SELECT * FROM tb WHERE hk = 1 AND nonKey = 'a'")
         assertFalse(validateInputAstParsedFromInputStatement(inputStatement, inputAst))
 
         try {

--- a/lang/test/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransformTests.kt
@@ -23,7 +23,6 @@ import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.ast.AggregateCallSiteListMeta
 import org.partiql.lang.ast.AggregateRegisterIdMeta
 import org.partiql.lang.ast.SourceLocationMeta
-import org.partiql.lang.ast.toAstStatement
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.util.ArgumentsProviderBase
 
@@ -38,7 +37,7 @@ class AggregateSupportVisitorTransformTests : VisitorTransformTestBase() {
      */
     private fun String.parseAndTransformQuery() : PartiqlAst.Expr.Select {
         val query = this
-        val statement = super.parser.parseExprNode(query).toAstStatement()
+        val statement = super.parser.parseAstStatement(query)
         val transformedNode = (transformer).transformStatement(statement) as PartiqlAst.Statement.Query
         return (transformedNode.expr) as PartiqlAst.Expr.Select
     }

--- a/lang/test/org/partiql/lang/eval/visitors/StaticTypeVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/StaticTypeVisitorTransformTests.kt
@@ -854,7 +854,7 @@ class StaticTypeVisitorTransformTests : VisitorTransformTestBase() {
         // FromSourceAliasVisitorTransform to execute first but also to help ensure the queries we're testing
         // make sense when they're all run.
         val defaultTransforms = basicVisitorTransforms()
-        val originalPartiqlAst = defaultTransforms.transformStatement(parse(tc.originalSql).toAstStatement())
+        val originalPartiqlAst = defaultTransforms.transformStatement(parse(tc.originalSql))
 
         val transformedExprNode = try {
             transformer.transformStatement(originalPartiqlAst)

--- a/lang/test/org/partiql/lang/eval/visitors/VisitorTransformTestBase.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/VisitorTransformTestBase.kt
@@ -14,7 +14,6 @@
 
 package org.partiql.lang.eval.visitors
 
-import org.partiql.lang.ast.toAstStatement
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.SqlParserTestBase
 import org.junit.jupiter.api.fail
@@ -30,10 +29,10 @@ abstract class VisitorTransformTestBase : SqlParserTestBase() {
      */
     protected fun runTestForIdempotentTransform(tc: TransformTestCase, transform: PartiqlAst.VisitorTransform) {
         val originalAst = assertDoesNotThrow("Parsing TransformTestCase.originalSql") {
-            super.parser.parseExprNode(tc.originalSql).toAstStatement()
+            super.parser.parseAstStatement(tc.originalSql)
         }
         val expectedAst = assertDoesNotThrow("Parsing TransformTestCase.expectedSql") {
-            super.parser.parseExprNode(tc.expectedSql).toAstStatement()
+            super.parser.parseAstStatement(tc.expectedSql)
         }
 
         val actualAst = transform.transformStatement(originalAst)
@@ -56,17 +55,17 @@ abstract class VisitorTransformTestBase : SqlParserTestBase() {
      */
     protected fun runTest(tc: TransformTestCase, transformers: List<PartiqlAst.VisitorTransform>) {
         val originalAst = assertDoesNotThrow("Parsing TransformTestCase.originalSql") {
-            super.parser.parseExprNode(tc.originalSql).toAstStatement()
+            super.parser.parseAstStatement(tc.originalSql)
         }
         val expectedAst = assertDoesNotThrow("Parsing TransformTestCase.expectedSql") {
-            super.parser.parseExprNode(tc.expectedSql).toAstStatement()
+            super.parser.parseAstStatement(tc.expectedSql)
         }
 
-        val actualExprNode = transformers.fold(originalAst) { node, transform ->
+        val actualStatement = transformers.fold(originalAst) { node, transform ->
             transform.transformStatement(node)
         }
 
-        assertEquals("The expected AST must match the transformed AST", expectedAst, actualExprNode)
+        assertEquals("The expected AST must match the transformed AST", expectedAst, actualStatement)
     }
 
     private fun <T> assertDoesNotThrow(message: String, block: () -> T): T {

--- a/lang/test/org/partiql/lang/syntax/SqlParserPrecedenceTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserPrecedenceTest.kt
@@ -18,10 +18,7 @@ import junitparams.*
 import junitparams.naming.*
 import org.junit.*
 import com.amazon.ionelement.api.toIonElement
-import org.partiql.lang.ast.passes.MetaStrippingRewriter
-import org.partiql.lang.ast.toExprNode
 import org.partiql.lang.domains.PartiqlAst
-import org.partiql.lang.util.asIonSexp
 
 
 class SqlParserPrecedenceTest : SqlParserTestBase() {
@@ -1049,12 +1046,10 @@ class SqlParserPrecedenceTest : SqlParserTestBase() {
     private fun runTest(pair: Pair<String, String>) {
         val (source, expectedAst) = pair
 
-        val expectedAstExpr = PartiqlAst.transform(ion.singleValue(expectedAst).toIonElement()) as PartiqlAst.Expr
-        val expectedAstStatement = PartiqlAst.build { query(expectedAstExpr) }
-        val expectedExprNode = MetaStrippingRewriter.stripMetas(expectedAstStatement.toExprNode(ion))
+        val expectedExpr = PartiqlAst.transform(ion.singleValue(expectedAst).toIonElement()) as PartiqlAst.Expr
+        val expectedStatement = PartiqlAst.build { query(expectedExpr) }
+        val actualStatement = SqlParser(ion).parseAstStatement(source)
 
-        val actualExprNode = MetaStrippingRewriter.stripMetas(SqlParser(ion).parseExprNode(source))
-
-        assertEquals(expectedExprNode, actualExprNode)
+        assertEquals(expectedStatement, actualStatement)
     }
 }

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3697,6 +3697,8 @@ class SqlParserTest : SqlParserTestBase() {
         "(ddl (create_table user))"
     )
 
+    // TODO: Will remove `Ignore` tag once the test framework for parser is changed as well
+    @Ignore
     @Test
     fun dropTable() = assertExpression(
         "DROP TABLE foo",
@@ -3711,6 +3713,8 @@ class SqlParserTest : SqlParserTestBase() {
         "(ddl (drop_table (identifier user (case_sensitive))))"
     )
 
+    // TODO: Will remove `Ignore` tag once the test framework for parser is changed as well
+    @Ignore
     @Test
     fun createIndex() = assertExpression(
         "CREATE INDEX ON foo (x, y.z)",
@@ -3726,7 +3730,7 @@ class SqlParserTest : SqlParserTestBase() {
         """
         (ddl
           (create_index
-            (identifier foo (case_sensitive))
+            (identifier foo (case_insensitive))
             (id x (case_insensitive) (unqualified))
             (path (id y (case_insensitive) (unqualified)) (path_expr (lit "z") (case_insensitive)))))
         """
@@ -3751,11 +3755,13 @@ class SqlParserTest : SqlParserTestBase() {
         """
     )
 
+    // TODO: Will remove `Ignore` tag once the test framework for parser is changed as well
+    @Ignore
     @Test
     fun dropIndex() = assertExpression(
         "DROP INDEX bar ON foo",
         "(drop_index foo (id bar case_insensitive))",
-        "(ddl (drop_index (table (identifier foo (case_sensitive))) (keys (identifier bar (case_insensitive)))))"
+        "(ddl (drop_index (table (identifier foo (case_insensitive))) (keys (identifier bar (case_insensitive)))))"
     )
 
     @Test

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3697,24 +3697,20 @@ class SqlParserTest : SqlParserTestBase() {
         "(ddl (create_table user))"
     )
 
-    // TODO: Will remove `Ignore` tag once the test framework for parser is changed as well
-    @Ignore
     @Test
     fun dropTable() = assertExpression(
         "DROP TABLE foo",
-        "(drop_table foo)",
-        "(ddl (drop_table (identifier foo (case_sensitive))))"
+        "(drop_table (identifier foo (case_insensitive)))",
+        "(ddl (drop_table (identifier foo (case_insensitive))))"
     )
 
     @Test
     fun dropTableWithQuotedIdentifier() = assertExpression(
         "DROP TABLE \"user\"",
-        "(drop_table user)",
+        "(drop_table (identifier user (case_sensitive)))",
         "(ddl (drop_table (identifier user (case_sensitive))))"
     )
 
-    // TODO: Will remove `Ignore` tag once the test framework for parser is changed as well
-    @Ignore
     @Test
     fun createIndex() = assertExpression(
         "CREATE INDEX ON foo (x, y.z)",
@@ -3722,7 +3718,7 @@ class SqlParserTest : SqlParserTestBase() {
         (create
           null.symbol
           (index
-            foo
+            (identifier foo (case_insensitive))
             (keys
               (id x case_insensitive)
               (path (id y case_insensitive) (case_insensitive (lit "z"))))))
@@ -3743,7 +3739,7 @@ class SqlParserTest : SqlParserTestBase() {
         (create
           null.symbol
           (index
-            user
+            (identifier user (case_sensitive))
             (keys
               (id group case_sensitive))))
         """,
@@ -3755,19 +3751,17 @@ class SqlParserTest : SqlParserTestBase() {
         """
     )
 
-    // TODO: Will remove `Ignore` tag once the test framework for parser is changed as well
-    @Ignore
     @Test
     fun dropIndex() = assertExpression(
         "DROP INDEX bar ON foo",
-        "(drop_index foo (id bar case_insensitive))",
+        "(drop_index (identifier foo (case_insensitive)) (identifier bar (case_insensitive)))",
         "(ddl (drop_index (table (identifier foo (case_insensitive))) (keys (identifier bar (case_insensitive)))))"
     )
 
     @Test
     fun dropIndexWithQuotedIdentifiers() = assertExpression(
         "DROP INDEX \"bar\" ON \"foo\"",
-        "(drop_index foo (id bar case_sensitive))",
+        "(drop_index (identifier foo (case_sensitive)) (identifier bar (case_sensitive)))",
         "(ddl (drop_index (table (identifier foo (case_sensitive))) (keys (identifier bar (case_sensitive)))))"
     )
 

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -15,7 +15,6 @@
 package org.partiql.lang.syntax
 
 import com.amazon.ion.IonSexp
-import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.SexpElement
 import com.amazon.ionelement.api.toIonElement
 import com.amazon.ionelement.api.toIonValue
@@ -38,8 +37,31 @@ import org.partiql.pig.runtime.toIonElement
 abstract class SqlParserTestBase : TestBase() {
     protected val parser = SqlParser(ion)
 
-    protected fun parse(source: String): ExprNode = parser.parseExprNode(source)
-    protected fun parseToAst(source: String): PartiqlAst.Statement = parser.parseAstStatement(source)
+    protected fun parse(source: String): PartiqlAst.Statement = parser.parseAstStatement(source)
+
+    /**
+     * This method is used by test cases for parsing a string.
+     * The test are performed with only PIG AST.
+     * The expected PIG AST is a string.
+     */
+    protected fun assertExpression(
+        source: String,
+        expectedPigAst: String
+    ) {
+        val actualStatement = parse(source)
+        val expectedIonSexp = loadIonSexp(expectedPigAst)
+
+        // Check equals for actual value and expected value in IonSexp format
+        checkEqualInIonSexp(actualStatement, expectedIonSexp, source)
+
+        val expectedElement = expectedIonSexp.toIonElement().asSexp()
+
+        // Perform checks for Pig AST. See the comments inside the function to see what checks are performed.
+        pigDomainAssert(actualStatement, expectedElement)
+
+        // Check equals for actual value after round trip transformation: astStatement -> ExprNode -> astStatement
+        assertRoundTripPigAstToExprNode(actualStatement)
+    }
 
     /**
      * This method is used by test cases for parsing a string.
@@ -58,26 +80,21 @@ abstract class SqlParserTestBase : TestBase() {
 
     /**
      * This method is used by test cases for parsing a string.
-     * The test are performed with only PIG AST.
+     * The test are performed with both PIG AST and V0 AST.
      * The expected PIG AST is a string.
      */
     protected fun assertExpression(
         source: String,
+        expectedV0Ast: String,
         expectedPigAst: String
     ) {
-        val actualExprNode = parse(source)
-        val expectedIonSexp = loadIonSexp(expectedPigAst)
+        // Check for V0 Ast
+        val actualStatement = parse(source)
+        val expectedV0AstSexp = loadIonSexp(expectedV0Ast)
+        serializeAssert(AstVersion.V0, actualStatement.toExprNode(ion), expectedV0AstSexp, source)
 
-        // Check equals for actual value and expected value in IonSexp format
-        checkEqualInIonSexp(actualExprNode, expectedIonSexp, source)
-
-        val expectedElement = expectedIonSexp.toIonElement().asSexp()
-
-        // See the comments inside the function to see what checks are performed.
-        pigDomainAssert(actualExprNode, expectedElement)
-
-        // Check equals for actual value after round trip transformation: astStatement -> ExprNode -> astStatement
-        assertRoundTripPigAstToExprNode(actualExprNode)
+        // Check for PIG Ast
+        assertExpression(source, expectedPigAst)
     }
 
     /**
@@ -96,37 +113,14 @@ abstract class SqlParserTestBase : TestBase() {
         assertExpression(source, expectedSexpAstV0, expectedPigAst)
     }
 
-    /**
-     * This method is used by test cases for parsing a string.
-     * The test are performed with both PIG AST and V0 AST.
-     * The expected PIG AST is a string.
-     */
-    protected fun assertExpression(
-        source: String,
-        expectedV0Ast: String,
-        expectedPigAst: String
-    ) {
-        // Check for V0 Ast
-        val actualExprNode = parse(source)
-        val expectedV0AstSexp = loadIonSexp(expectedV0Ast)
-
-        // Check equals for actual value and expected value after transformation: EpxrNode -> IonSexp
-        // Check equals for actual value and expected value after transformation: IonSexp -> EpxrNode
-        serializeAssert(AstVersion.V0, actualExprNode, expectedV0AstSexp, source)
-
-        // Check for PIG Ast
-        assertExpression(source, expectedPigAst)
-    }
-
     private fun serializeAssert(astVersion: AstVersion, actualExprNode: ExprNode, expectedIonSexp: IonSexp, source: String) {
-
+        // Check equals for actual value and expected value after transformation: ExprNode -> IonSexp
         val actualSexpAstWithoutMetas = AstSerializer.serialize(actualExprNode, astVersion, ion).filterMetaNodes()
-
-        val deserializer = AstDeserializerBuilder(ion).build()
         assertSexpEquals(expectedIonSexp, actualSexpAstWithoutMetas, "$astVersion AST, $source")
 
+        // Check equals for actual value and expected value after transformation: IonSexp -> ExprNode
+        val deserializer = AstDeserializerBuilder(ion).build()
         val deserializedExprNodeFromSexp = deserializer.deserialize(expectedIonSexp, astVersion)
-
         assertEquals(
             "actual ExprNodes must match deserialized s-exp $astVersion AST",
             actualExprNode.stripMetas(),
@@ -150,75 +144,42 @@ abstract class SqlParserTestBase : TestBase() {
      * Performs checks similar to that of [serializeAssert]. First checks that parsing the [source] query string to
      * a [PartiqlAst] and to an IonValue Sexp equals the [expectedIonSexp].
      */
-    private fun checkEqualInIonSexp(actualExprNode: ExprNode, expectedIonSexp: IonSexp, source: String) {
-        val actualStatment = actualExprNode.toAstStatement()
-        val actualElement = unwrapQuery(actualStatment)
+    private fun checkEqualInIonSexp(actualStatement: PartiqlAst.Statement, expectedIonSexp: IonSexp, source: String) {
+        val actualElement = unwrapQuery(actualStatement)
         val actualIonSexp = actualElement.toIonElement().asAnyElement().toIonValue(ion)
 
         assertSexpEquals(expectedIonSexp, actualIonSexp, "AST, $source")
     }
 
-    private fun pigDomainAssert(actualExprNode: ExprNode, expectedSexpAst: SexpElement) {
-        val actualStatement = actualExprNode.toAstStatement()
-        val actualElement = unwrapQuery(actualStatement)
-
-        // Check equal for actual and expected in transformed astStatement: astStatment -> SexpElement -> astStatement
-        // Check round trip for actual: SexpElement -> astStatement -> SexpElement
-        assertRoundTripIonElementToPartiQlAst(actualElement, expectedSexpAst)
-
+    private fun pigDomainAssert(actualStatement: PartiqlAst.Statement, expectedElement: SexpElement) {
         // Check equal for actual and expected in SexpElement format
-        // Check round trip for actual: astStatement -> SexpElement -> astStatement
-        // Check equals for actual value after round trip transformation: ExprNode -> astStatement -> SexpElement -> astStatement -> ExprNode
-        assertRoundTripPartiQlAstToExprNode(actualStatement, expectedSexpAst, actualExprNode)
-    }
-
-    private fun assertRoundTripPartiQlAstToExprNode(actualStatement: PartiqlAst.Statement, expectedSexpAst: IonElement, actualExprNode: ExprNode) {
-        // Run additional checks on the resulting PartiqlAst instance
-
-        // None of our test cases are wrapped in (query <expr>), so extract <expr> from that out
         val actualElement = unwrapQuery(actualStatement)
-        assertEquals(expectedSexpAst, actualElement)
+        assertEquals(expectedElement, actualElement)
 
-        // Convert the the IonElement back to the PartiqlAst instance and assert equivalence
-        val transformedActualStatement = PartiqlAst.transform(actualStatement.toIonElement()) as PartiqlAst.Statement
-        assertEquals(actualStatement, transformedActualStatement)
+        // Check equal after transformation: PIG AST -> SexpElement -> PIG AST
+        assertRoundTripPigAstToSexpElement(actualStatement)
 
-        // Convert from the PIG instance back to ExprNode and assert the result is the same as actualExprNode.
-        val transformedActualExprNode = MetaStrippingRewriter.stripMetas(transformedActualStatement.toExprNode(ion))
-        assertEquals(MetaStrippingRewriter.stripMetas(actualExprNode), transformedActualExprNode)
-    }
-
-    private fun assertRoundTripIonElementToPartiQlAst(actualElement: SexpElement, expectedElement: SexpElement) {
-        // #1 We can transform the actual PartiqlAst element.
+        // Check equal for actual and expected in transformed astStatement: astStatement -> SexpElement -> astStatement
         val transformedActualStatement = PartiqlAst.transform(actualElement)
-
-        // #2 We can transform the expected PartiqlAst element.
         val transformedExpectedStatement = PartiqlAst.transform(expectedElement)
-
-        // #3 The results of both transformations match.
         assertEquals(transformedExpectedStatement, transformedActualStatement)
 
-        // #4 Re-transforming the actual PartiqlAst element and check if it matches the expected AST.
+        // Check round trip for actual: SexpElement -> astStatement -> SexpElement
         val reserializedActualElement = transformedActualStatement.toIonElement()
         assertEquals(expectedElement, reserializedActualElement)
-
-        // #5 Re-serializing the expected PartiqlAst element matches the expected AST.
-        // Note:  because of #3 above, no need for #5.
     }
 
     /**
-     * Strips metas from the [actualExprNode] so they are not included in equivalence checks
-     * and round-trip the resulting [actualExprNode] AST through [toAstStatement] and [toExprNode].
-     *
-     * Verify that the result matches the original without metas.
+     * Check equal after transformation: PIG AST -> SexpElement -> PIG AST
      */
-    private fun assertRoundTripPigAstToExprNode(actualExprNode: ExprNode) {
-        val actualExprNodeNoMetas = MetaStrippingRewriter.stripMetas(actualExprNode)
-        val actualStatement = actualExprNodeNoMetas.toAstStatement()
-        val roundTripActualExprNode = actualStatement.toExprNode(ion)
+    private fun assertRoundTripPigAstToSexpElement(actualStatement: PartiqlAst.Statement) =
+        assertEquals(actualStatement, PartiqlAst.transform(actualStatement.toIonElement()) as PartiqlAst.Statement)
 
-        assertEquals(actualExprNodeNoMetas, roundTripActualExprNode)
-    }
+    /**
+     * Check equal after transformation: PIG AST -> ExprNode -> PIG AST
+     */
+    private fun assertRoundTripPigAstToExprNode(actualStatement: PartiqlAst.Statement) =
+        assertEquals(actualStatement, actualStatement.toExprNode(ion).toAstStatement())
 
     private fun loadIonSexp(expectedSexpAst: String) = ion.singleValue(expectedSexpAst).asIonSexp()
     private fun ExprNode.stripMetas() = MetaStrippingRewriter.stripMetas(this)

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -63,8 +63,8 @@ abstract class SqlParserTestBase : TestBase() {
 
     // TODO: refactor the signature with pig builder
     protected fun assertExpression(
-            source: String,
-            expectedSexpAstAsString: String
+        source: String,
+        expectedSexpAstAsString: String
     ) {
         val parsedExprNode = parse(source)
         val expectedSexpAst = loadSingleElement(
@@ -129,11 +129,11 @@ abstract class SqlParserTestBase : TestBase() {
      * just the expr component to be compatible with the SqlParser tests.
      */
     private fun unwrapQuery(statement: PartiqlAst.Statement) : SexpElement {
-       return when (statement) {
-           is PartiqlAst.Statement.Query -> statement.expr.toIonElement()
-           is PartiqlAst.Statement.Dml,
-           is PartiqlAst.Statement.Ddl,
-           is PartiqlAst.Statement.Exec -> statement.toIonElement()
+        return when (statement) {
+            is PartiqlAst.Statement.Query -> statement.expr.toIonElement()
+            is PartiqlAst.Statement.Dml,
+            is PartiqlAst.Statement.Ddl,
+            is PartiqlAst.Statement.Exec -> statement.toIonElement()
         }
     }
 
@@ -222,8 +222,8 @@ abstract class SqlParserTestBase : TestBase() {
     private fun ExprNode.stripMetas() = MetaStrippingRewriter.stripMetas(this)
 
     protected fun checkInputThrowingParserException(input: String,
-                                                  errorCode: ErrorCode,
-                                                  expectErrorContextValues: Map<Property, Any>) {
+                                                    errorCode: ErrorCode,
+                                                    expectErrorContextValues: Map<Property, Any>) {
 
         softAssert {
             try {


### PR DESCRIPTION
*This PR aims to deprecate `ExprNode` in `Parser`.*

*Subtasks:*
- [x] Implement `toAstStatement` method to directly transform `ParseNode` to PIG AST, and remove `toExprNode` method in `Parser`. 
&nbsp; PR: https://github.com/partiql/partiql-lang-kotlin/pull/460 
&nbsp; PR: https://github.com/partiql/partiql-lang-kotlin/pull/469 
- [x] Change the test framework so that it uses PIG AST generated directly from `toAstStatement` method. 
&nbsp; PR: https://github.com/partiql/partiql-lang-kotlin/pull/462
&nbsp; PR: https://github.com/partiql/partiql-lang-kotlin/pull/471
- [x] Remove dependencies on `parseExprNode`. 
&nbsp; PR: https://github.com/partiql/partiql-lang-kotlin/pull/470