### PR TITLE
Fixed the bug on CLI command with input argument

### DIFF
--- a/cli/src/org/partiql/cli/Cli.kt
+++ b/cli/src/org/partiql/cli/Cli.kt
@@ -42,7 +42,8 @@ internal class Cli(private val valueFactory: ExprValueFactory,
             val inputIonValue = valueFactory.ion.iterate(reader).asSequence().map { valueFactory.newFromIonValue(it) }
             val inputExprValue = valueFactory.newBag(inputIonValue)
             val bindings = Bindings.buildLazyBindings<ExprValue> {
-                addBinding("input_data") { inputExprValue }
+                // If `input` is a class of `EmptyInputStream`, it means there is no input data provided by user.
+                if (input !is EmptyInputStream){ addBinding("input_data") { inputExprValue } }
             }.delegate(globals)
 
             val result = compilerPipeline.compile(query).eval(EvaluationSession.build { globals(bindings) })

--- a/cli/src/org/partiql/cli/main.kt
+++ b/cli/src/org/partiql/cli/main.kt
@@ -18,7 +18,8 @@ package org.partiql.cli
 
 import com.amazon.ion.system.*
 import joptsimple.*
-import org.partiql.cli.functions.*
+import org.partiql.cli.functions.ReadFile
+import org.partiql.cli.functions.WriteFile
 import org.partiql.lang.*
 import org.partiql.lang.eval.*
 import org.partiql.lang.syntax.*
@@ -160,7 +161,7 @@ private fun runCli(environment: Bindings<ExprValue>, optionSet: OptionSet) {
         FileInputStream(optionSet.valueOf(inputFileOpt))
     }
     else {
-        emptyInputStream()
+        EmptyInputStream()
     }
 
     val output = if (optionSet.has(outputFileOpt)) {

--- a/cli/src/org/partiql/cli/main.kt
+++ b/cli/src/org/partiql/cli/main.kt
@@ -17,11 +17,11 @@
 package org.partiql.cli
 
 import com.amazon.ion.system.*
+import joptsimple.*
+import org.partiql.cli.functions.*
+import org.partiql.lang.*
 import org.partiql.lang.eval.*
 import org.partiql.lang.syntax.*
-import org.partiql.cli.functions.*
-import joptsimple.*
-import org.partiql.lang.*
 import java.io.*
 import kotlin.system.exitProcess
 
@@ -160,7 +160,7 @@ private fun runCli(environment: Bindings<ExprValue>, optionSet: OptionSet) {
         FileInputStream(optionSet.valueOf(inputFileOpt))
     }
     else {
-        UnclosableInputStream(System.`in`)
+        emptyInputStream()
     }
 
     val output = if (optionSet.has(outputFileOpt)) {

--- a/cli/src/org/partiql/cli/streams.kt
+++ b/cli/src/org/partiql/cli/streams.kt
@@ -27,11 +27,9 @@ internal class UnclosableOutputStream(out: OutputStream) : FilterOutputStream(ou
 }
 
 /**
- * Input stream that does nothing instead of closing, useful for decorating input streams that should not be closed but you
- * still want to use them in a use block.
+ * An empty InputStream, useful when users do not explicitly specify the input data while using CLI command.
  */
-internal class UnclosableInputStream(input: InputStream) : FilterInputStream(input) {
-    override fun close() {
-        // no-op
+internal fun emptyInputStream() =
+    object : InputStream() {
+        override fun read() = -1 // end of stream
     }
-}

--- a/cli/src/org/partiql/cli/streams.kt
+++ b/cli/src/org/partiql/cli/streams.kt
@@ -29,7 +29,6 @@ internal class UnclosableOutputStream(out: OutputStream) : FilterOutputStream(ou
 /**
  * An empty InputStream, useful when users do not explicitly specify the input data while using CLI command.
  */
-internal fun emptyInputStream() =
-    object : InputStream() {
-        override fun read() = -1 // end of stream
-    }
+internal class EmptyInputStream() : InputStream() {
+    override fun read() = -1 // end of stream
+}

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -38,7 +38,7 @@ class CliTest {
                         outputFormat: OutputFormat = OutputFormat.ION_TEXT) =
         Cli(
             valueFactory,
-            input?.byteInputStream(Charsets.UTF_8) ?: emptyInputStream(),
+            input?.byteInputStream(Charsets.UTF_8) ?: EmptyInputStream(),
             output,
             outputFormat,
             compilerPipeline,
@@ -132,9 +132,14 @@ class CliTest {
 
     @Test
     fun withoutInput() {
-        val subject = makeCli("SELECT * FROM input_data")
+        val subject = makeCli("1")
         val actual = subject.runAndOutput()
 
-        assertEquals("\n", actual)
+        assertEquals("1\n", actual)
+    }
+
+    @Test(expected = EvaluationException::class)
+    fun withoutInputWithInputDataBindingThrowsException() {
+        makeCli("SELECT * FROM input_data").runAndOutput()
     }
 }

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -33,11 +33,12 @@ class CliTest {
     }
 
     private fun makeCli(query: String,
-                        input: String, bindings: Bindings<ExprValue> = Bindings.empty(),
+                        input: String? = null,
+                        bindings: Bindings<ExprValue> = Bindings.empty(),
                         outputFormat: OutputFormat = OutputFormat.ION_TEXT) =
         Cli(
             valueFactory,
-            input.byteInputStream(Charsets.UTF_8),
+            input?.byteInputStream(Charsets.UTF_8) ?: emptyInputStream(),
             output,
             outputFormat,
             compilerPipeline,
@@ -127,5 +128,13 @@ class CliTest {
         val actual = subject.runAndOutput()
 
         assertEquals("{a:1}\n{b:1}\n", actual)
+    }
+
+    @Test
+    fun withoutInput() {
+        val subject = makeCli("SELECT * FROM input_data")
+        val actual = subject.runAndOutput()
+
+        assertEquals("\n", actual)
     }
 }

--- a/docs/user/CLI.md
+++ b/docs/user/CLI.md
@@ -22,7 +22,7 @@ Option                                Description
 ------                                -----------
 -e, --environment <File>              initial global environment (optional)
 -h, --help                            prints this help
--i, --input <File>                    input file, requires the query option (default: stdin)
+-i, --input <File>                    input file, requires the query option (optional)
 -o, --output <File>                   output file, requires the query option (default: stdout)
 --of, --output-format <OutputFormat:  output format, requires the query option (default: PARTIQL)
   (ION_TEXT|ION_BINARY|PARTIQL|PARTIQL_PRETTY)>


### PR DESCRIPTION
*Issue #475*

*Description of changes:*
1. Fixed the issue by assuming the input data is empty, if users do not explicit specify the input data argument while using CLI. 
2. Creates one test case to cover the case. 

