### PR TITLE
Implemented a basic PartiQL query formatter

### DIFF
--- a/lang/src/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
+++ b/lang/src/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
@@ -1,0 +1,738 @@
+package org.partiql.lang.prettyprint
+
+import com.amazon.ion.system.IonSystemBuilder
+import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.syntax.SqlParser
+import org.partiql.pig.runtime.SymbolPrimitive
+
+/**
+ * This class is used to pretty print PIG AST.
+ */
+class ASTPrettyPrinter {
+    fun prettyPrintAST(query: String): String {
+        val ion = IonSystemBuilder.standard().build()
+        val ast = SqlParser(ion).parseAstStatement(query)
+
+        return prettyPrintAST(ast)
+    }
+
+    /**
+     * PIG AST is first transformed into a recursive tree structure, RecursionTree, then it is pretty printed.
+     */
+    fun prettyPrintAST(ast: PartiqlAst.Statement): String {
+        val recursionTree = when (ast) {
+            is PartiqlAst.Statement.Query -> toRecursionTree(ast.expr)
+            is PartiqlAst.Statement.Dml -> toRecursionTree(ast)
+            is PartiqlAst.Statement.Ddl -> toRecursionTree(ast)
+            is PartiqlAst.Statement.Exec -> toRecursionTree(ast)
+        }
+
+        return recursionTree.convertToString()
+    }
+
+    // ********
+    // * EXEC *
+    // ********
+    private fun toRecursionTree(node: PartiqlAst.Statement.Exec): RecursionTree =
+        RecursionTree(
+            astType = "Exec",
+            children = listOf(
+                toRecursionTree(node.procedureName, "procedureName")
+            ) + node.args.mapIndexed { index, expr -> toRecursionTree(expr, "arg${index + 1}") }
+        )
+
+    // *******
+    // * DDL *
+    // *******
+    private fun toRecursionTree(node: PartiqlAst.Statement.Ddl): RecursionTree =
+        RecursionTree(
+            astType = "Ddl",
+            children = listOf(
+                toRecursionTree(node.op, "op")
+            )
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.DdlOp, attrOfParent: String? = null): RecursionTree =
+        when (node) {
+            is PartiqlAst.DdlOp.CreateIndex -> RecursionTree(
+                astType = "CreateIndex",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.indexName, "indexName")
+                ) + node.fields.mapIndexed { index, expr -> toRecursionTree(expr, "field${index + 1}") }
+            )
+            is PartiqlAst.DdlOp.CreateTable -> RecursionTree(
+                astType = "CreateTable",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.tableName, "tableName")
+                )
+            )
+            is PartiqlAst.DdlOp.DropIndex -> RecursionTree(
+                astType = "DropIndex",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.table, "table"),
+                    toRecursionTree(node.keys, "keys")
+                )
+            )
+            is PartiqlAst.DdlOp.DropTable -> RecursionTree(
+                astType = "DropTable",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.tableName, "tableName")
+                )
+            )
+        }
+
+    private fun toRecursionTree(node: PartiqlAst.Identifier, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "Identifier",
+            value = node.name.text + " " + node.case.toString(),
+            attrOfParent = attrOfParent
+        )
+
+    // *******
+    // * DML *
+    // *******
+    private fun toRecursionTree(node: PartiqlAst.Statement.Dml): RecursionTree =
+        RecursionTree(
+            astType = "Dml",
+            children = listOf(
+                toRecursionTree(node.operations, "operations")
+            ).let {
+                if (node.from == null) it else (it.plusElement(toRecursionTree(node.from!!, "from")))
+            }.let {
+                if (node.where == null) it else (it.plusElement(toRecursionTree(node.where!!, "where")))
+            }.let {
+                if (node.returning == null) it else (it.plusElement(toRecursionTree(node.returning!!, "returning")))
+            }
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.DmlOpList, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "DmlOpList",
+            attrOfParent = attrOfParent,
+            children = node.ops.mapIndexed { index, dmlOp -> toRecursionTree(dmlOp, "op${index + 1}") }
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.DmlOp, attrOfParent: String? = null): RecursionTree =
+        when (node) {
+            is PartiqlAst.DmlOp.Delete -> RecursionTree(
+                astType = "Delete",
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.DmlOp.Insert -> RecursionTree(
+                astType = "Insert",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.target, "target"),
+                    toRecursionTree(node.values, "values")
+                )
+            )
+            is PartiqlAst.DmlOp.InsertValue -> RecursionTree(
+                astType = "InsertValue",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.target, "target"),
+                    toRecursionTree(node.value, "value")
+                ).let {
+                    if (node.index == null) it else (it.plusElement(toRecursionTree(node.index!!, "index")))
+                }.let {
+                    if (node.onConflict == null) it else (it.plusElement(toRecursionTree(node.onConflict!!, "onConflict")))
+                }
+            )
+            is PartiqlAst.DmlOp.Remove -> RecursionTree(
+                astType = "Remove",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.target, "target")
+                )
+            )
+            is PartiqlAst.DmlOp.Set -> RecursionTree(
+                astType = "Set",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.assignment, "assignment")
+                )
+            )
+        }
+
+    private fun toRecursionTree(node: PartiqlAst.Assignment, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "Assignment",
+            attrOfParent = attrOfParent,
+            children = listOf(
+                toRecursionTree(node.target, "target"),
+                toRecursionTree(node.value, "value")
+            )
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.OnConflict, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "OnConflict",
+            attrOfParent = attrOfParent,
+            children = listOf(
+                toRecursionTree(node.expr, "expr"),
+                toRecursionTree(node.conflictAction, "conflictAction")
+            )
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.ConflictAction, attrOfParent: String? = null): RecursionTree =
+        when (node) {
+            is PartiqlAst.ConflictAction.DoNothing -> RecursionTree(
+                astType = "DoNothing",
+                attrOfParent = attrOfParent
+            )
+        }
+
+    private fun toRecursionTree(node: PartiqlAst.ReturningExpr, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "ReturningExpr",
+            attrOfParent = attrOfParent,
+            children = node.elems.mapIndexed { index, returningElem -> toRecursionTree(returningElem, "elem${index + 1}") }
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.ReturningElem, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "ReturningElem",
+            attrOfParent = attrOfParent,
+            children = listOf(
+                toRecursionTree(node.mapping, "mapping"),
+                toRecursionTree(node.column, "column")
+            )
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.ReturningMapping, attrOfParent: String? = null): RecursionTree =
+        when (node) {
+            is PartiqlAst.ReturningMapping.AllNew -> RecursionTree(
+                astType = "AllNew",
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.ReturningMapping.AllOld -> RecursionTree(
+                astType = "AllOld",
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.ReturningMapping.ModifiedNew -> RecursionTree(
+                astType = "ModifiedNew",
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.ReturningMapping.ModifiedOld -> RecursionTree(
+                astType = "ModifiedOld",
+                attrOfParent = attrOfParent
+            )
+        }
+
+    private fun toRecursionTree(node: PartiqlAst.ColumnComponent, attrOfParent: String? = null): RecursionTree =
+        when (node) {
+            is PartiqlAst.ColumnComponent.ReturningColumn -> RecursionTree(
+                astType = "ReturningColumn",
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.ColumnComponent.ReturningWildcard -> RecursionTree(
+                astType = "ReturningWildcard",
+                attrOfParent = attrOfParent
+            )
+        }
+
+    // *********
+    // * Query *
+    // *********
+    private fun toRecursionTree(node: PartiqlAst.Expr, attrOfParent: String? = null): RecursionTree =
+        when (node) {
+            is PartiqlAst.Expr.Id -> RecursionTree(
+                astType = "Id",
+                value = node.name.text + " " + node.case.toString() + " " + node.qualifier.toString(),
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.Expr.Missing -> RecursionTree(
+                astType = "missing",
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.Expr.Lit -> RecursionTree(
+                astType = "Lit",
+                value = node.value.toString(),
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.Expr.Parameter -> RecursionTree(
+                astType = "Parameter",
+                value = node.index.value.toString(),
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.Expr.Date -> RecursionTree(
+                astType = "Date",
+                value = node.year.value.toString() + "-" + node.month.value.toString() + "-" + node.day.value.toString(),
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.Expr.LitTime -> RecursionTree(
+                astType = "LitTime",
+                value = node.value.hour.value.toString() +
+                    ":" + node.value.minute.value.toString() +
+                    ":" + node.value.second.toString() +
+                    "." + node.value.nano.toString() +
+                    ", 'precision': " + node.value.precision.value.toString() +
+                    ", 'timeZone': " + node.value.withTimeZone.toString() +
+                    ", 'tzminute': " + node.value.tzMinutes.toString(),
+                attrOfParent = attrOfParent,
+            )
+            is PartiqlAst.Expr.Not -> RecursionTree(
+                astType = "Not",
+                attrOfParent = attrOfParent,
+                children = listOf(toRecursionTree(node.expr))
+            )
+            is PartiqlAst.Expr.Pos -> RecursionTree(
+                astType = "+",
+                attrOfParent = attrOfParent,
+                children = listOf(toRecursionTree(node.expr))
+            )
+            is PartiqlAst.Expr.Neg -> RecursionTree(
+                astType = "-",
+                attrOfParent = attrOfParent,
+                children = listOf(toRecursionTree(node.expr))
+            )
+            is PartiqlAst.Expr.Plus -> RecursionTree(
+                astType = "+",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Minus -> RecursionTree(
+                astType = "-",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Times -> RecursionTree(
+                astType = "*",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Divide -> RecursionTree(
+                astType = "/",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Modulo -> RecursionTree(
+                astType = "%",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Concat -> RecursionTree(
+                astType = "||",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.And -> RecursionTree(
+                astType = "And",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Or -> RecursionTree(
+                astType = "Or",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Eq -> RecursionTree(
+                astType = "=",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Ne -> RecursionTree(
+                astType = "!=",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Gt -> RecursionTree(
+                astType = ">",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Gte -> RecursionTree(
+                astType = ">=",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Lt -> RecursionTree(
+                astType = "<",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Lte -> RecursionTree(
+                astType = "<=",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.InCollection -> RecursionTree(
+                astType = "In",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Union -> RecursionTree(
+                astType = "Union",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Except -> RecursionTree(
+                astType = "Except",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Intersect -> RecursionTree(
+                astType = "Intersect",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.Like -> RecursionTree(
+                astType = "Like",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.value, "value"),
+                    toRecursionTree(node.pattern, "pattern")
+                ).let {
+                    if (node.escape == null) it else (it + listOf(toRecursionTree(node.escape!!, "escape")))
+                }
+            )
+            is PartiqlAst.Expr.Between -> RecursionTree(
+                astType = "Between",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.value, "value"),
+                    toRecursionTree(node.from, "from"),
+                    toRecursionTree(node.to, "to")
+                )
+            )
+            is PartiqlAst.Expr.SimpleCase -> RecursionTree(
+                astType = "SimpleCase",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.expr, "expr"),
+                    toRecursionTree(node.cases, "cases")
+                ).let {
+                    if (node.default == null) it else (it.plusElement(toRecursionTree(node.default!!, "default")))
+                }
+            )
+            is PartiqlAst.Expr.SearchedCase -> RecursionTree(
+                astType = "SearchedCase",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.cases, "cases")
+                ).let {
+                    if (node.default == null) it else (it.plusElement(toRecursionTree(node.default!!, "default")))
+                }
+            )
+            is PartiqlAst.Expr.Struct -> RecursionTree(
+                astType = "Struct",
+                attrOfParent = attrOfParent,
+                children = node.fields.mapIndexed { index, exprPair -> toRecursionTree(exprPair, "field${index + 1}") }
+            )
+            is PartiqlAst.Expr.Bag -> RecursionTree(
+                astType = "Bag",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.values)
+            )
+            is PartiqlAst.Expr.List -> RecursionTree(
+                astType = "List",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.values)
+            )
+            is PartiqlAst.Expr.Sexp -> RecursionTree(
+                astType = "Sexp",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.values)
+            )
+            is PartiqlAst.Expr.Path -> RecursionTree(
+                astType = "Path",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.root, "root")
+                ) + node.steps.mapIndexed { index, pathStep -> toRecursionTree(pathStep, "step${index + 1}") }
+            )
+            is PartiqlAst.Expr.Call -> RecursionTree(
+                astType = "Call",
+                value = node.funcName.text,
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.args, "arg")
+            )
+            is PartiqlAst.Expr.CallAgg -> RecursionTree(
+                astType = "CallAgg",
+                value = node.funcName.text,
+                attrOfParent = attrOfParent,
+                children = listOf(toRecursionTree(node.arg, "arg"))
+            )
+            is PartiqlAst.Expr.IsType -> RecursionTree(
+                astType = "Is",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.value, "value"),
+                    RecursionTree(
+                        astType = node.type.toString(),
+                        attrOfParent = "type"
+                    )
+                )
+            )
+            is PartiqlAst.Expr.Cast -> RecursionTree(
+                astType = "Cast",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.value, "value"),
+                    RecursionTree(
+                        astType = node.asType.toString(),
+                        attrOfParent = "asType"
+                    )
+                )
+            )
+            is PartiqlAst.Expr.CanCast -> RecursionTree(
+                astType = "CanCast",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.value, "value"),
+                    RecursionTree(
+                        astType = node.asType.toString(),
+                        attrOfParent = "asType"
+                    )
+                )
+            )
+            is PartiqlAst.Expr.CanLosslessCast -> RecursionTree(
+                astType = "CanLosslessCast",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.value, "value"),
+                    RecursionTree(
+                        astType = node.asType.toString(),
+                        attrOfParent = "asType"
+                    )
+                )
+            )
+            is PartiqlAst.Expr.NullIf -> RecursionTree(
+                astType = "NullIf",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.expr1, "expr1"),
+                    toRecursionTree(node.expr2, "expr2")
+                )
+            )
+            is PartiqlAst.Expr.Coalesce -> RecursionTree(
+                astType = "Coalesce",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.args, "arg")
+            )
+            is PartiqlAst.Expr.Select -> RecursionTree(
+                astType = "Select",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.project, "project"),
+                    toRecursionTree(node.from, "from")
+                ).let {
+                    if (node.fromLet == null) it else (it.plusElement(toRecursionTree(node.fromLet!!, "let")))
+                }.let {
+                    if (node.where == null) it else (it.plusElement(toRecursionTree(node.where!!, "where")))
+                }.let {
+                    if (node.group == null) it else (it.plusElement(toRecursionTree(node.group!!, "group")))
+                }.let {
+                    if (node.having == null) it else (it.plusElement(toRecursionTree(node.having!!, "having")))
+                }.let {
+                    if (node.order == null) it else (it.plusElement(toRecursionTree(node.order!!, "order")))
+                }.let {
+                    if (node.limit == null) it else (it.plusElement(toRecursionTree(node.limit!!, "limit")))
+                }.let {
+                    if (node.offset == null) it else (it.plusElement(toRecursionTree(node.offset!!, "offset")))
+                }
+            )
+        }
+
+    private fun toRecursionTreeList(nodes: List<PartiqlAst.Expr>, attrOfParent: String? = null): List<RecursionTree> =
+        nodes.map { toRecursionTree(it, attrOfParent) }
+
+    private fun toRecursionTree(node: PartiqlAst.ExprPair, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "Pair",
+            attrOfParent = attrOfParent,
+            children = listOf(
+                toRecursionTree(node.first, "first"),
+                toRecursionTree(node.second, "second")
+            )
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.ExprPairList, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "ExprPairList",
+            attrOfParent = attrOfParent,
+            children = node.pairs.mapIndexed { index, exprPair -> toRecursionTree(exprPair, "pair${index + 1}") }
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.PathStep, attrOfParent: String? = null): RecursionTree =
+        when (node) {
+            is PartiqlAst.PathStep.PathExpr -> toRecursionTree(node.index, attrOfParent)
+            is PartiqlAst.PathStep.PathWildcard -> RecursionTree(
+                astType = "[*]",
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.PathStep.PathUnpivot -> RecursionTree(
+                astType = "*",
+                attrOfParent = attrOfParent
+            )
+        }
+
+    private fun toRecursionTree(node: PartiqlAst.Projection, attrOfParent: String? = null): RecursionTree =
+        when (node) {
+            is PartiqlAst.Projection.ProjectStar -> RecursionTree(
+                astType = "*",
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.Projection.ProjectValue -> RecursionTree(
+                astType = "ProjectValue",
+                attrOfParent = attrOfParent,
+                children = listOf(toRecursionTree(node.value, "value"))
+            )
+            is PartiqlAst.Projection.ProjectList -> RecursionTree(
+                astType = "ProjectList",
+                attrOfParent = attrOfParent,
+                children = node.projectItems.mapIndexed { index, projectItem -> toRecursionTree(projectItem, "projectItem${index + 1}") }
+            )
+            is PartiqlAst.Projection.ProjectPivot -> RecursionTree(
+                astType = "ProjectPivot",
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.value, "value"),
+                    toRecursionTree(node.key, "key")
+                )
+            )
+        }
+
+    private fun toRecursionTree(node: PartiqlAst.ProjectItem, attrOfParent: String? = null): RecursionTree =
+        when (node) {
+            is PartiqlAst.ProjectItem.ProjectAll -> RecursionTree(
+                astType = "ProjectAll",
+                attrOfParent = attrOfParent,
+                children = listOf(toRecursionTree(node.expr, "expr"))
+            )
+            is PartiqlAst.ProjectItem.ProjectExpr -> RecursionTree(
+                astType = "ProjectExpr",
+                attrOfParent = attrOfParent,
+                children = listOf(toRecursionTree(node.expr, "expr")).let {
+                    if (node.asAlias == null) it else { it.plusElement(toRecursionTree(node.asAlias!!, "as")) }
+                }
+            )
+        }
+
+    private fun toRecursionTree(node: PartiqlAst.FromSource, attrOfParent: String? = null): RecursionTree =
+        when (node) {
+            is PartiqlAst.FromSource.Join -> RecursionTree(
+                astType = node.type.toString(),
+                attrOfParent = attrOfParent,
+                children = listOf(
+                    toRecursionTree(node.left, "left"),
+                    toRecursionTree(node.right, "right")
+                ).let {
+                    if (node.predicate == null) it else { it.plusElement(toRecursionTree(node.predicate!!, "on")) }
+                }
+            )
+            is PartiqlAst.FromSource.Scan -> RecursionTree(
+                astType = "Scan",
+                attrOfParent = attrOfParent,
+                children = listOf(toRecursionTree(node.expr)).let {
+                    if (node.asAlias == null) it else { it.plusElement(toRecursionTree(node.asAlias!!, attrOfParent = "as")) }
+                }.let {
+                    if (node.atAlias == null) it else { it.plusElement(toRecursionTree(node.atAlias!!, attrOfParent = "at")) }
+                }.let {
+                    if (node.byAlias == null) it else { it.plusElement(toRecursionTree(node.byAlias!!, attrOfParent = "by")) }
+                }
+            )
+            is PartiqlAst.FromSource.Unpivot -> RecursionTree(
+                astType = "Unpivot",
+                attrOfParent = attrOfParent,
+                children = listOf(toRecursionTree(node.expr)).let {
+                    if (node.asAlias == null) it else { it.plusElement(toRecursionTree(node.asAlias!!, attrOfParent = "as")) }
+                }.let {
+                    if (node.atAlias == null) it else { it.plusElement(toRecursionTree(node.atAlias!!, attrOfParent = "at")) }
+                }.let {
+                    if (node.byAlias == null) it else { it.plusElement(toRecursionTree(node.byAlias!!, attrOfParent = "by")) }
+                }
+            )
+        }
+
+    private fun toRecursionTree(node: PartiqlAst.Let, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "Let",
+            attrOfParent = attrOfParent,
+            children = node.letBindings.mapIndexed { index, letBinding -> toRecursionTree(letBinding, "letBinding${index + 1}") }
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.LetBinding, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "LetBinding",
+            attrOfParent = attrOfParent,
+            children = listOf(
+                toRecursionTree(node.expr, "expr"),
+                toRecursionTree(node.name, "name")
+            )
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.GroupBy, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "Group",
+            attrOfParent = attrOfParent,
+            children = listOf(
+                RecursionTree(
+                    astType = when (node.strategy) {
+                        is PartiqlAst.GroupingStrategy.GroupFull -> "GroupFull"
+                        is PartiqlAst.GroupingStrategy.GroupPartial -> "GroupPartial"
+                    },
+                    attrOfParent = "strategy"
+                ),
+                RecursionTree(
+                    astType = "GroupKeyList",
+                    attrOfParent = "keyList",
+                    children = node.keyList.keys.mapIndexed { index, groupKey ->
+                        RecursionTree(
+                            astType = "GroupKey",
+                            attrOfParent = "key${index + 1}",
+                            children = listOf(
+                                toRecursionTree(groupKey.expr, "expr")
+                            ).let {
+                                if (groupKey.asAlias == null) it else { it.plusElement(toRecursionTree(groupKey.asAlias!!, "as")) }
+                            }
+                        )
+                    }
+                )
+            ).let {
+                if (node.groupAsAlias == null) it else { it.plusElement(toRecursionTree(node.groupAsAlias!!, attrOfParent = "groupAs")) }
+            }
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.OrderBy, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "Order",
+            attrOfParent = attrOfParent,
+            children = node.sortSpecs.mapIndexed { index, sortSpec ->
+                RecursionTree(
+                    astType = "SortSpec",
+                    attrOfParent = "sortSpec${index + 1}",
+                    children = listOf(
+                        toRecursionTree(sortSpec.expr, "expr"),
+                        RecursionTree(
+                            astType = sortSpec.orderingSpec.toString(),
+                            attrOfParent = "orderingSpec"
+                        )
+                    )
+                )
+            }
+        )
+
+    private fun toRecursionTree(symbol: SymbolPrimitive, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "Symbol",
+            value = symbol.text,
+            attrOfParent = attrOfParent
+        )
+
+    private fun toRecursionTree(node: PartiqlAst.ScopeQualifier, attrOfParent: String? = null): RecursionTree =
+        when (node) {
+            is PartiqlAst.ScopeQualifier.Unqualified -> RecursionTree(
+                astType = "Unqualified",
+                attrOfParent = attrOfParent
+            )
+            is PartiqlAst.ScopeQualifier.LocalsFirst -> RecursionTree(
+                astType = "LocalsFirst",
+                attrOfParent = attrOfParent
+            )
+        }
+}

