### PR TITLE
[cli] Add permissive mode evaluation option to CLI/REPL

### DIFF
--- a/cli/src/org/partiql/cli/Repl.kt
+++ b/cli/src/org/partiql/cli/Repl.kt
@@ -25,6 +25,7 @@ import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
 import org.partiql.lang.eval.MapBindings
 import org.partiql.lang.eval.StructOrdering
+import org.partiql.lang.eval.TypingMode
 import org.partiql.lang.eval.delegate
 import org.partiql.lang.syntax.Parser
 import org.partiql.lang.util.ConfigurableExprValueFormatter
@@ -203,6 +204,15 @@ internal class Repl(
         outputWriter.write("\n")
     }
 
+    private fun printTypingMode() {
+        val typingModeString = when (compiler.compileOptions.typingMode) {
+            TypingMode.LEGACY -> "LEGACY"
+            TypingMode.PERMISSIVE -> "PERMISSIVE"
+        }
+        outputWriter.write("Typing mode: $typingModeString")
+        outputWriter.write("\n")
+    }
+
     fun retrievePartiQLVersionAndHash(): String {
         val properties = Properties()
         properties.load(this.javaClass.getResourceAsStream("/partiql.properties"))
@@ -286,6 +296,7 @@ internal class Repl(
             state = when (state) {
                 ReplState.INIT -> {
                     printWelcomeMessage()
+                    printTypingMode()
                     printVersionNumber()
                     ReplState.READY
                 }

--- a/docs/user/CLI.md
+++ b/docs/user/CLI.md
@@ -26,6 +26,7 @@ Option                                Description
 -o, --output <File>                   output file, requires the query option (default: stdout)
 --of, --output-format <OutputFormat:  output format, requires the query option (default: PARTIQL)
   (ION_TEXT|ION_BINARY|PARTIQL|PARTIQL_PRETTY)>
+-p, --permissive                      run the PartiQL query in PERMISSIVE typing mode
 -q, --query <String>                  PartiQL query, triggers non interactive mode
 ```
 
@@ -673,3 +674,26 @@ All the available options for customized CSV files are shown as following:
 5. Set escape sign (single character only): `'escape':'\'`
 6. Set quote sign (single character only): `'quote':'"'`
 7. Set delimiter sign (single character only): `'delimiter':','`
+
+## Permissive Typing Mode
+By default, the CLI/REPL runs in [LEGACY](https://github.com/partiql/partiql-lang-kotlin/blob/main/lang/src/org/partiql/lang/eval/CompileOptions.kt#L53-L62)
+typing mode, which will give an evaluation time error in the case of data type mismatches.
+
+```
+(Running in the default LEGACY typing mode)
+PartiQL> 1 + 'foo';
+org.partiql.lang.eval.EvaluationException: ...
+    ...
+```
+
+Specifying the `-p` or `-permissive` flag will allow you to run PartiQL queries in [PERMISSIVE](https://github.com/partiql/partiql-lang-kotlin/blob/main/lang/src/org/partiql/lang/eval/CompileOptions.kt#L64-L73)
+typing mode, which will return `MISSING` in the case of data type mismatches.
+
+```
+(Running in PERMISSIVE typing mode)
+PartiQL> 1 + 'foo';
+==='
+MISSING
+---
+OK!
+```


### PR DESCRIPTION
Implements #543.

Adds [PERMISSIVE](https://github.com/partiql/partiql-lang-kotlin/blob/3febaeec46a0b703781494699c445f2034e9c6c4/lang/src/org/partiql/lang/eval/CompileOptions.kt#L48-L76) typing mode evaluation option to CLI/REPL. Also prints the typing mode when running the REPL:

```
Welcome to the PartiQL REPL!
Typing mode: PERMISSIVE
Using version: 0.5.1-SNAPSHOT-a27123d
PartiQL>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
