### PR TITLE
Removed dependencies on `parseExprNode` from parser

### DIFF
--- a/examples/src/kotlin/org/partiql/examples/ParserErrorExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/ParserErrorExample.kt
@@ -24,7 +24,7 @@ class ParserErrorExample(out: PrintStream) : Example(out) {
         // Attempt to parse a query with invalid syntax.
         val invalidQuery = "SELECT 1 + "
         print("Invalid PartiQL query:", invalidQuery)
-        parser.parseExprNode(invalidQuery)
+        parser.parseAstStatement(invalidQuery)
 
         throw Exception("ParserException was not thrown")
     } catch (e: ParserException) {

--- a/examples/src/kotlin/org/partiql/examples/ParserExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/ParserExample.kt
@@ -24,29 +24,15 @@ class ParserExample(out: PrintStream) : Example(out) {
         print("PartiQL query", query)
 
         // Use the SqlParser instance to parse the example query.  This is very simple.
-        val originalAst = parser.parseExprNode(query)
-
-        // Now the originalAst can be inspected, transformed and/or serialized as needed.
-        // For now we're just going to serialize and deserialize it.
-
-        // Convert the ExprNode AST to the Ion s-expression form.
-        val serializedAst = originalAst.toAstStatement()
+        val ast = parser.parseAstStatement(query)
 
         // Create an IonWriter for printing of the PartiqlAst
         val partiqlAstString = StringBuilder()
         val ionWriter = IonTextWriterBuilder.minimal().withPrettyPrinting().build(partiqlAstString)
 
         // Now we can convert the Ion s-expression form into an Ion value to pretty print
-        serializedAst.toIonElement().writeTo(ionWriter)
+        ast.toIonElement().writeTo(ionWriter)
         print("Serialized AST", partiqlAstString.toString())
-
-        // Re-constitute the serialized AST.  The toExprNode will convert from any supported
-        // version of the s-expression form to an instance of [ExprNode].
-        val deserializedAst = serializedAst.toExprNode(ion)
-        // Verify that we have the correct AST.
-        if (originalAst != deserializedAst) {
-            throw Exception("expected AST to be equal")
-        }
 
         // Here we show how to parse a query directly to a PartiqlAst statement
         val statement = parser.parseAstStatement(query)

--- a/examples/src/kotlin/org/partiql/examples/ParserExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/ParserExample.kt
@@ -20,29 +20,28 @@ class ParserExample(out: PrintStream) : Example(out) {
         // An instance of [SqlParser].
         val parser: Parser = SqlParser(ion)
 
+        // A query in string format
         val query = "SELECT exampleField FROM exampleTable WHERE anotherField > 10"
         print("PartiQL query", query)
 
-        // Use the SqlParser instance to parse the example query.  This is very simple.
+        // Use the SqlParser instance to parse the example query and get the AST as a PartiqlAst Statement.
         val ast = parser.parseAstStatement(query)
 
-        // Create an IonWriter for printing of the PartiqlAst
-        val partiqlAstString = StringBuilder()
-        val ionWriter = IonTextWriterBuilder.minimal().withPrettyPrinting().build(partiqlAstString)
+        // We can transform the AST into SexpElement form to pretty print
+        val elements = ast.toIonElement()
 
-        // Now we can convert the Ion s-expression form into an Ion value to pretty print
-        ast.toIonElement().writeTo(ionWriter)
-        print("Serialized AST", partiqlAstString.toString())
+        // Create an IonWriter to print the AST
+        val astString = StringBuilder()
+        val ionWriter = IonTextWriterBuilder.minimal().withPrettyPrinting().build(astString)
 
-        // Here we show how to parse a query directly to a PartiqlAst statement
-        val statement = parser.parseAstStatement(query)
+        // Now use the IonWriter to write the SexpElement AST into the StringBuilder and pretty print it
+        elements.writeTo(ionWriter)
+        print("Serialized AST", astString.toString())
 
-        // We can easily convert the PartiqlAst statement into an Ion s-expression
-        val elements = statement.toIonElement()
-        // and back into a PartiqlAst statement
+        // We can also convert the SexpElement AST back into a PartiqlAst statement
         val roundTrippedStatement = PartiqlAst.transform(elements) as PartiqlAst.Statement
         // Verify that we have the original Partiql Ast statement
-        if (statement != roundTrippedStatement) {
+        if (ast != roundTrippedStatement) {
             throw Exception("Expected statements to be the same")
         }
     }

--- a/examples/src/kotlin/org/partiql/examples/ParserExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/ParserExample.kt
@@ -2,7 +2,6 @@ package org.partiql.examples
 
 import com.amazon.ion.system.*
 import org.partiql.examples.util.Example
-import org.partiql.lang.ast.*
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.*
 import java.io.PrintStream

--- a/examples/src/kotlin/org/partiql/examples/PreventJoinVistor.kt
+++ b/examples/src/kotlin/org/partiql/examples/PreventJoinVistor.kt
@@ -2,7 +2,6 @@ package org.partiql.examples
 
 import com.amazon.ion.system.*
 import org.partiql.examples.util.Example
-import org.partiql.lang.ast.*
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.*
 import java.io.PrintStream
@@ -21,12 +20,12 @@ class PreventJoinVisitorExample(out: PrintStream) : Example(out) {
     private val parser = SqlParser(ion)
 
     private fun hasJoins(sql: String): Boolean = try {
-        // TODO use PIG AST to iterate the AST
-        val ast = parser.parseExprNode(sql)
-
-        if(ast.any { it is FromSourceJoin }) {
-            throw InvalidAstException("JOINs are prevented")
-        }
+        val ast = parser.parseAstStatement(sql)
+        object : PartiqlAst.Visitor(){
+            override fun visitFromSourceJoin(node: PartiqlAst.FromSource.Join) {
+                throw InvalidAstException("JOINs are prevented")
+            }
+        }.walkStatement(ast)
 
         false
     } catch (e: InvalidAstException) {

--- a/examples/src/kotlin/org/partiql/examples/PreventJoinVistor.kt
+++ b/examples/src/kotlin/org/partiql/examples/PreventJoinVistor.kt
@@ -3,6 +3,7 @@ package org.partiql.examples
 import com.amazon.ion.system.*
 import org.partiql.examples.util.Example
 import org.partiql.lang.ast.*
+import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.*
 import java.io.PrintStream
 
@@ -20,6 +21,7 @@ class PreventJoinVisitorExample(out: PrintStream) : Example(out) {
     private val parser = SqlParser(ion)
 
     private fun hasJoins(sql: String): Boolean = try {
+        // TODO use PIG AST to iterate the AST
         val ast = parser.parseExprNode(sql)
 
         if(ast.any { it is FromSourceJoin }) {

--- a/lang/jmh/org/partiql/jmh/PartiQLBenchmark.kt
+++ b/lang/jmh/org/partiql/jmh/PartiQLBenchmark.kt
@@ -54,10 +54,12 @@ open class PartiQLBenchmark {
                 } 
             }
         """.trimIndent()
+        // TODO: replace `parseExprNode` with `ParseStatement` once evaluator deprecates `ExprNode`
         val bindings = pipeline.compile(parser.parseExprNode(data)).eval(EvaluationSession.standard()).bindings
         val session = EvaluationSession.build { globals(bindings) }
 
         val query = "SELECT * FROM hr.employeesNestScalars"
+        // TODO: replace `parseExprNode` with `ParseStatement` once evaluator deprecates `ExprNode`
         val exprNode = parser.parseExprNode(query)
         val expression = pipeline.compile(exprNode)
     }
@@ -68,6 +70,7 @@ open class PartiQLBenchmark {
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     fun testPartiQLParser(state: MyState, blackhole: Blackhole) {
+        // TODO: replace `parseExprNode` with `ParseStatement` once evaluator deprecates `ExprNode`
         val expr = state.parser.parseExprNode(state.query)
         blackhole.consume(expr)
     }

--- a/lang/src/org/partiql/lang/CompilerPipeline.kt
+++ b/lang/src/org/partiql/lang/CompilerPipeline.kt
@@ -193,6 +193,7 @@ internal class CompilerPipelineImpl(
     private val compiler = EvaluatingCompiler(valueFactory, functions, procedures, compileOptions)
 
     override fun compile(query: String): Expression {
+        // TODO: replace `parseExprNode` with `ParseStatement` once evaluator deprecates `ExprNode`
         return compile(parser.parseExprNode(query))
     }
 

--- a/lang/src/org/partiql/lang/ast/passes/StatementRedactor.kt
+++ b/lang/src/org/partiql/lang/ast/passes/StatementRedactor.kt
@@ -2,10 +2,8 @@ package org.partiql.lang.ast.passes
 
 import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionelement.api.StringElement
-import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.ast.sourceLocation
-import org.partiql.lang.ast.toAstStatement
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.SqlParser
 
@@ -71,7 +69,7 @@ fun skipRedaction(node: PartiqlAst.Expr, safeFieldNames: Set<String>): Boolean {
 fun redact(statement: String,
            providedSafeFieldNames: Set<String> = emptySet(),
            userDefinedFunctionRedactionConfig: Map<String, UserDefinedFunctionRedactionLambda> = emptyMap()): String {
-    return redact(statement, parser.parseExprNode(statement), providedSafeFieldNames, userDefinedFunctionRedactionConfig)
+    return redact(statement, parser.parseAstStatement(statement), providedSafeFieldNames, userDefinedFunctionRedactionConfig)
 }
 
 /**
@@ -88,11 +86,10 @@ fun redact(statement: String,
  * arguments are to be redacted. For an example, please check StatementRedactorTest.kt for more details.
  */
 fun redact(statement: String,
-           ast: ExprNode,
+           partiqlAst: PartiqlAst.Statement,
            providedSafeFieldNames: Set<String> = emptySet(),
            userDefinedFunctionRedactionConfig: Map<String, UserDefinedFunctionRedactionLambda> = emptyMap()): String {
 
-    val partiqlAst = ast.toAstStatement()
     val statementRedactionVisitor = StatementRedactionVisitor(statement, providedSafeFieldNames, userDefinedFunctionRedactionConfig)
     statementRedactionVisitor.walkStatement(partiqlAst)
     return statementRedactionVisitor.getRedactedStatement()

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -242,6 +242,7 @@ internal class EvaluatingCompiler(
     @Deprecated("Please use CompilerPipeline instead")
     fun compile(source: String): Expression {
         val parser = SqlParser(valueFactory.ion)
+        // TODO: replace `parseExprNode` with `ParseStatement` once evaluator deprecates `ExprNode`
         val ast = parser.parseExprNode(source)
         return compile(ast)
     }

--- a/lang/test/org/partiql/lang/ast/passes/StatementRedactorTest.kt
+++ b/lang/test/org/partiql/lang/ast/passes/StatementRedactorTest.kt
@@ -3,7 +3,6 @@ package org.partiql.lang.ast.passes
 import com.amazon.ionelement.api.StringElement
 import junitparams.Parameters
 import org.junit.Test
-import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.SqlParserTestBase
 

--- a/lang/test/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransformTests.kt
@@ -38,7 +38,7 @@ class AggregateSupportVisitorTransformTests : VisitorTransformTestBase() {
      */
     private fun String.parseAndTransformQuery() : PartiqlAst.Expr.Select {
         val query = this
-        val statement = super.parser.parseExprNode(query).toAstStatement()
+        val statement = super.parser.parseAstStatement(query)
         val transformedNode = (transformer).transformStatement(statement) as PartiqlAst.Statement.Query
         return (transformedNode.expr) as PartiqlAst.Expr.Select
     }

--- a/lang/test/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransformTests.kt
@@ -23,7 +23,6 @@ import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.ast.AggregateCallSiteListMeta
 import org.partiql.lang.ast.AggregateRegisterIdMeta
 import org.partiql.lang.ast.SourceLocationMeta
-import org.partiql.lang.ast.toAstStatement
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.util.ArgumentsProviderBase
 

--- a/lang/test/org/partiql/lang/eval/visitors/VisitorTransformTestBase.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/VisitorTransformTestBase.kt
@@ -14,7 +14,6 @@
 
 package org.partiql.lang.eval.visitors
 
-import org.partiql.lang.ast.toAstStatement
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.SqlParserTestBase
 import org.junit.jupiter.api.fail
@@ -62,11 +61,11 @@ abstract class VisitorTransformTestBase : SqlParserTestBase() {
             super.parser.parseAstStatement(tc.expectedSql)
         }
 
-        val actualExprNode = transformers.fold(originalAst) { node, transform ->
+        val actualStatement = transformers.fold(originalAst) { node, transform ->
             transform.transformStatement(node)
         }
 
-        assertEquals("The expected AST must match the transformed AST", expectedAst, actualExprNode)
+        assertEquals("The expected AST must match the transformed AST", expectedAst, actualStatement)
     }
 
     private fun <T> assertDoesNotThrow(message: String, block: () -> T): T {

--- a/lang/test/org/partiql/lang/eval/visitors/VisitorTransformTestBase.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/VisitorTransformTestBase.kt
@@ -30,10 +30,10 @@ abstract class VisitorTransformTestBase : SqlParserTestBase() {
      */
     protected fun runTestForIdempotentTransform(tc: TransformTestCase, transform: PartiqlAst.VisitorTransform) {
         val originalAst = assertDoesNotThrow("Parsing TransformTestCase.originalSql") {
-            super.parser.parseExprNode(tc.originalSql).toAstStatement()
+            super.parser.parseAstStatement(tc.originalSql)
         }
         val expectedAst = assertDoesNotThrow("Parsing TransformTestCase.expectedSql") {
-            super.parser.parseExprNode(tc.expectedSql).toAstStatement()
+            super.parser.parseAstStatement(tc.expectedSql)
         }
 
         val actualAst = transform.transformStatement(originalAst)
@@ -56,10 +56,10 @@ abstract class VisitorTransformTestBase : SqlParserTestBase() {
      */
     protected fun runTest(tc: TransformTestCase, transformers: List<PartiqlAst.VisitorTransform>) {
         val originalAst = assertDoesNotThrow("Parsing TransformTestCase.originalSql") {
-            super.parser.parseExprNode(tc.originalSql).toAstStatement()
+            super.parser.parseAstStatement(tc.originalSql)
         }
         val expectedAst = assertDoesNotThrow("Parsing TransformTestCase.expectedSql") {
-            super.parser.parseExprNode(tc.expectedSql).toAstStatement()
+            super.parser.parseAstStatement(tc.expectedSql)
         }
 
         val actualExprNode = transformers.fold(originalAst) { node, transform ->

--- a/lang/test/org/partiql/lang/syntax/SqlParserPrecedenceTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserPrecedenceTest.kt
@@ -1049,12 +1049,10 @@ class SqlParserPrecedenceTest : SqlParserTestBase() {
     private fun runTest(pair: Pair<String, String>) {
         val (source, expectedAst) = pair
 
-        val expectedAstExpr = PartiqlAst.transform(ion.singleValue(expectedAst).toIonElement()) as PartiqlAst.Expr
-        val expectedAstStatement = PartiqlAst.build { query(expectedAstExpr) }
-        val expectedExprNode = MetaStrippingRewriter.stripMetas(expectedAstStatement.toExprNode(ion))
+        val expectedExpr = PartiqlAst.transform(ion.singleValue(expectedAst).toIonElement()) as PartiqlAst.Expr
+        val expectedStatement = PartiqlAst.build { query(expectedExpr) }
+        val actualStatement = SqlParser(ion).parseAstStatement(source)
 
-        val actualExprNode = MetaStrippingRewriter.stripMetas(SqlParser(ion).parseExprNode(source))
-
-        assertEquals(expectedExprNode, actualExprNode)
+        assertEquals(expectedStatement, actualStatement)
     }
 }

--- a/lang/test/org/partiql/lang/syntax/SqlParserPrecedenceTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserPrecedenceTest.kt
@@ -18,10 +18,7 @@ import junitparams.*
 import junitparams.naming.*
 import org.junit.*
 import com.amazon.ionelement.api.toIonElement
-import org.partiql.lang.ast.passes.MetaStrippingRewriter
-import org.partiql.lang.ast.toExprNode
 import org.partiql.lang.domains.PartiqlAst
-import org.partiql.lang.util.asIonSexp
 
 
 class SqlParserPrecedenceTest : SqlParserTestBase() {


### PR DESCRIPTION
*This PR aims to remove dependencies on `parseExprNode` method from Parser as much as possible*

### Description of changes
Changed `parseExprNode` into `parseAstStatement` in multiple files. 

### What remains the same 
1. Some test files which are just for testing `ExprNode`. 
2. 'RewriterTestBase' and related files which currently do not support PIG AST. 
3. The files which are involved with Evaluator. Will change them once we are doing the work on deprecating `ExprNode` in Evaluator . 

### What's coming next
The file 'PreventJoinVisitor.kt' uses `ExprNode` to iterate the AST. However, since currently the PIG AST is not iterable, will need to see if there is another way to iterate the AST in format of PIG. 