### PR TITLE
Prepare v0.5.1-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ allprojects {
 
 subprojects {
     group = 'org.partiql'
-    version = '0.5.0'
+    version = '0.5.1-SNAPSHOT'
 }
 
 buildDir = new File(rootProject.projectDir, "gradle-build/" + project.name)


### PR DESCRIPTION
Bumps minor version to `v0.5.1` and appends `-SNAPSHOT`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
