### PR TITLE
CAST: Improve the CAST assertion assertEval

### DIFF
--- a/lang/test/org/partiql/lang/eval/EvaluatorTestBase.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTestBase.kt
@@ -97,20 +97,9 @@ abstract class EvaluatorTestBase : TestBase() {
         val originalExprNode = parser.parseExprNode(source)
 
         fun evalAndAssert(exprNodeToEvaluate: ExprNode, message: String) {
-            // LEGACY mode
-            val result = eval(exprNodeToEvaluate, compileOptions, session, compilerPipelineBuilderBlock)
-            AssertExprValue(result, message = "(LEGACY mode) Evaluated '$source' with evaluator ($message)")
-                .apply { assertIonValue(expectedIon) }.run(block)
-            // TODO this should not be here--this should be explicit in the test case
-            // PERMISSIVE mode
-            val resultForPermissiveMode = eval(
-                exprNodeToEvaluate,
-                CompileOptions.builder(compileOptions).typingMode(TypingMode.PERMISSIVE).build(),
-                session,
-                compilerPipelineBuilderBlock
-            )
-            AssertExprValue(resultForPermissiveMode, message = "(PERMISSIVE mode) Evaluated '$source' with evaluator ($message)")
-                .apply { assertIonValue(expectedIon) }.run(block)
+            AssertExprValue(eval(exprNodeToEvaluate, compileOptions, session, compilerPipelineBuilderBlock),
+                message =  "${compileOptions.typedOpBehavior} CAST in ${compileOptions.typingMode} typing mode, " +
+                    "evaluated '$source' with evaluator ($message)").apply { assertIonValue(expectedIon) }.run(block)
         }
 
         // Evaluate the ExprNodes originally obtained from the parser


### PR DESCRIPTION
Improve the CAST assertion assertEval with removing a redundant
assertion for permissive mode since we already run tests for this
mode as part of the overall process.

Issue #, if available: 519

Addressed the comment from the original PR which was closed because it was having changes from `remove-unused-imports` change:
https://github.com/partiql/partiql-lang-kotlin/pull/520

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