--- a/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
+++ b/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
@@ -1,0 +1,716 @@
+package org.partiql.lang.prettyprint
+
+import com.amazon.ion.system.IonSystemBuilder
+import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.syntax.SqlParser
+import org.partiql.pig.runtime.toIonElement
+import java.lang.StringBuilder
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.IllegalStateException
+import kotlin.math.abs
+
+/**
+ * This class is used to pretty print a query, which first transforms a query into a parsed tree,
+ * and then transform it back to a pretty string.
+ *
+ * The idea is to use a StringBuilder and write a pretty-printed query to it according to the like
+ * of the parsed tree
+ */
+class QueryPrettyPrinter {
+    fun prettyPrintQuery(query: String): String {
+        val ion = IonSystemBuilder.standard().build()
+        val ast = SqlParser(ion).parseAstStatement(query)
+
+        return astToPrettyQuery(ast)
+    }
+
+    fun astToPrettyQuery(ast: PartiqlAst.Statement): String {
+        val sb = StringBuilder()
+        writeAstNode(ast, sb)
+        if (sb.lastOrNull() == '\n') {
+            sb.removeLast(1)
+        }
+
+        return sb.toString()
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Statement, sb: StringBuilder) {
+        when (node) {
+            is PartiqlAst.Statement.Query -> writeAstNode(node.expr, sb, 0)
+            is PartiqlAst.Statement.Ddl -> TODO()
+            is PartiqlAst.Statement.Dml -> TODO()
+            is PartiqlAst.Statement.Exec -> TODO()
+        }
+    }
+
+    /**
+     * @param node is the PIG AST node
+     * @param sb is the StringBuilder where we write the pretty query according to the like of the parsed tree
+     * @param level is an integer which marks how deep in the nested query we are. It increments Only when we step
+     * into a Case or Select clause.
+     */
+    private fun writeAstNode(node: PartiqlAst.Expr, sb: StringBuilder, level: Int) {
+        when (node) {
+            is PartiqlAst.Expr.Missing -> writeAstNode(node, sb)
+            is PartiqlAst.Expr.Lit -> writeAstNode(node, sb)
+            is PartiqlAst.Expr.LitTime -> writeAstNode(node, sb)
+            is PartiqlAst.Expr.Date -> writeAstNode(node, sb)
+            is PartiqlAst.Expr.Id -> writeAstNode(node, sb)
+            is PartiqlAst.Expr.Bag -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.Sexp -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.Struct -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.List -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.Parameter -> writeAstNode(node, sb)
+            is PartiqlAst.Expr.Call -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.CallAgg -> writeAstNode(node, sb, level)
+
+            is PartiqlAst.Expr.Path -> writeAstNode(node, sb, level)
+
+            is PartiqlAst.Expr.SimpleCase -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.SearchedCase -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.Select -> writeAstNode(node, sb, level)
+
+            is PartiqlAst.Expr.Pos -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.Neg -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.Not -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.Between -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.Like -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.IsType -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.Cast -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.CanCast -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.CanLosslessCast -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.Coalesce -> writeAstNode(node, sb, level)
+            is PartiqlAst.Expr.NullIf -> writeAstNode(node, sb, level)
+
+            is PartiqlAst.Expr.Concat -> writeNAryOperator("||", node.operands, sb, level)
+            is PartiqlAst.Expr.Plus -> writeNAryOperator("+", node.operands, sb, level)
+            is PartiqlAst.Expr.Minus -> writeNAryOperator("-", node.operands, sb, level)
+            is PartiqlAst.Expr.Times -> writeNAryOperator("*", node.operands, sb, level)
+            is PartiqlAst.Expr.Divide -> writeNAryOperator("/", node.operands, sb, level)
+            is PartiqlAst.Expr.Modulo -> writeNAryOperator("%", node.operands, sb, level)
+            is PartiqlAst.Expr.Eq -> writeNAryOperator("=", node.operands, sb, level)
+            is PartiqlAst.Expr.Ne -> writeNAryOperator("!=", node.operands, sb, level)
+            is PartiqlAst.Expr.Gt -> writeNAryOperator(">", node.operands, sb, level)
+            is PartiqlAst.Expr.Gte -> writeNAryOperator(">=", node.operands, sb, level)
+            is PartiqlAst.Expr.Lt -> writeNAryOperator("<", node.operands, sb, level)
+            is PartiqlAst.Expr.Lte -> writeNAryOperator("<=", node.operands, sb, level)
+            is PartiqlAst.Expr.And -> writeNAryOperator("AND", node.operands, sb, level)
+            is PartiqlAst.Expr.Or -> writeNAryOperator("OR", node.operands, sb, level)
+            is PartiqlAst.Expr.InCollection -> writeNAryOperator("IN", node.operands, sb, level)
+            is PartiqlAst.Expr.Union -> when (node.setq) {
+                is PartiqlAst.SetQuantifier.Distinct -> writeNAryOperator("UNION", node.operands, sb, level)
+                is PartiqlAst.SetQuantifier.All -> writeNAryOperator("UNION ALL", node.operands, sb, level)
+            }
+            is PartiqlAst.Expr.Intersect -> when (node.setq) {
+                is PartiqlAst.SetQuantifier.Distinct -> writeNAryOperator("INTERSECT", node.operands, sb, level)
+                is PartiqlAst.SetQuantifier.All -> writeNAryOperator("INTERSECT ALL", node.operands, sb, level)
+            }
+            is PartiqlAst.Expr.Except -> when (node.setq) {
+                is PartiqlAst.SetQuantifier.Distinct -> writeNAryOperator("EXCEPT", node.operands, sb, level)
+                is PartiqlAst.SetQuantifier.All -> writeNAryOperator("EXCEPT ALL", node.operands, sb, level)
+            }
+        }
+    }
+
+    /**
+     * If the node indicates a sub-query, we surround it with parenthesis and start a new line for it.
+     */
+    private fun writeAstNodeCheckSubQuery(node: PartiqlAst.Expr, sb: StringBuilder, level: Int) {
+        when (isCaseOrSelect(node)) {
+            true -> {
+                val indent = getIndent(level + 1)
+                sb.append("(\n$indent")
+                writeAstNode(node, sb, level + 1)
+                sb.append(')')
+            }
+            false -> writeAstNode(node, sb, level)
+        }
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Missing, sb: StringBuilder) {
+        sb.append("MISSING")
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Lit, sb: StringBuilder) {
+        // Not sure if there is a better way to transform IonElement into a PartiQL value as string
+        val value = when (node.value.type) {
+            com.amazon.ionelement.api.ElementType.NULL -> "NULL"
+            com.amazon.ionelement.api.ElementType.BOOL -> node.value.booleanValue.toString().toUpperCase()
+            com.amazon.ionelement.api.ElementType.INT -> node.value.longValue.toString()
+            com.amazon.ionelement.api.ElementType.DECIMAL -> node.value.decimalValue.toString()
+            com.amazon.ionelement.api.ElementType.FLOAT -> node.value.doubleValue.toString()
+            com.amazon.ionelement.api.ElementType.STRING -> "'${node.value.stringValue}'"
+            else -> "`${node.value.toIonElement()}`"
+        }
+
+        sb.append(value)
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Date, sb: StringBuilder) {
+        val date = LocalDate.of(node.year.value.toInt(), node.month.value.toInt(), node.day.value.toInt())
+        sb.append("DATE '$date'")
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.LitTime, sb: StringBuilder) {
+        val localTime = LocalTime.of(
+            node.value.hour.value.toInt(),
+            node.value.minute.value.toInt(),
+            node.value.second.value.toInt(),
+            node.value.nano.value.toInt()
+        )
+        val precision = node.value.precision
+        val withTimeZone = node.value.withTimeZone
+        val tzTime = node.value.tzMinutes?.let {
+            val prefix = when {
+                (it.value >= 0) -> "+"
+                else -> "-"
+            }
+            val timeValue = abs(it.value.toInt())
+            val tzLocalTime = LocalTime.of(timeValue / 60, timeValue % 60)
+            "$prefix$tzLocalTime"
+        } ?: ""
+
+        when (withTimeZone.value) {
+            true -> sb.append("TIME ($precision) WITH TIME ZONE '$localTime$tzTime'")
+            false -> sb.append("TIME ($precision) '$localTime'")
+        }
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Bag, sb: StringBuilder, level: Int) {
+        sb.append("<< ")
+        node.values.forEach {
+            // The next line may need to be changed, as it does not produce a pretty query
+            // where CASE or SELECT clause is wrapped inside a bag
+            writeAstNodeCheckSubQuery(it, sb, level)
+            sb.append(", ")
+        }
+        if (node.values.isNotEmpty()) {
+            sb.removeLast(2)
+        }
+        sb.append(" >>")
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Sexp, sb: StringBuilder, level: Int) {
+        sb.append("sexp(")
+        node.values.forEach {
+            // The next line may need to be changed, as it does not produce a pretty query
+            // where CASE or SELECT clause is wrapped inside a sexp
+            writeAstNodeCheckSubQuery(it, sb, level)
+            sb.append(", ")
+        }
+        if (node.values.isNotEmpty()) {
+            sb.removeLast(2)
+        }
+        sb.append(")")
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.List, sb: StringBuilder, level: Int) {
+        sb.append("[ ")
+        node.values.forEach {
+            // The next line may need to be changed, as it does not produce a pretty query
+            // where CASE or SELECT clause is wrapped inside a list
+            writeAstNodeCheckSubQuery(it, sb, level)
+            sb.append(", ")
+        }
+        if (node.values.isNotEmpty()) {
+            sb.removeLast(2)
+        }
+        sb.append(" ]")
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Struct, sb: StringBuilder, level: Int) {
+        sb.append("{ ")
+        node.fields.forEach {
+            // The next line may need to be changed, as it does not produce a pretty query
+            // where CASE or SELECT clause is wrapped inside a struct
+            writeAstNodeCheckSubQuery(it.first, sb, level)
+            sb.append(": ")
+            writeAstNodeCheckSubQuery(it.second, sb, level)
+            sb.append(", ")
+        }
+        if (node.fields.isNotEmpty()) {
+            sb.removeLast(2)
+        }
+        sb.append(" }")
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Parameter, sb: StringBuilder) {
+        sb.append("?")
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Id, sb: StringBuilder) {
+        when (node.case) {
+            is PartiqlAst.CaseSensitivity.CaseSensitive -> sb.append("\"${node.name.text}\"")
+            is PartiqlAst.CaseSensitivity.CaseInsensitive -> sb.append(node.name.text)
+        }
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Call, sb: StringBuilder, level: Int) {
+        sb.append("${node.funcName.text}(")
+        node.args.forEach { arg ->
+            // The next line may need to be changed, as it does not produce a pretty query
+            // where CASE or SELECT clause is wrapped inside a function call
+            writeAstNodeCheckSubQuery(arg, sb, level)
+            sb.append(", ")
+        }
+        if (node.args.isNotEmpty()) {
+            sb.removeLast(2)
+        }
+        sb.append(')')
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.CallAgg, sb: StringBuilder, level: Int) {
+        sb.append("${node.funcName.text}(")
+        if (node.setq is PartiqlAst.SetQuantifier.Distinct) {
+            sb.append("DISTINCT ")
+        }
+        // The next line may need to be changed, as it does not produce a pretty query
+        // where CASE or SELECT clause is wrapped inside a function call
+        writeAstNodeCheckSubQuery(node.arg, sb, level + 1)
+        sb.append(')')
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Path, sb: StringBuilder, level: Int) {
+        when {
+            isOperator(node.root) || node.root is PartiqlAst.Expr.Path -> {
+                sb.append('(')
+                writeAstNode(node.root, sb, level)
+                sb.append(')')
+            }
+            else -> writeAstNode(node.root, sb, level) // Assume a path root is not a SELECT or CASE clause, i.e. people don't write (SELECT a FROM b).c
+        }
+        node.steps.forEach {
+            when (it) {
+                is PartiqlAst.PathStep.PathExpr -> when (it.case) {
+                    is PartiqlAst.CaseSensitivity.CaseSensitive -> {
+                        // This means the value of the path component is surrounded by square brackets '[' and ']'
+                        // or double-quotes i.e. either a[b] or a."b"
+                        // Here we just transform it to be surrounded by square brackets
+                        sb.append('[')
+                        writeAstNode(it.index, sb, level) // Assume a path component is not a SELECT or CASE clause, i.e. people don't write a[SELECT b FROM c]
+                        sb.append(']')
+                    }
+                    // Case for a.b
+                    is PartiqlAst.CaseSensitivity.CaseInsensitive -> when (it.index) {
+                        is PartiqlAst.Expr.Lit -> {
+                            val value = it.index.value.stringValue // It must be a string according to behavior of Lexer
+                            sb.append(".$value")
+                        }
+                        else -> IllegalArgumentException("PathExpr's attribute 'index' must be PartiqlAst.Expr.Lit when 'caseSensitive' is CaseInsensitive")
+                    }
+                }
+                is PartiqlAst.PathStep.PathUnpivot -> sb.append(".[*]")
+                is PartiqlAst.PathStep.PathWildcard -> sb.append(".*")
+            }
+        }
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.SimpleCase, sb: StringBuilder, level: Int) {
+        val indent = getIndent(level)
+        sb.append("CASE ")
+        // The next lines may need to be changed, as it does not produce a pretty query
+        // where CASE or SELECT clause is wrapped inside CASE clause
+        writeAstNodeCheckSubQuery(node.expr, sb, level)
+        writeCaseWhenClauses(node.cases.pairs, sb, level + 1)
+        writeCaseElseClause(node.default, sb, level + 1)
+        sb.append("\n${indent}END")
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.SearchedCase, sb: StringBuilder, level: Int) {
+        val indent = getIndent(level)
+        sb.append("CASE")
+        writeCaseWhenClauses(node.cases.pairs, sb, level + 1)
+        writeCaseElseClause(node.default, sb, level + 1)
+        sb.append("\n${indent}END")
+    }
+
+    private fun writeCaseWhenClauses(pairs: List<PartiqlAst.ExprPair>, sb: StringBuilder, level: Int) {
+        val indent = getIndent(level)
+        pairs.forEach { pair ->
+            sb.append("\n${indent}WHEN ")
+            writeAstNodeCheckSubQuery(pair.first, sb, level)
+            sb.append(" THEN ")
+            writeAstNodeCheckSubQuery(pair.second, sb, level)
+        }
+    }
+
+    private fun writeCaseElseClause(default: PartiqlAst.Expr?, sb: StringBuilder, level: Int) {
+        if (default != null) {
+            val indent = getIndent(level)
+            sb.append("\n${indent}ELSE ")
+            writeAstNodeCheckSubQuery(default, sb, level)
+        }
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Select, sb: StringBuilder, level: Int) {
+        val indent = getIndent(level)
+
+        // SELECT clause
+        when (node.project) {
+            is PartiqlAst.Projection.ProjectPivot -> sb.append("PIVOT ")
+            else -> when (node.setq) {
+                is PartiqlAst.SetQuantifier.Distinct -> sb.append("SELECT DISTINCT ")
+                else -> sb.append("SELECT ")
+            }
+        }
+        writeProjection(node.project, sb, level)
+
+        // FROM clause
+        sb.append("\n${indent}FROM ")
+        writeFromSource(node.from, sb, level)
+
+        // LET clause
+        node.fromLet?.let {
+            sb.append(" LET ")
+            writeFromLet(it, sb, level)
+        }
+
+        // WHERE clause
+        node.where?.let {
+            sb.append("\n${indent}WHERE ")
+            writeAstNodeCheckSubQuery(it, sb, level + 1)
+        }
+
+        // GROUP clause
+        node.group?.let {
+            sb.append("\n${indent}GROUP ")
+            writeGroupBy(it, sb, level)
+        }
+
+        // HAVING clause
+        node.having?.let {
+            sb.append("\n${indent}HAVING ")
+            writeAstNodeCheckSubQuery(it, sb, level)
+        }
+
+        // ORDER BY clause
+        node.order?.let { orderBy ->
+            sb.append("\n${indent}ORDER BY ")
+            orderBy.sortSpecs.forEach { sortSpec ->
+                writeSortSpec(sortSpec, sb, level)
+                sb.append(", ")
+            }
+            sb.removeLast(2)
+        }
+
+        // LIMIT clause
+        node.limit?.let {
+            sb.append("\n${indent}LIMIT ")
+            writeAstNodeCheckSubQuery(it, sb, level + 1)
+        }
+
+        // OFFSET clause
+        node.offset?.let {
+            sb.append("\n${indent}OFFSET ")
+            writeAstNodeCheckSubQuery(it, sb, level + 1)
+        }
+    }
+
+    private fun writeSortSpec(sortSpec: PartiqlAst.SortSpec, sb: StringBuilder, level: Int) {
+        writeAstNodeCheckSubQuery(sortSpec.expr, sb, level + 1)
+        when (sortSpec.orderingSpec) {
+            is PartiqlAst.OrderingSpec.Asc -> sb.append(" ASC")
+            is PartiqlAst.OrderingSpec.Desc -> sb.append(" DESC")
+        }
+    }
+
+    private fun writeGroupBy(group: PartiqlAst.GroupBy, sb: StringBuilder, level: Int) {
+        when (group.strategy) {
+            is PartiqlAst.GroupingStrategy.GroupFull -> sb.append("BY ")
+            is PartiqlAst.GroupingStrategy.GroupPartial -> sb.append("PARTIAL BY ")
+        }
+        group.keyList.keys.forEach {
+            writeGroupKey(it, sb, level)
+            sb.append(", ")
+        }
+        sb.removeLast(2)
+        group.groupAsAlias?.let { sb.append(" GROUP AS ${it.text}") }
+    }
+
+    private fun writeGroupKey(key: PartiqlAst.GroupKey, sb: StringBuilder, level: Int) {
+        writeAstNodeCheckSubQuery(key.expr, sb, level)
+        key.asAlias?.let { sb.append(" AS ${it.text}") }
+    }
+
+    private fun writeFromLet(fromLet: PartiqlAst.Let, sb: StringBuilder, level: Int) {
+        fromLet.letBindings.forEach {
+            writeLetBinding(it, sb, level)
+            sb.append(", ")
+        }
+        sb.removeLast(2)
+    }
+
+    private fun writeLetBinding(letBinding: PartiqlAst.LetBinding, sb: StringBuilder, level: Int) {
+        writeAstNodeCheckSubQuery(letBinding.expr, sb, level)
+        sb.append(" AS ${letBinding.name.text}")
+    }
+
+    private fun writeFromSource(from: PartiqlAst.FromSource, sb: StringBuilder, level: Int) {
+        val indent = getIndent(level)
+        when (from) {
+            is PartiqlAst.FromSource.Scan -> {
+                writeAstNodeCheckSubQuery(from.expr, sb, level)
+                from.asAlias?.let { sb.append(" AS ${it.text}") }
+                from.atAlias?.let { sb.append(" AT ${it.text}") }
+                from.byAlias?.let { sb.append(" BY ${it.text}") }
+            }
+            is PartiqlAst.FromSource.Join -> when {
+                (from.type is PartiqlAst.JoinType.Inner && from.predicate != null) -> {
+                    // This means we can use comma to separate JOIN left-hand side and right-hand side
+                    writeFromSource(from.left, sb, level)
+                    sb.append(", ")
+                    writeFromSource(from.right, sb, level)
+                }
+                else -> {
+                    val join = when (from.type) {
+                        is PartiqlAst.JoinType.Inner -> "JOIN"
+                        is PartiqlAst.JoinType.Left -> "LEFT CROSS JOIN"
+                        is PartiqlAst.JoinType.Right -> "RIGHT CROSS JOIN"
+                        is PartiqlAst.JoinType.Full -> "FULL CROSS JOIN"
+                    }
+                    writeFromSource(from.left, sb, level)
+                    sb.append("\n${indent}\t$join ")
+                    writeFromSource(from.right, sb, level)
+                    from.predicate?.let {
+                        sb.append(" ON ")
+                        writeAstNodeCheckSubQuery(it, sb, level)
+                    }
+                }
+            }
+            is PartiqlAst.FromSource.Unpivot -> {
+                sb.append("UNPIVOT ")
+                writeAstNodeCheckSubQuery(from.expr, sb, level)
+                from.asAlias?.let { sb.append(" AS ${it.text}") }
+                from.atAlias?.let { sb.append(" AT ${it.text}") }
+                from.byAlias?.let { sb.append(" BY ${it.text}") }
+            }
+        }
+    }
+
+    private fun writeProjection(project: PartiqlAst.Projection, sb: StringBuilder, level: Int) {
+        when (project) {
+            is PartiqlAst.Projection.ProjectStar -> sb.append('*')
+            is PartiqlAst.Projection.ProjectValue -> {
+                sb.append("VALUE ")
+                writeAstNode(project.value, sb, level)
+            }
+            is PartiqlAst.Projection.ProjectList -> {
+                val projectItems = project.projectItems
+                projectItems.forEach { item ->
+                    writeProjectItem(item, sb, level)
+                    sb.append(", ")
+                }
+                sb.removeLast(2)
+            }
+            is PartiqlAst.Projection.ProjectPivot -> {
+                writeAstNodeCheckSubQuery(project.key, sb, level)
+                sb.append(" AT ")
+                writeAstNodeCheckSubQuery(project.value, sb, level)
+            }
+        }
+    }
+
+    private fun writeProjectItem(item: PartiqlAst.ProjectItem, sb: StringBuilder, level: Int) {
+        when (item) {
+            is PartiqlAst.ProjectItem.ProjectAll -> {
+                writeAstNodeCheckSubQuery(item.expr, sb, level)
+                sb.append(".*")
+            }
+            is PartiqlAst.ProjectItem.ProjectExpr -> {
+                writeAstNodeCheckSubQuery(item.expr, sb, level)
+                item.asAlias?.let {
+                    sb.append(" AS ")
+                    sb.append(it.text)
+                }
+            }
+        }
+    }
+
+    // The logic here can be improved, so we can remove unnecessary parenthesis in different scenarios.
+    // i.e. currently, it transforms '1 + 2 + 3' as '(1 + 2) + 3', however, the parenthesis can be removed.
+    private fun writeAstNodeCheckOp(node: PartiqlAst.Expr, sb: StringBuilder, level: Int) {
+        when (isOperator(node)) {
+            true -> {
+                sb.append('(')
+                writeAstNode(node, sb, level)
+                sb.append(')')
+            }
+            // The next line may need to be changed, as it does not produce a pretty query
+            // where CASE or SELECT clause is wrapped inside operators
+            false -> writeAstNodeCheckSubQuery(node, sb, level)
+        }
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Pos, sb: StringBuilder, level: Int) {
+        sb.append('+')
+        writeAstNodeCheckOp(node.expr, sb, level)
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Neg, sb: StringBuilder, level: Int) {
+        sb.append('-')
+        writeAstNodeCheckOp(node.expr, sb, level)
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Not, sb: StringBuilder, level: Int) {
+        sb.append("NOT ")
+        writeAstNodeCheckOp(node.expr, sb, level)
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Between, sb: StringBuilder, level: Int) {
+        writeAstNodeCheckOp(node.value, sb, level)
+        sb.append(" BETWEEN ")
+        writeAstNodeCheckOp(node.from, sb, level)
+        sb.append(" AND ")
+        writeAstNodeCheckOp(node.to, sb, level)
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Like, sb: StringBuilder, level: Int) {
+        writeAstNodeCheckOp(node.value, sb, level)
+        sb.append(" LIKE ")
+        writeAstNodeCheckOp(node.pattern, sb, level)
+        node.escape?.let {
+            sb.append(" ESCAPE ")
+            writeAstNodeCheckOp(node.escape, sb, level)
+        }
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.IsType, sb: StringBuilder, level: Int) {
+        writeAstNodeCheckOp(node.value, sb, level)
+        sb.append(" IS ")
+        writeType(node.type, sb)
+    }
+
+    private fun writeType(node: PartiqlAst.Type, sb: StringBuilder) {
+        when (node) {
+            is PartiqlAst.Type.NullType -> sb.append("NULL")
+            is PartiqlAst.Type.AnyType -> sb.append("ANY")
+            is PartiqlAst.Type.BagType -> sb.append("BAG")
+            is PartiqlAst.Type.BlobType -> sb.append("BLOB")
+            is PartiqlAst.Type.BooleanType -> sb.append("BOOLEAN")
+            is PartiqlAst.Type.CharacterType -> sb.append("CHAR")
+            is PartiqlAst.Type.CharacterVaryingType -> sb.append("VARCHAR")
+            is PartiqlAst.Type.ClobType -> sb.append("CLOB")
+            is PartiqlAst.Type.DateType -> sb.append("DATE")
+            is PartiqlAst.Type.DecimalType -> sb.append("DECIMAL")
+            is PartiqlAst.Type.DoublePrecisionType -> sb.append("DOUBLE_PRECISION")
+            is PartiqlAst.Type.EsAny -> sb.append("ES_ANY")
+            is PartiqlAst.Type.EsBoolean -> sb.append("ES_BOOLEAN")
+            is PartiqlAst.Type.EsFloat -> sb.append("ES_FLOAT")
+            is PartiqlAst.Type.EsInteger -> sb.append("ES_INTEGER")
+            is PartiqlAst.Type.EsText -> sb.append("ES_TEXT")
+            is PartiqlAst.Type.FloatType -> sb.append("FLOAT")
+            is PartiqlAst.Type.Integer4Type -> sb.append("INT4")
+            is PartiqlAst.Type.Integer8Type -> sb.append("INT8")
+            is PartiqlAst.Type.IntegerType -> sb.append("INT")
+            is PartiqlAst.Type.ListType -> sb.append("LIST")
+            is PartiqlAst.Type.MissingType -> sb.append("MISSING")
+            is PartiqlAst.Type.NumericType -> sb.append("NUMERIC")
+            is PartiqlAst.Type.RealType -> sb.append("REAL")
+            is PartiqlAst.Type.RsBigint -> sb.append("RS_BIGINT")
+            is PartiqlAst.Type.RsBoolean -> sb.append("RS_BOOLEAN")
+            is PartiqlAst.Type.RsDoublePrecision -> sb.append("RS_DOUBLE_PRECISION")
+            is PartiqlAst.Type.RsInteger -> sb.append("RS_INTEGER")
+            is PartiqlAst.Type.RsReal -> sb.append("RS_REAL")
+            is PartiqlAst.Type.RsVarcharMax -> sb.append("RS_VARCHAR_MAX")
+            is PartiqlAst.Type.SexpType -> sb.append("SEXP")
+            is PartiqlAst.Type.SmallintType -> sb.append("SMALLINT")
+            is PartiqlAst.Type.SparkBoolean -> sb.append("SPARK_BOOLEAN")
+            is PartiqlAst.Type.SparkDouble -> sb.append("SPARK_DOUBLE")
+            is PartiqlAst.Type.SparkFloat -> sb.append("SPARK_FLOAT")
+            is PartiqlAst.Type.SparkInteger -> sb.append("SPARK_INTEGER")
+            is PartiqlAst.Type.SparkLong -> sb.append("SPARK_LONG")
+            is PartiqlAst.Type.SparkShort -> sb.append("SPARK_SHORT")
+            is PartiqlAst.Type.StringType -> sb.append("STRING")
+            is PartiqlAst.Type.StructType -> sb.append("STRUCT")
+            is PartiqlAst.Type.SymbolType -> sb.append("SYMBOL")
+            is PartiqlAst.Type.TimeType -> sb.append("TIME")
+            is PartiqlAst.Type.TimeWithTimeZoneType -> sb.append("TIME WITH TIME ZONE")
+            is PartiqlAst.Type.TimestampType -> sb.append("TIMESTAMP")
+            is PartiqlAst.Type.TupleType -> sb.append("TUPLE")
+            is PartiqlAst.Type.CustomType -> error("CustomType is not supported yet. ")
+        }
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Cast, sb: StringBuilder, level: Int) {
+        sb.append("CAST (")
+        writeAstNodeCheckOp(node.value, sb, level)
+        sb.append(" AS ")
+        writeType(node.asType, sb)
+        sb.append(')')
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.CanCast, sb: StringBuilder, level: Int) {
+        sb.append("CAN_CAST (")
+        writeAstNodeCheckOp(node.value, sb, level)
+        sb.append(" AS ")
+        writeType(node.asType, sb)
+        sb.append(')')
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.CanLosslessCast, sb: StringBuilder, level: Int) {
+        sb.append("CAN_LOSSLESS_CAST (")
+        writeAstNodeCheckOp(node.value, sb, level)
+        sb.append(" AS ")
+        writeType(node.asType, sb)
+        sb.append(')')
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Coalesce, sb: StringBuilder, level: Int) {
+        sb.append("COALESCE(")
+        node.args.forEach { arg ->
+            writeAstNodeCheckSubQuery(arg, sb, level)
+            sb.append(", ")
+        }
+        if (node.args.isNotEmpty()) {
+            sb.removeLast(2)
+        }
+        sb.append(')')
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.NullIf, sb: StringBuilder, level: Int) {
+        sb.append("NULLIF(")
+        writeAstNodeCheckSubQuery(node.expr1, sb, level)
+        sb.append(", ")
+        writeAstNodeCheckSubQuery(node.expr2, sb, level)
+        sb.append(')')
+    }
+
+    private fun writeNAryOperator(operatorName: String, operands: List<PartiqlAst.Expr>, sb: StringBuilder, level: Int) {
+        if (operands.size < 2) IllegalStateException("Internal Error: NAry operator $operatorName must have at least 2 operands")
+        operands.forEach {
+            writeAstNodeCheckOp(it, sb, level)
+            sb.append(" $operatorName ")
+        }
+        sb.removeLast(operatorName.length + 2)
+    }
+
+    private fun isCaseOrSelect(node: PartiqlAst.Expr): Boolean =
+        when (node) {
+            is PartiqlAst.Expr.SimpleCase, is PartiqlAst.Expr.SearchedCase, is PartiqlAst.Expr.Select -> true
+            else -> false
+        }
+
+    private fun isOperator(node: PartiqlAst.Expr): Boolean =
+        when (node) {
+            is PartiqlAst.Expr.And, is PartiqlAst.Expr.Between, is PartiqlAst.Expr.CanCast,
+            is PartiqlAst.Expr.CanLosslessCast, is PartiqlAst.Expr.Cast, is PartiqlAst.Expr.Concat,
+            is PartiqlAst.Expr.Divide, is PartiqlAst.Expr.Eq, is PartiqlAst.Expr.Except,
+            is PartiqlAst.Expr.Gt, is PartiqlAst.Expr.Gte, is PartiqlAst.Expr.InCollection,
+            is PartiqlAst.Expr.Intersect, is PartiqlAst.Expr.IsType, is PartiqlAst.Expr.Like,
+            is PartiqlAst.Expr.Lt, is PartiqlAst.Expr.Lte, is PartiqlAst.Expr.Minus,
+            is PartiqlAst.Expr.Modulo, is PartiqlAst.Expr.Ne, is PartiqlAst.Expr.Neg,
+            is PartiqlAst.Expr.Not, is PartiqlAst.Expr.Or, is PartiqlAst.Expr.Plus,
+            is PartiqlAst.Expr.Pos, is PartiqlAst.Expr.Times, is PartiqlAst.Expr.Union -> true
+            else -> false
+        }
+
+    private fun getIndent(level: Int) = "\t".repeat(level)
+
+    private fun StringBuilder.removeLast(n: Int): StringBuilder {
+        for (i in 1..n) {
+            deleteCharAt(length - 1)
+        }
+        return this
+    }
+}

