### PR TITLE
Design for an open type system architecture inspired by PrestoDB.

### DIFF
--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.4.0"
 }
 
 sourceSets {

--- a/lang/src/org/partiql/lang/CompilerPipeline.kt
+++ b/lang/src/org/partiql/lang/CompilerPipeline.kt
@@ -33,6 +33,7 @@ import org.partiql.lang.eval.visitors.StaticTypeVisitorTransform
 import org.partiql.lang.syntax.Parser
 import org.partiql.lang.syntax.SqlParser
 import org.partiql.lang.types.CustomType
+import org.partiql.lang.types.Plugin
 import org.partiql.lang.types.StaticType
 import org.partiql.lang.util.interruptibleFold
 
@@ -140,6 +141,7 @@ interface CompilerPipeline  {
         private var compileOptions: CompileOptions? = null
         private val customFunctions: MutableMap<String, ExprFunction> = HashMap()
         private var customDataTypes: List<CustomType> = listOf()
+        private var plugins: List<Plugin> = listOf()
         private val customProcedures: MutableMap<String, StoredProcedure> = HashMap()
         private val preProcessingSteps: MutableList<ProcessingStep> = ArrayList()
         private var globalTypeBindings: Bindings<StaticType>? = null
@@ -180,6 +182,14 @@ interface CompilerPipeline  {
          */
         fun customDataTypes(customTypes: List<CustomType>) = this.apply {
             customDataTypes = customTypes
+        }
+
+        /**
+         * Register a list of [Plugin]s.
+         */
+        fun registerPlugins(externalPlugins: List<Plugin>) = this.apply {
+            plugins = externalPlugins
+            // TODO: Register types and functions in these plugins to TypeAndFunctionManager
         }
 
         /**

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -753,6 +753,7 @@ class SqlParser(
         }
     }
 
+     // Resolve types here with the help of type and function manager.
     private fun ParseNode.toAstType(): PartiqlAst.Type {
         if (type != ParseType.TYPE) {
             errMalformedParseTree("Expected ParseType.TYPE instead of $type")

--- a/lang/src/org/partiql/lang/types/Plugin.kt
+++ b/lang/src/org/partiql/lang/types/Plugin.kt
@@ -1,0 +1,52 @@
+package org.partiql.lang.types
+
+import org.partiql.lang.eval.ExprValue
+import kotlin.reflect.KClass
+
+/**
+ * The symbol table entry for a function is a unique function signature that is uniquely
+ * identified by the name and the order of the arguments and the function definition itself.
+ * The function signature also supports overloading the functions.
+ * PartiQ's evaluator will look up the symbol table to uniquely a
+ * symbol table entry and [invoke] this function to get an [ExprValue].
+ */
+interface SymbolTableEntry {
+    /**
+     * Name of the function.
+     */
+    val funName: String
+
+    /**
+     * List of argument types the function accepts in that order.
+     */
+    val argTypes: List<Type>
+
+    /**
+     * The callback invoked by PartiQL's evaluator to execute the function returning an [ExprValue]
+     */
+    fun invoke(exprValues: List<ExprValue>): ExprValue
+}
+
+/**
+ * A type and function registry plugin interface to enable external customers to register types and functions supported
+ * on these types. Implementers are expected to provide the correct class definitions of [Type] and the functions supported on it.
+ */
+interface Plugin {
+
+    /**
+     * The types are registered as a map of Class definitions keyed by the unique type name.
+     * Implementations are expected to have the type names unique in
+     * PartiQL's global (built in + User-defined) type system.
+     * For example, a user may not define a type with name "STRING" as it is already present in
+     * PartiQL's built in types.
+     * Implementations are also expected to provide the correct Class definitions of types which implement
+     * the [Type] interface.
+     *
+     */
+    fun getTypes(): Map<String, KClass<*>>
+
+    /**
+     * The functions supported on the above types are registered as a list of [SymbolTableEntry].
+     */
+    fun getFunctions(): List<SymbolTableEntry>
+}

--- a/lang/src/org/partiql/lang/types/RSPlugin.kt
+++ b/lang/src/org/partiql/lang/types/RSPlugin.kt
@@ -1,0 +1,75 @@
+package org.partiql.lang.types
+
+import com.amazon.ion.system.IonSystemBuilder
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.stringValue
+import kotlin.reflect.KClass
+
+val valueFactory = ExprValueFactory.standard(IonSystemBuilder.standard().build())
+
+/**
+ * An example implementation of a RedShift's VARCHAR type.
+ * TODO: Remove this file or move this to a test location.
+ */
+data class RSVarcharType(val length: Int): Type {
+
+    override val typeSignature: TypeSignature
+        get() = TypeSignature("RS_VARCHAR", listOf(TypeSignatureParameter.of(Integer.MAX_VALUE)))
+
+    override fun getDisplayName(): String {
+        return "RS_VARCHAR"
+    }
+
+    override fun writeExprValue(value: Any): ExprValue {
+        value as String
+        return valueFactory.newString(value)
+    }
+
+    override fun readExprValue(value: ExprValue): Any {
+        return value.stringValue()
+    }
+
+    override fun cast(value: ExprValue): ExprValue {
+        TODO("Not yet implemented")
+    }
+
+    override fun matches(value: ExprValue): Boolean {
+        TODO("Not yet implemented")
+    }
+
+}
+
+/**
+ * An example implementation of RedShift plugin registering RS_VARCHAR type and RS_CONCAT function.
+ */
+class RSPlugin : Plugin {
+    override fun getTypes(): Map<String, KClass<*>> {
+        return mapOf("RS_VARCHAR" to RSVarcharType::class)
+    }
+
+    override fun getFunctions(): List<SymbolTableEntry> {
+        val rsTypeSignature = TypeSignature(
+            "RS_VARCHAR",
+            listOf(TypeSignatureParameter.of(Integer.MAX_VALUE))
+        )
+        val rsConcat = object: SymbolTableEntry {
+            override val funName: String
+                get() = "RS_CONCAT"
+
+            override val argTypes: List<Type>
+                get() = listOf(
+                    TypeAndFunctionManager.getType(rsTypeSignature),
+                    TypeAndFunctionManager.getType(rsTypeSignature)
+                )
+
+            override fun invoke(exprValues: List<ExprValue>): ExprValue {
+                assert(exprValues.size == 2)
+                val str1 = exprValues[0].stringValue()
+                val str2 = exprValues[1].stringValue()
+                return valueFactory.newString(str1 + str2)
+            }
+        }
+        return listOf(rsConcat)
+    }
+}

--- a/lang/src/org/partiql/lang/types/Type.kt
+++ b/lang/src/org/partiql/lang/types/Type.kt
@@ -1,0 +1,37 @@
+package org.partiql.lang.types
+
+import org.partiql.lang.eval.ExprValue
+
+interface Type {
+    /**
+     * Represents the type signature for this type.
+     */
+    val typeSignature: TypeSignature
+
+    /**
+     * A type name is unique across all PartiQL's global types.
+     */
+    fun getDisplayName(): String
+
+    /**
+     * Converts the Object [value] to [ExprValue]
+     */
+    fun writeExprValue(value: Any): ExprValue
+
+    /**
+     * Read ExprValue [value] and convert it into an [Any]
+     */
+    fun readExprValue(value: ExprValue): Any
+
+    /**
+     * Cast/convert an ExprValue [value] to output a value of this type and convert it to an [ExprValue].
+     * This function will be called by PartiQL's evaluator for CASTing a value to a type.
+     * For e.g., CAST(<exprValue> AS <type>)
+     */
+    fun cast(value: ExprValue): ExprValue
+
+    /**
+     * Checks if the given exprvalue is of this type. The function is used by PartiQL's evaluator for IS operator.
+     */
+    fun matches(value: ExprValue): Boolean
+}

--- a/lang/src/org/partiql/lang/types/TypeAndFunctionManager.kt
+++ b/lang/src/org/partiql/lang/types/TypeAndFunctionManager.kt
@@ -1,0 +1,64 @@
+package org.partiql.lang.types
+
+import kotlin.reflect.KClass
+
+data class FunctionSignatureForLookup(val funcName: String, val params: List<Type>) {
+    // TODO: Define a better hash function
+    override fun hashCode(): Int {
+        var hashCode = funcName.hashCode()
+        params.forEachIndexed { index, type ->
+            hashCode += index * 7 * type.typeSignature.typeName.hashCode()
+        }
+        return hashCode
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return super.equals(other)
+    }
+}
+
+/**
+ * A singleton instance that resolves the types and functions globally.
+ */
+object TypeAndFunctionManager {
+    val types: HashMap<String, KClass<*>> = HashMap()
+    val functions: HashMap<FunctionSignatureForLookup, SymbolTableEntry> = HashMap()
+
+    /**
+     * Registers new types. Use this API to register builtin as well as external implementations of [Type]
+     */
+    fun addTypes(newTypes: Map<String, KClass<*>>) {
+        newTypes.forEach { (typeName, typeClass) ->
+            // TODO: Assert that all the typeClasses are instance of [Type]
+            types[typeName.toLowerCase()] = typeClass
+        }
+    }
+
+    /**
+     * Registers new functions. Use this API to register builtin as well as external implementations of [Type]
+     */
+    fun addFunctions(newFunctions: List<SymbolTableEntry>) {
+        newFunctions.forEach {
+            functions[FunctionSignatureForLookup(it.funName, it.argTypes)] = it
+        }
+    }
+
+    /**
+     * Returns a type for a type signature.
+     */
+    fun getType(typeSignature: TypeSignature): Type {
+        TODO()
+        // Get a reflection class by looking up the typeSignature.typeName in types map.
+        // Then create an instance of this reflection class by passing the typeSignature
+        // as an argument to the constructor
+    }
+
+    /**
+     * Returns a function definition for a given function signature.
+     */
+    fun getFunction(funcName: String, params: List<Type>): SymbolTableEntry? {
+        // Create a unique hash from funcName and params and then look it up
+        // TODO: Throw an error if the function signature is not found.
+        return functions[FunctionSignatureForLookup(funcName, params)]
+    }
+}

--- a/lang/src/org/partiql/lang/types/TypeSignature.kt
+++ b/lang/src/org/partiql/lang/types/TypeSignature.kt
@@ -1,0 +1,42 @@
+package org.partiql.lang.types
+
+/**
+ * Type signature of a [Type].
+ */
+data class TypeSignature(
+    val typeName: String,
+    val typeParameters: List<TypeSignatureParameter> = listOf()
+)
+
+/**
+ * Parameter kind for a [TypeSignatureParameter].
+ */
+enum class ParameterKind {
+    TYPE,
+    INT,
+    LONG,
+    STRING
+}
+
+/**
+ * Represents parameter of a [TypeSignature]
+ */
+class TypeSignatureParameter private constructor(val kind: ParameterKind, val value: Any) {
+    companion object {
+        fun of(typeSignature: TypeSignature): TypeSignatureParameter {
+            return TypeSignatureParameter(ParameterKind.TYPE, typeSignature)
+        }
+
+        fun of(longLiteral: Long): TypeSignatureParameter {
+            return TypeSignatureParameter(ParameterKind.LONG, longLiteral)
+        }
+
+        fun of(integer: Int): TypeSignatureParameter {
+            return TypeSignatureParameter(ParameterKind.INT, integer)
+        }
+
+        fun of(string: String): TypeSignatureParameter {
+            return TypeSignatureParameter(ParameterKind.STRING, string)
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
* Introduces the following key interfaces as part of the design:
        1. `Plugin`: Plugin to register types and functions supported on it.
        2. `Type`: PartiQL's type which would potentially replace the current `StaticType`. 
        3. `SymbolTableEntry`: A function signature and its implementation.
* `TypeAndFunctionManager`: A singleton instance that manages and resolves all the types and functions globally. 
* Note that this isn't a working piece of code but a design proposal for an open type system architecture. The design is expected to evolve and get better as we see fit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
