### PR TITLE
Rename DatePart to DateTimePart

### DIFF
--- a/docs/user/BuiltInFunctions.md
+++ b/docs/user/BuiltInFunctions.md
@@ -288,12 +288,12 @@ COALESCE(missing, 1)       -- 1
 
 ### DATE_ADD
 
-Given a data part, a quantity and a timestamp, returns an updated timestamp by altering date part by quantity
+Given a data part, a quantity and a timestamp, returns an updated timestamp by altering datetime part by quantity
 
 Signature 
-: `DATE_ADD: DatePart Integer Timestamp -> Timestamp`
+: `DATE_ADD: DateTimePart Integer Timestamp -> Timestamp`
 
-Where `DatePart` is one of 
+Where `DateTimePart` is one of 
 
 * `year`
 * `month`
@@ -327,19 +327,19 @@ DATE_ADD(second, 1, `2017-01-02T03:04:05.006Z`) -- 2017-01-02T03:04:06.006Z
 
 ### DATE_DIFF
 
-Given a date part and two valid timestamps returns the difference in date parts.
+Given a datetime part and two valid timestamps returns the difference in datetime parts.
 
 Signature
-: `DATE_DIFF: DatePart Timestamp Timestamp -> Integer`
+: `DATE_DIFF: DateTimePart Timestamp Timestamp -> Integer`
 