--- a/lang/src/org/partiql/lang/prettyprint/RecursionTree.kt
+++ b/lang/src/org/partiql/lang/prettyprint/RecursionTree.kt
@@ -1,0 +1,51 @@
+package org.partiql.lang.prettyprint
+
+import org.partiql.lang.domains.PartiqlAst
+
+/**
+ * PIG AST is not a recursive data structure, thus it is not easy to transform it directly to a pretty printed string.
+ * So we need to first transform it into RecursionTree, which is a recursive tree structure (it has a list of children which are also RecursionTree),
+ * then we can recursively pretty print the RecursionTree as we want.
+ *
+ * @param astType is a string of the PIG AST node type
+ * @param value is the value in case node type is [PartiqlAst.Expr.Lit]
+ * @param attrOfParent is a string which represents which attribute it belongs to its parent
+ * @param children is a list of child RecursionTree
+ *
+ * Take the [PartiqlAst.Expr.Eq] node in the WHERE clause in `SELECT a FROM b WHERE c = d` as example.
+ * [astType] is '=', [value] is null, [attrOfParent] is 'where', [children] is a list of [PartiqlAst.Expr.Id] c and d.
+ */
+class RecursionTree(astType: String, value: String? = null, attrOfParent: String? = null, children: List<RecursionTree>? = null) {
+    private val astType = astType
+    private val value = value
+    private val attrOfParent = attrOfParent
+    private val children = children
+
+    fun convertToString(): String {
+        val result = StringBuilder()
+        recurseToResult(0, result)
+        return result.toString().dropLast(1) // Drop last line separator \n
+    }
+
+    private fun recurseToResult(indent: Int, result: StringBuilder) {
+        val prefix = when (attrOfParent) {
+            null -> ""
+            else -> "$attrOfParent: "
+        }
+
+        val displayedValue = when (value) {
+            null -> ""
+            else -> " $value"
+        }
+
+        result.append("\t".repeat(indent))
+            .append(prefix)
+            .append(astType)
+            .append(displayedValue)
+            .append('\n')
+
+        children?.forEach {
+            it.recurseToResult(indent + 1, result)
+        }
+    }
+}

