### PR TITLE
Inital definition of PartiQL's relational algebra and converstion from the AST

### DIFF
--- a/docs/dev/RELATIONAL-ALGEBRA.md
+++ b/docs/dev/RELATIONAL-ALGEBRA.md
@@ -1,0 +1,445 @@
+# PartiQL’s Relational Algebra
+
+This document is a work-in-progress document that describes the PartiQL’s equivalent of the relational algebra that will
+be used by all implementations of PartiQL owned by the PartiQL team. This document is early in its life, and currently
+only lays out some basic details of the relational algebra and 4 preliminary operators.
+
+## Notation
+
+We will use a Ion text syntax with two extensions:
+
+* `<< >>` will be used to denote a bag.
+* `<{ variable_1: value_1, variable_2: value_2, variable_n: value_n, ... }>` will be used to denote a *bindings tuple*,
+  described later in this document.
+
+We will also wrap binding tuples in Ion’s bag or list notation, i..e  `<< <{ ... }>, ... >>`, `[ <{ ... }>, ... ]`, to
+denote a bag or list of binding tuples, respectively.
+
+## What is a Bindings Collection?
+
+_PartiQL considers a bindings collection to_ _be a_ _bag or list of_ *_binding tuples_ and a binding tuple is
+a map of variable names and their values. Bindings collections take the place of 
+[relations](https://en.wikipedia.org/wiki/Relation_(database)), which are employed heavily by traditional RDBMs. The
+departure is needed to account for schema-less and schema-optional scenarios, where assumptions cannot be made about the
+presence of certain fields.
+
+It is important to know that binding tuples are *distinct* from values. It is not possible to directly substitute a
+binding tuple for a value or vice-versa, although facilities to convert between them are provided (see 
+[Operator: scan](#operator-scan) and [Operator: map_values](#operator-map_values)).
+
+The distinction between binding tuples and values is needed because it simplifies rewriting the algebra by reducing
+total number of operators that are applicable within a given context, and constrains the possible inputs and outputs of
+those operators.
+
+## What is a Relational Algebra?
+
+The definition used by PartiQL is: a well-defined set of operators (i.e. functions) that manipulate bindings
+collections. Such functions can include: projection, selection (filtering), Cartesian products, joins, and more. The
+algebra defined here is based on [Codd’s relational algebra](https://en.wikipedia.org/wiki/Relational_algebra).
+
+## Requirements for PartiQL’s Relational Algebra
+
+A relational algebra must:
+
+* Be able to express any PartiQL query.
+* Be easily rewritten to effect query optimization and planning.
+
+## Logical vs Physical Operators
+
+This document does not (yet) attempt to define any physical operators to perform operations such
+as [full table scans, range scans, indexed range scans](https://code.amazon.com/packages/PenningPlaygroundJavaKotlin/blobs/c238aed25a72372315ef70c24bc2706ef470bfc6/--/schemas/penning.ion#L475-L489)
+, etc. However, it is worthwhile to describe some properties of physical operators, given their similarities to logical
+operators.
+
+Like logical operators, physical operators will always return bindings collections. Unlike logical operators, physical
+operators may:
+
+* Access a storage layer or other data source.
+* Be semantically redundant with logical or other physical operators while specifying different implementation
+  strategies, allowing the best one to be selected for a given scenario.
+* Combine multiple logical operations for the purpose of enhanced performance.
+
+## Algebra Overview
+
+The following operators are defined:
+
+* [Operator: scan](#operator-scan): converts a PartiQL value to a binding collection.
+* [Operator: cross_join](#operator-cross_join): computes a Cartesian product of two bindings collections.
+* [Operator: filter](#operator-filter): selects the subset of rows of an input binding collection that satisfies a
+certain condition.
+* [Operator: map_values](#operator-map_values): converts a binding collection into a value collection.
+
+**This document does not yet define all the operators that we will need.**
+
+See [Appendix - Other Operators To Be Defined During Steel Threading](#appendix---other-operators-to-be-defined-during-steel-threading) 
+for a preliminary list.
+
+### Relational Algebra Grammar
+
+```
+// Nodes that work on bindings collections.
+bindings_expr ::=
+      (scan <value_expr> <as_alias> <at_alias> | null <by_alias> | null)
+    | (cross_join <bindings_expr> <bindings_expr>))
+    | (filter <value_expr> <bindings_expr>)
+    | ... future operators go here ...
+
+// Nodes that work on values.
+value_expr ::=
+      ... arithmetic, function calls, `when` expressions, etc go here ...
+      ... see note ...
+    | (map_values <value_expr> <bindings_expr>)    
+```
+
+Note: a detailed discussion of `value_expr` is beyond the scope of this document, but some explanation is
+required:  `value_expr` will contain constructs to represent all PartiQL expressions that appear in the PartiQL AST
+today. The key difference is that there will be no SFW queries (i.e. no `(select ...)` node) in the `value_expr` as the
+query semantics of that are now represented by the far easier to rewrite  `bindings_expr`.
+
+## Schema Used With Examples Below
+
+The examples used below assume a database created with this script exists:
+
+```
+CREATE TABLE Foo
+(
+    FooId INT NOT NULL PRIMARY KEY,
+    FooName VARCHAR(50)
+);
+
+INSERT INTO Foo VALUES(100, 'Foo #1');
+INSERT INTO Foo VALUES(200, 'Foo #2');
+
+CREATE TABLE Bar
+(
+    BarId INT NOT NULL PRIMARY KEY,
+    BarName VARCHAR(50)
+);
+
+INSERT INTO Bar VALUES(300, 'Bar #1');
+INSERT INTO Bar VALUES(400, 'Bar #2');
+```
+
+## Bridges Between Bindings Collections and Values
+
+### Operator: `scan`
+
+```
+bindings_expr ::=
+      ... 
+    | (scan <value_expr> <as_alias> <at_alias> | null <by_alias> | null)
+```
+
+Evaluates a `value_expr` and converts the result to a bindings collection. The returned collection’s type (bag or
+struct) is bag if the expression returned a bag or struct of values. The result is a bindings list if the expression
+returned a list of values. If the expression returns a value of any other type, a binding list containing a single
+binding tuple will be returned.
+
+#### `scan` Elements
+
+* `<value_expr>`: The expression to be evaluated.
+* `<as_alias>`: Every value in the collection is bound to this name in each binding tuple in the returned bindings
+  collection.
+* `<at_alias>`: If specified, the integer index or symbol name of the current value in the containing is bound to this
+  name. This applies to values contained within lists, but not values in bags. If this is specified and `<value_expr>`
+  returns a bag, the name is bound to `MISSING`.
+* `<by_alias>`: If specified, the current unique record identifier is bound to this name. The type of the unique record
+  identifier is implementation defined and supplied. It is typically a UUID or similar value that is assigned by the
+  storage layer to the record on insertion. If this is specified and the implementation has not supplied a unique record
+  identifier, the name will be bound to `MISSING`.
+
+#### Example #1 - Conversion of a values bag into a bindings bag
+
+```
+// Equivalent to: FROM Foo AS f AT idx BY uid
+(scan (id Foo) f idx uid)
+```
+
+Results in the following bindings bag:
+
+```
+<<
+  <{ f: { FooId: 100, FooName: 'Foo #1' }, idx: MISSING, uid: 'c7559f84-3768' }>,
+  <{ f: { FooId: 200, FooName: 'Foo #2' }, idx: MISSING, uid: 'd2bdb79e-4432' }>,
+>>
+```
+
+Note that `idx` is bound to `MISSING` in this case because `(id Foo)` returns a bag, which does not have a notion of an
+index. However, `uid` is bound to a unique id assigned by the storage layer for the given record.
+
+#### Example #2 - Conversion of a values list into a bindings list
+
+```
+// Equivalent to: 
+// FROM `[{x: 1}, {x: 2}]` AS f AT idx BY uid
+(scan (lit [{x: 1}, {x: 2}]) f idx uid) 
+```
+
+The returned bindings collection is below.
+
+```
+[
+    <{ f: { x: 1 }, idx: 0, uid: MISSING }>,
+    <{ f: { x: 2 }, idx: 1, uid: MISSING }>
+]
+```
+
+Note that `idx` is bound to the index of the current value, and that `uid` is bound to `MISSING` because the values in
+the list returned by `<value_expr>` do not have unique record identifiers.
+
+#### Example #3 - Conversion of a scalar into a bindings list
+
+```
+// Equivalent to: SELECT * FROM 42 AS f AT idx BY uid
+(scan (lit 42) f idx uid)
+```
+
+The returned bindings bag is below.
+
+```
+<<
+    <{ f: 42, idx: MISSING, uid: MISSING }>
+>>
+```
+
+Note that the scalar has been coerced to a singleton bag before being converted into a bindings collection. Also note
+that, as demonstrated here, the value bound to `f` need not be a struct--it can be any value.
+
+TODO: add example showing `scan` with null `AT` and `BY` variables.
+
+### Operator: `map_values`
+
+```
+value_expr ::=
+       ...
+    | (map_values <value_expr> <bindings_expr>)  
+```
+
+`map_values` performs a map operation over the `bindings_expr`, invoking `value_expr` within the context of each binding
+tuple in succession. The type of bindings collection returned by `map_values` (list or bag) is the same as the
+collection returned from `bindings_expr`.
+
+#### Example #1 - `SELECT VALUE`
+
+The query:
+
+```
+SELECT VALUE f.FooId
+FROM Foo AS f
+```
+
+Is represented with the following logical algebra:
+
+```
+(map_values
+    (path (id f) (lit FooId))
+    (scan (id Foo) f null null))
+```
+
+And returns:
+
+```
+<< 100, 200 >>
+```
+
+#### Example #2 - `SELECT` (SQL-92)
+
+The query:
+
+```
+SELECT
+    f.FooId AS fid
+    f.FooName AS fname
+FROM Foo AS f
+```
+
+Is represented with the following logical algebra:
+
+```
+(map_values
+    (struct
+        (expr_pair (lit fid) (path (id f) (lit FooId)))
+        (expr_pair (lit fname) (path (id f) (lit FooName))))
+    (scan (id Foo) f null null))
+```
+
+And returns:
+
+```
+<< 
+    { fid: 100, fname: "Foo #1" },
+    { fid: 200, fname: "Foo #2" }
+>>
+```
+
+#### Example #3: `SELECT *` - single from source
+
+The query:
+
+```
+SELECT * FROM Foo AS f
+```
+
+Is represented with the following logical algebra:
+
+```
+(map_values
+    (id f)
+   (scan (id Foo) f null null))
+```
+
+The output is the entire `Foo` table contents shown earlier in the document and is omitted for brevity.
+
+#### Example #4: `SELECT *` - multiple from sources
+
+To accomplish this, a `struct_concat` function is required that merges two struct values, i.e.:
+
+```
+struct_concat({'a': 1}, {'a': 2, b: 3}) → {'a': 1, 'a': 2, b: 3 }
+```
+
+With that defined we can represent the query:
+
+```
+SELECT * FROM Foo AS f, Bar AS b
+```
+
+With the following relational algebra:
+
+```
+(map_values
+    (call struct_concat (id f) (id b))
+    (cross_join 
+       (scan (id Foo) f null null)
+       (scan (id Bar) b null null)))
+```
+
+The output is the Cartesian product of the `Foo` and `Bar` tables defined earlier in the document and is omitted for
+brevity.
+
+## Operators That Accept and Return Bindings Collections
+
+### Operator: `cross_join`
+
+```
+bindings_expr ::=
+       ... 
+    | (cross_join <bindings_expr> <bindings_expr>))
+```
+
+Computes the Cartesian product of both binding expressions, returning a single bindings tuple for every pairwise
+combination. In pseudo-code:
+
+```
+for l in bindings_expr_1
+    for r in bindings_expr_2
+        output the concatenation of binding tuples l and r
+    next
+next
+```
+
+Since binding tuples must not contain duplicate names, a compile-time exception is raised if `l` or `r` contain the same
+binding name.
+
+```
+// Equivalent to: FROM Foo AS f, Bar AS b
+(cross_join
+    (scan (id Foo) f)
+    (scan (id Bar) b)
+)
+```
+
+The resulting bindings collection is the Cartesian product:
+
+```
+<<
+    <{ 
+        f: { FooId: 100, FooName: 'Foo #1' }, 
+        b: { BarId: 300, BarName: 'Bar #1' } 
+    }>,
+    <{ 
+        f: { FooId: 100, FooName: 'Foo #1' }, 
+        b: { BarId: 400, BarName: 'Bar #2' } 
+    }>,
+    <{ 
+        f: { FooId: 200, FooName: 'Foo #2' }, 
+        b: { BarId: 300, BarName: 'Bar #1' } 
+    }>,
+    <{
+        f: { FooId: 200, FooName: 'Foo #2' }, 
+        b: { BarId: 400, BarName: 'Bar #2' } 
+    }>
+>>
+```
+
+### Operator: `filter`
+
+```
+bindings_expr ::=
+      ...
+    | (filter <value_expr> <bindings_expr>)
+```
+
+Inputs a bindings collection returned from `<bindings_expr>` and outputs a bindings collection containing only those
+binding tuples that satisfy `<value_expr>`. If `<value_expr>` returns a value that is not a boolean value: in strict mode
+a runtime exception occurs, in permissive mode, the value is coerced into `MISSING`, which is then considered the same
+as if it had evaluated to `false`.  The output is a bindings bag if `<bindings_expr>` returns a bag, a bindings list if 
+`<bindings_expr>` returns a list.
+
+#### Example - Filtering `Foo`
+
+```
+// Equivalent to: FROM Foo AS f WHERE f.FooId = 200
+(filter
+    (eq (path (id f) (lit FooId) (lit 200)))
+    (scan (id Foo) f null null))
+```
+
+First, `(scan (id Foo) f null null)` bindings expression returns the following bindings bag:
+
+```
+<<
+    <{ f: { FooId: 100, FooName: 'Foo #1' } }>,
+    <{ f: { FooId: 200, FooName: 'Foo #2' }}>
+>>
+```
+
+Then, the bindings bag is iterated over. The `condition` expression is evaluated within the context of each bindings
+tuple, and only those bindings tuples causing `condition` to return true are included:
+
+```
+<<
+    <{ f: { FooId: 200, FooName: 'Foo #2' }}>
+>>
+```
+
+## Appendix - Other Operators To Be Defined During Steel Threading
+
+We are punting for now on defining the following operators:
+
+* Something for: `pivot`
+* Something for: `unpivot`
+* `map_let`: like `map_values`, but returns a bindings collection instead of values.
+* `limit`: truncates a bindings collection after `n` rows.
+* `offset`: skips `n` rows of a bindings collection.
+* `join`: performs a theta join
+* other join types: left, right, outer, full
+* `group_by`: grouping & aggregation
+* `order_by`: sorting
+* All the physical operators.
+
+## Appendix - Further Reading
+
+An introduction to the relational theory is beyond the scope of this document. The author of this document has found the
+following books to be helpful to introduce the concepts here.
+
+* [Database Systems: The Complete Book](https://www.amazon.com/Database-Systems-Complete-Book-2nd/dp/0131873253), Hector
+  Molina-Garcia, et al, chapters 2, 5, 15 and 16.
+* [Relational Theory for Computer Professionals](https://www.amazon.com/Relational-Theory-Computer-Professionals-Databases/dp/144936943X)
+  , C.J. Date, chapters 2, 5, 7, 11, 12, 14 and appendix D.
+
+Also see:
+
+* The original [IonSQL++ paper](https://arxiv.org/pdf/1405.3631.pdf) by Kian Win Ong, Yannis Papakonstantinou, and
+  Romain Vernoux.
+

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -1,3 +1,8 @@
+
+// This line cause PIG to emit the PartiqlAstToPartiqlAlgebraVisitorTransform base class with abstract methods which
+// is (currently) the easiest way to transform from the AST to the algebra.
+(transform partiql_ast partiql_algebra)
+
 /*
     The PartiQL AST.
 
@@ -378,4 +383,100 @@
     ) // end of domain
 ) // end of define
 
+
+(define partiql_algebra
+    (permute_domain partiql_ast
+
+        (with expr
+            // Remove the select node from the `expr` sum type.
+            (exclude select)
+
+            (include
+                // Invokes `exp` once in the context of every binding tuple returned by `query`, returning a
+                // collection of values produced by `query`.  The returned collection's type (bag or list) is the same
+                // as the bindings collection returned by `query`.
+                (map_values exp::expr query::bindings_term))
+        )
+
+        // These should be excluded as well since they were referenced only by the `select` variant of `expr`, which
+        // was excluded above.
+        (exclude
+            projection
+            project_item
+            from_source
+        )
+
+        // Now we include new stuff that's unique to PartiQL's relational algebra.
+        (include
+            // `bindings_term` A node that initially contains only a `bindings_expr` but can be permuted in subsequent
+            // domains to // include additional information about the contained bindings_expr, i.e. the data type
+            // (schema) of the input and outputs required by the `bindings_expr`.  The purpose this serves is similar
+            // to that of "meta"s, but this is better because it's strongly typed and can be part of cross-domain
+            // visitor transforms.
+            (product bindings_term exp::bindings_expr)
+
+            // The operators of PartiQL's relational algebra. See `$projectDir/docs/dev/RELATIONAL-ALGEBRA.md` for the
+            // documentation of each node. (Note that we do not permute and reuse `from_source` here because:
+            // 1. it has the wrong name and 2. every variant is slightly different, meaning it would be completely
+            // redefined anyway.  In the future, we might consider renaming `from_source` to `bindings_expr` so that it
+            // can be permuted here more easily, but this comes with breaking API changes and other issues that are
+            // beyond the scope of our current goals.)
+            (sum bindings_expr
+                (scan expr::expr as_alias::var_decl at_alias::(? var_decl) by_alias::(? var_decl))
+                (cross_join left::bindings_term right::bindings_term)
+                (filter predicate::expr term::bindings_term)
+
+                // TODO: numerous other relational operators added to be incrementally via steel thread approach.
+            )
+
+            // Every instance of var_decl introduces a new binding in the current scope.
+            // Modeling variable declarations this way all of the places bindings are introduced to be be permuted in
+            // subsequent domains at the same time.   This allows DeBruijn indexes to be added to all nodes that
+            // declare bindings easily.  Later permuted domains will add an index to this node.
+            (product var_decl name::symbol)
+        )
+
+        // Nodes excluded below this line will eventually have a representation in the logical algebra, but not
+        // initially.  We will incrementally remove the exclusions in a steel thread fashion in subsequent PRs.
+
+        (with statement
+            (exclude
+                dml
+                ddl
+                exec
+            )
+        )
+
+        (exclude
+            group_by
+            grouping_strategy
+            group_key
+            group_key_list
+            order_by
+            sort_spec
+            ordering_spec
+
+            dml_op
+            dml_op_list
+            ddl_op
+            conflict_action
+            on_conflict
+            returning_expr
+            returning_elem
+            column_component
+            returning_mapping
+            assignment
+            identifier
+        )
+
+    )
+)
+
+// TODO??
+//
+//(define piql
+//    (permute_domain logical_algebra
+//        ???
+//    )
+//)
 

--- a/lang/src/org/partiql/lang/domains/PartiqlAlgebraUtils.kt
+++ b/lang/src/org/partiql/lang/domains/PartiqlAlgebraUtils.kt
@@ -1,0 +1,6 @@
+package org.partiql.lang.domains
+
+import com.amazon.ionelement.api.ionSymbol
+
+fun PartiqlAlgebra.Builder.id(name: String) =
+    id(name, caseInsensitive(), unqualified())

--- a/lang/src/org/partiql/lang/domains/util.kt
+++ b/lang/src/org/partiql/lang/domains/util.kt
@@ -12,7 +12,6 @@ import org.partiql.lang.eval.BindingCase
 fun PartiqlAst.Builder.id(name: String) =
     id(name, caseInsensitive(), unqualified())
 
-
 /**
  * Returns a [MetaContainer] with *only* the source location of the receiver [MetaContainer], if present.
  *

--- a/lang/src/org/partiql/lang/planner/AstToAlgebra.kt
+++ b/lang/src/org/partiql/lang/planner/AstToAlgebra.kt
@@ -1,0 +1,139 @@
+package org.partiql.lang.planner
+
+import com.amazon.ionelement.api.ionSymbol
+import org.partiql.lang.domains.PartiqlAlgebra
+import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.PartiqlAstToPartiqlAlgebraVisitorTransform
+
+fun astToAlgebra(ast: PartiqlAst.Statement): PartiqlAlgebra.Statement =
+    AstToAlgebra.transformStatement(ast)
+
+/*
+Notes:
+
+- May still need to think about which metas we are going to propagate from the original AST here, i.e. it may be
+required to include *only* the source location meta but elide all others.  For now we are just copying all the metas
+from the original AST nodes.
+- Also related to metas, it would be especially great if https://github.com/partiql/partiql-ir-generator/issues/69 were
+completed to avoid bugs where we inadvertently drop metas.
+ */
+
+
+private fun errAstNotNormalized(message: String): Nothing =
+    error("$message - have the basic visitor transforms been executed first?")
+
+private object AstToAlgebra : PartiqlAstToPartiqlAlgebraVisitorTransform() {
+    override fun transformExprSelect(node: PartiqlAst.Expr.Select): PartiqlAlgebra.Expr {
+        checkForUnsupportedSelectClauses(node)
+
+        var algebra = FromSourceToBindingsExpr.convert(node.from)
+
+        algebra = node.where?.let {
+            PartiqlAlgebra.build {
+                bindingsTerm(filter(transformExpr(it), algebra, it.metas), it.metas)
+            }
+        } ?: algebra
+
+
+        return convertProjectionToMapValues(node, algebra)
+    }
+
+    private fun convertProjectionToMapValues(
+        node: PartiqlAst.Expr.Select,
+        algebra: PartiqlAlgebra.BindingsTerm
+    ) = PartiqlAlgebra.build {
+        // TODO: support SELECT x.*, y.*, etc.  For now we only support SELECT VALUE and SELECT <expr> AS <alias>,...
+        // note that have AST rewrite already which converts:
+        //    SELECT * FROM foo AS f, bar as B to
+        //    SELECT f.*, b.* FROM foo AS f, bar as B to
+        // So, supporting SELECT * here is not necessary.
+
+        mapValues(
+            when (val project = node.project) {
+                is PartiqlAst.Projection.ProjectValue -> transformExpr(project.value)
+                is PartiqlAst.Projection.ProjectList -> {
+                    val structFields = project.projectItems.map {
+                        when (it) {
+                            is PartiqlAst.ProjectItem.ProjectAll -> TODO("Support SELECT <alias>.*")
+                            is PartiqlAst.ProjectItem.ProjectExpr -> {
+                                val asAliasText = it.asAlias ?: errAstNotNormalized("projectItem.asAlias is null")
+                                exprPair(
+                                    lit(ionSymbol(asAliasText.text), it.metas),
+                                    transformExpr(it.expr),
+                                    it.metas
+                                )
+                            }
+                        }
+                    }
+
+                    struct(structFields)
+                }
+                is PartiqlAst.Projection.ProjectStar -> errAstNotNormalized("Expected SELECT * to be removed")
+                is PartiqlAst.Projection.ProjectPivot -> TODO("PIVOT ...")
+            },
+            algebra
+        )
+    }
+
+    /**
+     * Throws [NotImplementedError] if any `SELECT` clauses were used that are not mappable to [PartiqlAlgebra].
+     *
+     * This function is temporary and will be removed when all the clauses of the `SELECT` expression are mappable
+     * to [PartiqlAlgebra].
+     */
+    private fun checkForUnsupportedSelectClauses(node: PartiqlAst.Expr.Select) {
+        when {
+            node.fromLet != null -> TODO("support FROM LET")
+            node.group != null -> TODO("Support GROUP BY")
+            node.order != null -> TODO("Support ORDER BY")
+            node.having != null -> TODO("Support HAVING")
+            node.limit != null -> TODO("Support LIMIT")
+        }
+
+        when (node.setq) {
+            null, is PartiqlAst.SetQuantifier.All -> {
+                /* do nothing, this is supported (if null, default is SetQuantifier.All) */
+            }
+            is PartiqlAst.SetQuantifier.Distinct -> TODO("Support SELECT DISTINCT")
+        }
+    }
+
+
+    override fun transformStatementDml(node: PartiqlAst.Statement.Dml): PartiqlAlgebra.Statement {
+        TODO("support DML in algebra")
+    }
+
+    override fun transformStatementDdl(node: PartiqlAst.Statement.Ddl): PartiqlAlgebra.Statement {
+        TODO("support DDL in algebra")
+    }
+
+    override fun transformStatementExec(node: PartiqlAst.Statement.Exec): PartiqlAlgebra.Statement {
+        TODO("support stored procedure calls in algebra")
+    }
+}
+
+private object FromSourceToBindingsExpr : PartiqlAst.FromSource.Converter<PartiqlAlgebra.BindingsTerm> {
+
+    override fun convertScan(node: PartiqlAst.FromSource.Scan): PartiqlAlgebra.BindingsTerm =
+        PartiqlAlgebra.build {
+            bindingsTerm(
+                scan(
+                    AstToAlgebra.transformExpr(node.expr),
+                    varDecl_(node.asAlias ?: errAstNotNormalized("node.asAlias is null")),
+                    node.atAlias?.let { varDecl_(it) },
+                    node.byAlias?.let { varDecl_(it) },
+                    node.metas
+                ),
+                node.metas
+            )
+        }
+
+    override fun convertUnpivot(node: PartiqlAst.FromSource.Unpivot): PartiqlAlgebra.BindingsTerm {
+        TODO("support unpivot in algebra")
+    }
+
+    override fun convertJoin(node: PartiqlAst.FromSource.Join): PartiqlAlgebra.BindingsTerm {
+        TODO("support join in algebra")
+    }
+
+}

--- a/lang/test/org/partiql/lang/planner/AstToAlgebraTests.kt
+++ b/lang/test/org/partiql/lang/planner/AstToAlgebraTests.kt
@@ -1,0 +1,109 @@
+package org.partiql.lang.planner
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.ionString
+import com.amazon.ionelement.api.ionSymbol
+import junit.framework.Assert.assertEquals
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.partiql.lang.domains.PartiqlAlgebra
+import org.partiql.lang.domains.id
+import org.partiql.lang.syntax.SqlParser
+import org.partiql.lang.util.ArgumentsProviderBase
+
+
+class AstToAlgebraTests {
+
+    private fun parseToAlgebra(sql: String): PartiqlAlgebra.Statement {
+        val ion = IonSystemBuilder.standard().build()
+        val parser = SqlParser(ion)
+
+        // For now we will elide `basicVisitorTransforms`, but may need to include them later if we find having to
+        // specify normalized SQL in our test cases to be too onerous for some reason.
+
+        return astToAlgebra(parser.parseAstStatement(sql))
+    }
+
+    data class TestCase(val sql: String, val expectedAlgebra: PartiqlAlgebra.Statement)
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgumentsForAstToAlgebraTests::class)
+    fun testAstToLogicalAlgebra(tc: TestCase) {
+        val algebra = assertDoesNotThrow("Parsing TestCase.sql should not throw") {
+            parseToAlgebra(tc.sql)
+        }
+        assertEquals(tc.expectedAlgebra, algebra)
+    }
+
+    class ArgumentsForAstToAlgebraTests : ArgumentsProviderBase() {
+        // Note that: test cases for SELECT * are not needed since we already have an AST transform which converts
+        // it to SELECT f.*, b.*, etc.
+
+        override fun getParameters() = listOf(
+            // Basic SELECT VALUE with all three bindings specified
+            TestCase(
+                "SELECT VALUE foo FROM bar AS b AT c BY d",
+                PartiqlAlgebra.build {
+                    query(
+                        mapValues(
+                            id("foo"),
+                            bindingsTerm(scan(id("bar"), varDecl("b"), varDecl("c"), varDecl("d")))
+                        )
+                    )
+                }
+            ),
+            // Basic SELECT VALUE with PATH expression and WHERE clause
+            TestCase(
+                "SELECT VALUE x.y FROM z AS x WHERE x.y = 42",
+                PartiqlAlgebra.build {
+                    query(
+                        mapValues(
+                            path(id("x"), pathExpr(lit(ionString("y")), caseInsensitive())),
+                            bindingsTerm(
+                                filter(
+                                    eq(
+                                        path(id("x"), pathExpr(lit(ionString("y")), caseInsensitive())),
+                                        lit(ionInt(42))
+                                    ),
+                                    bindingsTerm(scan(id("z"), varDecl("x"), null, null))
+                                )
+                            )
+                        )
+                    )
+                }
+            ),
+            // Basic SELECT LIST with single item
+            TestCase(
+                "SELECT f.bar AS b FROM foo AS f",
+                PartiqlAlgebra.build {
+                    query(
+                        mapValues(
+                            struct(
+                                exprPair(lit(ionSymbol("b")), path(id("f"), pathExpr(lit(ionString("bar")), caseInsensitive())))
+                            ),
+                            bindingsTerm(scan(id("foo"), varDecl("f"), null, null))
+                        )
+                    )
+                }
+            ),
+            // Basic SELECT LIST with multiple items
+            TestCase(
+                "SELECT f.bar AS b, f.bat AS t, f.baz AS z FROM foo AS f",
+                PartiqlAlgebra.build {
+                    query(
+                        mapValues(
+                            struct(
+                                exprPair(lit(ionSymbol("b")), path(id("f"), pathExpr(lit(ionString("bar")), caseInsensitive()))),
+                                exprPair(lit(ionSymbol("t")), path(id("f"), pathExpr(lit(ionString("bat")), caseInsensitive()))),
+                                exprPair(lit(ionSymbol("z")), path(id("f"), pathExpr(lit(ionString("baz")), caseInsensitive())))
+                            ),
+                            bindingsTerm(scan(id("foo"), varDecl("f"), null, null))
+                        )
+                    )
+                }
+            )
+        )
+    }
+}


### PR DESCRIPTION
This is the absolute beginning of PartiQL's experimental relational algebra which will be used to optimize PartiQL queries.  It's very early in its design so far.  For instance, many more operators other than the 4 defined so far are needed.  These will be defined later, incrementally.

This PR will merge to the `query-planner` branch where we will be also be building an experimental planner. 

- `docs/dev/RELATIONAL-ALGEBRA.md`  is intended to be the long term home for the documentation of the relational algebra.  Start there for details.
- `partiql.ion` includes a permuted PIG domain for the algebra. 
- Also included is a `astToAlgebra` function which performs conversion from the AST to the relational algebra.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
