### PR TITLE
For ExprFunction, replace Environment with EvaluationSession

### DIFF
--- a/cli/src/org/partiql/cli/functions/ReadFile.kt
+++ b/cli/src/org/partiql/cli/functions/ReadFile.kt
@@ -16,7 +16,7 @@ package org.partiql.cli.functions
 
 import com.amazon.ion.IonStruct
 import org.apache.commons.csv.CSVFormat
-import org.partiql.lang.eval.Environment
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
 import org.partiql.lang.eval.io.DelimitedValues
@@ -84,7 +84,7 @@ internal class ReadFile(valueFactory: ExprValueFactory) : BaseFunction(valueFact
         "customized" to fileReadHandler(CSVFormat.DEFAULT)
     )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         val fileName = required[0].stringValue()
         val fileType = "ion"
         val handler = readHandlers[fileType] ?: throw IllegalArgumentException("Unknown file type: $fileType")
@@ -97,7 +97,7 @@ internal class ReadFile(valueFactory: ExprValueFactory) : BaseFunction(valueFact
         return valueFactory.newBag(seq)
     }
 
-    override fun callWithOptional(env: Environment, required: List<ExprValue>, opt: ExprValue): ExprValue {
+    override fun callWithOptional(session: EvaluationSession, required: List<ExprValue>, opt: ExprValue): ExprValue {
         val options = opt.ionValue.asIonStruct()
         val fileName = required[0].stringValue()
         val fileType = options["type"]?.stringValue() ?: "ion"

--- a/cli/src/org/partiql/cli/functions/WriteFile.kt
+++ b/cli/src/org/partiql/cli/functions/WriteFile.kt
@@ -16,7 +16,7 @@ package org.partiql.cli.functions
 
 import com.amazon.ion.IonStruct
 import com.amazon.ion.system.IonTextWriterBuilder
-import org.partiql.lang.eval.Environment
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
 import org.partiql.lang.eval.io.DelimitedValues
@@ -63,7 +63,7 @@ internal class WriteFile(valueFactory: ExprValueFactory) : BaseFunction(valueFac
         "ion" to PRETTY_ION_WRITER
     )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         val fileName = required[0].stringValue()
         val fileType = "ion"
         val results = required[1]
@@ -79,7 +79,7 @@ internal class WriteFile(valueFactory: ExprValueFactory) : BaseFunction(valueFac
         }
     }
 
-    override fun callWithOptional(env: Environment, required: List<ExprValue>, opt: ExprValue): ExprValue {
+    override fun callWithOptional(session: EvaluationSession, required: List<ExprValue>, opt: ExprValue): ExprValue {
         val options = opt.ionValue.asIonStruct()
         val fileName = required[0].stringValue()
         val fileType = options["type"]?.stringValue() ?: "ion"

--- a/cli/test/org/partiql/cli/functions/ReadFileTest.kt
+++ b/cli/test/org/partiql/cli/functions/ReadFileTest.kt
@@ -22,8 +22,6 @@ import junit.framework.Assert.assertSame
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
-import org.partiql.lang.eval.Bindings
-import org.partiql.lang.eval.Environment
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -35,10 +33,7 @@ class ReadFileTest {
     private val ion = IonSystemBuilder.standard().build()
     private val valueFactory = ExprValueFactory.standard(ion)
     private val function = ReadFile(valueFactory)
-    private val env = Environment(
-        locals = Bindings.empty(),
-        session = EvaluationSession.standard()
-    )
+    private val session = EvaluationSession.standard()
 
     private fun String.exprValue() = valueFactory.newFromIonValue(ion.singleValue(this))
     private fun writeFile(path: String, content: String) = File(dirPath(path)).writeText(content)
@@ -97,7 +92,7 @@ class ReadFileTest {
         writeFile("data.ion", "1 2")
 
         val args = listOf("\"${dirPath("data.ion")}\"").map { it.exprValue() }
-        val actual = function.callWithRequired(env, args)
+        val actual = function.callWithRequired(session, args)
         val expected = "[1, 2]"
 
         assertValues(expected, actual)
@@ -109,7 +104,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("data.ion")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"ion\"}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[1, 2]"
 
         assertValues(expected, actual)
@@ -121,7 +116,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("data.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"csv\"}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{_1:\"1\",_2:\"2\"}]"
 
         assertValues(expected, actual)
@@ -133,7 +128,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("data_with_ion_symbol_as_input.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:csv}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{_1:\"1\",_2:\"2\"}]"
 
         assertValues(expected, actual)
@@ -145,7 +140,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("data_with_double_quotes_escape.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"csv\"}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{_1:\"1,2\",_2:\"2\"}]"
 
         assertValues(expected, actual)
@@ -157,7 +152,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("data_with_double_quotes_escape.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"csv\"}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{_1:\"1\",_2:\"2\"},{_1:\"3\"}]"
 
         assertValues(expected, actual)
@@ -169,7 +164,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("data_with_header_line.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"csv\", header:true}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{col1:\"1\",col2:\"2\"}]"
 
         assertValues(expected, actual)
@@ -181,7 +176,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("data.tsv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"tsv\"}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{_1:\"1\",_2:\"2\"}]"
 
         assertValues(expected, actual)
@@ -193,7 +188,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("data_with_header_line.tsv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"tsv\", header:true}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{col1:\"1\",col2:\"2\"}]"
 
         assertValues(expected, actual)
@@ -205,7 +200,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("simple_excel.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"excel_csv\", header:true}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{title:\"harry potter\",category:\"book\",price:\"7.99\"}]"
 
         assertValues(expected, actual)
@@ -217,7 +212,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("simple_postgresql.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"postgresql_csv\", header:true}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{id:\"1\",name:\"B\\\"ob\",balance:\"10000.00\"}]"
 
         assertValues(expected, actual)
@@ -229,7 +224,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("simple_postgresql.txt")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"postgresql_text\", header:true}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{id:\"1\",name:\"Bob\",balance:\"10000.00\"}]"
 
         assertValues(expected, actual)
@@ -241,7 +236,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("simple_mysql.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"mysql_csv\", header:true}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{id:\"1\",name:\"B\\\"ob\",balance:\"10000.00\"}]"
 
         assertValues(expected, actual)
@@ -253,7 +248,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("customized.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"customized\", header:true, delimiter:' '}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{id:\"1\",name:\"Bob\",balance:\"10000.00\"}]"
 
         assertValues(expected, actual)
@@ -265,7 +260,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("customized.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"customized\", header:true, ignore_empty_line: false}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{id:\"\"},{id:\"1\",name:\"Bob\",balance:\"10000.00\"}]"
 
         assertValues(expected, actual)
@@ -277,7 +272,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("customized.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"customized\", header:true, ignore_surrounding_space:false, trim:false}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{id:\" 1 \",name:\" Bob \",balance:\" 10000.00 \"}]"
 
         assertValues(expected, actual)
@@ -289,7 +284,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("customized.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"customized\", header:true, line_breaker:'\\\r\\\n'}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{id:\"1\",name:\"Bob\",balance:\"10000.00\"}]"
 
         assertValues(expected, actual)
@@ -301,7 +296,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("customized.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"customized\", header:true, escape:'/'}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{id:\"\\\"1\",name:\"Bob\",balance:\"10000.00\"}]"
 
         assertValues(expected, actual)
@@ -313,7 +308,7 @@ class ReadFileTest {
 
         val args = listOf("\"${dirPath("customized.csv")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"customized\", header:true, quote:\"'\"}".exprValue()
-        val actual = function.callWithOptional(env, args, additionalOptions)
+        val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{id:\"1,\",name:\"Bob\",balance:\"10000.00\"}]"
 
         assertValues(expected, actual)

--- a/cli/test/org/partiql/cli/functions/WriteFileTest.kt
+++ b/cli/test/org/partiql/cli/functions/WriteFileTest.kt
@@ -19,8 +19,6 @@ import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import org.partiql.lang.eval.Bindings
-import org.partiql.lang.eval.Environment
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValueFactory
 import java.io.File
@@ -29,10 +27,7 @@ class WriteFileTest {
     private val ion = IonSystemBuilder.standard().build()
     private val valueFactory = ExprValueFactory.standard(ion)
     private val function = WriteFile(valueFactory)
-    private val env = Environment(
-        locals = Bindings.empty(),
-        session = EvaluationSession.standard()
-    )
+    private val session = EvaluationSession.standard()
 
     private fun String.exprValue() = valueFactory.newFromIonValue(ion.singleValue(this))
     private fun readFile(path: String) = File(dirPath(path)).readText()
@@ -52,7 +47,7 @@ class WriteFileTest {
     @Test
     fun writeIonAsDefault() {
         val args = listOf(""" "${dirPath("data.ion")}" """, "[1, 2]").map { it.exprValue() }
-        function.callWithRequired(env, args).ionValue
+        function.callWithRequired(session, args).ionValue
 
         val expected = "1 2"
 
@@ -63,7 +58,7 @@ class WriteFileTest {
     fun readIon() {
         val args = listOf(""" "${dirPath("data1.ion")}" """, "[1, 2]").map { it.exprValue() }
         val additionalOptions = """{type: "ion"}""".exprValue()
-        function.callWithOptional(env, args, additionalOptions).ionValue
+        function.callWithOptional(session, args, additionalOptions).ionValue
 
         val expected = "1 2"
 

--- a/examples/src/kotlin/org/partiql/examples/CustomFunctionsExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/CustomFunctionsExample.kt
@@ -4,7 +4,6 @@ import com.amazon.ion.system.IonSystemBuilder
 import org.partiql.examples.util.Example
 import org.partiql.lang.CompilerPipeline
 import org.partiql.lang.errors.ErrorCode
-import org.partiql.lang.eval.Environment
 import org.partiql.lang.eval.EvaluationException
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
@@ -42,7 +41,7 @@ class FibScalarExprFunc(private val valueFactory: ExprValueFactory) : ExprFuncti
         returnType = StaticType.INT
     )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         // [NullPropagatingExprFunction] also checks arity of the function call, so
         // there is no need to ensure [args] is the correct size.
         // However, at the moment there is no facility for ensuring that the arguments are
@@ -76,7 +75,7 @@ class FibListExprFunc(private val valueFactory: ExprValueFactory) : ExprFunction
         returnType = StaticType.LIST
     )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         val argN = required.first()
         if (argN.type != ExprValueType.INT) {
             throw EvaluationException("Argument to fib_list was not an integer", ErrorCode.INTERNAL_ERROR, internal = false)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.parallel=true
 org.gradle.caching=true
+#kotlin.daemon.jvmargs="-Xmx8g"
+org.gradle.jvmargs="-Xmx8g"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,2 @@
 org.gradle.parallel=true
 org.gradle.caching=true
-#kotlin.daemon.jvmargs="-Xmx8g"
-org.gradle.jvmargs="-Xmx8g"

--- a/lang/src/org/partiql/lang/eval/Environment.kt
+++ b/lang/src/org/partiql/lang/eval/Environment.kt
@@ -25,7 +25,7 @@ import java.util.TreeMap
  * @param session The evaluation session.
  * @param groups The map of [Group]s that is currently being built during query execution.
  */
-data class Environment(
+internal data class Environment(
     internal val locals: Bindings<ExprValue>,
     val current: Bindings<ExprValue> = locals,
     val session: EvaluationSession,

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -1011,12 +1011,12 @@ internal class EvaluatingCompiler(
         val computeThunk = when (func.signature.unknownArguments) {
             UnknownArguments.PROPAGATE -> thunkFactory.thunkEnvOperands(metas, funcArgThunks) { env, values ->
                 val checkedArgs = checkArgumentTypes(func.signature, values)
-                func.call(env, checkedArgs)
+                func.call(env.session, checkedArgs)
             }
             UnknownArguments.PASS_THRU -> thunkFactory.thunkEnv(metas) { env ->
                 val funcArgValues = funcArgThunks.map { it(env) }
                 val checkedArgs = checkArgumentTypes(func.signature, funcArgValues)
-                func.call(env, checkedArgs)
+                func.call(env.session, checkedArgs)
             }
         }
 

--- a/lang/src/org/partiql/lang/eval/ExprAggregator.kt
+++ b/lang/src/org/partiql/lang/eval/ExprAggregator.kt
@@ -23,7 +23,7 @@ package org.partiql.lang.eval
  * operand.  The evaluator's responsibility is to effectively compile this definition
  * into a form of [ExprFunction] that operates over the collection as an [ExprValue].
  */
-interface ExprAggregator {
+internal interface ExprAggregator {
     /** Accumulates the next value into this [ExprAggregator]. */
     fun next(value: ExprValue)
 

--- a/lang/src/org/partiql/lang/eval/ExprAggregatorFactory.kt
+++ b/lang/src/org/partiql/lang/eval/ExprAggregatorFactory.kt
@@ -19,7 +19,7 @@ package org.partiql.lang.eval
  *
  * This is the entry point for aggregate function definitions in the evaluator.
  */
-interface ExprAggregatorFactory {
+internal interface ExprAggregatorFactory {
     companion object {
         fun over(func: () -> ExprAggregator): ExprAggregatorFactory =
             object : ExprAggregatorFactory {

--- a/lang/src/org/partiql/lang/eval/ExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/ExprFunction.kt
@@ -44,10 +44,10 @@ interface ExprFunction {
      * [EvaluatingCompiler] validates the arguments before calling [ExprFunction]s.
      * Hence the implementations are not required to deal with it.
      *
-     * @param env The calling environment.
+     * @param session The current [EvaluationSession].
      * @param required The required arguments.
      */
-    fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         // Deriving ExprFunctions must implement this if they have a valid call form including only required parameters
         errNoContext("Invalid implementation for ${signature.name}#call", ErrorCode.INTERNAL_ERROR, true)
     }
@@ -60,11 +60,11 @@ interface ExprFunction {
      * [EvaluatingCompiler] validates the arguments before calling [ExprFunction]s.
      * Hence the implementations are not required to deal with it.
      *
-     * @param env The calling environment.
+     * @param session The current [EvaluationSession].
      * @param required The required arguments.
      * @param opt The optional arguments.
      */
-    fun callWithOptional(env: Environment, required: List<ExprValue>, opt: ExprValue): ExprValue {
+    fun callWithOptional(session: EvaluationSession, required: List<ExprValue>, opt: ExprValue): ExprValue {
         // Deriving ExprFunctions must implement this if they have a valid call form including required parameters and optional
         errNoContext("Invalid implementation for ${signature.name}#call", ErrorCode.INTERNAL_ERROR, true)
     }
@@ -77,11 +77,11 @@ interface ExprFunction {
      * [EvaluatingCompiler] validates the arguments before calling [ExprFunction]s.
      * Hence the implementations are not required to deal with it.
      *
-     * @param env The calling environment.
+     * @param session The current [EvaluationSession].
      * @param required The required arguments.
      * @param variadic The variadic arguments.
      */
-    fun callWithVariadic(env: Environment, required: List<ExprValue>, variadic: List<ExprValue>): ExprValue {
+    fun callWithVariadic(session: EvaluationSession, required: List<ExprValue>, variadic: List<ExprValue>): ExprValue {
         // Deriving ExprFunctions must implement this if they have a valid call form including required parameters and variadic
         errNoContext("Invalid implementation for ${signature.name}#call", ErrorCode.INTERNAL_ERROR, true)
     }
@@ -95,12 +95,12 @@ interface ExprFunction {
  * [EvaluatingCompiler] validates the arguments before calling [ExprFunction]s.
  * Hence the implementations are not required to deal with it.
  *
- * @param env The calling environment.
+ * @param session The current [EvaluationSession].
  * @param args The argument list.
  */
-fun ExprFunction.call(env: Environment, args: Arguments): ExprValue =
+fun ExprFunction.call(session: EvaluationSession, args: Arguments): ExprValue =
     when (args) {
-        is RequiredArgs -> callWithRequired(env, args.required)
-        is RequiredWithOptional -> callWithOptional(env, args.required, args.opt)
-        is RequiredWithVariadic -> callWithVariadic(env, args.required, args.variadic)
+        is RequiredArgs -> callWithRequired(session, args.required)
+        is RequiredWithOptional -> callWithOptional(session, args.required, args.opt)
+        is RequiredWithVariadic -> callWithVariadic(session, args.required, args.variadic)
     }

--- a/lang/src/org/partiql/lang/eval/Group.kt
+++ b/lang/src/org/partiql/lang/eval/Group.kt
@@ -17,6 +17,6 @@ package org.partiql.lang.eval
 /**
  * Defines a group and tracks the values of each group as they are processed into a final result.
  */
-class Group(val key: ExprValue, val registers: RegisterBank) {
+internal class Group(val key: ExprValue, val registers: RegisterBank) {
     val groupValues: MutableList<ExprValue> = ArrayList()
 }

--- a/lang/src/org/partiql/lang/eval/Register.kt
+++ b/lang/src/org/partiql/lang/eval/Register.kt
@@ -20,7 +20,7 @@ package org.partiql.lang.eval
  * Currently this supports registers that are [ExprAggregator], but may be expanded in the future
  * to support other things like [ExprValue] for things like optimized local variable access.
  */
-abstract class Register {
+internal abstract class Register {
     companion object {
         /** The empty register. */
         val EMPTY = object : Register() {

--- a/lang/src/org/partiql/lang/eval/RegisterBank.kt
+++ b/lang/src/org/partiql/lang/eval/RegisterBank.kt
@@ -17,7 +17,7 @@ package org.partiql.lang.eval
 /**
  * Represents a set of internal compiler slots for intermediate execution states.
  */
-class RegisterBank(size: Int) {
+internal class RegisterBank(size: Int) {
 
     private val bank: Array<Register> = Array(size) { Register.EMPTY }
 

--- a/lang/src/org/partiql/lang/eval/Thunk.kt
+++ b/lang/src/org/partiql/lang/eval/Thunk.kt
@@ -29,7 +29,7 @@ import org.partiql.lang.errors.Property
  *
  * This name was chosen because it is a thunk that accepts an instance of `Environment`.
  */
-typealias ThunkEnv = (Environment) -> ExprValue
+internal typealias ThunkEnv = (Environment) -> ExprValue
 
 /**
  * A thunk taking a single [T] argument and the current environment.
@@ -39,17 +39,17 @@ typealias ThunkEnv = (Environment) -> ExprValue
  * This name was chosen because it is a thunk that accepts an instance of `Environment` and an [ExprValue] as
  * its arguments.
  */
-typealias ThunkEnvValue<T> = (Environment, T) -> ExprValue
+internal typealias ThunkEnvValue<T> = (Environment, T) -> ExprValue
 
 /**
  * A type alias for an exception handler which always throws(primarily used for [TypingMode.LEGACY]).
  */
-typealias ThunkExceptionHandlerForLegacyMode = (Throwable, SourceLocationMeta?) -> Nothing
+internal typealias ThunkExceptionHandlerForLegacyMode = (Throwable, SourceLocationMeta?) -> Nothing
 
 /**
  * A type alias for an exception handler which does not always throw(primarily used for [TypingMode.PERMISSIVE]).
  */
-typealias ThunkExceptionHandlerForPermissiveMode = (Throwable, SourceLocationMeta?) -> Unit
+internal typealias ThunkExceptionHandlerForPermissiveMode = (Throwable, SourceLocationMeta?) -> Unit
 
 /**
  * Options for thunk construction.
@@ -98,7 +98,7 @@ data class ThunkOptions private constructor(
     }
 }
 
-val DEFAULT_EXCEPTION_HANDLER_FOR_LEGACY_MODE: ThunkExceptionHandlerForLegacyMode = { e, sourceLocation ->
+internal val DEFAULT_EXCEPTION_HANDLER_FOR_LEGACY_MODE: ThunkExceptionHandlerForLegacyMode = { e, sourceLocation ->
     val message = e.message ?: "<NO MESSAGE>"
     throw EvaluationException(
         "Internal error, $message",
@@ -109,7 +109,7 @@ val DEFAULT_EXCEPTION_HANDLER_FOR_LEGACY_MODE: ThunkExceptionHandlerForLegacyMod
     )
 }
 
-val DEFAULT_EXCEPTION_HANDLER_FOR_PERMISSIVE_MODE: ThunkExceptionHandlerForPermissiveMode = { _, _ -> }
+internal val DEFAULT_EXCEPTION_HANDLER_FOR_PERMISSIVE_MODE: ThunkExceptionHandlerForPermissiveMode = { _, _ -> }
 
 /**
  * An extension method for creating [ThunkFactory] based on the type of [TypingMode]

--- a/lang/src/org/partiql/lang/eval/builtins/BuiltinFunctions.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/BuiltinFunctions.kt
@@ -15,7 +15,7 @@
 package org.partiql.lang.eval.builtins
 
 import com.amazon.ion.system.IonSystemBuilder
-import org.partiql.lang.eval.Environment
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -62,7 +62,7 @@ internal fun createExists(valueFactory: ExprValueFactory): ExprFunction = object
         unknownArguments = UnknownArguments.PASS_THRU
     )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue =
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue =
         valueFactory.newBoolean(required[0].any())
 }
 
@@ -73,8 +73,8 @@ internal fun createUtcNow(valueFactory: ExprValueFactory): ExprFunction = object
         returnType = StaticType.TIMESTAMP
     )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue =
-        valueFactory.newTimestamp(env.session.now)
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue =
+        valueFactory.newTimestamp(session.now)
 }
 
 internal fun createCharacterLength(name: String, valueFactory: ExprValueFactory): ExprFunction =
@@ -89,7 +89,7 @@ internal fun createCharacterLength(name: String, valueFactory: ExprValueFactory)
                 )
             }
 
-        override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+        override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
             val s = required.first().stringValue()
             return valueFactory.newInt(s.codePointCount(0, s.length))
         }
@@ -103,7 +103,7 @@ internal fun createUpper(valueFactory: ExprValueFactory): ExprFunction = object 
             returnType = StaticType.STRING
         )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue =
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue =
         valueFactory.newString(required.first().stringValue().toUpperCase())
 }
 
@@ -115,6 +115,6 @@ internal fun createLower(valueFactory: ExprValueFactory): ExprFunction = object 
             returnType = StaticType.STRING
         )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue =
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue =
         valueFactory.newString(required.first().stringValue().toLowerCase())
 }

--- a/lang/src/org/partiql/lang/eval/builtins/DateAddExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/DateAddExprFunction.kt
@@ -17,8 +17,8 @@ package org.partiql.lang.eval.builtins
 import com.amazon.ion.Timestamp
 import com.amazon.ion.Timestamp.Precision
 import org.partiql.lang.errors.ErrorCode
-import org.partiql.lang.eval.Environment
 import org.partiql.lang.eval.EvaluationException
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -98,7 +98,7 @@ internal class DateAddExprFunction(val valueFactory: ExprValueFactory) : ExprFun
         }
     }
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         val dateTimePart = required[0].dateTimePartValue()
         val interval = required[1].intValue()
         val timestamp = required[2].timestampValue()

--- a/lang/src/org/partiql/lang/eval/builtins/DateDiffExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/DateDiffExprFunction.kt
@@ -16,7 +16,7 @@ package org.partiql.lang.eval.builtins
 
 import com.amazon.ion.Timestamp
 import org.partiql.lang.errors.ErrorCode
-import org.partiql.lang.eval.Environment
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -87,7 +87,7 @@ internal class DateDiffExprFunction(val valueFactory: ExprValueFactory) : ExprFu
     private fun secondsSince(left: OffsetDateTime, right: OffsetDateTime): Number =
         Duration.between(left, right).toMillis() / 1_000
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         val dateTimePart = required[0].dateTimePartValue()
         val left = required[1].timestampValue()
         val right = required[2].timestampValue()

--- a/lang/src/org/partiql/lang/eval/builtins/ExtractExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/ExtractExprFunction.kt
@@ -16,7 +16,7 @@ package org.partiql.lang.eval.builtins
 
 import com.amazon.ion.Timestamp
 import org.partiql.lang.errors.ErrorCode
-import org.partiql.lang.eval.Environment
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -69,10 +69,10 @@ internal class ExtractExprFunction(val valueFactory: ExprValueFactory) : ExprFun
 
     private fun Timestamp.minuteOffset() = (localOffset ?: 0) % SECONDS_PER_MINUTE
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         return when {
             required[1].isUnknown() -> valueFactory.nullValue
-            else -> eval(env, required)
+            else -> eval(session, required)
         }
     }
 
@@ -127,7 +127,7 @@ internal class ExtractExprFunction(val valueFactory: ExprValueFactory) : ExprFun
         }
     }
 
-    private fun eval(env: Environment, args: List<ExprValue>): ExprValue {
+    private fun eval(session: EvaluationSession, args: List<ExprValue>): ExprValue {
         val dateTimePart = args[0].dateTimePartValue()
         val extractedValue = when (args[1].type) {
             ExprValueType.TIMESTAMP -> args[1].timestampValue().extractedValue(dateTimePart)

--- a/lang/src/org/partiql/lang/eval/builtins/FromUnixTimeFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/FromUnixTimeFunction.kt
@@ -1,7 +1,7 @@
 package org.partiql.lang.eval.builtins
 
 import com.amazon.ion.Timestamp
-import org.partiql.lang.eval.Environment
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -33,7 +33,7 @@ internal class FromUnixTimeFunction(val valueFactory: ExprValueFactory) : ExprFu
 
     private val millisPerSecond = BigDecimal(1000)
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         val unixTimestamp = required[0].bigDecimalValue()
 
         val numMillis = unixTimestamp.times(millisPerSecond).stripTrailingZeros()

--- a/lang/src/org/partiql/lang/eval/builtins/MakeDateExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/MakeDateExprFunction.kt
@@ -2,7 +2,7 @@ package org.partiql.lang.eval.builtins
 
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
-import org.partiql.lang.eval.Environment
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -28,7 +28,7 @@ internal class MakeDateExprFunction(val valueFactory: ExprValueFactory) : ExprFu
         returnType = StaticType.DATE
     )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         required.map {
             if (it.type != ExprValueType.INT) {
                 err(

--- a/lang/src/org/partiql/lang/eval/builtins/MakeTimeExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/MakeTimeExprFunction.kt
@@ -1,8 +1,8 @@
 package org.partiql.lang.eval.builtins
 
 import org.partiql.lang.errors.ErrorCode
-import org.partiql.lang.eval.Environment
 import org.partiql.lang.eval.EvaluationException
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -29,12 +29,12 @@ internal class MakeTimeExprFunction(val valueFactory: ExprValueFactory) : ExprFu
         returnType = StaticType.TIME
     )
 
-    override fun callWithOptional(env: Environment, required: List<ExprValue>, opt: ExprValue): ExprValue {
+    override fun callWithOptional(session: EvaluationSession, required: List<ExprValue>, opt: ExprValue): ExprValue {
         val (hour, min, sec) = required
         return makeTime(hour.intValue(), min.intValue(), sec.bigDecimalValue(), opt.intValue())
     }
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         val (hour, min, sec) = required
         return makeTime(hour.intValue(), min.intValue(), sec.bigDecimalValue(), null)
     }

--- a/lang/src/org/partiql/lang/eval/builtins/SizeExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/SizeExprFunction.kt
@@ -15,7 +15,7 @@
 package org.partiql.lang.eval.builtins
 
 import com.amazon.ion.IonContainer
-import org.partiql.lang.eval.Environment
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -37,7 +37,7 @@ internal class SizeExprFunction(val valueFactory: ExprValueFactory) : ExprFuncti
         returnType = StaticType.INT
     )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         val ionContainer = required.first().ionValue as IonContainer
 
         return valueFactory.newInt(ionContainer.size)

--- a/lang/src/org/partiql/lang/eval/builtins/SubstringExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/SubstringExprFunction.kt
@@ -15,7 +15,7 @@
 package org.partiql.lang.eval.builtins
 
 import org.partiql.lang.errors.ErrorCode
-import org.partiql.lang.eval.Environment
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -102,10 +102,10 @@ internal class SubstringExprFunction(private val valueFactory: ExprValueFactory)
         returnType = StaticType.STRING
     )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue =
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue =
         substring(required[0].stringValue(), required[1].intValue(), null)
 
-    override fun callWithOptional(env: Environment, required: List<ExprValue>, opt: ExprValue): ExprValue {
+    override fun callWithOptional(session: EvaluationSession, required: List<ExprValue>, opt: ExprValue): ExprValue {
         val quantity = opt.intValue()
         if (quantity < 0) {
             errNoContext("Argument 3 of substring has to be greater than 0.", errorCode = ErrorCode.EVALUATOR_INVALID_ARGUMENTS_FOR_FUNC_CALL, internal = false)

--- a/lang/src/org/partiql/lang/eval/builtins/ToStringExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/ToStringExprFunction.kt
@@ -17,8 +17,8 @@ package org.partiql.lang.eval.builtins
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.errors.PropertyValueMap
-import org.partiql.lang.eval.Environment
 import org.partiql.lang.eval.EvaluationException
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -38,7 +38,7 @@ class ToStringExprFunction(private val valueFactory: ExprValueFactory) : ExprFun
         returnType = StaticType.STRING
     )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         val pattern = required[1].ionValue.stringValue()!!
 
         val formatter: DateTimeFormatter = try {

--- a/lang/src/org/partiql/lang/eval/builtins/ToTimestampExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/ToTimestampExprFunction.kt
@@ -17,8 +17,8 @@ package org.partiql.lang.eval.builtins
 import com.amazon.ion.Timestamp
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.PropertyValueMap
-import org.partiql.lang.eval.Environment
 import org.partiql.lang.eval.EvaluationException
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -37,7 +37,7 @@ class ToTimestampExprFunction(private val valueFactory: ExprValueFactory) : Expr
         returnType = StaticType.TIMESTAMP
     )
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         val ts = try {
             Timestamp.valueOf(required[0].ionValue.stringValue())
         } catch (ex: IllegalArgumentException) {
@@ -52,7 +52,7 @@ class ToTimestampExprFunction(private val valueFactory: ExprValueFactory) : Expr
         return valueFactory.newTimestamp(ts)
     }
 
-    override fun callWithOptional(env: Environment, required: List<ExprValue>, opt: ExprValue): ExprValue {
+    override fun callWithOptional(session: EvaluationSession, required: List<ExprValue>, opt: ExprValue): ExprValue {
         val ts = TimestampParser.parseTimestamp(required[0].ionValue.stringValue()!!, opt.ionValue.stringValue()!!)
         return valueFactory.newTimestamp(ts)
     }

--- a/lang/src/org/partiql/lang/eval/builtins/TrimExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/TrimExprFunction.kt
@@ -15,7 +15,7 @@
 package org.partiql.lang.eval.builtins
 
 import org.partiql.lang.errors.ErrorCode
-import org.partiql.lang.eval.Environment
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -147,8 +147,8 @@ internal class TrimExprFunction(private val valueFactory: ExprValueFactory) : Ex
         return trim(trimSpec, toRemove.codePoints(), sourceString.codePoints())
     }
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>) = trim1Arg(required[0])
-    override fun callWithVariadic(env: Environment, required: List<ExprValue>, variadic: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>) = trim1Arg(required[0])
+    override fun callWithVariadic(session: EvaluationSession, required: List<ExprValue>, variadic: List<ExprValue>): ExprValue {
         return when (variadic.size) {
             0 -> trim1Arg(required[0])
             1 -> trim2Arg(required[0], variadic[0])

--- a/lang/src/org/partiql/lang/eval/builtins/UnixTimestampFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/UnixTimestampFunction.kt
@@ -1,7 +1,7 @@
 package org.partiql.lang.eval.builtins
 
 import com.amazon.ion.Timestamp
-import org.partiql.lang.eval.Environment
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
@@ -38,11 +38,11 @@ internal class UnixTimestampFunction(val valueFactory: ExprValueFactory) : ExprF
     private val millisPerSecond = BigDecimal(1000)
     private fun epoch(timestamp: Timestamp): BigDecimal = timestamp.decimalMillis.divide(millisPerSecond)
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
-        return valueFactory.newInt(epoch(env.session.now).toLong())
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
+        return valueFactory.newInt(epoch(session.now).toLong())
     }
 
-    override fun callWithOptional(env: Environment, required: List<ExprValue>, opt: ExprValue): ExprValue {
+    override fun callWithOptional(session: EvaluationSession, required: List<ExprValue>, opt: ExprValue): ExprValue {
         val timestamp = opt.timestampValue()
         val epochTime = epoch(timestamp)
         return if (timestamp.decimalSecond.scale() == 0) {

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerUnknownValuesTest.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerUnknownValuesTest.kt
@@ -45,7 +45,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
                                 unknownArguments = UnknownArguments.PROPAGATE
                             )
 
-                        override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue =
+                        override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue =
                             valueFactory.newInt(required.map { it.numberValue().toLong() }.sum())
                     }
                 )

--- a/lang/test/org/partiql/lang/eval/ExceptionWrappingTest.kt
+++ b/lang/test/org/partiql/lang/eval/ExceptionWrappingTest.kt
@@ -19,13 +19,13 @@ class ExceptionWrappingTest {
         override val signature: FunctionSignature
             get() = FunctionSignature("throw_illegal_state_exception", listOf(), returnType = StaticType.ANY)
 
-        override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+        override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
             throw IllegalStateException("Intentionally throw an IllegalStateException")
         }
     }
 
     private val throwSemanticExceptionExprFunction = object : ExprFunction {
-        override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+        override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
             throw SemanticException("Intentionally throw a SemanticException", ErrorCode.SEMANTIC_AMBIGUOUS_BINDING, null)
         }
 

--- a/lang/test/org/partiql/lang/eval/io/CustomExceptionHandlerTest.kt
+++ b/lang/test/org/partiql/lang/eval/io/CustomExceptionHandlerTest.kt
@@ -4,20 +4,18 @@ import com.amazon.ion.system.IonSystemBuilder
 import org.junit.Test
 import org.partiql.lang.CompilerPipeline
 import org.partiql.lang.eval.CompileOptions
-import org.partiql.lang.eval.Environment
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ThunkOptions
 import org.partiql.lang.types.FunctionSignature
 import org.partiql.lang.types.StaticType
-import java.lang.IllegalStateException
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
 class AlwaysThrowsFunc : ExprFunction {
 
-    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         throw IllegalStateException()
     }
     override val signature: FunctionSignature


### PR DESCRIPTION
I am working on a significant evaluator refactor to work with the new relational algebra.  There is a requirement that this be implemented as a refactored copy of the original `EvaluatingCompiler` to allow customers to switch between the old and new evaluators via runtime configuration.  One challenge associated with this is: the new evaluator does not use the same `Environment` class of the legacy evaluator and (until this PR) and the `ExprFunction.call*` functions all accepted `Environment` as a first argument.  This PR changes that argument to `session: EvaluationSession` instead.  Unfortunately, this is a breaking API change and customers who have their own `ExprFunction` implementations.  (Although this has gone through a breaking change in the last release anyway and most of our customers probably haven't migrated yet.)   There is, however, no other way that I can see to accomplish the goal of exposing the new physical plan evaluator as an alternative to the legacy AST evaluator.

Aside from the above:

- Exposing `Environment` as public API wasn't a great idea because it exposed implementation details that the customer should never depend on (i.e. all of the properties [here](https://github.com/partiql/partiql-lang-kotlin/blob/d6ad8d202797c0b1afbccb91dcbc11a507c7fdf7/lang/src/org/partiql/lang/eval/Environment.kt#L29-L33) except for `session`).
- No customer that I am aware of uses the `env: Environment` parameter.  Nor is there any reason to that I am aware of, outside of accessing its `session: EvaluationSession` property.

This PR also makes `Environment` and several other types `internal` as well.  These other types were all implementation details that customers should not be depending on and could not be made `internal` previously due to the requirement that `Environment` be public.