--- a/lang/test/org/partiql/lang/prettyprint/ASTPrettyPrinterTest.kt
+++ b/lang/test/org/partiql/lang/prettyprint/ASTPrettyPrinterTest.kt
@@ -1,0 +1,917 @@
+package org.partiql.lang.prettyprint
+
+import org.junit.Assert
+import org.junit.Test
+
+class ASTPrettyPrinterTest {
+    private val prettyPrinter = ASTPrettyPrinter()
+
+    private fun checkPrettyPrintAst(query: String, expected: String) {
+        // In triples quotes, a tab consists of 4 whitespaces. We need to transform them into a tab.
+        val newExpected = expected.replace("    ", "\t")
+        Assert.assertEquals(newExpected, prettyPrinter.prettyPrintAST(query))
+    }
+
+    // ********
+    // * EXEC *
+    // ********
+    @Test
+    fun exec() {
+        checkPrettyPrintAst(
+            "EXEC foo 'bar0', `1d0`, 2, [3], SELECT baz FROM bar",
+            """
+                Exec
+                    procedureName: Symbol foo
+                    arg1: Lit "bar0"
+                    arg2: Lit 1.
+                    arg3: Lit 2
+                    arg4: List
+                        Lit 3
+                    arg5: Select
+                        project: ProjectList
+                            projectItem1: ProjectExpr
+                                expr: Id baz (case_insensitive) (unqualified)
+                        from: Scan
+                            Id bar (case_insensitive) (unqualified)
+            """.trimIndent()
+        )
+    }
+
+    // *******
+    // * DDL *
+    // *******
+    @Test
+    fun createIndex() {
+        checkPrettyPrintAst(
+            "CREATE INDEX ON foo (x, y.z)",
+            """
+                Ddl
+                    op: CreateIndex
+                        indexName: Identifier foo (case_insensitive)
+                        field1: Id x (case_insensitive) (unqualified)
+                        field2: Path
+                            root: Id y (case_insensitive) (unqualified)
+                            step1: Lit "z"
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun createTable() {
+        checkPrettyPrintAst(
+            "CREATE TABLE foo",
+            """
+                Ddl
+                    op: CreateTable
+                        tableName: Symbol foo
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun dropIndex() {
+        checkPrettyPrintAst(
+            "DROP INDEX bar ON foo",
+            """
+                Ddl
+                    op: DropIndex
+                        table: Identifier foo (case_insensitive)
+                        keys: Identifier bar (case_insensitive)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun dropTable() {
+        checkPrettyPrintAst(
+            "DROP TABLE foo",
+            """
+                Ddl
+                    op: DropTable
+                        tableName: Identifier foo (case_insensitive)
+            """.trimIndent()
+        )
+    }
+
+    // *******
+    // * Dml *
+    // *******
+    @Test
+    fun insert() {
+        checkPrettyPrintAst(
+            "INSERT INTO foo VALUES (1, 2), (3, 4)",
+            """
+                Dml
+                    operations: DmlOpList
+                        op1: Insert
+                            target: Id foo (case_insensitive) (unqualified)
+                            values: Bag
+                                List
+                                    Lit 1
+                                    Lit 2
+                                List
+                                    Lit 3
+                                    Lit 4
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun insertValue() {
+        checkPrettyPrintAst(
+            "INSERT INTO foo VALUE 1 AT bar ON CONFLICT WHERE a DO NOTHING",
+            """
+                Dml
+                    operations: DmlOpList
+                        op1: InsertValue
+                            target: Id foo (case_insensitive) (unqualified)
+                            value: Lit 1
+                            index: Id bar (case_insensitive) (unqualified)
+                            onConflict: OnConflict
+                                expr: Id a (case_insensitive) (unqualified)
+                                conflictAction: DoNothing
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun set() {
+        checkPrettyPrintAst(
+            "UPDATE x SET k.m = 5",
+            """
+                Dml
+                    operations: DmlOpList
+                        op1: Set
+                            assignment: Assignment
+                                target: Path
+                                    root: Id k (case_insensitive) (unqualified)
+                                    step1: Lit "m"
+                                value: Lit 5
+                    from: Scan
+                        Id x (case_insensitive) (unqualified)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun remove() {
+        checkPrettyPrintAst(
+            "FROM x WHERE a = b REMOVE y",
+            """
+                Dml
+                    operations: DmlOpList
+                        op1: Remove
+                            target: Id y (case_insensitive) (unqualified)
+                    from: Scan
+                        Id x (case_insensitive) (unqualified)
+                    where: =
+                        Id a (case_insensitive) (unqualified)
+                        Id b (case_insensitive) (unqualified)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun delete() {
+        checkPrettyPrintAst(
+            "DELETE FROM y",
+            """
+                Dml
+                    operations: DmlOpList
+                        op1: Delete
+                    from: Scan
+                        Id y (case_insensitive) (unqualified)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun longDmlQuery() {
+        checkPrettyPrintAst(
+            "UPDATE x SET k = 5, m = 6 INSERT INTO c VALUE << 1 >> REMOVE a SET l = 3 REMOVE b WHERE a = b RETURNING MODIFIED OLD a",
+            """
+                Dml
+                    operations: DmlOpList
+                        op1: Set
+                            assignment: Assignment
+                                target: Id k (case_insensitive) (unqualified)
+                                value: Lit 5
+                        op2: Set
+                            assignment: Assignment
+                                target: Id m (case_insensitive) (unqualified)
+                                value: Lit 6
+                        op3: InsertValue
+                            target: Id c (case_insensitive) (unqualified)
+                            value: Bag
+                                Lit 1
+                        op4: Remove
+                            target: Id a (case_insensitive) (unqualified)
+                        op5: Set
+                            assignment: Assignment
+                                target: Id l (case_insensitive) (unqualified)
+                                value: Lit 3
+                        op6: Remove
+                            target: Id b (case_insensitive) (unqualified)
+                    from: Scan
+                        Id x (case_insensitive) (unqualified)
+                    where: =
+                        Id a (case_insensitive) (unqualified)
+                        Id b (case_insensitive) (unqualified)
+                    returning: ReturningExpr
+                        elem1: ReturningElem
+                            mapping: ModifiedOld
+                            column: ReturningColumn
+            """.trimIndent()
+        )
+    }
+
+    // *********
+    // * Query *
+    // *********
+    @Test
+    fun id() {
+        checkPrettyPrintAst(
+            "a",
+            """
+                Id a (case_insensitive) (unqualified)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun missing() {
+        checkPrettyPrintAst(
+            "MISSING",
+            """
+                missing
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun litNumber() {
+        checkPrettyPrintAst(
+            "1",
+            """
+                Lit 1
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun litString() {
+        checkPrettyPrintAst(
+            "'1'",
+            """
+                Lit "1"
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun litTimestamp() {
+        checkPrettyPrintAst(
+            "`2017-01-10T05:30:55Z`",
+            """
+                Lit 2017-01-10T05:30:55Z
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun parameter() {
+        checkPrettyPrintAst(
+            "?",
+            """
+                Parameter 1
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun date() {
+        checkPrettyPrintAst(
+            "DATE '2022-03-16'",
+            """
+                Date 2022-3-16
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun litTimeTime() {
+        checkPrettyPrintAst(
+            "Time '01:02:03'",
+            """
+                LitTime 1:2:3.0, 'precision': 0, 'timeZone': false, 'tzminute': null
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun litTimeTimeWithTimeZone() {
+        checkPrettyPrintAst(
+            "Time With Time Zone '01:02:03-05:30'",
+            """
+                LitTime 1:2:3.0, 'precision': 0, 'timeZone': true, 'tzminute': -330
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun not() {
+        checkPrettyPrintAst(
+            "NOT TRUE",
+            """
+                Not
+                    Lit true
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun pos() {
+        checkPrettyPrintAst(
+            "+function1()",
+            """
+                +
+                    Call function1
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun neg() {
+        checkPrettyPrintAst(
+            "-function1()",
+            """
+                -
+                    Call function1
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun plus() {
+        checkPrettyPrintAst(
+            "1 + 2",
+            """
+                +
+                    Lit 1
+                    Lit 2
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun minus() {
+        checkPrettyPrintAst(
+            "3 - 2",
+            """
+                -
+                    Lit 3
+                    Lit 2
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun times() {
+        checkPrettyPrintAst(
+            "1 * 2",
+            """
+                *
+                    Lit 1
+                    Lit 2
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun divide() {
+        checkPrettyPrintAst(
+            "4 / 2",
+            """
+                /
+                    Lit 4
+                    Lit 2
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun modulo() {
+        checkPrettyPrintAst(
+            "3 % 2",
+            """
+                %
+                    Lit 3
+                    Lit 2
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun concat() {
+        checkPrettyPrintAst(
+            "'1' || '2'",
+            """
+                ||
+                    Lit "1"
+                    Lit "2"
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun and() {
+        checkPrettyPrintAst(
+            "TRUE AND FALSE",
+            """
+                And
+                    Lit true
+                    Lit false
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun or() {
+        checkPrettyPrintAst(
+            "TRUE OR FALSE",
+            """
+                Or
+                    Lit true
+                    Lit false
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun eq() {
+        checkPrettyPrintAst(
+            "1 = 2",
+            """
+                =
+                    Lit 1
+                    Lit 2
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun ne() {
+        checkPrettyPrintAst(
+            "1 != 2",
+            """
+                !=
+                    Lit 1
+                    Lit 2
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun gt() {
+        checkPrettyPrintAst(
+            "2 > 1",
+            """
+                >
+                    Lit 2
+                    Lit 1
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun gte() {
+        checkPrettyPrintAst(
+            "2 >= 1",
+            """
+                >=
+                    Lit 2
+                    Lit 1
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun lt() {
+        checkPrettyPrintAst(
+            "1 < 2",
+            """
+                <
+                    Lit 1
+                    Lit 2
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun lte() {
+        checkPrettyPrintAst(
+            "1 <= 2",
+            """
+                <=
+                    Lit 1
+                    Lit 2
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun inCollection() {
+        checkPrettyPrintAst(
+            "1 IN [1, 2, 3]",
+            """
+                In
+                    Lit 1
+                    List
+                        Lit 1
+                        Lit 2
+                        Lit 3
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun union() {
+        checkPrettyPrintAst(
+            "a UNION b",
+            """
+                Union
+                    Id a (case_insensitive) (unqualified)
+                    Id b (case_insensitive) (unqualified)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun except() {
+        checkPrettyPrintAst(
+            "a EXCEPT b",
+            """
+                Except
+                    Id a (case_insensitive) (unqualified)
+                    Id b (case_insensitive) (unqualified)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun intersect() {
+        checkPrettyPrintAst(
+            "a INTERSECT b",
+            """
+                Intersect
+                    Id a (case_insensitive) (unqualified)
+                    Id b (case_insensitive) (unqualified)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun like() {
+        checkPrettyPrintAst(
+            "a LIKE b",
+            """
+                Like
+                    value: Id a (case_insensitive) (unqualified)
+                    pattern: Id b (case_insensitive) (unqualified)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun between() {
+        checkPrettyPrintAst(
+            "5 BETWEEN 1 AND 10",
+            """
+                Between
+                    value: Lit 5
+                    from: Lit 1
+                    to: Lit 10
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun simpleCase() {
+        checkPrettyPrintAst(
+            "CASE name WHEN 'jack' THEN 1 END",
+            """
+                SimpleCase
+                    expr: Id name (case_insensitive) (unqualified)
+                    cases: ExprPairList
+                        pair1: Pair
+                            first: Lit "jack"
+                            second: Lit 1
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun searchedCase() {
+        checkPrettyPrintAst(
+            "CASE WHEN name = 'jack' THEN 1 END",
+            """
+                SearchedCase
+                    cases: ExprPairList
+                        pair1: Pair
+                            first: =
+                                Id name (case_insensitive) (unqualified)
+                                Lit "jack"
+                            second: Lit 1
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun struct() {
+        checkPrettyPrintAst(
+            "{ a: 1 }",
+            """
+                Struct
+                    field1: Pair
+                        first: Id a (case_insensitive) (unqualified)
+                        second: Lit 1
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun bag() {
+        checkPrettyPrintAst(
+            "<< 1, 2, 3 >>",
+            """
+                Bag
+                    Lit 1
+                    Lit 2
+                    Lit 3
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun list() {
+        checkPrettyPrintAst(
+            "[ 1, 2, 3 ]",
+            """
+                List
+                    Lit 1
+                    Lit 2
+                    Lit 3
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun sexp() {
+        checkPrettyPrintAst(
+            "sexp(1, 2, 3)",
+            """
+                Sexp
+                    Lit 1
+                    Lit 2
+                    Lit 3
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun path() {
+        checkPrettyPrintAst(
+            "a.b",
+            """
+                Path
+                    root: Id a (case_insensitive) (unqualified)
+                    step1: Lit "b"
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun call() {
+        checkPrettyPrintAst(
+            "function1(1)",
+            """
+                Call function1
+                    arg: Lit 1
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun callAgg() {
+        checkPrettyPrintAst(
+            "SUM(a)",
+            """
+                CallAgg sum
+                    arg: Id a (case_insensitive) (unqualified)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun isType() {
+        checkPrettyPrintAst(
+            "1 IS INT",
+            """
+                Is
+                    value: Lit 1
+                    type: (integer_type)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun cast() {
+        checkPrettyPrintAst(
+            "CAST (1 AS STRING)",
+            """
+                Cast
+                    value: Lit 1
+                    asType: (string_type)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun canCast() {
+        checkPrettyPrintAst(
+            "CAN_CAST (1 AS STRING)",
+            """
+                CanCast
+                    value: Lit 1
+                    asType: (string_type)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun canLosslessCast() {
+        checkPrettyPrintAst(
+            "CAN_Lossless_CAST (1 AS STRING)",
+            """
+                CanLosslessCast
+                    value: Lit 1
+                    asType: (string_type)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun nullIf() {
+        checkPrettyPrintAst(
+            "NULLIF(1, 2)",
+            """
+                NullIf
+                    expr1: Lit 1
+                    expr2: Lit 2
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun coalesce() {
+        checkPrettyPrintAst(
+            "COALESCE(1, 2)",
+            """
+                Coalesce
+                    arg: Lit 1
+                    arg: Lit 2
+            """.trimIndent()
+        )
+    }
+
+    // Select
+    @Test
+    fun selectFrom() {
+        checkPrettyPrintAst(
+            "SELECT * FROM 1",
+            """
+                Select
+                    project: *
+                    from: Scan
+                        Lit 1
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectFromLet() {
+        checkPrettyPrintAst(
+            "SELECT * FROM 1 LET 1 AS a",
+            """
+                Select
+                    project: *
+                    from: Scan
+                        Lit 1
+                    let: Let
+                        letBinding1: LetBinding
+                            expr: Lit 1
+                            name: Symbol a
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectFromWhere() {
+        checkPrettyPrintAst(
+            "SELECT * FROM 1 WHERE a = b",
+            """
+                Select
+                    project: *
+                    from: Scan
+                        Lit 1
+                    where: =
+                        Id a (case_insensitive) (unqualified)
+                        Id b (case_insensitive) (unqualified)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectFromWhereGroupHaving() {
+        checkPrettyPrintAst(
+            "SELECT * FROM 1 WHERE a = b GROUP BY c HAVING d = '123'",
+            """
+                Select
+                    project: *
+                    from: Scan
+                        Lit 1
+                    where: =
+                        Id a (case_insensitive) (unqualified)
+                        Id b (case_insensitive) (unqualified)
+                    group: Group
+                        strategy: GroupFull
+                        keyList: GroupKeyList
+                            key1: GroupKey
+                                expr: Id c (case_insensitive) (unqualified)
+                    having: =
+                        Id d (case_insensitive) (unqualified)
+                        Lit "123"
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectFromWhereGroupHavingLimitOffset() {
+        checkPrettyPrintAst(
+            "SELECT * FROM 1 WHERE a = b GROUP BY c HAVING d = '123' LIMIT 3 OFFSET 4",
+            """
+                Select
+                    project: *
+                    from: Scan
+                        Lit 1
+                    where: =
+                        Id a (case_insensitive) (unqualified)
+                        Id b (case_insensitive) (unqualified)
+                    group: Group
+                        strategy: GroupFull
+                        keyList: GroupKeyList
+                            key1: GroupKey
+                                expr: Id c (case_insensitive) (unqualified)
+                    having: =
+                        Id d (case_insensitive) (unqualified)
+                        Lit "123"
+                    limit: Lit 3
+                    offset: Lit 4
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectFromWhereGroupHavingLimitOffsetWithSubQuery() {
+        checkPrettyPrintAst(
+            "SELECT (SELECT * FROM foo WHERE bar = 1) FROM 1 WHERE a = b GROUP BY c HAVING d = '123' LIMIT 3 OFFSET 4",
+            """
+                Select
+                    project: ProjectList
+                        projectItem1: ProjectExpr
+                            expr: Select
+                                project: *
+                                from: Scan
+                                    Id foo (case_insensitive) (unqualified)
+                                where: =
+                                    Id bar (case_insensitive) (unqualified)
+                                    Lit 1
+                    from: Scan
+                        Lit 1
+                    where: =
+                        Id a (case_insensitive) (unqualified)
+                        Id b (case_insensitive) (unqualified)
+                    group: Group
+                        strategy: GroupFull
+                        keyList: GroupKeyList
+                            key1: GroupKey
+                                expr: Id c (case_insensitive) (unqualified)
+                    having: =
+                        Id d (case_insensitive) (unqualified)
+                        Lit "123"
+                    limit: Lit 3
+                    offset: Lit 4
+            """.trimIndent()
+        )
+    }
+}

--- a/lang/test/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
+++ b/lang/test/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
@@ -1,0 +1,726 @@
+package org.partiql.lang.prettyprint
+
+import com.amazon.ion.system.IonSystemBuilder
+import org.junit.Assert
+import org.junit.Test
+import org.partiql.lang.syntax.SqlParser
+
+class QueryPrettyPrinterTest {
+    private val prettyPrinter = QueryPrettyPrinter()
+    private val sqlParser = SqlParser(IonSystemBuilder.standard().build())
+
+    private fun checkPrettyPrintQuery(query: String, expected: String) {
+        // In triples quotes, a tab consists of 4 whitespaces. We need to transform them into a tab.
+        val newExpected = expected.replace("    ", "\t")
+        Assert.assertEquals(newExpected, prettyPrinter.prettyPrintQuery(query))
+        // New sting and old string should be the same when transformed into PIG AST
+        Assert.assertEquals(sqlParser.parseAstStatement(query), sqlParser.parseAstStatement(newExpected))
+    }
+
+    // ********
+    // * EXEC *
+    // ********
+
+    // *******
+    // * DDL *
+    // *******
+
+    // *******
+    // * Dml *
+    // *******
+
+    // *********
+    // * Query *
+    // *********
+    @Test
+    fun id1() {
+        checkPrettyPrintQuery("a", "a")
+    }
+
+    @Test
+    fun id2() {
+        checkPrettyPrintQuery("\"a\"", "\"a\"")
+    }
+
+    @Test
+    fun missing() {
+        checkPrettyPrintQuery("MISSING", "MISSING")
+    }
+
+    @Test
+    fun null1() {
+        checkPrettyPrintQuery("NULL", "NULL")
+    }
+
+    @Test
+    fun null2() {
+        checkPrettyPrintQuery("`null`", "NULL")
+    }
+
+    @Test
+    fun litBoolean1() {
+        checkPrettyPrintQuery("TRUE", "TRUE")
+    }
+
+    @Test
+    fun litBoolean2() {
+        checkPrettyPrintQuery("`false`", "FALSE")
+    }
+
+    @Test
+    fun litInt1() {
+        checkPrettyPrintQuery("1", "1")
+    }
+
+    @Test
+    fun litInt2() {
+        checkPrettyPrintQuery("`1`", "1")
+    }
+
+    @Test
+    fun litDecimal() {
+        checkPrettyPrintQuery("0.1", "0.1")
+    }
+
+    @Test
+    fun litString1() {
+        checkPrettyPrintQuery("'0.1'", "'0.1'")
+    }
+
+    @Test
+    fun litString2() {
+        checkPrettyPrintQuery("'TRUE'", "'TRUE'")
+    }
+
+    @Test
+    fun litString3() {
+        checkPrettyPrintQuery("'NULL'", "'NULL'")
+    }
+
+    @Test
+    fun litString4() {
+        checkPrettyPrintQuery("`\"0.1\"`", "'0.1'")
+    }
+
+    @Test
+    fun litString5() {
+        checkPrettyPrintQuery("`\"TRUE\"`", "'TRUE'")
+    }
+
+    @Test
+    fun litString6() {
+        checkPrettyPrintQuery("`\"NULL\"`", "'NULL'")
+    }
+
+    @Test
+    fun litTimestamp() {
+        checkPrettyPrintQuery("`2017-01-10T05:30:55Z`", "`2017-01-10T05:30:55Z`")
+    }
+
+    @Test
+    fun date() {
+        checkPrettyPrintQuery("DATE '2022-03-16'", "DATE '2022-03-16'")
+    }
+
+    @Test
+    fun litTime1() {
+        checkPrettyPrintQuery("TIME (9) '23:59:59.123456789'", "TIME (9) '23:59:59.123456789'")
+    }
+
+    @Test
+    fun litTime2() {
+        checkPrettyPrintQuery("TIME (7) WITH TIME ZONE '23:59:59.123456789'", "TIME (7) WITH TIME ZONE '23:59:59.123456789'")
+    }
+
+    @Test
+    fun litTime3() {
+        checkPrettyPrintQuery("TIME (7) WITH TIME ZONE '23:59:59.123456789-01:00'", "TIME (7) WITH TIME ZONE '23:59:59.123456789-01:00'")
+    }
+
+    @Test
+    fun parameter() {
+        checkPrettyPrintQuery("?", "?")
+    }
+
+    @Test
+    fun struct1() {
+        checkPrettyPrintQuery("{ a: 1 }", "{ a: 1 }")
+    }
+
+    @Test
+    fun struct2() {
+        checkPrettyPrintQuery("{a:1,'b':\"c\"}", "{ a: 1, 'b': \"c\" }")
+    }
+
+    @Test
+    fun bag() {
+        checkPrettyPrintQuery("<<1,2,3>>", "<< 1, 2, 3 >>")
+    }
+
+    @Test
+    fun list() {
+        checkPrettyPrintQuery("[1,2,3]", "[ 1, 2, 3 ]")
+    }
+
+    @Test
+    fun sexp() {
+        checkPrettyPrintQuery("sexp(1,2,3)", "sexp(1, 2, 3)")
+    }
+
+    @Test
+    fun not1() {
+        checkPrettyPrintQuery("NOT TRUE", "NOT TRUE")
+    }
+
+    @Test
+    fun not2() {
+        checkPrettyPrintQuery("NOT (TRUE AND FALSE)", "NOT (TRUE AND FALSE)")
+    }
+
+    @Test
+    fun pos() {
+        checkPrettyPrintQuery("+function1()", "+function1()")
+    }
+
+    @Test
+    fun neg() {
+        checkPrettyPrintQuery("-function1()", "-function1()")
+    }
+
+    @Test
+    fun plus1() {
+        checkPrettyPrintQuery("1 + 2", "1 + 2")
+    }
+
+    @Test
+    fun plus2() {
+        checkPrettyPrintQuery("1 + 2 + 3", "(1 + 2) + 3")
+    }
+
+    @Test
+    fun plus3() {
+        checkPrettyPrintQuery("1 + (2 + 3)", "1 + (2 + 3)")
+    }
+
+    @Test
+    fun minus1() {
+        checkPrettyPrintQuery("1 - 2", "1 - 2")
+    }
+
+    @Test
+    fun minus2() {
+        checkPrettyPrintQuery("1 - 2 - 3", "(1 - 2) - 3")
+    }
+
+    @Test
+    fun minus3() {
+        checkPrettyPrintQuery("1 - 2 - 3 - 4", "((1 - 2) - 3) - 4")
+    }
+
+    @Test
+    fun times() {
+        checkPrettyPrintQuery("1 * 2", "1 * 2")
+    }
+
+    @Test
+    fun divide() {
+        checkPrettyPrintQuery("1 / 2", "1 / 2")
+    }
+
+    @Test
+    fun modulo() {
+        checkPrettyPrintQuery("3 % 2", "3 % 2")
+    }
+
+    @Test
+    fun concat() {
+        checkPrettyPrintQuery("1 || 2", "1 || 2")
+    }
+
+    @Test
+    fun and() {
+        checkPrettyPrintQuery("TRUE AND FALSE", "TRUE AND FALSE")
+    }
+
+    @Test
+    fun or1() {
+        checkPrettyPrintQuery("TRUE OR FALSE", "TRUE OR FALSE")
+    }
+
+    @Test
+    fun or2() {
+        checkPrettyPrintQuery("TRUE OR FALSE AND TRUE", "TRUE OR (FALSE AND TRUE)")
+    }
+
+    @Test
+    fun or3() {
+        checkPrettyPrintQuery("(TRUE OR FALSE) AND TRUE", "(TRUE OR FALSE) AND TRUE")
+    }
+
+    @Test
+    fun eq() {
+        checkPrettyPrintQuery("1 = 2 = 3", "(1 = 2) = 3")
+    }
+
+    @Test
+    fun ne() {
+        checkPrettyPrintQuery("1 != 2", "1 != 2")
+    }
+
+    @Test
+    fun gt() {
+        checkPrettyPrintQuery("2 > 1", "2 > 1")
+    }
+
+    @Test
+    fun gte() {
+        checkPrettyPrintQuery("2 >= 1", "2 >= 1")
+    }
+
+    @Test
+    fun lt() {
+        checkPrettyPrintQuery("1 < 2", "1 < 2")
+    }
+
+    @Test
+    fun lte() {
+        checkPrettyPrintQuery("1 <= 2", "1 <= 2")
+    }
+
+    @Test
+    fun inCollection() {
+        checkPrettyPrintQuery("1 IN [1, 2, 3]", "1 IN [ 1, 2, 3 ]")
+    }
+
+    @Test
+    fun union1() {
+        checkPrettyPrintQuery("a UNION b", "a UNION b")
+    }
+
+    @Test
+    fun union2() {
+        checkPrettyPrintQuery("a UNION ALL b", "a UNION ALL b")
+    }
+
+    @Test
+    fun except() {
+        checkPrettyPrintQuery("a EXCEPT b", "a EXCEPT b")
+    }
+
+    @Test
+    fun intersect() {
+        checkPrettyPrintQuery("a INTERSECT b", "a INTERSECT b")
+    }
+
+    @Test
+    fun like() {
+        checkPrettyPrintQuery("a LIKE b ESCAPE c", "a LIKE b ESCAPE c")
+    }
+
+    @Test
+    fun between1() {
+        checkPrettyPrintQuery("a BETWEEN b AND c", "a BETWEEN b AND c")
+    }
+
+    @Test
+    fun between2() {
+        checkPrettyPrintQuery("a NOT BETWEEN b AND c", "NOT (a BETWEEN b AND c)")
+    }
+
+    @Test
+    fun path1() {
+        checkPrettyPrintQuery("a.b", "a.b")
+    }
+
+    @Test
+    fun path2() {
+        checkPrettyPrintQuery("a.\"b\"", "a['b']")
+    }
+
+    @Test
+    fun path3() {
+        checkPrettyPrintQuery("a[b]", "a[b]")
+    }
+
+    @Test
+    fun path4() {
+        checkPrettyPrintQuery("a.b.c", "a.b.c")
+    }
+
+    @Test
+    fun path5() {
+        checkPrettyPrintQuery("(a.b).c", "(a.b).c")
+    }
+
+    @Test
+    fun path6() {
+        checkPrettyPrintQuery("(a.b)[c.d].e", "(a.b)[c.d].e")
+    }
+
+    @Test
+    fun call1() {
+        checkPrettyPrintQuery("function1(1)", "function1(1)")
+    }
+
+    @Test
+    fun call2() {
+        checkPrettyPrintQuery("function1(a)", "function1(a)")
+    }
+
+    @Test
+    fun callAgg1() {
+        checkPrettyPrintQuery("sum(a)", "sum(a)")
+    }
+
+    @Test
+    fun callAgg2() {
+        checkPrettyPrintQuery("sum(DISTINCT a)", "sum(DISTINCT a)")
+    }
+
+    @Test
+    fun isType() {
+        checkPrettyPrintQuery("1 IS INT", "1 IS INT")
+    }
+
+    @Test
+    fun cast() {
+        checkPrettyPrintQuery("CAST (1 AS STRING)", "CAST (1 AS STRING)")
+    }
+
+    @Test
+    fun canCast() {
+        checkPrettyPrintQuery("CAN_CAST (1 AS STRING)", "CAN_CAST (1 AS STRING)")
+    }
+
+    @Test
+    fun canLosslessCast() {
+        checkPrettyPrintQuery("CAN_LOSSLESS_CAST (1 AS STRING)", "CAN_LOSSLESS_CAST (1 AS STRING)")
+    }
+
+    @Test
+    fun nullIf() {
+        checkPrettyPrintQuery("NULLIF(1, 2)", "NULLIF(1, 2)")
+    }
+
+    @Test
+    fun coalesce() {
+        checkPrettyPrintQuery("COALESCE(1, 2)", "COALESCE(1, 2)")
+    }
+
+    @Test
+    fun simpleCase1() {
+        checkPrettyPrintQuery(
+            "CASE name WHEN 'jack' THEN 1 WHEN 'joe' THEN 2 ELSE 3 END",
+            """
+                CASE name
+                    WHEN 'jack' THEN 1
+                    WHEN 'joe' THEN 2
+                    ELSE 3
+                END
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun simpleCase2() {
+        checkPrettyPrintQuery(
+            "CASE name WHEN a.b + c THEN 1 WHEN 1 + 1 - 2 THEN 2 ELSE 3 END",
+            """
+                CASE name
+                    WHEN a.b + c THEN 1
+                    WHEN (1 + 1) - 2 THEN 2
+                    ELSE 3
+                END
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun searchedCase() {
+        checkPrettyPrintQuery(
+            "CASE WHEN name = 'jack' THEN 1 WHEN 1 + 1 = 2 THEN 2 ELSE 3 END",
+            """
+                CASE
+                    WHEN name = 'jack' THEN 1
+                    WHEN (1 + 1) = 2 THEN 2
+                    ELSE 3
+                END
+            """.trimIndent()
+        )
+    }
+
+    // Select
+    @Test
+    fun selectFrom() {
+        checkPrettyPrintQuery(
+            "SELECT * FROM 1",
+            """
+                SELECT *
+                FROM 1
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectFromLet() {
+        checkPrettyPrintQuery(
+            "SELECT * FROM 1 LET 1 AS a",
+            """
+                SELECT *
+                FROM 1 LET 1 AS a
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectFromLetWhere() {
+        checkPrettyPrintQuery(
+            "SELECT * FROM 1 LET 1 AS a WHERE a = b",
+            """
+                SELECT *
+                FROM 1 LET 1 AS a
+                WHERE a = b
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectFromWhereGroupHaving() {
+        checkPrettyPrintQuery(
+            "SELECT * FROM 1 LET 1 AS a WHERE b = c GROUP BY d GROUP AS e HAVING f = '123'",
+            """
+                SELECT *
+                FROM 1 LET 1 AS a
+                WHERE b = c
+                GROUP BY d GROUP AS e
+                HAVING f = '123'
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectFromWhereGroupHavingLimitOffset() {
+        checkPrettyPrintQuery(
+            "SELECT * FROM 1 LET 1 AS a WHERE b = c GROUP BY d GROUP AS e HAVING f = '123' LIMIT 3 OFFSET 4",
+            """
+                SELECT *
+                FROM 1 LET 1 AS a
+                WHERE b = c
+                GROUP BY d GROUP AS e
+                HAVING f = '123'
+                LIMIT 3
+                OFFSET 4
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectFromWhereGroupHavingLimitOffsetWithSubQuery1() {
+        checkPrettyPrintQuery(
+            "SELECT (SELECT * FROM foo WHERE bar = 1) FROM 1 LET 1 AS a WHERE b = c GROUP BY d GROUP AS e HAVING f = '123' LIMIT 3 OFFSET 4",
+            """
+                SELECT (
+                    SELECT *
+                    FROM foo
+                    WHERE bar = 1)
+                FROM 1 LET 1 AS a
+                WHERE b = c
+                GROUP BY d GROUP AS e
+                HAVING f = '123'
+                LIMIT 3
+                OFFSET 4
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectFromWhereGroupHavingLimitOffsetWithSubQuery2() {
+        checkPrettyPrintQuery(
+            "SELECT (SELECT * FROM (SELECT foo FROM t1 AS t2) AS foo1 WHERE bar = 1) FROM 1 LET 1 AS a WHERE b = c GROUP BY d GROUP AS e HAVING f = '123' LIMIT 3 OFFSET 4",
+            """
+                SELECT (
+                    SELECT *
+                    FROM (
+                        SELECT foo
+                        FROM t1 AS t2) AS foo1
+                    WHERE bar = 1)
+                FROM 1 LET 1 AS a
+                WHERE b = c
+                GROUP BY d GROUP AS e
+                HAVING f = '123'
+                LIMIT 3
+                OFFSET 4
+            """.trimIndent()
+        )
+    }
+
+    // TODO: Make the following queries looks better after formatting
+    @Test
+    fun selectInFunction() {
+        checkPrettyPrintQuery(
+            "function0((SELECT a FROM b), c)",
+            """
+                function0((
+                    SELECT a
+                    FROM b), c)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun caseInFunction() {
+        checkPrettyPrintQuery(
+            "function0((CASE name WHEN 'jack' THEN 1 WHEN 'joe' THEN 2 END), c)",
+            """
+                function0((
+                    CASE name
+                        WHEN 'jack' THEN 1
+                        WHEN 'joe' THEN 2
+                    END), c)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectInContainerType() {
+        checkPrettyPrintQuery(
+            "<< (SELECT a FROM b), c >>",
+            """
+                << (
+                    SELECT a
+                    FROM b), c >>
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun caseInContainerType() {
+        checkPrettyPrintQuery(
+            "<< (CASE name WHEN 'jack' THEN 1 WHEN 'joe' THEN 2 END), c >>",
+            """
+                << (
+                    CASE name
+                        WHEN 'jack' THEN 1
+                        WHEN 'joe' THEN 2
+                    END), c >>
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectInOperator1() {
+        checkPrettyPrintQuery(
+            "(SELECT a FROM b) UNION (SELECT c FROM d) UNION (SELECT e FROM f)",
+            """
+                ((
+                    SELECT a
+                    FROM b) UNION (
+                    SELECT c
+                    FROM d)) UNION (
+                    SELECT e
+                    FROM f)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectInOperator2() {
+        checkPrettyPrintQuery(
+            "(SELECT a FROM b) UNION c",
+            """
+                (
+                    SELECT a
+                    FROM b) UNION c
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectInOperator3() {
+        checkPrettyPrintQuery(
+            "CAST((SELECT VALUE a FROM b) AS STRING)",
+            """
+                CAST ((
+                    SELECT VALUE a
+                    FROM b) AS STRING)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun caseInOperator1() {
+        checkPrettyPrintQuery(
+            "(CASE name WHEN 'jack' THEN 1 WHEN 'joe' THEN 2 END) || ' alice'",
+            """
+                (
+                    CASE name
+                        WHEN 'jack' THEN 1
+                        WHEN 'joe' THEN 2
+                    END) || ' alice'
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun caseInOperator2() {
+        checkPrettyPrintQuery(
+            "CAST((CASE name WHEN 'jack' THEN 1 WHEN 'joe' THEN 2 END) AS STRING)",
+            """
+                CAST ((
+                    CASE name
+                        WHEN 'jack' THEN 1
+                        WHEN 'joe' THEN 2
+                    END) AS STRING)
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectInSimpleCase() {
+        checkPrettyPrintQuery(
+            "CASE (SELECT name FROM t) WHEN (SELECT a FROM b) UNION c THEN 1 WHEN (SELECT c FROM d) THEN 2 ELSE (SELECT e FROM f) END",
+            """
+                CASE (
+                    SELECT name
+                    FROM t)
+                    WHEN (
+                        SELECT a
+                        FROM b) UNION c THEN 1
+                    WHEN (
+                        SELECT c
+                        FROM d) THEN 2
+                    ELSE (
+                        SELECT e 
+                        FROM f)
+                END
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun selectInSearchedCase() {
+        checkPrettyPrintQuery(
+            "CASE WHEN name = 'jack' THEN (SELECT a FROM b) WHEN (SELECT c FROM d) IS INT THEN (SELECT f FROM g) WHEN (SELECT foo FROM t1) THEN (SELECT bar FROM t2) ELSE (SELECT h FROM i) END",
+            """
+                CASE
+                    WHEN name = 'jack' THEN (
+                        SELECT a
+                        FROM b)
+                    WHEN (
+                        SELECT c
+                        FROM d) IS INT THEN (
+                        SELECT f
+                        FROM g)
+                    WHEN (
+                        SELECT foo
+                        FROM t1) THEN (
+                        SELECT bar
+                        FROM t2)
+                    ELSE (
+                        SELECT h
+                        FROM i)
+                END
+            """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
*Description of changes:*
1. Implemented a basic PartiQL query formatter, which works on a simple SFW query. DDL, DML EXEC queries are not supported yet. Also, nested SFW query may not be formatted beautifully. 
2. Added test cases. The test cases which are below TODO comment show currently, how the formatter formats different nested queries. They are not printed beautifully and I put them there as a remind of what is needed to be done in the future. 

*What's next to be done in this PR:*
1. Enable the formatter to format DML, DDL and EXEC queries, and add corresponding test cases. 