### PR TITLE
Fixed bug for 3 failed test cases

### DIFF
--- a/lang/src/org/partiql/lang/ast/AstDeserialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstDeserialization.kt
@@ -673,10 +673,10 @@ internal class AstDeserializerInternal(
                 CreateTable(tableName, metas)
             }
             NodeTag.INDEX -> {
-                val tableName = args[0].stringValue() ?: err("Table name must be specified")
+                val tableId = deserializeExprNode(args[0].asIonSexp()) as VariableReference
                 val children = args.drop(1).toListOfIonSexp().map { Pair(it.nodeTag, it) }.toMap()
                 val keys = children[NodeTag.KEYS]?.args?.deserializeAllExprNodes() ?: err("Index definition expects keys")
-                CreateIndex(tableName, keys, metas)
+                CreateIndex(tableId, keys, metas)
             }
             else -> errInvalidContext(target.nodeTag)
         }

--- a/lang/src/org/partiql/lang/ast/AstDeserialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstDeserialization.kt
@@ -686,8 +686,8 @@ internal class AstDeserializerInternal(
         targetArgs: List<IonValue>,
         metas: MetaContainer
     ): DropTable {
-        val tableName = targetArgs[0].stringValue() ?: err("Table name must be specified")
-        return DropTable(tableName, metas)
+        val tableId = deserializeExprNode(targetArgs[0].asIonSexp()) as VariableReference
+        return DropTable(tableId, metas)
     }
 
     private fun deserializeDropIndexV0(

--- a/lang/src/org/partiql/lang/ast/AstDeserialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstDeserialization.kt
@@ -694,9 +694,9 @@ internal class AstDeserializerInternal(
         targetArgs: List<IonValue>,
         metas: MetaContainer
     ): DropIndex {
-        val tableName = targetArgs[0].stringValue() ?: err("Table name must be specified")
+        val tableId = deserializeExprNode(targetArgs[0].asIonSexp()) as VariableReference
         val id = deserializeExprNode(targetArgs[1].asIonSexp()) as VariableReference
-        return DropIndex(tableName, id, metas)
+        return DropIndex(tableId, id, metas)
     }
 
     private fun deserializeIdentifier(targetArgs: List<IonValue>): Pair<String, CaseSensitivity> {

--- a/lang/src/org/partiql/lang/ast/AstDeserialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstDeserialization.kt
@@ -708,9 +708,6 @@ internal class AstDeserializerInternal(
             CaseSensitivity.fromSymbol(targetArgs[1].asIonSexp().tagText),
             emptyMetaContainer
         )
-
-        // return (targetArgs[0].stringValue() ?: err("Identifier deserialization: expecting string value, got ${targetArgs[0]}")) to
-        //    CaseSensitivity.fromSymbol(targetArgs[1].asIonSexp().tagText)
     }
 
     private fun deserializeTypedIs(

--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -22,6 +22,7 @@ import org.partiql.lang.util.asIonSexp
 import org.partiql.lang.util.case
 import org.partiql.lang.util.checkThreadInterrupted
 import kotlin.UnsupportedOperationException
+import kotlin.math.exp
 
 /**
  * Serializes an instance of [ExprNode] to one of the s-expression based ASTs.
@@ -743,7 +744,7 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
                 symbol(null)
                 sexp {
                     symbol("index")
-                    writeExprNode(expr.tableId)
+                    writeIdentifier(expr.tableId.id, expr.tableId.case)
                     sexp {
                         symbol("keys")
                         expr.keys.forEach {
@@ -771,7 +772,7 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
         when (astVersion) {
             AstVersion.V0 -> {
                 symbol("drop_table")
-                writeExprNode(expr.tableId)
+                writeIdentifier(expr.tableId.id, expr.tableId.case)
             }
         }
     }
@@ -780,8 +781,8 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
         when (astVersion) {
             AstVersion.V0 -> {
                 symbol("drop_index")
-                writeExprNode(expr.tableId)
-                writeExprNode(expr.identifier)
+                writeIdentifier(expr.tableId.id, expr.tableId.case)
+                writeIdentifier(expr.indexId.id, expr.indexId.case)
             }
         }
     }

--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -743,7 +743,7 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
                 symbol(null)
                 sexp {
                     symbol("index")
-                    symbol(expr.tableName)
+                    writeExprNode(expr.tableId)
                     sexp {
                         symbol("keys")
                         expr.keys.forEach {

--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -780,7 +780,7 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
         when (astVersion) {
             AstVersion.V0 -> {
                 symbol("drop_index")
-                symbol(expr.tableName)
+                writeExprNode(expr.tableId)
                 writeExprNode(expr.identifier)
             }
         }

--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -22,7 +22,6 @@ import org.partiql.lang.util.asIonSexp
 import org.partiql.lang.util.case
 import org.partiql.lang.util.checkThreadInterrupted
 import kotlin.UnsupportedOperationException
-import kotlin.math.exp
 
 /**
  * Serializes an instance of [ExprNode] to one of the s-expression based ASTs.

--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -771,7 +771,7 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem):
         when (astVersion) {
             AstVersion.V0 -> {
                 symbol("drop_table")
-                symbol(expr.tableName)
+                writeExprNode(expr.tableId)
             }
         }
     }

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -56,7 +56,11 @@ private fun ExprNode.toAstDdl(): PartiqlAst.Statement {
                     metas)
             is DropTable ->
                 // case-sensitivity of table names cannot be represented with ExprNode.
-                ddl(dropTable(identifier(thiz.tableName, caseSensitive())), metas)
+                ddl(
+                    dropTable(
+                        identifier(thiz.tableId.id, thiz.tableId.case.toAstCaseSensitivity())
+                    ),
+                    metas)
         }
     }
 }

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -40,7 +40,13 @@ private fun ExprNode.toAstDdl(): PartiqlAst.Statement {
             is DataManipulation, is Exec -> error("Can't convert ${thiz.javaClass} to PartiqlAst.ddl")
 
             is CreateTable -> ddl(createTable(thiz.tableName), metas)
-            is CreateIndex -> ddl(createIndex(identifier(thiz.tableName, caseSensitive()), thiz.keys.map { it.toAstExpr() }), metas)
+            is CreateIndex ->
+                ddl(
+                    createIndex(
+                        identifier(thiz.tableId.id, thiz.tableId.case.toAstCaseSensitivity()),
+                        thiz.keys.map { it.toAstExpr() }
+                    ),
+                    metas)
             is DropIndex ->
                 ddl(
                     dropIndex(

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -51,7 +51,7 @@ private fun ExprNode.toAstDdl(): PartiqlAst.Statement {
                 ddl(
                     dropIndex(
                         // case-sensitivity of table names cannot be represented with ExprNode.
-                        identifier(thiz.tableName, caseSensitive()),
+                        identifier(thiz.tableId.id, thiz.tableId.case.toAstCaseSensitivity()),
                         identifier(thiz.identifier.id, thiz.identifier.case.toAstCaseSensitivity())),
                     metas)
             is DropTable ->

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -52,7 +52,7 @@ private fun ExprNode.toAstDdl(): PartiqlAst.Statement {
                     dropIndex(
                         // case-sensitivity of table names cannot be represented with ExprNode.
                         identifier(thiz.tableId.id, thiz.tableId.case.toAstCaseSensitivity()),
-                        identifier(thiz.identifier.id, thiz.identifier.case.toAstCaseSensitivity())),
+                        identifier(thiz.indexId.id, thiz.indexId.case.toAstCaseSensitivity())),
                     metas)
             is DropTable ->
                 // case-sensitivity of table names cannot be represented with ExprNode.

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -430,7 +430,16 @@ private class StatementTransformer(val ion: IonSystem) {
         return when(op) {
             is DdlOp.CreateTable -> CreateTable(op.tableName.text, metas)
             is DdlOp.DropTable -> DropTable(op.tableName.name.text, metas)
-            is DdlOp.CreateIndex -> CreateIndex(op.indexName.name.text, op.fields.map { it.toExprNode() }, metas)
+            is DdlOp.CreateIndex ->
+                CreateIndex(
+                    VariableReference(
+                        op.indexName.name.text,
+                        op.indexName.case.toCaseSensitivity(),
+                        org.partiql.lang.ast.ScopeQualifier.UNQUALIFIED,
+                        metas
+                    ),
+                op.fields.map { it.toExprNode() },
+                metas)
             is DdlOp.DropIndex ->
                 DropIndex(
                     tableName = op.table.name.text,

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -442,7 +442,12 @@ private class StatementTransformer(val ion: IonSystem) {
                 metas)
             is DdlOp.DropIndex ->
                 DropIndex(
-                    tableName = op.table.name.text,
+                    tableId = VariableReference(
+                        id = op.table.name.text,
+                        case = op.table.case.toCaseSensitivity(),
+                        scopeQualifier = org.partiql.lang.ast.ScopeQualifier.UNQUALIFIED,
+                        metas = emptyMetaContainer
+                    ),
                     identifier = VariableReference(
                         id = op.keys.name.text,
                         case = op.keys.case.toCaseSensitivity(),

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -431,35 +431,31 @@ private class StatementTransformer(val ion: IonSystem) {
             is DdlOp.CreateTable -> CreateTable(op.tableName.text, metas)
             is DdlOp.DropTable ->
                 DropTable(
-                    tableId = VariableReference(
+                    tableId = Identifier(
                         id = op.tableName.name.text,
                         case = op.tableName.case.toCaseSensitivity(),
-                        scopeQualifier = org.partiql.lang.ast.ScopeQualifier.UNQUALIFIED,
                         metas = emptyMetaContainer
                     ),
                     metas = metas)
             is DdlOp.CreateIndex ->
                 CreateIndex(
-                    tableId = VariableReference(
+                    tableId = Identifier(
                         id = op.indexName.name.text,
                         case = op.indexName.case.toCaseSensitivity(),
-                        scopeQualifier = org.partiql.lang.ast.ScopeQualifier.UNQUALIFIED,
                         metas = emptyMetaContainer
                     ),
                     keys = op.fields.map { it.toExprNode() },
                     metas = metas)
             is DdlOp.DropIndex ->
                 DropIndex(
-                    tableId = VariableReference(
+                    tableId = Identifier(
                         id = op.table.name.text,
                         case = op.table.case.toCaseSensitivity(),
-                        scopeQualifier = org.partiql.lang.ast.ScopeQualifier.UNQUALIFIED,
                         metas = emptyMetaContainer
                     ),
-                    identifier = VariableReference(
+                    indexId = Identifier(
                         id = op.keys.name.text,
                         case = op.keys.case.toCaseSensitivity(),
-                        scopeQualifier = org.partiql.lang.ast.ScopeQualifier.UNQUALIFIED,
                         metas = emptyMetaContainer
                     ),
                     metas = metas)

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -431,24 +431,23 @@ private class StatementTransformer(val ion: IonSystem) {
             is DdlOp.CreateTable -> CreateTable(op.tableName.text, metas)
             is DdlOp.DropTable ->
                 DropTable(
-                    VariableReference(
-                        op.tableName.name.text,
-                        op.tableName.case.toCaseSensitivity(),
-                        org.partiql.lang.ast.ScopeQualifier.UNQUALIFIED,
-                        emptyMetaContainer
+                    tableId = VariableReference(
+                        id = op.tableName.name.text,
+                        case = op.tableName.case.toCaseSensitivity(),
+                        scopeQualifier = org.partiql.lang.ast.ScopeQualifier.UNQUALIFIED,
+                        metas = emptyMetaContainer
                     ),
-                    metas
-                )
+                    metas = metas)
             is DdlOp.CreateIndex ->
                 CreateIndex(
-                    VariableReference(
-                        op.indexName.name.text,
-                        op.indexName.case.toCaseSensitivity(),
-                        org.partiql.lang.ast.ScopeQualifier.UNQUALIFIED,
-                        emptyMetaContainer
+                    tableId = VariableReference(
+                        id = op.indexName.name.text,
+                        case = op.indexName.case.toCaseSensitivity(),
+                        scopeQualifier = org.partiql.lang.ast.ScopeQualifier.UNQUALIFIED,
+                        metas = emptyMetaContainer
                     ),
-                op.fields.map { it.toExprNode() },
-                metas)
+                    keys = op.fields.map { it.toExprNode() },
+                    metas = metas)
             is DdlOp.DropIndex ->
                 DropIndex(
                     tableId = VariableReference(

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -429,7 +429,16 @@ private class StatementTransformer(val ion: IonSystem) {
         val metas = this.metas.toPartiQlMetaContainer()
         return when(op) {
             is DdlOp.CreateTable -> CreateTable(op.tableName.text, metas)
-            is DdlOp.DropTable -> DropTable(op.tableName.name.text, metas)
+            is DdlOp.DropTable ->
+                DropTable(
+                    VariableReference(
+                        op.tableName.name.text,
+                        op.tableName.case.toCaseSensitivity(),
+                        org.partiql.lang.ast.ScopeQualifier.UNQUALIFIED,
+                        emptyMetaContainer
+                    ),
+                    metas
+                )
             is DdlOp.CreateIndex ->
                 CreateIndex(
                     VariableReference(

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -488,7 +488,7 @@ data class CreateIndex(
  * Represents a `DROP TABLE...` statement.
  */
 data class DropTable(
-    val tableName: String,
+    val tableId: VariableReference,
     override val metas: MetaContainer
 ) : ExprNode() {
     override val children: List<AstNode> get() = emptyList()

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -504,7 +504,7 @@ data class DropTable(
  * [AstNode] named `Identifier` which has `id` and `case` properties.
  */
 data class DropIndex(
-    val tableName: String,
+    val tableId: VariableReference,
     val identifier: VariableReference,
     override val metas: MetaContainer
 ) : ExprNode() {

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -195,7 +195,9 @@ data class VariableReference(
     override val children: List<AstNode> = listOf()
 }
 
-
+/**
+ * an Identifier, which can be used for names that need to be looked up with a notion of case-sensitivity.
+ */
 data class Identifier(
     val id: String,
     val case: CaseSensitivity,
@@ -484,7 +486,7 @@ data class CreateTable(
  * @param keys The expressions that extract the keys from the target to be applied to the index.
  */
 data class CreateIndex(
-    val tableId: VariableReference,
+    val tableId: Identifier,
     val keys: List<ExprNode>,
     override val metas: MetaContainer
 ) : ExprNode() {
@@ -495,7 +497,7 @@ data class CreateIndex(
  * Represents a `DROP TABLE...` statement.
  */
 data class DropTable(
-    val tableId: VariableReference,
+    val tableId: Identifier,
     override val metas: MetaContainer
 ) : ExprNode() {
     override val children: List<AstNode> get() = emptyList()
@@ -503,16 +505,10 @@ data class DropTable(
 
 /**
  * Represents a `DROP INDEX $index_identifier ON $table_name` statement.
- *
- * TODO:  [identifier] should not be modeled as a [VariableReference] since it is not actually
- * a reference to a variable.  It actually a reference to an index identifier, which doesn't have
- * the same semantics--for instance identifier only exists within a scope that is limited to its
- * table and should not be resolved in the same way a variable does.  We should create a new
- * [AstNode] named `Identifier` which has `id` and `case` properties.
  */
 data class DropIndex(
-    val tableId: VariableReference,
-    val identifier: VariableReference,
+    val tableId: Identifier,
+    val indexId: Identifier,
     override val metas: MetaContainer
 ) : ExprNode() {
     override val children: List<AstNode> get() = emptyList()

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -477,7 +477,7 @@ data class CreateTable(
  * @param keys The expressions that extract the keys from the target to be applied to the index.
  */
 data class CreateIndex(
-    val tableName: String,
+    val tableId: VariableReference,
     val keys: List<ExprNode>,
     override val metas: MetaContainer
 ) : ExprNode() {

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -195,6 +195,13 @@ data class VariableReference(
     override val children: List<AstNode> = listOf()
 }
 
+
+data class Identifier(
+    val id: String,
+    val case: CaseSensitivity,
+    override val metas: MetaContainer
+) : HasMetas
+
 /**
  * Represents a dynamic parameter with ordinal position for a variable to be provided
  * by the evaluation environment.

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -434,7 +434,7 @@ open class AstRewriterBase : AstRewriter {
             rewriteMetas(node))
 
     open fun rewriteDropTable(node: DropTable): DropTable =
-        DropTable(node.tableName, rewriteMetas(node))
+        DropTable(rewriteVariableReference(node.tableId) as VariableReference, rewriteMetas(node))
 
     open fun rewriteDropIndex(node: DropIndex): DropIndex =
         DropIndex(

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -438,7 +438,7 @@ open class AstRewriterBase : AstRewriter {
 
     open fun rewriteDropIndex(node: DropIndex): DropIndex =
         DropIndex(
-            node.tableName,
+            rewriteVariableReference(node.tableId) as VariableReference,
             rewriteVariableReference(node.identifier) as VariableReference,
             rewriteMetas(node))
 

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -429,17 +429,17 @@ open class AstRewriterBase : AstRewriter {
 
     open fun rewriteCreateIndex(node: CreateIndex): CreateIndex =
         CreateIndex(
-            rewriteVariableReference(node.tableId) as VariableReference,
+            rewriteIdentifier(node.tableId),
             node.keys.map { rewriteExprNode(it) },
             rewriteMetas(node))
 
     open fun rewriteDropTable(node: DropTable): DropTable =
-        DropTable(rewriteVariableReference(node.tableId) as VariableReference, rewriteMetas(node))
+        DropTable(rewriteIdentifier(node.tableId), rewriteMetas(node))
 
     open fun rewriteDropIndex(node: DropIndex): DropIndex =
         DropIndex(
-            rewriteVariableReference(node.tableId) as VariableReference,
-            rewriteVariableReference(node.identifier) as VariableReference,
+            rewriteIdentifier(node.tableId),
+            rewriteIdentifier(node.indexId),
             rewriteMetas(node))
 
     open fun rewriteExec(node: Exec): Exec =
@@ -466,5 +466,12 @@ open class AstRewriterBase : AstRewriter {
             node.with_time_zone,
             node.tz_minutes,
             rewriteMetas(node)
+        )
+
+    open fun rewriteIdentifier(identifier: Identifier): Identifier =
+        Identifier(
+            identifier.id,
+            identifier.case,
+            rewriteMetas(identifier)
         )
 }

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -429,7 +429,7 @@ open class AstRewriterBase : AstRewriter {
 
     open fun rewriteCreateIndex(node: CreateIndex): CreateIndex =
         CreateIndex(
-            node.tableName,
+            rewriteVariableReference(node.tableId) as VariableReference,
             node.keys.map { rewriteExprNode(it) },
             rewriteMetas(node))
 

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3743,7 +3743,7 @@ class SqlParserTest : SqlParserTestBase() {
         (create
           null.symbol
           (index
-            user
+            (id user case_sensitive)
             (keys
               (id group case_sensitive))))
         """,

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3697,24 +3697,20 @@ class SqlParserTest : SqlParserTestBase() {
         "(ddl (create_table user))"
     )
 
-    // TODO: Will remove `Ignore` tag once the test framework for parser is changed as well
-    @Ignore
     @Test
     fun dropTable() = assertExpression(
         "DROP TABLE foo",
-        "(drop_table foo)",
-        "(ddl (drop_table (identifier foo (case_sensitive))))"
+        "(drop_table (id foo case_insensitive))",
+        "(ddl (drop_table (identifier foo (case_insensitive))))"
     )
 
     @Test
     fun dropTableWithQuotedIdentifier() = assertExpression(
         "DROP TABLE \"user\"",
-        "(drop_table user)",
+        "(drop_table (id user case_sensitive))",
         "(ddl (drop_table (identifier user (case_sensitive))))"
     )
 
-    // TODO: Will remove `Ignore` tag once the test framework for parser is changed as well
-    @Ignore
     @Test
     fun createIndex() = assertExpression(
         "CREATE INDEX ON foo (x, y.z)",

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3700,14 +3700,14 @@ class SqlParserTest : SqlParserTestBase() {
     @Test
     fun dropTable() = assertExpression(
         "DROP TABLE foo",
-        "(drop_table (id foo case_insensitive))",
+        "(drop_table (identifier foo (case_insensitive)))",
         "(ddl (drop_table (identifier foo (case_insensitive))))"
     )
 
     @Test
     fun dropTableWithQuotedIdentifier() = assertExpression(
         "DROP TABLE \"user\"",
-        "(drop_table (id user case_sensitive))",
+        "(drop_table (identifier user (case_sensitive)))",
         "(ddl (drop_table (identifier user (case_sensitive))))"
     )
 
@@ -3718,7 +3718,7 @@ class SqlParserTest : SqlParserTestBase() {
         (create
           null.symbol
           (index
-            (id foo case_insensitive)
+            (identifier foo (case_insensitive))
             (keys
               (id x case_insensitive)
               (path (id y case_insensitive) (case_insensitive (lit "z"))))))
@@ -3739,7 +3739,7 @@ class SqlParserTest : SqlParserTestBase() {
         (create
           null.symbol
           (index
-            (id user case_sensitive)
+            (identifier user (case_sensitive))
             (keys
               (id group case_sensitive))))
         """,
@@ -3754,14 +3754,14 @@ class SqlParserTest : SqlParserTestBase() {
     @Test
     fun dropIndex() = assertExpression(
         "DROP INDEX bar ON foo",
-        "(drop_index (id foo case_insensitive) (id bar case_insensitive))",
+        "(drop_index (identifier foo (case_insensitive)) (identifier bar (case_insensitive)))",
         "(ddl (drop_index (table (identifier foo (case_insensitive))) (keys (identifier bar (case_insensitive)))))"
     )
 
     @Test
     fun dropIndexWithQuotedIdentifiers() = assertExpression(
         "DROP INDEX \"bar\" ON \"foo\"",
-        "(drop_index (id foo case_sensitive) (id bar case_sensitive))",
+        "(drop_index (identifier foo (case_sensitive)) (identifier bar (case_sensitive)))",
         "(ddl (drop_index (table (identifier foo (case_sensitive))) (keys (identifier bar (case_sensitive)))))"
     )
 

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3722,7 +3722,7 @@ class SqlParserTest : SqlParserTestBase() {
         (create
           null.symbol
           (index
-            foo
+            (id foo case_insensitive)
             (keys
               (id x case_insensitive)
               (path (id y case_insensitive) (case_insensitive (lit "z"))))))

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3755,19 +3755,17 @@ class SqlParserTest : SqlParserTestBase() {
         """
     )
 
-    // TODO: Will remove `Ignore` tag once the test framework for parser is changed as well
-    @Ignore
     @Test
     fun dropIndex() = assertExpression(
         "DROP INDEX bar ON foo",
-        "(drop_index foo (id bar case_insensitive))",
+        "(drop_index (id foo case_insensitive) (id bar case_insensitive))",
         "(ddl (drop_index (table (identifier foo (case_insensitive))) (keys (identifier bar (case_insensitive)))))"
     )
 
     @Test
     fun dropIndexWithQuotedIdentifiers() = assertExpression(
         "DROP INDEX \"bar\" ON \"foo\"",
-        "(drop_index foo (id bar case_sensitive))",
+        "(drop_index (id foo case_sensitive) (id bar case_sensitive))",
         "(ddl (drop_index (table (identifier foo (case_sensitive))) (keys (identifier bar (case_sensitive)))))"
     )
 

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -118,10 +118,13 @@ abstract class SqlParserTestBase : TestBase() {
 
         val deserializedExprNodeFromSexp = deserializer.deserialize(expectedSexpAst, astVersion)
 
+        val test1 = parsedExprNode.stripMetas()
+        val test2 = deserializedExprNodeFromSexp.stripMetas()
+
         assertEquals(
             "Parsed ExprNodes must match deserialized s-exp $astVersion AST",
-            parsedExprNode.stripMetas(),
-            deserializedExprNodeFromSexp.stripMetas())
+            test1,
+            test2)
     }
 
     /**

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -118,13 +118,10 @@ abstract class SqlParserTestBase : TestBase() {
 
         val deserializedExprNodeFromSexp = deserializer.deserialize(expectedSexpAst, astVersion)
 
-        val test1 = parsedExprNode.stripMetas()
-        val test2 = deserializedExprNodeFromSexp.stripMetas()
-
         assertEquals(
             "Parsed ExprNodes must match deserialized s-exp $astVersion AST",
-            test1,
-            test2)
+            parsedExprNode.stripMetas(),
+            deserializedExprNodeFromSexp.stripMetas())
     }
 
     /**


### PR DESCRIPTION
*This PR is aimed to fix the bug causing 3 test cases failed in FB-deprecate-ExprNode branch*

### Problem Description:
1. The `CreateIndex` in `ExprNode` AST has a field `tableName`, which is a `String` type, as shown [here](https://github.com/partiql/partiql-lang-kotlin/blob/main/lang/src/org/partiql/lang/ast/ast.kt#L480). However, in PIG AST, it is an `identifier`, as shown [here](https://github.com/partiql/partiql-lang-kotlin/blob/main/lang/resources/org/partiql/type-domains/partiql.ion#L275).
2. Similarly for `DropIndex`, refer to [here](https://github.com/partiql/partiql-lang-kotlin/blob/main/lang/src/org/partiql/lang/ast/ast.kt#L507) (`ExprNode`) and [here](https://github.com/partiql/partiql-lang-kotlin/blob/main/lang/resources/org/partiql/type-domains/partiql.ion#L280) (PIG AST).
3. Similarly for `DropTable`, refer to [here](https://github.com/partiql/partiql-lang-kotlin/blob/main/lang/src/org/partiql/lang/ast/ast.kt#L490) (`ExprNode`) and [here](https://github.com/partiql/partiql-lang-kotlin/blob/main/lang/resources/org/partiql/type-domains/partiql.ion#L270) (PIG AST).

### Changes Details: 
1. Changed the `String` type into `VariableReference` type in `ExprNode` version AST. 
2. Made corresponding changes in 'ExprNodeToStatement', 'StatmentToExprNode', 'AstSerialization' and 'AstDeserialization' files. 
3. Made corresponding changes in rewriter. 
4. Changed expected value in test cases. 

