### PR TITLE
Deprecate ExprNode metas

### DIFF
--- a/lang/src/org/partiql/lang/ast/StaticTypeMeta.kt
+++ b/lang/src/org/partiql/lang/ast/StaticTypeMeta.kt
@@ -79,4 +79,5 @@ data class StaticTypeMeta(val type: StaticType) : Meta {
     }
 }
 
+@Deprecated("Please use org.partiql.lang.domains.staticType")
 val MetaContainer.staticType: StaticTypeMeta? get() = find(StaticTypeMeta.TAG) as StaticTypeMeta?

--- a/lang/src/org/partiql/lang/ast/meta.kt
+++ b/lang/src/org/partiql/lang/ast/meta.kt
@@ -64,6 +64,7 @@ interface HasMetas {
 /**
  * An immutable container for [Meta] instances.
  */
+@Deprecated("Please use com.amazon.ionelement.api.MetaContainer")
 interface MetaContainer : Iterable<Meta> {
 
     /**
@@ -172,14 +173,17 @@ private data class MetaContainerImpl internal constructor(private val metas: Tre
 }
 
 /** Constructs a container with the specified metas. */
+@Deprecated("Please use org.partiql.lang.domains.metaContainerOf")
 fun metaContainerOf(vararg metas: Meta): MetaContainer = metaContainerOf(metas.asIterable())
 
 /** Empty meta container. */
+@Deprecated("Please use com.amazon.ionelement.api.emptyMetaContainer")
 val emptyMetaContainer: MetaContainer = metaContainerOf()
 
 /**
  * Constructs a container with the elements found within [metas].
  */
+@Deprecated("Please use com.amazon.ionelement.api.metaContainerOf")
 fun metaContainerOf(metas: Iterable<Meta>): MetaContainer {
     return MetaContainerImpl(
         TreeMap<String, Meta>().apply {

--- a/lang/src/org/partiql/lang/domains/util.kt
+++ b/lang/src/org/partiql/lang/domains/util.kt
@@ -3,6 +3,7 @@ package org.partiql.lang.domains
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
 import com.amazon.ionelement.api.metaContainerOf
+import org.partiql.lang.ast.Meta
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.ast.StaticTypeMeta
 import org.partiql.lang.errors.Property
@@ -15,6 +16,9 @@ fun PartiqlAst.Builder.id(name: String) =
 
 
 val MetaContainer.staticType: StaticTypeMeta? get() = this[StaticTypeMeta.TAG] as StaticTypeMeta?
+
+fun metaContainerOf(vararg metas: Meta): MetaContainer =
+    metaContainerOf(metas.map { Pair(it.tag, it) })
 
 /**
  * Returns a [MetaContainer] with *only* the source location of the receiver [MetaContainer], if present.

--- a/lang/src/org/partiql/lang/domains/util.kt
+++ b/lang/src/org/partiql/lang/domains/util.kt
@@ -17,6 +17,7 @@ fun PartiqlAst.Builder.id(name: String) =
 
 val MetaContainer.staticType: StaticTypeMeta? get() = this[StaticTypeMeta.TAG] as StaticTypeMeta?
 
+/** Constructs a container with the specified metas. */
 fun metaContainerOf(vararg metas: Meta): MetaContainer =
     metaContainerOf(metas.map { Pair(it.tag, it) })
 

--- a/lang/src/org/partiql/lang/eval/AnyOfCastTable.kt
+++ b/lang/src/org/partiql/lang/eval/AnyOfCastTable.kt
@@ -1,6 +1,6 @@
 package org.partiql.lang.eval
 
-import org.partiql.lang.ast.MetaContainer
+import com.amazon.ionelement.api.MetaContainer
 import org.partiql.lang.ast.sourceLocation
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property

--- a/lang/src/org/partiql/lang/eval/ErrorSignaler.kt
+++ b/lang/src/org/partiql/lang/eval/ErrorSignaler.kt
@@ -1,6 +1,6 @@
 package org.partiql.lang.eval
 
-import org.partiql.lang.ast.MetaContainer
+import com.amazon.ionelement.api.MetaContainer
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.errors.ErrorBehaviorInPermissiveMode
 import org.partiql.lang.errors.ErrorCode

--- a/lang/src/org/partiql/lang/eval/Exceptions.kt
+++ b/lang/src/org/partiql/lang/eval/Exceptions.kt
@@ -110,14 +110,14 @@ fun fillErrorContext(errorContext: PropertyValueMap, location: SourceLocationMet
     }
 }
 
-fun fillErrorContext(errorContext: PropertyValueMap, metaContainer: com.amazon.ionelement.api.MetaContainer) {
+fun fillErrorContext(errorContext: PropertyValueMap, metaContainer: MetaContainer) {
     val location = metaContainer[SourceLocationMeta.TAG] as? SourceLocationMeta
     if(location != null) {
         fillErrorContext(errorContext, location)
     }
 }
 
-fun errorContextFrom(metaContainer: com.amazon.ionelement.api.MetaContainer?): PropertyValueMap {
+fun errorContextFrom(metaContainer: MetaContainer?): PropertyValueMap {
     if(metaContainer == null) {
         return PropertyValueMap()
     }

--- a/lang/src/org/partiql/lang/eval/Exceptions.kt
+++ b/lang/src/org/partiql/lang/eval/Exceptions.kt
@@ -14,8 +14,8 @@
 
 package org.partiql.lang.eval
 
+import com.amazon.ionelement.api.MetaContainer
 import org.partiql.lang.SqlException
-import org.partiql.lang.ast.MetaContainer
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
@@ -110,18 +110,18 @@ fun fillErrorContext(errorContext: PropertyValueMap, location: SourceLocationMet
     }
 }
 
-fun fillErrorContext(errorContext: PropertyValueMap, metaContainer: MetaContainer) {
-    val location = metaContainer.find(SourceLocationMeta.TAG) as? SourceLocationMeta
+fun fillErrorContext(errorContext: PropertyValueMap, metaContainer: com.amazon.ionelement.api.MetaContainer) {
+    val location = metaContainer[SourceLocationMeta.TAG] as? SourceLocationMeta
     if(location != null) {
         fillErrorContext(errorContext, location)
     }
 }
 
-fun errorContextFrom(metaContainer: MetaContainer?): PropertyValueMap {
+fun errorContextFrom(metaContainer: com.amazon.ionelement.api.MetaContainer?): PropertyValueMap {
     if(metaContainer == null) {
         return PropertyValueMap()
     }
-    val location = metaContainer.find(SourceLocationMeta.TAG) as? SourceLocationMeta
+    val location = metaContainer[SourceLocationMeta.TAG] as? SourceLocationMeta
     return if(location != null) {
         errorContextFrom(location)
     } else {

--- a/lang/src/org/partiql/lang/eval/Thunk.kt
+++ b/lang/src/org/partiql/lang/eval/Thunk.kt
@@ -17,6 +17,7 @@ package org.partiql.lang.eval
 import com.amazon.ionelement.api.MetaContainer
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.ast.StaticTypeMeta
+import org.partiql.lang.domains.staticType
 import org.partiql.lang.errors.ErrorBehaviorInPermissiveMode
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
@@ -133,7 +134,7 @@ internal abstract class ThunkFactory(
         // When this check is enabled we throw an exception the [MetaContainer] does not have a
         // [StaticTypeMeta].  This indicates a bug or unimplemented support for an AST node in
         // [StaticTypeInferenceVisitorTransform].
-        val staticType = (metas["\$static_type"]as StaticTypeMeta?)?.type ?: error("Metas collection does not have a StaticTypeMeta")
+        val staticType = metas.staticType?.type ?: error("Metas collection does not have a StaticTypeMeta")
         if (!staticType.isInstance(thunkResult)) {
             throw EvaluationException(
                 "Runtime type does not match the expected StaticType",

--- a/lang/src/org/partiql/lang/eval/Thunk.kt
+++ b/lang/src/org/partiql/lang/eval/Thunk.kt
@@ -14,9 +14,9 @@
 
 package org.partiql.lang.eval
 
-import org.partiql.lang.ast.MetaContainer
+import com.amazon.ionelement.api.MetaContainer
 import org.partiql.lang.ast.SourceLocationMeta
-import org.partiql.lang.ast.staticType
+import org.partiql.lang.ast.StaticTypeMeta
 import org.partiql.lang.errors.ErrorBehaviorInPermissiveMode
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
@@ -133,7 +133,7 @@ internal abstract class ThunkFactory(
         // When this check is enabled we throw an exception the [MetaContainer] does not have a
         // [StaticTypeMeta].  This indicates a bug or unimplemented support for an AST node in
         // [StaticTypeInferenceVisitorTransform].
-        val staticType = metas.staticType?.type ?: error("Metas collection does not have a StaticTypeMeta")
+        val staticType = (metas["\$static_type"]as StaticTypeMeta?)?.type ?: error("Metas collection does not have a StaticTypeMeta")
         if (!staticType.isInstance(thunkResult)) {
             throw EvaluationException(
                 "Runtime type does not match the expected StaticType",
@@ -203,7 +203,7 @@ internal abstract class ThunkFactory(
      * (`crossinline`).
      */
     internal inline fun thunkEnv(metas: MetaContainer, crossinline t: ThunkEnv): ThunkEnv {
-        val sourceLocationMeta = metas.find(SourceLocationMeta.TAG) as? SourceLocationMeta
+        val sourceLocationMeta = metas[SourceLocationMeta.TAG] as? SourceLocationMeta
 
         return { env: Environment ->
             handleException(sourceLocationMeta) {
@@ -315,7 +315,7 @@ internal abstract class ThunkFactory(
         metas: MetaContainer,
         crossinline t: ThunkEnvValue<ExprValue>
     ): ThunkEnvValue<ExprValue> {
-        val sourceLocationMeta = metas.find(SourceLocationMeta.TAG) as? SourceLocationMeta
+        val sourceLocationMeta = metas[SourceLocationMeta.TAG] as? SourceLocationMeta
 
         return { env: Environment, arg1: ExprValue ->
             handleException(sourceLocationMeta) {
@@ -329,7 +329,7 @@ internal abstract class ThunkFactory(
         metas: MetaContainer,
         crossinline t: ThunkEnvValue<List<ExprValue>>
     ): ThunkEnvValue<List<ExprValue>> {
-        val sourceLocationMeta = metas.find(SourceLocationMeta.TAG) as? SourceLocationMeta
+        val sourceLocationMeta = metas[SourceLocationMeta.TAG] as? SourceLocationMeta
 
         return { env: Environment, arg1: List<ExprValue> ->
             handleException(sourceLocationMeta) {

--- a/lang/test/org/partiql/lang/eval/ErrorSignalerTests.kt
+++ b/lang/test/org/partiql/lang/eval/ErrorSignalerTests.kt
@@ -3,7 +3,7 @@ package org.partiql.lang.eval
 import com.amazon.ion.system.IonSystemBuilder
 import org.junit.Test
 import org.partiql.lang.ast.SourceLocationMeta
-import org.partiql.lang.ast.metaContainerOf
+import org.partiql.lang.domains.metaContainerOf
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import kotlin.test.assertEquals

--- a/lang/test/org/partiql/lang/eval/ThunkFactoryTests.kt
+++ b/lang/test/org/partiql/lang/eval/ThunkFactoryTests.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.partiql.lang.ION
 import org.partiql.lang.ast.StaticTypeMeta
-import org.partiql.lang.ast.metaContainerOf
+import org.partiql.lang.domains.metaContainerOf
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.types.NumberConstraint
 import org.partiql.lang.types.StaticType

--- a/lang/test/org/partiql/lang/eval/visitors/StaticTypeVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/StaticTypeVisitorTransformTests.kt
@@ -12,12 +12,9 @@ import org.junit.Test
 import org.partiql.ionschema.model.IonSchemaModel
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.ast.StaticTypeMeta
-import org.partiql.lang.ast.emptyMetaContainer
-import org.partiql.lang.ast.metaContainerOf
 import org.partiql.lang.ast.passes.SemanticException
-import org.partiql.lang.ast.plus
-import org.partiql.lang.ast.toIonElementMetaContainer
 import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.metaContainerOf
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.errors.Property.BINDING_NAME
@@ -892,9 +889,9 @@ class StaticTypeVisitorTransformTests : VisitorTransformTestBase() {
 
     private fun metas(line: Long, column: Long, type: StaticType? = null): com.amazon.ionelement.api.MetaContainer =
         (metaContainerOf(SourceLocationMeta(line, column)) +
-        (type?.let { metaContainerOf(StaticTypeMeta(it)) } ?: emptyMetaContainer)).toIonElementMetaContainer()
+        (type?.let { metaContainerOf(StaticTypeMeta(it)) } ?: emptyMetaContainer()))
 
-    private fun StaticType.toMetas(): com.amazon.ionelement.api.MetaContainer = metaContainerOf(StaticTypeMeta(this)).toIonElementMetaContainer()
+    private fun StaticType.toMetas(): com.amazon.ionelement.api.MetaContainer = metaContainerOf(StaticTypeMeta(this))
 
     private fun runSTRTest(
         tc: STRTestCase

--- a/lang/test/org/partiql/lang/eval/visitors/SubstitutionVisitorTransformTest.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/SubstitutionVisitorTransformTest.kt
@@ -18,14 +18,13 @@ import com.amazon.ionelement.api.emptyMetaContainer
 import com.amazon.ionelement.api.ionInt
 import org.junit.Test
 import org.partiql.lang.ast.SourceLocationMeta
-import org.partiql.lang.ast.metaContainerOf
-import org.partiql.lang.ast.toIonElementMetaContainer
+import org.partiql.lang.domains.metaContainerOf
 import org.partiql.lang.domains.PartiqlAst
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class SubstitutionVisitorTransformTest {
-    private val metasWithSourceLocation = metaContainerOf(SourceLocationMeta(100, 101)).toIonElementMetaContainer()
+    private val metasWithSourceLocation = metaContainerOf(SourceLocationMeta(100, 101))
 
     private fun litInt(value: Long) = PartiqlAst.build { lit(ionInt(value), emptyMetaContainer()) }
 


### PR DESCRIPTION
*Motivation:*
The meta container PIG AST uses is `com.amazon.ionelement.api.MetaContainer`, while `ExprNode` uses `org.partiql.lang.ast.MetaContainer`. As we are deprecating `ExprNode`, we need to replace meta container as well. 

Note that the meta inside meta container is still the same. 

*Description of changes:*
1. Added `metaContainerOf(vararg Meta)` in util.kt file. 
2. Replaced `org.partiql.lang.ast.MetaContainer` with `com.amazon.ionelement.api.MetaContainer` in EvaluatingCompiler.kt, Thunk.kt and related files. 


