### PR TITLE
Bump Kotlin version to 1.4.32 from 1.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@
  */
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.4.0' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.4.32' apply false
     // https://arturbosch.github.io/detekt/groovydsl.html
     id "io.gitlab.arturbosch.detekt" version "1.20.0-RC1" apply false
     id 'org.jlleitschuh.gradle.ktlint' version '10.2.1'


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
