### PR TITLE
Replaced self-implemented CSV file reader with Apache CSVParser for CLI

### DIFF
--- a/cli/src/org/partiql/cli/functions/WriteFile.kt
+++ b/cli/src/org/partiql/cli/functions/WriteFile.kt
@@ -31,7 +31,7 @@ internal class WriteFile(valueFactory: ExprValueFactory) : BaseFunction(valueFac
         }
     }
 
-    private fun delimitedWriteHandler(delimiter: String): (ExprValue, OutputStream, IonStruct) -> Unit = { results, out, options ->
+    private fun delimitedWriteHandler(delimiter: Char): (ExprValue, OutputStream, IonStruct) -> Unit = { results, out, options ->
         val encoding = options["encoding"]?.stringValue() ?: "UTF-8"
         val writeHeader = options["header"]?.booleanValue() ?: false
         val nl = options["nl"]?.stringValue() ?: "\n"
@@ -43,8 +43,8 @@ internal class WriteFile(valueFactory: ExprValueFactory) : BaseFunction(valueFac
     }
 
     private val writeHandlers = mapOf(
-        "tsv" to delimitedWriteHandler("\t"),
-        "csv" to delimitedWriteHandler(","),
+        "tsv" to delimitedWriteHandler('\t'),
+        "csv" to delimitedWriteHandler(','),
         "ion" to PRETTY_ION_WRITER)
 
     override fun call(env: Environment, args: List<ExprValue>): ExprValue {

--- a/cli/test/org/partiql/cli/functions/ReadFileTest.kt
+++ b/cli/test/org/partiql/cli/functions/ReadFileTest.kt
@@ -81,6 +81,18 @@ class ReadFileTest {
     }
 
     @Test
+    fun readCsvWithIonSymbolAsInput() {
+        writeFile("data_with_ion_symbol_as_input.csv", "1,2")
+
+        val args = listOf("\"${dirPath("data_with_ion_symbol_as_input.csv")}\"", "{type:csv}").map { it.exprValue() }
+
+        val actual = function.call(env, args).ionValue
+        val expected = "[{_1:\"1\",_2:\"2\"}]"
+
+        assertEquals(ion.singleValue(expected), actual)
+    }
+
+    @Test
     fun readCsvWithDoubleQuotesEscape() {
         writeFile("data_with_double_quotes_escape.csv", "\"1,2\",2")
 

--- a/cli/test/org/partiql/cli/functions/ReadFileTest.kt
+++ b/cli/test/org/partiql/cli/functions/ReadFileTest.kt
@@ -54,7 +54,7 @@ class ReadFileTest {
         val actual = function.call(env, args).ionValue
         val expected = "[1, 2]"
 
-        assertEquals(actual, ion.singleValue(expected))
+        assertEquals(ion.singleValue(expected), actual)
     }
 
     @Test
@@ -65,7 +65,7 @@ class ReadFileTest {
         val actual = function.call(env, args).ionValue
         val expected = "[1, 2]"
 
-        assertEquals(actual, ion.singleValue(expected))
+        assertEquals(ion.singleValue(expected), actual)
     }
 
     @Test
@@ -77,7 +77,55 @@ class ReadFileTest {
         val actual = function.call(env, args).ionValue
         val expected = "[{_1:\"1\",_2:\"2\"}]"
 
-        assertEquals(actual, ion.singleValue(expected))
+        assertEquals(ion.singleValue(expected), actual)
+    }
+
+    @Test
+    fun readCsvWithSpacesSurroundingComma() {
+        writeFile("data_with_spaces_surrounding_comma.csv", "1 , 2")
+
+        val args = listOf("\"${dirPath("data_with_spaces_surrounding_comma.csv")}\"", "{type:\"csv\"}").map { it.exprValue() }
+
+        val actual = function.call(env, args).ionValue
+        val expected = "[{_1:\"1\",_2:\"2\"}]"
+
+        assertEquals(ion.singleValue(expected), actual)
+    }
+
+    @Test
+    fun readCsvWithDoubleQuotesEscape() {
+        writeFile("data_with_double_quotes_escape.csv", "\"1,2\",2")
+
+        val args = listOf("\"${dirPath("data_with_double_quotes_escape.csv")}\"", "{type:\"csv\"}").map { it.exprValue() }
+
+        val actual = function.call(env, args).ionValue
+        val expected = "[{_1:\"1,2\",_2:\"2\"}]"
+
+        assertEquals(ion.singleValue(expected), actual)
+    }
+
+    @Test
+    fun readCsvWithEmptyLines() {
+        writeFile("data_with_double_quotes_escape.csv", "1,2\n\n3\n\n")
+
+        val args = listOf("\"${dirPath("data_with_double_quotes_escape.csv")}\"", "{type:\"csv\"}").map { it.exprValue() }
+
+        val actual = function.call(env, args).ionValue
+        val expected = "[{_1:\"1\",_2:\"2\"},{_1:\"3\"}]"
+
+        assertEquals(ion.singleValue(expected), actual)
+    }
+
+    @Test
+    fun readCsvWithHeaderLine() {
+        writeFile("data_with_header_line.csv", "col1,col2\n1,2")
+
+        val args = listOf("\"${dirPath("data_with_header_line.csv")}\"", "{type:\"csv\", header:true}").map { it.exprValue() }
+
+        val actual = function.call(env, args).ionValue
+        val expected = "[{col1:\"1\",col2:\"2\"}]"
+
+        assertEquals(ion.singleValue(expected), actual)
     }
 
     @Test
@@ -89,6 +137,6 @@ class ReadFileTest {
         val actual = function.call(env, args).ionValue
         val expected = "[{_1:\"1\",_2:\"2\"}]"
 
-        assertEquals(actual, ion.singleValue(expected))
+        assertEquals(ion.singleValue(expected), actual)
     }
 }

--- a/cli/test/org/partiql/cli/functions/ReadFileTest.kt
+++ b/cli/test/org/partiql/cli/functions/ReadFileTest.kt
@@ -81,18 +81,6 @@ class ReadFileTest {
     }
 
     @Test
-    fun readCsvWithSpacesSurroundingComma() {
-        writeFile("data_with_spaces_surrounding_comma.csv", "1 , 2")
-
-        val args = listOf("\"${dirPath("data_with_spaces_surrounding_comma.csv")}\"", "{type:\"csv\"}").map { it.exprValue() }
-
-        val actual = function.call(env, args).ionValue
-        val expected = "[{_1:\"1\",_2:\"2\"}]"
-
-        assertEquals(ion.singleValue(expected), actual)
-    }
-
-    @Test
     fun readCsvWithDoubleQuotesEscape() {
         writeFile("data_with_double_quotes_escape.csv", "\"1,2\",2")
 
@@ -136,6 +124,18 @@ class ReadFileTest {
 
         val actual = function.call(env, args).ionValue
         val expected = "[{_1:\"1\",_2:\"2\"}]"
+
+        assertEquals(ion.singleValue(expected), actual)
+    }
+
+    @Test
+    fun readTsvWithHeaderLine() {
+        writeFile("data_with_header_line.tsv", "col1\tcol2\n1\t2")
+
+        val args = listOf("\"${dirPath("data_with_header_line.tsv")}\"", "{type:\"tsv\", header:true}").map { it.exprValue() }
+
+        val actual = function.call(env, args).ionValue
+        val expected = "[{col1:\"1\",col2:\"2\"}]"
 
         assertEquals(ion.singleValue(expected), actual)
     }

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     api 'com.amazon.ion:ion-element:0.2.0'
     api 'org.partiql:partiql-ir-generator-runtime:0.4.0'
 
+    implementation 'org.apache.commons:commons-csv:1.8'
+
     // test-time dependencies
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testImplementation 'pl.pragmatists:JUnitParams:[1.0.0,1.1.0)'

--- a/lang/src/org/partiql/lang/eval/io/DelimitedValues.kt
+++ b/lang/src/org/partiql/lang/eval/io/DelimitedValues.kt
@@ -57,7 +57,7 @@ object DelimitedValues {
 
     /**
      * Lazily loads a stream of values from a [Reader] into a sequence backed [ExprValue].
-     * The [ExprValue] is single pass only.  This does **not** close the [Reader].
+     * This does **not** close the [Reader].
      *
      * @param ion The system to use.
      * @param input The input source.
@@ -90,7 +90,7 @@ object DelimitedValues {
                 },
                 StructOrdering.ORDERED
             )
-        }.constrainOnce()
+        }
 
         return valueFactory.newBag(seq)
     }

--- a/lang/test/org/partiql/lang/eval/io/DelimitedValuesTest.kt
+++ b/lang/test/org/partiql/lang/eval/io/DelimitedValuesTest.kt
@@ -36,23 +36,16 @@ class DelimitedValuesTest : TestBase() {
     }
 
     private fun read(text: String,
-                     delimiter: String,
+                     delimiter: Char,
                      hasHeader: Boolean,
                      conversionMode: ConversionMode): ExprValue =
         DelimitedValues.exprValue(valueFactory, StringReader(text), delimiter, hasHeader, conversionMode)
-
-    private fun voidRead(text: String,
-                         delimiter: String,
-                         hasHeader: Boolean,
-                         conversionMode: ConversionMode): Unit {
-        read(text, delimiter, hasHeader, conversionMode)
-    }
 
     private fun assertWrite(expectedText: String,
                             valueText: String,
                             names: List<String>,
                             writeHeader: Boolean,
-                            delimiter: String = ",",
+                            delimiter: Char = ',',
                             newline: String = "\n") {
         val actualText = StringWriter().use {
 
@@ -79,7 +72,7 @@ class DelimitedValuesTest : TestBase() {
 
     private fun voidWrite(exprValue: ExprValue,
                           writeHeader: Boolean,
-                          delimiter: String = ",",
+                          delimiter: Char = ',',
                           newline: String = "\n") {
         DelimitedValues.writeTo(ion, StringWriter(), exprValue, delimiter, newline, writeHeader)
     }
@@ -89,7 +82,7 @@ class DelimitedValuesTest : TestBase() {
         """[]""",
         read(
             "",
-            delimiter = ",",
+            delimiter = ',',
             hasHeader = false,
             conversionMode = NONE
         )
@@ -100,18 +93,10 @@ class DelimitedValuesTest : TestBase() {
         """[]""",
         read(
             "",
-            delimiter = ",\t",
+            delimiter = ',',
             hasHeader = false,
             conversionMode = AUTO
         )
-    )
-
-    @Test(expected = IllegalArgumentException::class)
-    fun emptyExprValueTabAutoHeader() = voidRead(
-        "",
-        delimiter = ",\t",
-        hasHeader = true,
-        conversionMode = AUTO
     )
 
     @Test
@@ -119,7 +104,7 @@ class DelimitedValuesTest : TestBase() {
         """[{_1: "1", _2: "2", _3: "3"}]""",
         read(
             """1,2,3""",
-            delimiter = ",",
+            delimiter = ',',
             hasHeader = false,
             conversionMode = NONE
         )
@@ -138,7 +123,7 @@ class DelimitedValuesTest : TestBase() {
             |1.0,2e0,2007-10-10T12:00:00Z
             |hello,{,}
             """.trimMargin(),
-            delimiter = ",",
+            delimiter = ',',
             hasHeader = false,
             conversionMode = AUTO
         )
@@ -158,7 +143,7 @@ class DelimitedValuesTest : TestBase() {
             |1.0,2e0,2007-10-10T12:00:00Z
             |hello,{,}
             """.trimMargin(),
-            delimiter = ",",
+            delimiter = ',',
             hasHeader = true,
             conversionMode = AUTO
         )

--- a/lang/test/org/partiql/lang/eval/io/DelimitedValuesTest.kt
+++ b/lang/test/org/partiql/lang/eval/io/DelimitedValuesTest.kt
@@ -29,10 +29,6 @@ class DelimitedValuesTest : TestBase() {
 
         assertSame(ExprValueType.BAG, value.type)
         assertEquals(expectedValues, value.ionValue)
-        try {
-            value.iterator()
-            fail("Expected single pass sequence")
-        } catch (e: IllegalStateException) {}
     }
 
     private fun read(text: String,


### PR DESCRIPTION
*This PR aims to resolve the issue on CLI reading CSV files reported in Issue #366*

### Problem Description
Originally, we were implementing the CSV file reader for CLI by ourselves. Our implementation does not follow the standard CSV format as defined in [rfc4180](https://datatracker.ietf.org/doc/html/rfc4180), and it casues the following problems: 
1. Cannot recognize the double quotes escape. As a result, the comma in between double quotes escape are considered as a delimiter in a line. 
2. Cannot ignore the the empty lines. 
3. Each row can have different numbers of fields. 

### Solution Description 
This PR migrates from the self-implemented CSV reader to a standard [Apache CSVParser library](https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/CSVParser.html). Thus, all the above problems except the last one are solved. Also, adopting this library can make it easier to realize more functionalities for CLI file reader, such as supporting reading files in other formats. 

### Changes Details
1. In 'DelimitedValues.kt', changed the file reader so now it uses the Apache `CSVParser` library to pares the CSV file. 
2. In 'DelimitedValues.kt', slightly changed the file writer so now it uses the Apache `CSVPrinter` library to help print the CSV file. 
3. Added test cases for all the problems solved. 
4. Changed the type of the variable `delimiter` from `String` into `Char`, since the `CSVParser` library only accepts the delimiter as `Char`. 

*For reviewers:*
First review 'DelimitedValues.kt', then 'DelimitedValuesTest.kt'. Other changes are minor. 
It might take up to 1.5 hours to review all the changes.  