### PR TITLE
Added Pos and Neg operators.

### DIFF
--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -91,8 +91,16 @@ fun ExprNode.toAstExpr(): PartiqlAst.Expr {
             is NAry -> {
                 val args = node.args.map { it.toAstExpr() }
                 when(node.op) {
-                    NAryOp.ADD -> plus(args, metas)
-                    NAryOp.SUB -> minus(args, metas)
+                    NAryOp.ADD -> when (args.size) {
+                        0 -> throw IllegalArgumentException("Operator 'Add' must have at least one argument")
+                        1 -> pos(args.first(), metas)
+                        else -> plus(args, metas)
+                    }
+                    NAryOp.SUB -> when (args.size) {
+                        0 -> throw IllegalArgumentException("Operator 'Sub' must have at least one argument")
+                        1 -> neg(args.first(), metas)
+                        else -> minus(args, metas)
+                    }
                     NAryOp.MUL -> times(args, metas)
                     NAryOp.DIV -> divide(args, metas)
                     NAryOp.MOD -> modulo(args, metas)

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -69,7 +69,7 @@ private class StatementTransformer(val ion: IonSystem) {
             is PartiqlAst.Expr.Id -> VariableReference(name.text, case.toCaseSensitivity(), qualifier.toScopeQualifier(), metas)
             is PartiqlAst.Expr.Parameter -> Parameter(index.value.toInt(), metas)
             is PartiqlAst.Expr.Not -> NAry(NAryOp.NOT, listOf(expr.toExprNode()), metas)
-            is PartiqlAst.Expr.Pos -> expr.toExprNode()
+            is PartiqlAst.Expr.Pos -> NAry(NAryOp.ADD, listOf(expr.toExprNode()), metas)
             is PartiqlAst.Expr.Neg -> NAry(NAryOp.SUB, listOf(expr.toExprNode()), metas)
             is PartiqlAst.Expr.Plus -> NAry(NAryOp.ADD, operands.toExprNodeList(), metas)
             is PartiqlAst.Expr.Minus -> NAry(NAryOp.SUB, operands.toExprNodeList(), metas)

--- a/lang/src/org/partiql/lang/ast/passes/StatementRedactor.kt
+++ b/lang/src/org/partiql/lang/ast/passes/StatementRedactor.kt
@@ -186,13 +186,16 @@ private class StatementRedactionVisitor(
 
     private fun plusMinusRedaction(args: List<PartiqlAst.Expr>) {
         when (args.size) {
-            1 -> redactExpr(args[0])
             2 -> {
                 redactExpr(args[0])
                 redactExpr(args[1])
             }
             else -> throw IllegalArgumentException(INVALID_NUM_ARGS)
         }
+    }
+
+    private fun posNegRedaction(expr: PartiqlAst.Expr) {
+        redactExpr(expr)
     }
 
     private fun arithmeticOpRedaction(args: List<PartiqlAst.Expr>) {
@@ -220,6 +223,8 @@ private class StatementRedactionVisitor(
             // Arithmetic Ops
             is PartiqlAst.Expr.Plus -> plusMinusRedaction(node.operands)
             is PartiqlAst.Expr.Minus -> plusMinusRedaction(node.operands)
+            is PartiqlAst.Expr.Pos -> posNegRedaction(node.expr)
+            is PartiqlAst.Expr.Neg -> posNegRedaction(node.expr)
             is PartiqlAst.Expr.Times -> arithmeticOpRedaction(node.operands)
             is PartiqlAst.Expr.Divide -> arithmeticOpRedaction(node.operands)
             is PartiqlAst.Expr.Modulo -> arithmeticOpRedaction(node.operands)
@@ -305,6 +310,8 @@ private class StatementRedactionVisitor(
                 || this is PartiqlAst.Expr.Lt
                 || this is PartiqlAst.Expr.Lte
                 || this is PartiqlAst.Expr.InCollection
+                || this is PartiqlAst.Expr.Pos
+                || this is PartiqlAst.Expr.Neg
                 || this is PartiqlAst.Expr.Plus
                 || this is PartiqlAst.Expr.Minus
                 || this is PartiqlAst.Expr.Times

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -386,8 +386,8 @@ internal class EvaluatingCompiler(
 
             // unary
             is PartiqlAst.Expr.Not -> compileNot(expr, metas)
-            is PartiqlAst.Expr.Pos -> TODO() // compilePos(expr)
-            is PartiqlAst.Expr.Neg -> TODO() // compileNeg(expr)
+            is PartiqlAst.Expr.Pos -> compilePos(expr, metas)
+            is PartiqlAst.Expr.Neg -> compileNeg(expr, metas)
 
             // other operators
             is PartiqlAst.Expr.Concat -> compileConcat(expr, metas)
@@ -543,44 +543,51 @@ internal class EvaluatingCompiler(
         }
 
     private fun compilePlus(expr: PartiqlAst.Expr.Plus, metas: MetaContainer): ThunkEnv {
+        if (expr.operands.size < 2) {
+            error("Internal Error: PartiqlAst.Expr.Plus must have at lest 2 arguments")
+        }
+
         val argThunks = compileAstExprs(expr.operands)
 
-        val computeThunk = when (argThunks.size) {
-            //Unary +
-            1 -> {
-                val firstThunk = argThunks[0]
-                thunkFactory.thunkEnvOperands(metas, firstThunk) { _, value ->
-                    //Invoking .numberValue() here makes this essentially just a type check
-                    value.numberValue()
-                    //Original value is returned unmodified.
-                    value
-                }
-            }
-            //N-ary +
-            else -> thunkFactory.thunkFold(metas, argThunks) { lValue, rValue ->
-                (lValue.numberValue() + rValue.numberValue()).exprValue()
-            }
+        val computeThunk = thunkFactory.thunkFold(metas, argThunks) { lValue, rValue ->
+            (lValue.numberValue() + rValue.numberValue()).exprValue()
         }
 
         return resolveIntConstraint(computeThunk, metas)
     }
 
     private fun compileMinus(expr: PartiqlAst.Expr.Minus, metas: MetaContainer): ThunkEnv {
+        if (expr.operands.size < 2) {
+            error("Internal Error: PartiqlAst.Expr.Plus must have at lest 2 arguments")
+        }
+
         val argThunks = compileAstExprs(expr.operands)
 
-        val computeThunk = when (argThunks.size) {
-            //Unary -
-            1 -> {
-                val firstThunk = argThunks[0]
-                thunkFactory.thunkEnvOperands(metas, firstThunk) { _, value ->
-                    (-value.numberValue()).exprValue()
-                }
-            }
+        val computeThunk = thunkFactory.thunkFold(metas, argThunks) { lValue, rValue ->
+            (lValue.numberValue() - rValue.numberValue()).exprValue()
+        }
 
-            //N-ary -
-            else -> thunkFactory.thunkFold(metas, argThunks) { lValue, rValue ->
-                (lValue.numberValue() - rValue.numberValue()).exprValue()
-            }
+        return resolveIntConstraint(computeThunk, metas)
+    }
+
+    private fun compilePos(expr: PartiqlAst.Expr.Pos, metas: MetaContainer): ThunkEnv {
+        val exprThunk = compileAstExpr(expr.expr)
+
+        val computeThunk = thunkFactory.thunkEnvOperands(metas, exprThunk) { _, value ->
+            //Invoking .numberValue() here makes this essentially just a type check
+            value.numberValue()
+            //Original value is returned unmodified.
+            value
+        }
+
+        return resolveIntConstraint(computeThunk, metas)
+    }
+
+    private fun compileNeg(expr: PartiqlAst.Expr.Neg, metas: MetaContainer): ThunkEnv {
+        val exprThunk = compileAstExpr(expr.expr)
+
+        val computeThunk = thunkFactory.thunkEnvOperands(metas, exprThunk) { _, value ->
+            (-value.numberValue()).exprValue()
         }
 
         return resolveIntConstraint(computeThunk, metas)

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -544,7 +544,7 @@ internal class EvaluatingCompiler(
 
     private fun compilePlus(expr: PartiqlAst.Expr.Plus, metas: MetaContainer): ThunkEnv {
         if (expr.operands.size < 2) {
-            error("Internal Error: PartiqlAst.Expr.Plus must have at lest 2 arguments")
+            error("Internal Error: PartiqlAst.Expr.Plus must have at least 2 arguments")
         }
 
         val argThunks = compileAstExprs(expr.operands)

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -558,7 +558,7 @@ internal class EvaluatingCompiler(
 
     private fun compileMinus(expr: PartiqlAst.Expr.Minus, metas: MetaContainer): ThunkEnv {
         if (expr.operands.size < 2) {
-            error("Internal Error: PartiqlAst.Expr.Plus must have at lest 2 arguments")
+            error("Internal Error: PartiqlAst.Expr.Minus must have at least 2 arguments")
         }
 
         val argThunks = compileAstExprs(expr.operands)

--- a/lang/src/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
@@ -257,18 +257,30 @@ internal class StaticTypeInferenceVisitorTransform(
         override fun transformExprPlus(node: PartiqlAst.Expr.Plus): PartiqlAst.Expr {
             val nAry = super.transformExprPlus(node) as PartiqlAst.Expr.Plus
             val type = when (nAry.operands.size) {
-                1    -> computeReturnTypeForArithmeticUnary(nAry, nAry.operands, "+")
+                1    -> throw IllegalArgumentException("PartiqlAst.Expr.Plus must have at least 2 arguments")
                 else -> computeReturnTypeForArithmeticNAry(nAry, nAry.operands, "+")
             }
+            return nAry.withStaticType(type)
+        }
+
+        override fun transformExprPos(node: PartiqlAst.Expr.Pos): PartiqlAst.Expr {
+            val nAry = super.transformExprPos(node) as PartiqlAst.Expr.Pos
+            val type = computeReturnTypeForArithmeticUnary(nAry, listOf(nAry.expr), "+")
             return nAry.withStaticType(type)
         }
 
         override fun transformExprMinus(node: PartiqlAst.Expr.Minus): PartiqlAst.Expr {
             val nAry = (super.transformExprMinus(node) as PartiqlAst.Expr.Minus)
             val type = when (nAry.operands.size) {
-                1    -> computeReturnTypeForArithmeticUnary(nAry, nAry.operands, "-")
+                1    -> throw IllegalArgumentException("PartiqlAst.Expr.Minus must have at least 2 arguments")
                 else -> computeReturnTypeForArithmeticNAry(nAry, nAry.operands, "-")
             }
+            return nAry.withStaticType(type)
+        }
+
+        override fun transformExprNeg(node: PartiqlAst.Expr.Neg): PartiqlAst.Expr {
+            val nAry = super.transformExprNeg(node) as PartiqlAst.Expr.Neg
+            val type = computeReturnTypeForArithmeticUnary(nAry, listOf(nAry.expr), "-")
             return nAry.withStaticType(type)
         }
 

--- a/lang/src/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
@@ -256,8 +256,8 @@ internal class StaticTypeInferenceVisitorTransform(
         // Arithmetic NAry ops: ADD, SUB, MUL, DIV, MOD
         override fun transformExprPlus(node: PartiqlAst.Expr.Plus): PartiqlAst.Expr {
             val nAry = super.transformExprPlus(node) as PartiqlAst.Expr.Plus
-            val type = when (nAry.operands.size) {
-                1    -> throw IllegalArgumentException("PartiqlAst.Expr.Plus must have at least 2 arguments")
+            val type = when {
+                nAry.operands.size < 2 -> throw IllegalArgumentException("PartiqlAst.Expr.Plus must have at least 2 arguments")
                 else -> computeReturnTypeForArithmeticNAry(nAry, nAry.operands, "+")
             }
             return nAry.withStaticType(type)
@@ -271,8 +271,8 @@ internal class StaticTypeInferenceVisitorTransform(
 
         override fun transformExprMinus(node: PartiqlAst.Expr.Minus): PartiqlAst.Expr {
             val nAry = (super.transformExprMinus(node) as PartiqlAst.Expr.Minus)
-            val type = when (nAry.operands.size) {
-                1    -> throw IllegalArgumentException("PartiqlAst.Expr.Minus must have at least 2 arguments")
+            val type = when {
+                nAry.operands.size < 2 -> throw IllegalArgumentException("PartiqlAst.Expr.Minus must have at least 2 arguments")
                 else -> computeReturnTypeForArithmeticNAry(nAry, nAry.operands, "-")
             }
             return nAry.withStaticType(type)

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -821,8 +821,16 @@ class SqlParser(
     private fun NAryOp.toAstExpr(args: List<PartiqlAst.Expr>, metas: IonElementMetaContainer): PartiqlAst.Expr {
         return PartiqlAst.build {
             when (this@toAstExpr) {
-                NAryOp.ADD -> plus(args, metas)
-                NAryOp.SUB -> minus(args, metas)
+                NAryOp.ADD -> when (args.size) {
+                    0 -> throw IllegalArgumentException("Operator 'Add' must have at least one argument")
+                    1 -> pos(args.first(), metas)
+                    else -> plus(args, metas)
+                }
+                NAryOp.SUB -> when (args.size) {
+                    0 -> throw IllegalArgumentException("Operator 'Sub' must have at least one argument")
+                    1 -> neg(args.first(), metas)
+                    else -> minus(args, metas)
+                }
                 NAryOp.MUL -> times(args, metas)
                 NAryOp.DIV -> divide(args, metas)
                 NAryOp.MOD -> modulo(args, metas)

--- a/lang/test/org/partiql/lang/syntax/SqlParserPrecedenceTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserPrecedenceTest.kt
@@ -1022,8 +1022,8 @@ class SqlParserPrecedenceTest : SqlParserTestBase() {
                 (not (id e (case_insensitive) (unqualified)))
             )""",
 
-        // minus and plus unary
-        "- a + b" to "(plus (minus (id a (case_insensitive) (unqualified))) (id b (case_insensitive) (unqualified)) )",
+        // pos and neg
+        "- a + b" to "(plus (neg (id a (case_insensitive) (unqualified))) (id b (case_insensitive) (unqualified)) )",
 
         "(a+-5e0) and (c-+7.0)" to """
             (and
@@ -1036,7 +1036,7 @@ class SqlParserPrecedenceTest : SqlParserTestBase() {
                 (times (id d (case_insensitive) (unqualified)) (lit 9) )
                 (gte
                     (id e (case_insensitive) (unqualified))
-                    (plus (minus (plus (id foo (case_insensitive) (unqualified)))))
+                    (pos (neg (pos (id foo (case_insensitive) (unqualified)))))
                 )
             )""")
 

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -274,24 +274,24 @@ class SqlParserTest : SqlParserTestBase() {
     //****************************************
 
     @Test
-    fun unaryMinusCall() = assertExpression(
+    fun negCall() = assertExpression(
         "-baz()",
         "(- (call baz))",
-        "(minus (call baz))"
+        "(neg (call baz))"
     )
 
     @Test
-    fun unaryPlusMinusIdent() = assertExpression(
+    fun posNegIdent() = assertExpression(
         "+(-baz())",
         "(+ (- (call baz)))",
-        "(plus (minus (call baz)))"
+        "(pos (neg (call baz)))"
     )
 
     @Test
-    fun unaryPlusMinusIdentNoSpaces() = assertExpression(
+    fun posNegIdentNoSpaces() = assertExpression(
         "+-baz()",
         "(+ (- (call baz)))",
-        "(plus (minus (call baz)))"
+        "(pos (neg (call baz)))"
     )
 
     @Test
@@ -310,7 +310,7 @@ class SqlParserTest : SqlParserTestBase() {
     fun unaryIonTimestampLiteral() = assertExpression(
         "+-`2017-01-01`",
         "(+ (- (lit 2017-01-01T)))",
-        "(plus (minus (lit 2017-01-01T)))"
+        "(pos (neg (lit 2017-01-01T)))"
     )
 
     @Test


### PR DESCRIPTION
*Motivation:*
As we are replacing `ExprNode` with PIG-generated AST, we need to resolve the inconsistency between them. 

With 2 or more arguments provided, `ExprNode` uses `NAry.add`(`NAry.Sub`) to model the addition operator, while PIG-generated AST uses `Plus`(`Minus`) to model it. However, with only one argument provided, the addition operator is modeled as `Pos`(`Neg`) in PIG AST, while in `ExprNode` it is still `NAry.add`(`NAry.Sub`). 

This PR aims to resolve this inconsistency. 

*Suggested reviewing order:*
1. SqlParser.kt and EvaluatingCompiler.kt 
2. ExprNodeToStatement.kt and StatementToExprNode.kt. 
3. Other files. 

