### PR TITLE
Removed `ExprNode` in SqlParserTestBase as much as possible

### DIFF
--- a/lang/test/org/partiql/lang/eval/visitors/StaticTypeVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/StaticTypeVisitorTransformTests.kt
@@ -854,7 +854,7 @@ class StaticTypeVisitorTransformTests : VisitorTransformTestBase() {
         // FromSourceAliasVisitorTransform to execute first but also to help ensure the queries we're testing
         // make sense when they're all run.
         val defaultTransforms = basicVisitorTransforms()
-        val originalPartiqlAst = defaultTransforms.transformStatement(parse(tc.originalSql).toAstStatement())
+        val originalPartiqlAst = defaultTransforms.transformStatement(parse(tc.originalSql))
 
         val transformedExprNode = try {
             transformer.transformStatement(originalPartiqlAst)

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -42,21 +42,6 @@ abstract class SqlParserTestBase : TestBase() {
     /**
      * This method is used by test cases for parsing a string.
      * The test are performed with only PIG AST.
-     * The expected PIG AST is a PIG builder.
-     */
-    protected fun assertExpression(
-        source: String,
-        expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
-    ) {
-        val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
-
-        // Refer to comments inside the main body of the following function to see what checks are performed.
-        assertExpression(source, expectedPigAst)
-    }
-
-    /**
-     * This method is used by test cases for parsing a string.
-     * The test are performed with only PIG AST.
      * The expected PIG AST is a string.
      */
     protected fun assertExpression(
@@ -80,18 +65,17 @@ abstract class SqlParserTestBase : TestBase() {
 
     /**
      * This method is used by test cases for parsing a string.
-     * The test are performed with both PIG AST and V0 AST.
+     * The test are performed with only PIG AST.
      * The expected PIG AST is a PIG builder.
      */
     protected fun assertExpression(
         source: String,
-        expectedSexpAstV0: String,
         expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
     ) {
         val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
 
         // Refer to comments inside the main body of the following function to see what checks are performed.
-        assertExpression(source, expectedSexpAstV0, expectedPigAst)
+        assertExpression(source, expectedPigAst)
     }
 
     /**
@@ -111,6 +95,22 @@ abstract class SqlParserTestBase : TestBase() {
 
         // Check for PIG Ast
         assertExpression(source, expectedPigAst)
+    }
+
+    /**
+     * This method is used by test cases for parsing a string.
+     * The test are performed with both PIG AST and V0 AST.
+     * The expected PIG AST is a PIG builder.
+     */
+    protected fun assertExpression(
+        source: String,
+        expectedSexpAstV0: String,
+        expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
+    ) {
+        val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
+
+        // Refer to comments inside the main body of the following function to see what checks are performed.
+        assertExpression(source, expectedSexpAstV0, expectedPigAst)
     }
 
     private fun serializeAssert(astVersion: AstVersion, actualExprNode: ExprNode, expectedIonSexp: IonSexp, source: String) {

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -114,11 +114,11 @@ abstract class SqlParserTestBase : TestBase() {
     }
 
     private fun serializeAssert(astVersion: AstVersion, actualExprNode: ExprNode, expectedIonSexp: IonSexp, source: String) {
-        // Check equals for actual value and expected value after transformation: EpxrNode -> IonSexp
+        // Check equals for actual value and expected value after transformation: ExprNode -> IonSexp
         val actualSexpAstWithoutMetas = AstSerializer.serialize(actualExprNode, astVersion, ion).filterMetaNodes()
         assertSexpEquals(expectedIonSexp, actualSexpAstWithoutMetas, "$astVersion AST, $source")
 
-        // Check equals for actual value and expected value after transformation: IonSexp -> EpxrNode
+        // Check equals for actual value and expected value after transformation: IonSexp -> ExprNode
         val deserializer = AstDeserializerBuilder(ion).build()
         val deserializedExprNodeFromSexp = deserializer.deserialize(expectedIonSexp, astVersion)
         assertEquals(
@@ -159,7 +159,7 @@ abstract class SqlParserTestBase : TestBase() {
         // Check equal after transformation: PIG AST -> SexpElement -> PIG AST
         assertRoundTripPigAstToSexpElement(actualStatement)
 
-        // Check equal for actual and expected in transformed astStatement: astStatment -> SexpElement -> astStatement
+        // Check equal for actual and expected in transformed astStatement: astStatement -> SexpElement -> astStatement
         val transformedActualStatement = PartiqlAst.transform(actualElement)
         val transformedExpectedStatement = PartiqlAst.transform(expectedElement)
         assertEquals(transformedExpectedStatement, transformedActualStatement)


### PR DESCRIPTION
*Description of changes:*
1. Changed `parse` method so it uses `parseAstStatement` to produce PIG AST node instead of `ExprNode`. Also, changed a few function's signature so they receive PIG AST node now, instead of `ExprNode`. 
2. Removed `assertRoundTripIonElementToPartiQlAst` and `assertRoundTripPartiQlAstToExprNode` and merged the checks into `pigDomainAssert`. 
3. Removed the check for actual value after round trip transformation: `ExprNode` -> PIG AST -> `SexpElement` -> PIG AST -> `ExprNode`. 
4. Changed round trip order in `assertRoundTripPigAstToExprNode` from (`ExprNode` -> PIG AST -> `ExprNode`) into (PIG AST -> `ExprNode` -> PIG AST). 
5. See other changes in comments. 


