### PR TITLE
Update maven publishing name and email

### DIFF
--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -135,8 +135,8 @@ publishing {
                 }
                 developers {
                     developer {
-                        name = "Amazon Ion Team"
-                        email = "ion-team@amazon.com"
+                        name = "PartiQL Team"
+                        email = "partiql-team@amazon.com"
                         organization = "PartiQL"
                         organizationUrl = "https://github.com/partiql"
                     }


### PR DESCRIPTION
Previous Maven publishing would include the Ion team's name and email as the developers (e.g. [v0.4.0 release on Maven](https://search.maven.org/artifact/org.partiql/partiql-lang-kotlin/0.4.0/jar)). Updates to use the PartiQL team's info.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