-See [DATE_ADD](#date_add) for the definition of `DatePart`
+See [DATE_ADD](#date_add) for the definition of `DateTimePart`
 
 Header
 : `DATE_DIFF(dp, t1, t2)`
 
 
 Purpose
-: Given a date part `dp` and two timestamps `t1` and `t2` returns the difference in value for `dp` part of `t1` with `t2`. 
+: Given a datetime part `dp` and two timestamps `t1` and `t2` returns the difference in value for `dp` part of `t1` with `t2`. 
 The return value is a negative integer when the `dp` value of `t1` is greater than the `dp` value of `t2`, and, a positive 
 integer when the `dp` value of `t1` is less than the `dp` value of `t2`. 
 
@@ -392,12 +392,12 @@ EXISTS(missing)     -- false
 
 ### EXTRACT
 
-Given a date part and a datetime type returns then datetime's date part value. 
+Given a datetime part and a datetime type returns then datetime's datetime part value. 
 
 Signature
-: `EXTRACT: ExtractDatePart DateTime -> Integer`
+: `EXTRACT: ExtractDateTimePart DateTime -> Integer`
 
-where `ExtractDatePart` is one of 
+where `ExtractDateTimePart` is one of 
 
 * `year`
 * `month`
@@ -414,13 +414,13 @@ and `DateTime` type is one of
 * `TIME`
 * `TIMESTAMP` 
 
-*Note* that `ExtractDatePart` **differs** from `DatePart` in [DATE_ADD](#date_add). 
+*Note* that `ExtractDateTimePart` **differs** from `DateTimePart` in [DATE_ADD](#date_add). 
 
 Header
 : `EXTRACT(edp FROM t)`
 
 Purpose 
-: Given a date part, `edp`, and a datetime type `t` return `t`'s value for `edp`. 
+: Given a datetime part, `edp`, and a datetime type `t` return `t`'s value for `edp`. 
 This function allows for `t` to be unknown (`null` or `missing`) but **not** `edp`.
 If `t` is unknown the function returns `null`. 
 

--- a/lang/src/org/partiql/lang/errors/ErrorCode.kt
+++ b/lang/src/org/partiql/lang/errors/ErrorCode.kt
@@ -15,7 +15,7 @@
 package org.partiql.lang.errors
 
 import org.partiql.lang.eval.ExprValueType
-import org.partiql.lang.syntax.DATE_PART_KEYWORDS
+import org.partiql.lang.syntax.DATE_TIME_PART_KEYWORDS
 import org.partiql.lang.syntax.TokenType
 
 
@@ -155,10 +155,10 @@ enum class ErrorCode(private val category: ErrorCategory,
         LOC_TOKEN,
         "expected MEMBER node"),
 
-    PARSE_EXPECTED_DATE_PART(
+    PARSE_EXPECTED_DATE_TIME_PART(
         ErrorCategory.PARSER,
         LOC_TOKEN,
-        "expected one of: [${DATE_PART_KEYWORDS.joinToString()}]"),
+        "expected one of: [${DATE_TIME_PART_KEYWORDS.joinToString()}]"),
 
     PARSE_UNSUPPORTED_SELECT(
         ErrorCategory.PARSER,

--- a/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
@@ -100,9 +100,9 @@ fun ExprValue.stringValue(): String =
 fun ExprValue.bytesValue(): ByteArray =
     scalar.bytesValue() ?: errNoContext("Expected LOB: $ionValue", internal = false)
 
-internal fun ExprValue.datePartValue(): DatePart =
+internal fun ExprValue.datePartValue(): DateTimePart =
     try {
-        DatePart.valueOf(this.stringValue().toUpperCase())
+        DateTimePart.valueOf(this.stringValue().toUpperCase())
     }
     catch (e : IllegalArgumentException)  {
         throw EvaluationException(cause = e,

--- a/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
@@ -100,13 +100,13 @@ fun ExprValue.stringValue(): String =
 fun ExprValue.bytesValue(): ByteArray =
     scalar.bytesValue() ?: errNoContext("Expected LOB: $ionValue", internal = false)
 
-internal fun ExprValue.datePartValue(): DateTimePart =
+internal fun ExprValue.dateTimePartValue(): DateTimePart =
     try {
         DateTimePart.valueOf(this.stringValue().toUpperCase())
     }
     catch (e : IllegalArgumentException)  {
         throw EvaluationException(cause = e,
-                                  message = "invalid date part, valid values: [${DATE_PART_KEYWORDS.joinToString()}]",
+                                  message = "invalid datetime part, valid values: [${DATE_TIME_PART_KEYWORDS.joinToString()}]",
                                   internal = false)
     }
 

--- a/lang/src/org/partiql/lang/eval/builtins/DateAddExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/DateAddExprFunction.kt
@@ -18,7 +18,6 @@ import com.amazon.ion.*
 import com.amazon.ion.Timestamp.*
 import org.partiql.lang.eval.*
 import org.partiql.lang.syntax.*
-import org.partiql.lang.util.*
 
 internal class DateAddExprFunction(valueFactory: ExprValueFactory) : NullPropagatingExprFunction("date_add", 3, valueFactory) {
     companion object {
@@ -28,12 +27,12 @@ internal class DateAddExprFunction(valueFactory: ExprValueFactory) : NullPropaga
                                                        Precision.MINUTE,
                                                        Precision.SECOND)
 
-        @JvmStatic private val datePartToPrecision = mapOf(DatePart.YEAR to Precision.YEAR,
-                                                           DatePart.MONTH to Precision.MONTH,
-                                                           DatePart.DAY to Precision.DAY,
-                                                           DatePart.HOUR to Precision.MINUTE,
-                                                           DatePart.MINUTE to Precision.MINUTE,
-                                                           DatePart.SECOND to Precision.SECOND)
+        @JvmStatic private val dateTimePartToPrecision = mapOf(DateTimePart.YEAR to Precision.YEAR,
+                                                           DateTimePart.MONTH to Precision.MONTH,
+                                                           DateTimePart.DAY to Precision.DAY,
+                                                           DateTimePart.HOUR to Precision.MINUTE,
+                                                           DateTimePart.MINUTE to Precision.MINUTE,
+                                                           DateTimePart.SECOND to Precision.SECOND)
     }
 
     private fun Timestamp.hasSufficientPrecisionFor(requiredPrecision: Precision): Boolean {
@@ -43,8 +42,8 @@ internal class DateAddExprFunction(valueFactory: ExprValueFactory) : NullPropaga
         return precisionPos >= requiredPrecisionPos
     }
 
-    private fun Timestamp.adjustPrecisionTo(datePart: DatePart): Timestamp {
-        val requiredPrecision = datePartToPrecision[datePart]!!
+    private fun Timestamp.adjustPrecisionTo(dateTimePart: DateTimePart): Timestamp {
+        val requiredPrecision = dateTimePartToPrecision[dateTimePart]!!
 
         if (this.hasSufficientPrecisionFor(requiredPrecision)) {
             return this
@@ -67,7 +66,7 @@ internal class DateAddExprFunction(valueFactory: ExprValueFactory) : NullPropaga
                                                       this.hour,
                                                       this.minute,
                                                       this.localOffset)
-            else                -> errNoContext("invalid date part for date_add: ${datePart.toString().toLowerCase()}",
+            else                -> errNoContext("invalid date part for date_add: ${dateTimePart.toString().toLowerCase()}",
                                                 internal = false)
         }
     }
@@ -79,12 +78,12 @@ internal class DateAddExprFunction(valueFactory: ExprValueFactory) : NullPropaga
 
         try {
             val addedTimestamp = when (datePart) {
-                DatePart.YEAR   -> timestamp.adjustPrecisionTo(datePart).addYear(interval)
-                DatePart.MONTH  -> timestamp.adjustPrecisionTo(datePart).addMonth(interval)
-                DatePart.DAY    -> timestamp.adjustPrecisionTo(datePart).addDay(interval)
-                DatePart.HOUR   -> timestamp.adjustPrecisionTo(datePart).addHour(interval)
-                DatePart.MINUTE -> timestamp.adjustPrecisionTo(datePart).addMinute(interval)
-                DatePart.SECOND -> timestamp.adjustPrecisionTo(datePart).addSecond(interval)
+                DateTimePart.YEAR   -> timestamp.adjustPrecisionTo(datePart).addYear(interval)
+                DateTimePart.MONTH  -> timestamp.adjustPrecisionTo(datePart).addMonth(interval)
+                DateTimePart.DAY    -> timestamp.adjustPrecisionTo(datePart).addDay(interval)
+                DateTimePart.HOUR   -> timestamp.adjustPrecisionTo(datePart).addHour(interval)
+                DateTimePart.MINUTE -> timestamp.adjustPrecisionTo(datePart).addMinute(interval)
+                DateTimePart.SECOND -> timestamp.adjustPrecisionTo(datePart).addSecond(interval)
                 else            -> errNoContext("invalid date part for date_add: ${datePart.toString().toLowerCase()}",
                                                 internal = false)
             }

--- a/lang/src/org/partiql/lang/eval/builtins/DateAddExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/DateAddExprFunction.kt
@@ -66,25 +66,25 @@ internal class DateAddExprFunction(valueFactory: ExprValueFactory) : NullPropaga
                                                       this.hour,
                                                       this.minute,
                                                       this.localOffset)
-            else                -> errNoContext("invalid date part for date_add: ${dateTimePart.toString().toLowerCase()}",
+            else                -> errNoContext("invalid datetime part for date_add: ${dateTimePart.toString().toLowerCase()}",
                                                 internal = false)
         }
     }
 
     override fun eval(env: Environment, args: List<ExprValue>): ExprValue {
-        val datePart = args[0].datePartValue()
+        val dateTimePart = args[0].dateTimePartValue()
         val interval = args[1].intValue()
         val timestamp = args[2].timestampValue()
 
         try {
-            val addedTimestamp = when (datePart) {
-                DateTimePart.YEAR   -> timestamp.adjustPrecisionTo(datePart).addYear(interval)
-                DateTimePart.MONTH  -> timestamp.adjustPrecisionTo(datePart).addMonth(interval)
-                DateTimePart.DAY    -> timestamp.adjustPrecisionTo(datePart).addDay(interval)
-                DateTimePart.HOUR   -> timestamp.adjustPrecisionTo(datePart).addHour(interval)
-                DateTimePart.MINUTE -> timestamp.adjustPrecisionTo(datePart).addMinute(interval)
-                DateTimePart.SECOND -> timestamp.adjustPrecisionTo(datePart).addSecond(interval)
-                else            -> errNoContext("invalid date part for date_add: ${datePart.toString().toLowerCase()}",
+            val addedTimestamp = when (dateTimePart) {
+                DateTimePart.YEAR   -> timestamp.adjustPrecisionTo(dateTimePart).addYear(interval)
+                DateTimePart.MONTH  -> timestamp.adjustPrecisionTo(dateTimePart).addMonth(interval)
+                DateTimePart.DAY    -> timestamp.adjustPrecisionTo(dateTimePart).addDay(interval)
+                DateTimePart.HOUR   -> timestamp.adjustPrecisionTo(dateTimePart).addHour(interval)
+                DateTimePart.MINUTE -> timestamp.adjustPrecisionTo(dateTimePart).addMinute(interval)
+                DateTimePart.SECOND -> timestamp.adjustPrecisionTo(dateTimePart).addSecond(interval)
+                else            -> errNoContext("invalid datetime part for date_add: ${dateTimePart.toString().toLowerCase()}",
                                                 internal = false)
             }
 

--- a/lang/src/org/partiql/lang/eval/builtins/DateDiffExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/DateDiffExprFunction.kt
@@ -20,12 +20,12 @@ import org.partiql.lang.syntax.*
 import java.time.*
 
 /**
- * Difference in date parts between two timestamps. If the first timestamp is later than the second the result is negative.
+ * Difference in datetime parts between two timestamps. If the first timestamp is later than the second the result is negative.
  *
- * Syntax: `DATE_DIFF(<date part>, <timestamp>, <timestamp>)`
- * Where date part is one of the following keywords: `year, month, day, hour, minute, second`
+ * Syntax: `DATE_DIFF(<datetime part>, <timestamp>, <timestamp>)`
+ * Where date time part is one of the following keywords: `year, month, day, hour, minute, second`
  *
- * Timestamps without all date parts are considered to be in the beginning of the missing parts to make calculation possible.
+ * Timestamps without all datetime parts are considered to be in the beginning of the missing parts to make calculation possible.
  * For example:
  * - 2010T is interpreted as 2010-01-01T00:00:00.000Z
  * - date_diff(month, `2010T`, `2010-05T`) results in 4
@@ -36,10 +36,10 @@ import java.time.*
  */
 internal class DateDiffExprFunction(valueFactory: ExprValueFactory) : NullPropagatingExprFunction("date_diff", 3, valueFactory) {
 
-    // Since we don't have a date part for `milliseconds` we can safely set the OffsetDateTime to 0 as it won't
+    // Since we don't have a datetime part for `milliseconds` we can safely set the OffsetDateTime to 0 as it won't
     // affect any of the possible calculations.
     //
-    // If we introduce the `milliseconds` date part this will need to be
+    // If we introduce the `milliseconds` datetime part this will need to be
     // revisited
     private fun Timestamp.toJava() = OffsetDateTime.of(year,
                                                        month,
@@ -69,21 +69,21 @@ internal class DateDiffExprFunction(valueFactory: ExprValueFactory) : NullPropag
         Duration.between(left, right).toMillis() / 1_000
 
     override fun eval(env: Environment, args: List<ExprValue>): ExprValue {
-        val datePart = args[0].datePartValue()
+        val dateTimePart = args[0].dateTimePartValue()
         val left = args[1].timestampValue()
         val right = args[2].timestampValue()
 
         val leftAsJava = left.toJava()
         val rightAsJava = right.toJava()
 
-        val difference = when (datePart) {
+        val difference = when (dateTimePart) {
             DateTimePart.YEAR   -> yearsSince(leftAsJava, rightAsJava)
             DateTimePart.MONTH  -> monthsSince(leftAsJava, rightAsJava)
             DateTimePart.DAY    -> daysSince(leftAsJava, rightAsJava)
             DateTimePart.HOUR   -> hoursSince(leftAsJava, rightAsJava)
             DateTimePart.MINUTE -> minutesSince(leftAsJava, rightAsJava)
             DateTimePart.SECOND -> secondsSince(leftAsJava, rightAsJava)
-            else            -> errNoContext("invalid date part for date_diff: ${datePart.toString().toLowerCase()}",
+            else            -> errNoContext("invalid datetime part for date_diff: ${dateTimePart.toString().toLowerCase()}",
                                             internal = false)
         }
 

--- a/lang/src/org/partiql/lang/eval/builtins/DateDiffExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/DateDiffExprFunction.kt
@@ -77,12 +77,12 @@ internal class DateDiffExprFunction(valueFactory: ExprValueFactory) : NullPropag
         val rightAsJava = right.toJava()
 
         val difference = when (datePart) {
-            DatePart.YEAR   -> yearsSince(leftAsJava, rightAsJava)
-            DatePart.MONTH  -> monthsSince(leftAsJava, rightAsJava)
-            DatePart.DAY    -> daysSince(leftAsJava, rightAsJava)
-            DatePart.HOUR   -> hoursSince(leftAsJava, rightAsJava)
-            DatePart.MINUTE -> minutesSince(leftAsJava, rightAsJava)
-            DatePart.SECOND -> secondsSince(leftAsJava, rightAsJava)
+            DateTimePart.YEAR   -> yearsSince(leftAsJava, rightAsJava)
+            DateTimePart.MONTH  -> monthsSince(leftAsJava, rightAsJava)
+            DateTimePart.DAY    -> daysSince(leftAsJava, rightAsJava)
+            DateTimePart.HOUR   -> hoursSince(leftAsJava, rightAsJava)
+            DateTimePart.MINUTE -> minutesSince(leftAsJava, rightAsJava)
+            DateTimePart.SECOND -> secondsSince(leftAsJava, rightAsJava)
             else            -> errNoContext("invalid date part for date_diff: ${datePart.toString().toLowerCase()}",
                                             internal = false)
         }

--- a/lang/src/org/partiql/lang/eval/builtins/ExtractExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/ExtractExprFunction.kt
@@ -24,15 +24,15 @@ import java.time.LocalDate
 private const val SECONDS_PER_MINUTE = 60
 
 /**
- * Extracts a date part from a datetime type and returns a [DecimalExprValue] where date part is one of the following keywords:
+ * Extracts a datetime part from a datetime type and returns a [DecimalExprValue] where datetime part is one of the following keywords:
  * `year, month, day, hour, minute, second, timestamp_hour, timestamp_minute`.
  * Datetime type can be one of DATE, TIME or TIMESTAMP
- * **Note** that the allowed date parts for `EXTRACT` is not the same as `DATE_ADD`
+ * **Note** that the allowed datetime parts for `EXTRACT` is not the same as `DATE_ADD`
  *
- * Extract does not propagate null for its first parameter, the date part. From the SQL92 spec only the date part
+ * Extract does not propagate null for its first parameter, the datetime part. From the SQL92 spec only the datetime part
  * keywords are allowed as first argument
  *
- * `EXTRACT(<date part> FROM <datetime_type>)`
+ * `EXTRACT(<datetime part> FROM <datetime_type>)`
  */
 internal class ExtractExprFunction(valueFactory: ExprValueFactory) : NullPropagatingExprFunction("extract", 2, valueFactory) {
 
@@ -89,11 +89,11 @@ internal class ExtractExprFunction(valueFactory: ExprValueFactory) : NullPropaga
     }
 
     override fun eval(env: Environment, args: List<ExprValue>): ExprValue {
-        val datePart = args[0].datePartValue()
+        val dateTimePart = args[0].dateTimePartValue()
         val extractedValue = when(args[1].type) {
-            ExprValueType.TIMESTAMP -> args[1].timestampValue().extractedValue(datePart)
-            ExprValueType.DATE      -> args[1].dateValue().extractedValue(datePart)
-            ExprValueType.TIME      -> args[1].timeValue().extractedValue(datePart)
+            ExprValueType.TIMESTAMP -> args[1].timestampValue().extractedValue(dateTimePart)
+            ExprValueType.DATE      -> args[1].dateValue().extractedValue(dateTimePart)
+            ExprValueType.TIME      -> args[1].timeValue().extractedValue(dateTimePart)
             else                    -> errNoContext("Expected date or timestamp: ${args[1]}", internal = false)
         }
 

--- a/lang/src/org/partiql/lang/eval/builtins/ExtractExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/ExtractExprFunction.kt
@@ -41,48 +41,48 @@ internal class ExtractExprFunction(valueFactory: ExprValueFactory) : NullPropaga
 
     private fun Timestamp.minuteOffset() = (localOffset ?: 0) % SECONDS_PER_MINUTE
 
-    private fun Timestamp.extractedValue(datePart: DatePart): BigDecimal {
-        return when (datePart) {
-            DatePart.YEAR -> year
-            DatePart.MONTH -> month
-            DatePart.DAY -> day
-            DatePart.HOUR -> hour
-            DatePart.MINUTE -> minute
-            DatePart.SECOND -> second
-            DatePart.TIMEZONE_HOUR -> hourOffset()
-            DatePart.TIMEZONE_MINUTE -> minuteOffset()
+    private fun Timestamp.extractedValue(dateTimePart: DateTimePart): BigDecimal {
+        return when (dateTimePart) {
+            DateTimePart.YEAR -> year
+            DateTimePart.MONTH -> month
+            DateTimePart.DAY -> day
+            DateTimePart.HOUR -> hour
+            DateTimePart.MINUTE -> minute
+            DateTimePart.SECOND -> second
+            DateTimePart.TIMEZONE_HOUR -> hourOffset()
+            DateTimePart.TIMEZONE_MINUTE -> minuteOffset()
         }.toBigDecimal()
     }
 
-    private fun LocalDate.extractedValue(datePart: DatePart) : BigDecimal {
-        return when (datePart) {
-            DatePart.YEAR -> year
-            DatePart.MONTH -> monthValue
-            DatePart.DAY -> dayOfMonth
-            DatePart.TIMEZONE_HOUR,
-            DatePart.TIMEZONE_MINUTE -> errNoContext(
-                "Timestamp unit ${datePart.name.toLowerCase()} not supported for DATE type",
+    private fun LocalDate.extractedValue(dateTimePart: DateTimePart) : BigDecimal {
+        return when (dateTimePart) {
+            DateTimePart.YEAR -> year
+            DateTimePart.MONTH -> monthValue
+            DateTimePart.DAY -> dayOfMonth
+            DateTimePart.TIMEZONE_HOUR,
+            DateTimePart.TIMEZONE_MINUTE -> errNoContext(
+                "Timestamp unit ${dateTimePart.name.toLowerCase()} not supported for DATE type",
                 internal = false
             )
-            DatePart.HOUR, DatePart.MINUTE, DatePart.SECOND -> 0
+            DateTimePart.HOUR, DateTimePart.MINUTE, DateTimePart.SECOND -> 0
         }.toBigDecimal()
     }
 
-    private fun Time.extractedValue(datePart: DatePart) : BigDecimal {
-        return when (datePart) {
-            DatePart.HOUR -> localTime.hour.toBigDecimal()
-            DatePart.MINUTE -> localTime.minute.toBigDecimal()
-            DatePart.SECOND -> secondsWithFractionalPart
-            DatePart.TIMEZONE_HOUR -> timezoneHour?.toBigDecimal() ?: errNoContext(
-                "Time unit ${datePart.name.toLowerCase()} not supported for TIME type without TIME ZONE",
+    private fun Time.extractedValue(dateTimePart: DateTimePart) : BigDecimal {
+        return when (dateTimePart) {
+            DateTimePart.HOUR -> localTime.hour.toBigDecimal()
+            DateTimePart.MINUTE -> localTime.minute.toBigDecimal()
+            DateTimePart.SECOND -> secondsWithFractionalPart
+            DateTimePart.TIMEZONE_HOUR -> timezoneHour?.toBigDecimal() ?: errNoContext(
+                "Time unit ${dateTimePart.name.toLowerCase()} not supported for TIME type without TIME ZONE",
                 internal = false
             )
-            DatePart.TIMEZONE_MINUTE -> timezoneMinute?.toBigDecimal() ?: errNoContext(
-                "Time unit ${datePart.name.toLowerCase()} not supported for TIME type without TIME ZONE",
+            DateTimePart.TIMEZONE_MINUTE -> timezoneMinute?.toBigDecimal() ?: errNoContext(
+                "Time unit ${dateTimePart.name.toLowerCase()} not supported for TIME type without TIME ZONE",
                 internal = false
             )
-            DatePart.YEAR, DatePart.MONTH, DatePart.DAY -> errNoContext(
-                "Time unit ${datePart.name.toLowerCase()} not supported for TIME type.",
+            DateTimePart.YEAR, DateTimePart.MONTH, DateTimePart.DAY -> errNoContext(
+                "Time unit ${dateTimePart.name.toLowerCase()} not supported for TIME type.",
                 internal = false
             )
         }

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -19,12 +19,11 @@ import org.partiql.lang.syntax.TokenType.OPERATOR
 
 @JvmField internal val TRIM_SPECIFICATION_KEYWORDS = setOf("both", "leading", "trailing")
 
-//TODO: Rename DatePart to DateTimePart. Check issue https://github.com/partiql/partiql-lang-kotlin/issues/409
-internal enum class DatePart {
+internal enum class DateTimePart {
     YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, TIMEZONE_HOUR, TIMEZONE_MINUTE
 }
 
-internal val DATE_PART_KEYWORDS: Set<String> = DatePart.values()
+internal val DATE_PART_KEYWORDS: Set<String> = DateTimePart.values()
     .map { it.toString().toLowerCase() }.toSet()
 
 /** All SQL-92 keywords. */

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -23,7 +23,7 @@ internal enum class DateTimePart {
     YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, TIMEZONE_HOUR, TIMEZONE_MINUTE
 }
 
-internal val DATE_PART_KEYWORDS: Set<String> = DateTimePart.values()
+internal val DATE_TIME_PART_KEYWORDS: Set<String> = DateTimePart.values()
     .map { it.toString().toLowerCase() }.toSet()
 
 /** All SQL-92 keywords. */
@@ -247,7 +247,7 @@ internal val DATE_PART_KEYWORDS: Set<String> = DateTimePart.values()
     "write",
     "zone"
 )
-// Note: DATE_PART_KEYWORDs are not keywords in the traditional sense--they are only keywords within
+// Note: DATE_TIME_PART_KEYWORDs are not keywords in the traditional sense--they are only keywords within
 // the context of the DATE_ADD, DATE_DIFF and EXTRACT functions, for which [SqlParser] has special support.
 // Similarly, TRIM_SPECIFICATION_KEYWORDS are only keywords within the context of the TRIM function.
 

--- a/lang/src/org/partiql/lang/syntax/TokenType.kt
+++ b/lang/src/org/partiql/lang/syntax/TokenType.kt
@@ -48,7 +48,7 @@ enum class TokenType {
     DESC,
     // function specific
     TRIM_SPECIFICATION,
-    DATE_PART,
+    DATETIME_PART,
     EOF // End of Stream token.
     ;
     fun isIdentifier() = this == TokenType.IDENTIFIER || this == TokenType.QUOTED_IDENTIFIER

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -1170,9 +1170,9 @@ class ParserErrorsTest : SqlParserTestBase() {
     }
 
     @Test
-    fun callExtractMissingDatePart() {
+    fun callExtractMissingDateTimePart() {
         checkInputThrowingParserException("extract(from b)",
-                                          ErrorCode.PARSE_EXPECTED_DATE_PART,
+                                          ErrorCode.PARSE_EXPECTED_DATE_TIME_PART,
                                           mapOf(Property.LINE_NUMBER to 1L,
                                                 Property.COLUMN_NUMBER to 9L,
                                                 Property.TOKEN_TYPE to TokenType.KEYWORD,
@@ -1182,7 +1182,7 @@ class ParserErrorsTest : SqlParserTestBase() {
     @Test
     fun callExtractOnlySecondArgument() {
         checkInputThrowingParserException("extract(b)",
-                                          ErrorCode.PARSE_EXPECTED_DATE_PART,
+                                          ErrorCode.PARSE_EXPECTED_DATE_TIME_PART,
                                           mapOf(Property.LINE_NUMBER to 1L,
                                                 Property.COLUMN_NUMBER to 9L,
                                                 Property.TOKEN_TYPE to TokenType.IDENTIFIER,
@@ -1190,7 +1190,7 @@ class ParserErrorsTest : SqlParserTestBase() {
     }
 
     @Test
-    fun callExtractOnlyDatePart() {
+    fun callExtractOnlyDateTimePart() {
         checkInputThrowingParserException("extract(year)",
                                           ErrorCode.PARSE_EXPECTED_KEYWORD,
                                           mapOf(Property.LINE_NUMBER to 1L,
@@ -1205,7 +1205,7 @@ class ParserErrorsTest : SqlParserTestBase() {
     @Test
     fun callDateAddNoArguments() {
         checkInputThrowingParserException("date_add()",
-            ErrorCode.PARSE_EXPECTED_DATE_PART,
+            ErrorCode.PARSE_EXPECTED_DATE_TIME_PART,
             mapOf(Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 10L,
                 Property.TOKEN_TYPE to TokenType.RIGHT_PAREN,
@@ -1213,9 +1213,9 @@ class ParserErrorsTest : SqlParserTestBase() {
     }
 
     @Test
-    fun callDateAddInvalidDatePart() {
+    fun callDateAddInvalidDateTimePart() {
         checkInputThrowingParserException("date_add(foobar",
-            ErrorCode.PARSE_EXPECTED_DATE_PART,
+            ErrorCode.PARSE_EXPECTED_DATE_TIME_PART,
             mapOf(Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 10L,
                 Property.TOKEN_TYPE to TokenType.IDENTIFIER,
@@ -1277,9 +1277,9 @@ class ParserErrorsTest : SqlParserTestBase() {
     }
 
     @Test
-    fun callDateAddMissingDatePart() {
+    fun callDateAddMissingDateTimePart() {
         checkInputThrowingParserException("date_add(a, b, c)",
-            ErrorCode.PARSE_EXPECTED_DATE_PART,
+            ErrorCode.PARSE_EXPECTED_DATE_TIME_PART,
             mapOf(Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 10L,
                 Property.TOKEN_TYPE to TokenType.IDENTIFIER,

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerTests.kt
@@ -1750,10 +1750,10 @@ class EvaluatingCompilerTests : EvaluatorTestBase() {
     /**
      * Regression test for https://github.com/partiql/partiql-lang-kotlin/issues/314
      *
-     * Ensures that date parts can be used as variable names.
+     * Ensures that datetime parts can be used as variable names.
      */
     @Test
-    fun datePartsAsVariableNames() =
+    fun dateTimePartsAsVariableNames() =
         assertEvalExprValue(
             """
             SELECT VALUE [year, month, day, hour, minute, second]
@@ -1764,10 +1764,10 @@ class EvaluatingCompilerTests : EvaluatorTestBase() {
     /**
      * Regression test for https://github.com/partiql/partiql-lang-kotlin/issues/121
      *
-     * Ensures that date parts can be used as struct field names.
+     * Ensures that datetime parts can be used as struct field names.
      */
     @Test
-    fun datePartsAsStructFieldNames() =
+    fun dateTimePartsAsStructFieldNames() =
         assertEvalExprValue(
             """
             SELECT VALUE [x.year, x.month, x.day, x.hour, x.minute, x.second]

--- a/lang/test/org/partiql/lang/eval/builtins/DateAddExprFunctionTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/DateAddExprFunctionTest.kt
@@ -52,9 +52,9 @@ class DateAddExprFunctionTest : TestBase() {
     }
 
     @Test
-    fun nonExistingDatePart() {
+    fun nonExistingDateTimePart() {
         assertThatThrownBy { callDateAdd("foobar", 1, Timestamp.valueOf("2017T")) }
-            .hasMessage("invalid date part, valid values: [year, month, day, hour, minute, second, timezone_hour, timezone_minute]")
+            .hasMessage("invalid datetime part, valid values: [year, month, day, hour, minute, second, timezone_hour, timezone_minute]")
             .isExactlyInstanceOf(EvaluationException::class.java)
     }
 
@@ -72,14 +72,14 @@ class DateAddExprFunctionTest : TestBase() {
             .isExactlyInstanceOf(EvaluationException::class.java)
     }
 
-    fun parametersForInvalidDatePart() = listOf(DateTimePart.TIMEZONE_HOUR,
+    fun parametersForInvalidDateTimePart() = listOf(DateTimePart.TIMEZONE_HOUR,
                                                 DateTimePart.TIMEZONE_MINUTE).map { it.toString().toLowerCase() }
 
     @Test
     @Parameters
-    fun invalidDatePart(datePart: String) {
-        assertThatThrownBy { callDateAdd(datePart, 1, Timestamp.valueOf("2017T")) }
-            .hasMessage("invalid date part for date_add: $datePart")
+    fun invalidDateTimePart(dateTimePart: String) {
+        assertThatThrownBy { callDateAdd(dateTimePart, 1, Timestamp.valueOf("2017T")) }
+            .hasMessage("invalid datetime part for date_add: $dateTimePart")
             .isExactlyInstanceOf(EvaluationException::class.java)
     }
 

--- a/lang/test/org/partiql/lang/eval/builtins/DateAddExprFunctionTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/DateAddExprFunctionTest.kt
@@ -18,7 +18,6 @@ import com.amazon.ion.*
 import org.partiql.lang.*
 import org.partiql.lang.eval.*
 import org.partiql.lang.syntax.*
-import org.partiql.lang.util.*
 import junitparams.*
 import org.assertj.core.api.Assertions.*
 import org.junit.*
@@ -73,8 +72,8 @@ class DateAddExprFunctionTest : TestBase() {
             .isExactlyInstanceOf(EvaluationException::class.java)
     }
 
-    fun parametersForInvalidDatePart() = listOf(DatePart.TIMEZONE_HOUR,
-                                                DatePart.TIMEZONE_MINUTE).map { it.toString().toLowerCase() }
+    fun parametersForInvalidDatePart() = listOf(DateTimePart.TIMEZONE_HOUR,
+                                                DateTimePart.TIMEZONE_MINUTE).map { it.toString().toLowerCase() }
 
     @Test
     @Parameters

--- a/lang/test/org/partiql/lang/eval/builtins/DateDiffExprFunctionTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/DateDiffExprFunctionTest.kt
@@ -46,7 +46,7 @@ class DateDiffExprFunctionTest : TestBase() {
     @Test
     fun wrongTypeOfFirstArgument() {
         assertThatThrownBy { callDateDiff("foobar", Timestamp.valueOf("2017T"), Timestamp.valueOf("2017T")) }
-            .hasMessage("invalid date part, valid values: [year, month, day, hour, minute, second, timezone_hour, timezone_minute]")
+            .hasMessage("invalid datetime part, valid values: [year, month, day, hour, minute, second, timezone_hour, timezone_minute]")
             .isExactlyInstanceOf(EvaluationException::class.java)
     }
 

--- a/lang/test/org/partiql/lang/eval/builtins/ExtractEvaluationTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/ExtractEvaluationTest.kt
@@ -20,7 +20,7 @@ import org.assertj.core.api.Assertions
 import org.partiql.lang.eval.*
 import org.junit.*
 import org.partiql.lang.eval.time.Time
-import org.partiql.lang.syntax.DatePart
+import org.partiql.lang.syntax.DateTimePart
 import java.time.LocalDate
 
 /**
@@ -83,19 +83,19 @@ class ExtractEvaluationTest : EvaluatorTestBase() {
     data class ExtractFromDateTC(val source: String, val expected: ExprValue?)
 
     private fun createDateTC(source: String, expected: LocalDate) =
-        DatePart.values()
+        DateTimePart.values()
             .map { datePart ->
                 ExtractFromDateTC(
                     source = "EXTRACT(${datePart.name} FROM $source)",
                     expected = when (datePart) {
-                        DatePart.YEAR -> valueFactory.newInt(expected.year)
-                        DatePart.MONTH -> valueFactory.newInt(expected.monthValue)
-                        DatePart.DAY -> valueFactory.newInt(expected.dayOfMonth)
-                        DatePart.HOUR -> valueFactory.newInt(0)
-                        DatePart.MINUTE -> valueFactory.newInt(0)
-                        DatePart.SECOND -> valueFactory.newInt(0)
-                        DatePart.TIMEZONE_HOUR -> null
-                        DatePart.TIMEZONE_MINUTE -> null
+                        DateTimePart.YEAR -> valueFactory.newInt(expected.year)
+                        DateTimePart.MONTH -> valueFactory.newInt(expected.monthValue)
+                        DateTimePart.DAY -> valueFactory.newInt(expected.dayOfMonth)
+                        DateTimePart.HOUR -> valueFactory.newInt(0)
+                        DateTimePart.MINUTE -> valueFactory.newInt(0)
+                        DateTimePart.SECOND -> valueFactory.newInt(0)
+                        DateTimePart.TIMEZONE_HOUR -> null
+                        DateTimePart.TIMEZONE_MINUTE -> null
                     }
                 )
             }
@@ -123,19 +123,19 @@ class ExtractEvaluationTest : EvaluatorTestBase() {
     data class ExtractFromTimeTC(val source: String, val expected: ExprValue?)
 
     private fun createTimeTC(source: String, expected: Time) =
-        DatePart.values()
+        DateTimePart.values()
             .map { datePart ->
                 ExtractFromTimeTC(
                     source = "EXTRACT(${datePart.name} FROM $source)",
                     expected = when (datePart) {
-                        DatePart.YEAR -> null
-                        DatePart.MONTH -> null
-                        DatePart.DAY -> null
-                        DatePart.HOUR -> valueFactory.newDecimal(expected.localTime.hour)
-                        DatePart.MINUTE -> valueFactory.newDecimal(expected.localTime.minute)
-                        DatePart.SECOND -> valueFactory.newDecimal(expected.secondsWithFractionalPart)
-                        DatePart.TIMEZONE_HOUR -> expected.timezoneHour?.let { valueFactory.newInt(it) }
-                        DatePart.TIMEZONE_MINUTE -> expected.timezoneMinute?.let { valueFactory.newInt(it) }
+                        DateTimePart.YEAR -> null
+                        DateTimePart.MONTH -> null
+                        DateTimePart.DAY -> null
+                        DateTimePart.HOUR -> valueFactory.newDecimal(expected.localTime.hour)
+                        DateTimePart.MINUTE -> valueFactory.newDecimal(expected.localTime.minute)
+                        DateTimePart.SECOND -> valueFactory.newDecimal(expected.secondsWithFractionalPart)
+                        DateTimePart.TIMEZONE_HOUR -> expected.timezoneHour?.let { valueFactory.newInt(it) }
+                        DateTimePart.TIMEZONE_MINUTE -> expected.timezoneMinute?.let { valueFactory.newInt(it) }
                     }
                 )
             }

--- a/lang/test/org/partiql/lang/eval/builtins/ExtractEvaluationTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/ExtractEvaluationTest.kt
@@ -84,10 +84,10 @@ class ExtractEvaluationTest : EvaluatorTestBase() {
 
     private fun createDateTC(source: String, expected: LocalDate) =
         DateTimePart.values()
-            .map { datePart ->
+            .map { dateTimePart ->
                 ExtractFromDateTC(
-                    source = "EXTRACT(${datePart.name} FROM $source)",
-                    expected = when (datePart) {
+                    source = "EXTRACT(${dateTimePart.name} FROM $source)",
+                    expected = when (dateTimePart) {
                         DateTimePart.YEAR -> valueFactory.newInt(expected.year)
                         DateTimePart.MONTH -> valueFactory.newInt(expected.monthValue)
                         DateTimePart.DAY -> valueFactory.newInt(expected.dayOfMonth)
@@ -124,10 +124,10 @@ class ExtractEvaluationTest : EvaluatorTestBase() {
 
     private fun createTimeTC(source: String, expected: Time) =
         DateTimePart.values()
-            .map { datePart ->
+            .map { dateTimePart ->
                 ExtractFromTimeTC(
-                    source = "EXTRACT(${datePart.name} FROM $source)",
-                    expected = when (datePart) {
+                    source = "EXTRACT(${dateTimePart.name} FROM $source)",
+                    expected = when (dateTimePart) {
                         DateTimePart.YEAR -> null
                         DateTimePart.MONTH -> null
                         DateTimePart.DAY -> null
@@ -188,7 +188,7 @@ class ExtractEvaluationTest : EvaluatorTestBase() {
     @Test
     fun wrongTypeOfFirstArgument() {
         Assertions.assertThatThrownBy { callExtract("foobar", 1) }
-            .hasMessage("invalid date part, valid values: [year, month, day, hour, minute, second, timezone_hour, timezone_minute]")
+            .hasMessage("invalid datetime part, valid values: [year, month, day, hour, minute, second, timezone_hour, timezone_minute]")
             .isExactlyInstanceOf(EvaluationException::class.java)
     }
 


### PR DESCRIPTION
As `DatePart` type includes Time components too, rename the type to
reflect the current value range.  In addition rename the related
functions.

GitHub Issue: https://github.com/partiql/partiql-lang-kotlin/issues/409

*Issue #, if available:* 409

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
