### PR TITLE
WIP to fix missing DML ParseNode tokens

### DIFF
--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -2111,6 +2111,56 @@ class ParserErrorsTest : SqlParserTestBase() {
             Property.TOKEN_VALUE to ion.newSymbol("undrop")))
 
     @Test
+    fun execWithDmlInsert() = checkInputThrowingParserException(
+        "EXEC abc_proc INSERT INTO dogs <<{}>>",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 15L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("insert_into")))
+
+    @Test
+    fun execWithDmlDelete() = checkInputThrowingParserException(
+        "EXEC abc_proc DELETE FROM dogs WHERE name = 'Jack'",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 15L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("delete")))
+
+    @Test
+    fun execWithDmlUpdate() = checkInputThrowingParserException(
+        "EXEC abc_proc UPDATE dogs SET dogs.name = '1'",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 15L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("update")))
+
+    @Test
+    fun execWithDmlRemove() = checkInputThrowingParserException(
+        "EXEC abc_proc FROM dogs REMOVE dogs.name",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 25L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("remove")))
+
+    @Test
+    fun execWithDmlList() = checkInputThrowingParserException(
+        "EXEC abc_proc UPDATE x SET k = 5, m = 6 INSERT INTO c VALUE << 1 >> REMOVE a SET l = 3 REMOVE b WHERE a = b RETURNING MODIFIED OLD a",
+        ErrorCode.PARSE_UNEXPECTED_TERM,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 15L,
+            Property.TOKEN_TYPE to TokenType.KEYWORD,
+            Property.TOKEN_VALUE to ion.newSymbol("update")))
+
+    @Test
     fun missingDateString() = checkInputThrowingParserException(
         "DATE",
         ErrorCode.PARSE_UNEXPECTED_TOKEN,


### PR DESCRIPTION
WIP until
- other DML edge cases are sorted out
  - `SET` without `UPDATE` (like following `FROM`)
  - `UPDATE` without `SET`
- source location for error is agreed upon
  - If there's a DML `FROM`, should the error point here?
  - If there's a DML `UPDATE`, should the error point here?

Initial attempt to fix #465 (Inconsistent exceptions and error messages for DML statements as arguments for EXEC). For some DML expressions following stored procedure calls, there would be a "null" appearing in the parser error. This is due to some DML `ParseNode`s not storing the associated `Token`.

At the moment, I think resolving the above WIP issues will involve refactoring `ParseNode` for DML in a non-trivial way.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
