### PR TITLE
Fixed bug on CLI output IONTEXT to file

### DIFF
--- a/cli/src/org/partiql/cli/Cli.kt
+++ b/cli/src/org/partiql/cli/Cli.kt
@@ -48,8 +48,8 @@ internal class Cli(private val valueFactory: ExprValueFactory,
             val result = compilerPipeline.compile(query).eval(EvaluationSession.build { globals(bindings) })
 
             when (format) {
-                ION_TEXT   -> {
-                    ionTextWriterBuilder.build(output).use { printIon(it, result) }
+                ION_TEXT   -> ionTextWriterBuilder.build(output).use {
+                    printIon(it, result)
                     output.write(System.lineSeparator().toByteArray(Charsets.UTF_8))
                 }
                 ION_BINARY -> valueFactory.ion.newBinaryWriter(output).use { printIon(it, result) }

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -36,10 +36,7 @@ class CliTest {
 
     @After
     fun cleanTestFile() {
-        val testFilePath = testFile.toPath()
-        if (Files.exists(testFilePath)){
-            Files.delete(testFilePath)
-        }
+        Files.deleteIfExists(testFile.toPath())
     }
 
     private fun makeCli(query: String,

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -21,7 +21,6 @@ import org.junit.Assert.*
 import org.partiql.lang.*
 import java.io.*
 import java.nio.file.Files
-import java.nio.file.Paths
 
 class CliTest {
     private val ion = IonSystemBuilder.standard().build()
@@ -44,8 +43,7 @@ class CliTest {
     }
 
     private fun makeCli(query: String,
-                        input: String,
-                        bindings: Bindings<ExprValue> = Bindings.empty(),
+                        input: String, bindings: Bindings<ExprValue> = Bindings.empty(),
                         outputFormat: OutputFormat = OutputFormat.ION_TEXT,
                         output: OutputStream = this.output) =
         Cli(

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -20,21 +20,34 @@ import org.junit.*
 import org.junit.Assert.*
 import org.partiql.lang.*
 import java.io.*
+import java.nio.file.Files
+import java.nio.file.Paths
 
 class CliTest {
     private val ion = IonSystemBuilder.standard().build()
     private val valueFactory = ExprValueFactory.standard(ion)
     private val output = ByteArrayOutputStream()
     private val compilerPipeline = CompilerPipeline.standard(ion)
+    private val testFile = File("test.ion")
 
     @Before
     fun setUp() {
         output.reset()
     }
 
+    @After
+    fun cleanTestFile() {
+        val testFilePath = testFile.toPath()
+        if (Files.exists(testFilePath)){
+            Files.delete(testFilePath)
+        }
+    }
+
     private fun makeCli(query: String,
-                        input: String, bindings: Bindings<ExprValue> = Bindings.empty(),
-                        outputFormat: OutputFormat = OutputFormat.ION_TEXT) =
+                        input: String,
+                        bindings: Bindings<ExprValue> = Bindings.empty(),
+                        outputFormat: OutputFormat = OutputFormat.ION_TEXT,
+                        output: OutputStream = this.output) =
         Cli(
             valueFactory,
             input.byteInputStream(Charsets.UTF_8),
@@ -125,6 +138,19 @@ class CliTest {
     fun withIonTextOutput() {
         val subject = makeCli("SELECT * FROM input_data", "{a: 1} {b: 1}", outputFormat = OutputFormat.ION_TEXT)
         val actual = subject.runAndOutput()
+
+        assertEquals("{a:1}\n{b:1}\n", actual)
+    }
+
+    @Test
+    fun withIonTextOutputToFile() {
+        makeCli(
+            "SELECT * FROM input_data",
+            "{a: 1} {b: 1}",
+            output = FileOutputStream(testFile),
+            outputFormat = OutputFormat.ION_TEXT
+        ).run()
+        val actual = testFile.bufferedReader().use { it.readText() }
 
         assertEquals("{a:1}\n{b:1}\n", actual)
     }


### PR DESCRIPTION
*Issue #473*

### Problem Description
As show in https://github.com/partiql/partiql-lang-kotlin/blob/main/cli/src/org/partiql/cli/Cli.kt#L52-53, the `use` block in L52 invokes `close()` function on `output`. In case of `FileOutputStream`, it indeed closes the output stream. Thus, the `write()` function in L53 throws an exception. 

*Description of changes:*
1. Move L53 into the `use` block. 
2. Create a test case to cover file output. 

