### PR TITLE
Fix all compiler warnings

### DIFF
--- a/cli/src/org/partiql/cli/Repl.kt
+++ b/cli/src/org/partiql/cli/Repl.kt
@@ -313,7 +313,7 @@ internal class Repl(
                 }
 
                 ReplState.READ_PARTIQL -> {
-                    buffer.appendln(line)
+                    buffer.appendLine(line)
                     line = readLine()
                     when {
                         line == null -> ReplState.FINAL
@@ -325,12 +325,12 @@ internal class Repl(
                 }
 
                 ReplState.LAST_PARTIQL_LINE -> {
-                    buffer.appendln(line)
+                    buffer.appendLine(line)
                     ReplState.EXECUTE_PARTIQL
                 }
 
                 ReplState.READ_REPL_COMMAND -> {
-                    buffer.appendln(line)
+                    buffer.appendLine(line)
                     line = readLine()
                     when (line) {
                         null -> ReplState.FINAL

--- a/cli/src/org/partiql/cli/functions/ReadFile.kt
+++ b/cli/src/org/partiql/cli/functions/ReadFile.kt
@@ -70,6 +70,7 @@ internal class ReadFile(valueFactory: ExprValueFactory) : BaseFunction(valueFact
     }
 
     private fun ionReadHandler(): (InputStream, IonStruct) -> ExprValue = { input, _ ->
+        @Suppress("DEPRECATION")
         valueFactory.newBag(valueFactory.ion.iterate(input).asSequence().map { valueFactory.newFromIonValue(it) })
     }
 

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -15,8 +15,8 @@
 package org.partiql.cli
 
 import com.amazon.ion.system.IonSystemBuilder
-import junit.framework.Assert.assertEquals
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.partiql.lang.CompilerPipeline

--- a/cli/test/org/partiql/cli/functions/ReadFileTest.kt
+++ b/cli/test/org/partiql/cli/functions/ReadFileTest.kt
@@ -17,9 +17,9 @@ package org.partiql.cli.functions
 import com.amazon.ion.IonType
 import com.amazon.ion.IonValue
 import com.amazon.ion.system.IonSystemBuilder
-import junit.framework.Assert.assertEquals
-import junit.framework.Assert.assertSame
 import org.junit.AfterClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.BeforeClass
 import org.junit.Test
 import org.partiql.lang.eval.EvaluationSession

--- a/lang/src/org/partiql/lang/CompilerPipeline.kt
+++ b/lang/src/org/partiql/lang/CompilerPipeline.kt
@@ -12,6 +12,8 @@
  *  language governing permissions and limitations under the License.
  */
 
+@file:Suppress("DEPRECATION") // We don't need warnings about deprecated ExprNode.
+
 package org.partiql.lang
 
 import com.amazon.ion.IonSystem

--- a/lang/src/org/partiql/lang/ast/AstDeserialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstDeserialization.kt
@@ -43,6 +43,7 @@ import org.partiql.lang.util.toListOfIonSexp
  */
 @Deprecated("Please use PartiqlAst")
 interface AstDeserializer {
+    @Suppress("DEPRECATION") // We don't need warnings about deprecated ExprNode.
     @Deprecated("Please use PartiqlAst")
     fun deserialize(sexp: IonSexp, astVersion: AstVersion): ExprNode
 }
@@ -257,6 +258,7 @@ private enum class NodeTag(val definition: TagDefinition) {
 
 // TODO: CustomTypes in this signature should be removed along with all it's usages
 //  once hardcoded types are removed from the PIG domain https://github.com/partiql/partiql-lang-kotlin/issues/510
+@Suppress("DEPRECATION") // We don't need warnings about deprecated ExprNode.
 class AstDeserializerBuilder(val ion: IonSystem, val customTypes: List<CustomType> = listOf()) {
     private val metaDeserializers = mutableMapOf(
         SourceLocationMeta.deserializer.tag to SourceLocationMeta.deserializer,
@@ -286,6 +288,7 @@ class AstDeserializerBuilder(val ion: IonSystem, val customTypes: List<CustomTyp
 
 // TODO: CustomTypes in this signature should be removed along with all it's usages
 //  once hardcoded types are removed from the PIG domain https://github.com/partiql/partiql-lang-kotlin/issues/510
+@Suppress("DEPRECATION") // We don't need warnings about deprecated ExprNode
 internal class AstDeserializerInternal(
     val astVersion: AstVersion,
     val ion: IonSystem,

--- a/lang/src/org/partiql/lang/ast/AstSerialization.kt
+++ b/lang/src/org/partiql/lang/ast/AstSerialization.kt
@@ -12,6 +12,9 @@
  *  language governing permissions and limitations under the License.
  */
 
+// We don't need warnings about deprecated ExprNode.
+@file: Suppress("DEPRECATION")
+
 package org.partiql.lang.ast
 
 import com.amazon.ion.IonSexp
@@ -96,7 +99,6 @@ private class AstSerializerImpl(val astVersion: AstVersion, val ion: IonSystem) 
                     is Parameter -> case { writeParameter(expr) }
                     is NullIf -> case { writeNullIf(expr) }
                     is Coalesce -> case { writeCoalesce(expr) }
-                    is Parameter -> case { writeParameter(expr) }
                     is DateLiteral -> throw UnsupportedOperationException("DATE literals not supported by the V0 AST")
                     is TimeLiteral -> throw UnsupportedOperationException("TIME literals not supported by the V0 AST")
                     is Exec -> throw UnsupportedOperationException("EXEC clause not supported by the V0 AST")

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -1,3 +1,7 @@
+
+// We don't need warnings about deprecated ExprNode.
+@file: Suppress("DEPRECATION")
+
 package org.partiql.lang.ast
 
 import com.amazon.ionelement.api.emptyMetaContainer
@@ -23,6 +27,7 @@ fun ExprNode.toAstStatement(): PartiqlAst.Statement {
     }
 }
 
+@Suppress("TYPEALIAS_EXPANSION_DEPRECATION")
 internal fun PartiQlMetaContainer.toIonElementMetaContainer(): IonElementMetaContainer =
     com.amazon.ionelement.api.metaContainerOf(map { it.tag to it })
 

--- a/lang/src/org/partiql/lang/ast/SourceLocationMeta.kt
+++ b/lang/src/org/partiql/lang/ast/SourceLocationMeta.kt
@@ -12,6 +12,8 @@
  *  language governing permissions and limitations under the License.
  */
 
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.ast
 
 import com.amazon.ion.IonValue
@@ -68,8 +70,8 @@ data class SourceLocationMeta(val lineNum: Long, val charOffset: Long, val lengt
         const val TAG = "\$source_location"
         val deserializer = object : MetaDeserializer {
             override val tag = TAG
-            override fun deserialize(value: IonValue): Meta {
-                val struct = value.asIonStruct()
+            override fun deserialize(sexp: IonValue): Meta {
+                val struct = sexp.asIonStruct()
                 val lineNum = struct.field("line_num").longValue()
                 val charOffset = struct.field("char_offset").longValue()
                 val length = struct.field("length").longValue()

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UnusedImport")
+@file:Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION") // We don't need warnings about ExprNode deprecation.
 
 package org.partiql.lang.ast
 

--- a/lang/src/org/partiql/lang/ast/StaticTypeMeta.kt
+++ b/lang/src/org/partiql/lang/ast/StaticTypeMeta.kt
@@ -33,6 +33,7 @@ data class StaticTypeMeta(val type: StaticType) : Meta {
         val isl = when (hasISL) {
             true -> {
                 // Get name from metas if present, fallback to base type name
+                @Suppress("UNCHECKED_CAST")
                 name = (type.metas[ISL_META_KEY] as List<IonSchemaModel.TypeDefinition>)[0].name?.text ?: name
                 IonSchemaMapper(type).toIonSchema(name).toIsl()
             }
@@ -54,8 +55,8 @@ data class StaticTypeMeta(val type: StaticType) : Meta {
 
         val deserializer = object : MetaDeserializer {
             override val tag = TAG
-            override fun deserialize(value: IonValue): Meta {
-                val struct = value.asIonStruct()
+            override fun deserialize(sexp: IonValue): Meta {
+                val struct = sexp.asIonStruct()
 
                 // get serialized fields
                 val name = struct.field("name").stringValue()!!
@@ -79,5 +80,6 @@ data class StaticTypeMeta(val type: StaticType) : Meta {
     }
 }
 
+@Suppress("DEPRECATION")
 @Deprecated("Please use org.partiql.lang.domains.staticType")
 val MetaContainer.staticType: StaticTypeMeta? get() = find(StaticTypeMeta.TAG) as StaticTypeMeta?

--- a/lang/src/org/partiql/lang/ast/Util.kt
+++ b/lang/src/org/partiql/lang/ast/Util.kt
@@ -19,6 +19,7 @@ import com.amazon.ion.IonSystem
 import org.partiql.lang.errors.Property
 import org.partiql.lang.errors.PropertyValueMap
 
+@Suppress("DEPRECATION")
 fun PropertyValueMap.addSourceLocation(metas: MetaContainer): PropertyValueMap {
     (metas.find(SourceLocationMeta.TAG) as? SourceLocationMeta)?.let {
         this[Property.LINE_NUMBER] = it.lineNum
@@ -31,6 +32,7 @@ fun PropertyValueMap.addSourceLocation(metas: MetaContainer): PropertyValueMap {
  * Creates an instance of [CallAgg] which is intended to be used to represent `COUNT(*)` when it is
  * used in a select list.
  */
+@Suppress("DEPRECATION")
 fun createCountStar(ion: IonSystem, metas: MetaContainer): CallAgg {
     // The [VariableReference] and [Literal] below should only get the [SourceLocationMeta] if present,
     // not any other metas.

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -12,6 +12,9 @@
  *  language governing permissions and limitations under the License.
  */
 
+// Many deprecated things in this file refer to other things in this file that are deprecated.
+@file:Suppress("DEPRECATION")
+
 package org.partiql.lang.ast
 
 import com.amazon.ion.IonType

--- a/lang/src/org/partiql/lang/ast/meta.kt
+++ b/lang/src/org/partiql/lang/ast/meta.kt
@@ -12,6 +12,8 @@
  *  language governing permissions and limitations under the License.
  */
 
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.ast
 
 import com.amazon.ion.IonWriter

--- a/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstRewriterBase.kt
@@ -11,6 +11,7 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
  *  language governing permissions and limitations under the License.
  */
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
 
 package org.partiql.lang.ast.passes
 

--- a/lang/src/org/partiql/lang/ast/passes/AstVisitor.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstVisitor.kt
@@ -11,7 +11,7 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
  *  language governing permissions and limitations under the License.
  */
-
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
 package org.partiql.lang.ast.passes
 
 import org.partiql.lang.ast.DataManipulationOperation

--- a/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
+++ b/lang/src/org/partiql/lang/ast/passes/AstWalker.kt
@@ -11,7 +11,7 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
  *  language governing permissions and limitations under the License.
  */
-
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
 package org.partiql.lang.ast.passes
 
 import org.partiql.lang.ast.AssignmentOp
@@ -138,7 +138,7 @@ open class AstWalker(private val visitor: AstVisitor) {
                     }
                 }
                 is Select -> case {
-                    val (_, projection, from, fromLet, where, groupBy, having, orderBy, limit, offset, _: MetaContainer) = expr
+                    val (_, projection, from, _, where, groupBy, having, orderBy, limit, offset, _: MetaContainer) = expr
                     walkSelectProjection(projection)
                     walkFromSource(from)
                     walkExprNode(where)

--- a/lang/src/org/partiql/lang/ast/passes/MetaStrippingRewriter.kt
+++ b/lang/src/org/partiql/lang/ast/passes/MetaStrippingRewriter.kt
@@ -12,6 +12,8 @@
  *  language governing permissions and limitations under the License.
  */
 
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.ast.passes
 
 import org.partiql.lang.ast.DataType

--- a/lang/src/org/partiql/lang/ast/passes/V0AstSerializer.kt
+++ b/lang/src/org/partiql/lang/ast/passes/V0AstSerializer.kt
@@ -1,4 +1,6 @@
 
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.ast.passes
 
 import com.amazon.ion.IonSexp
@@ -22,6 +24,7 @@ class V0AstSerializer {
          * Converts an instance of [ExprNode] to the legacy s-expression based AST.
          */
         @JvmStatic
+        @Suppress("DEPRECATION")
         fun serialize(expr: ExprNode, ion: IonSystem): IonSexp =
             AstSerializer.serialize(expr, AstVersion.V0, ion)
     }

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -12,6 +12,8 @@
  *  language governing permissions and limitations under the License.
  */
 
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.eval
 
 import com.amazon.ion.IntegerSize
@@ -980,7 +982,6 @@ internal class EvaluatingCompiler(
                     errInvalidArgumentType(
                         signature = signature,
                         position = position,
-                        numArgs = args.size,
                         expectedTypes = formalExprValueTypeDomain.toList(),
                         actualType = actualExprValueType
                     )

--- a/lang/src/org/partiql/lang/eval/Exceptions.kt
+++ b/lang/src/org/partiql/lang/eval/Exceptions.kt
@@ -71,11 +71,9 @@ internal fun expectedArgTypeErrorMsg(types: List<ExprValueType>): String = when 
 internal fun errInvalidArgumentType(
     signature: FunctionSignature,
     position: Int,
-    numArgs: Int,
     expectedTypes: List<ExprValueType>,
     actualType: ExprValueType
 ): Nothing {
-    val arity = signature.arity
 
     val expectedTypeMsg = expectedArgTypeErrorMsg(expectedTypes)
 

--- a/lang/src/org/partiql/lang/eval/ExprNodeExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/ExprNodeExtensions.kt
@@ -12,6 +12,8 @@
  *  language governing permissions and limitations under the License.
  */
 
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.eval
 
 import com.amazon.ion.IonString

--- a/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
@@ -394,7 +394,7 @@ fun ExprValue.cast(
                     }
 
                     valueFactory.newString(
-                        when (val l = type.lengthConstraint.length) {
+                        when (type.lengthConstraint.length) {
                             is NumberConstraint.Equals -> truncatedString.trimEnd { c -> c == '\u0020' }
                             is NumberConstraint.UpTo -> truncatedString
                         }

--- a/lang/src/org/partiql/lang/eval/builtins/ExtractExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/ExtractExprFunction.kt
@@ -72,7 +72,7 @@ internal class ExtractExprFunction(val valueFactory: ExprValueFactory) : ExprFun
     override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         return when {
             required[1].isUnknown() -> valueFactory.nullValue
-            else -> eval(session, required)
+            else -> eval(required)
         }
     }
 
@@ -127,7 +127,7 @@ internal class ExtractExprFunction(val valueFactory: ExprValueFactory) : ExprFun
         }
     }
 
-    private fun eval(session: EvaluationSession, args: List<ExprValue>): ExprValue {
+    private fun eval(args: List<ExprValue>): ExprValue {
         val dateTimePart = args[0].dateTimePartValue()
         val extractedValue = when (args[1].type) {
             ExprValueType.TIMESTAMP -> args[1].timestampValue().extractedValue(dateTimePart)

--- a/lang/src/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
@@ -868,7 +868,11 @@ internal class StaticTypeInferenceVisitorTransform(
          * Even if the escape character is of length 1, escape sequence can be incorrect.
          * Check [EvaluatingCompiler.checkPattern] method for more details.
          */
-        fun getTypeForNAryLike(nAryOp: PartiqlAst.Expr, args: List<SingleType>): StaticType {
+        fun getTypeForNAryLike(
+            @Suppress("UNUSED_PARAMETER")
+            nAryOp: PartiqlAst.Expr,
+            args: List<SingleType>
+        ): StaticType {
             return when {
                 // If any one of the operands is missing, return MISSING. MISSING has precedence over NULL
                 args.any { it is MissingType } -> StaticType.MISSING

--- a/lang/src/org/partiql/lang/eval/visitors/StaticTypeVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/StaticTypeVisitorTransform.kt
@@ -409,8 +409,8 @@ class StaticTypeVisitorTransform(
             return from
         }
 
-        override fun transformLetBinding(letBinding: PartiqlAst.LetBinding): PartiqlAst.LetBinding {
-            val binding = super.transformLetBinding(letBinding)
+        override fun transformLetBinding(node: PartiqlAst.LetBinding): PartiqlAst.LetBinding {
+            val binding = super.transformLetBinding(node)
             addLocal(binding.name.text, StaticType.ANY, binding.name.metas)
             return binding
         }

--- a/lang/src/org/partiql/lang/mappers/IonSchemaMapper.kt
+++ b/lang/src/org/partiql/lang/mappers/IonSchemaMapper.kt
@@ -108,6 +108,7 @@ class IonSchemaMapper(private val staticType: StaticType) {
             val isNullable = ionBool(isNullable(this) || nullable)
 
             // Get type definitions stored in metas
+            @Suppress("UNCHECKED_CAST")
             val typeDefsFromMetas = metas[ISL_META_KEY] as? List<IonSchemaModel.TypeDefinition>
             // Get type definition for `typeDefName` if exists. Note that `typeDefName` may be null but there may still be a valid type definition.
             val currentTypeDef = typeDefsFromMetas?.firstOrNull { typeDefName == it.name?.text }
@@ -235,6 +236,7 @@ class IonSchemaMapper(private val staticType: StaticType) {
      */
     private fun StaticType.getOtherConstraints(topLevelTypeName: String, typeDefName: String? = null): Set<IonSchemaModel.Constraint> {
         // Get type definitions from metas, if present
+        @Suppress("UNCHECKED_CAST")
         val typeDefsFromMetas = metas[ISL_META_KEY] as? List<IonSchemaModel.TypeDefinition> ?: listOf()
 
         // If there are multiple type definitions, only consider constraints for the relevant one
@@ -360,6 +362,7 @@ class IonSchemaMapper(private val staticType: StaticType) {
     private fun StaticType.toTypeReference(topLevelTypeName: String, nullable: Boolean = false): IonSchemaModel.TypeReference {
         // If ISL in metas has exactly one top-level type, create type reference as a named type with that top-level type name
         // In all other cases, create an inline type definition
+        @Suppress("UNCHECKED_CAST")
         val typeDefsFromMetas = metas[ISL_META_KEY] as? List<IonSchemaModel.TypeDefinition> ?: listOf()
         if (typeDefsFromMetas.size == 1) {
             val typeDefName = typeDefsFromMetas[0].name?.text
@@ -477,6 +480,7 @@ private fun IonSchemaModel.TypeDefinition.getTypeConstraintName(): String? {
  * it was a top-level type in original ISL (ISL used to create the StaticType instance)
  */
 private fun StaticType.addTopLevelTypesFromMetas(): Map<String, IonSchemaModel.TypeDefinition> {
+    @Suppress("UNCHECKED_CAST")
     val typeDefs = this.metas[ISL_META_KEY] as? List<IonSchemaModel.TypeDefinition> ?: emptyList()
     return typeDefs.filter { it.name != null }.map { it.name!!.text to it }.toMap()
 }

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -482,8 +482,8 @@ internal val DATE_TIME_PART_KEYWORDS: Set<String> = DateTimePart.values()
     listOf("all", "new") to ("all_new" to KEYWORD)
 )
 
-@JvmField internal val MULTI_LEXEME_MIN_LENGTH = MULTI_LEXEME_TOKEN_MAP.keys.map { it.size }.min()!!
-@JvmField internal val MULTI_LEXEME_MAX_LENGTH = MULTI_LEXEME_TOKEN_MAP.keys.map { it.size }.max()!!
+@JvmField internal val MULTI_LEXEME_MIN_LENGTH = MULTI_LEXEME_TOKEN_MAP.keys.minOf { it.size }
+@JvmField internal val MULTI_LEXEME_MAX_LENGTH = MULTI_LEXEME_TOKEN_MAP.keys.maxOf { it.size }
 
 @JvmField internal val MULTI_LEXEME_BINARY_OPERATORS =
     MULTI_LEXEME_TOKEN_MAP.values.filter {

--- a/lang/src/org/partiql/lang/syntax/Parser.kt
+++ b/lang/src/org/partiql/lang/syntax/Parser.kt
@@ -12,6 +12,8 @@
  *  language governing permissions and limitations under the License.
  */
 
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.syntax
 
 import com.amazon.ion.IonSexp

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -23,9 +23,7 @@ import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.ionString
 import com.amazon.ionelement.api.metaContainerOf
 import com.amazon.ionelement.api.toIonElement
-import org.partiql.lang.ast.AstSerializer
 import org.partiql.lang.ast.AstVersion
-import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.ast.IonElementMetaContainer
 import org.partiql.lang.ast.IsCountStarMeta
 import org.partiql.lang.ast.IsImplictJoinMeta
@@ -822,7 +820,7 @@ class SqlParser(
                 SqlDataType.TIME -> timeType(arg1, metas)
                 SqlDataType.TIME_WITH_TIME_ZONE -> timeWithTimeZoneType(arg1, metas)
                 SqlDataType.ANY -> anyType(metas)
-                is SqlDataType.CustomDataType -> customType(typeName!!, metas)
+                is SqlDataType.CustomDataType -> customType(typeName, metas)
             }
         }
     }
@@ -2853,6 +2851,7 @@ class SqlParser(
                     )
                     rem = rem.tail
                 }
+                else -> { /* intentionally blank. */ }
             }
             ParseNode(type = ParseType.SORT_SPEC, token = null, children = sortSpecKey, remaining = rem)
         }
@@ -2976,7 +2975,7 @@ class SqlParser(
     ): ParseNode {
         val parseDelim = parseCommaDelim
 
-        return parseDelimitedList(parseDelim) { delim ->
+        return parseDelimitedList(parseDelim) { _ ->
             var rem = this
             var child = when (mode) {
                 ArgListMode.STRUCT_LITERAL_ARG_LIST -> {
@@ -3152,7 +3151,8 @@ class SqlParser(
 
     /** Entry point into the parser. */
     @Deprecated("`ExprNode` is deprecated. Please use `parseAstStatement` instead. ")
-    override fun parseExprNode(source: String): ExprNode {
+    @Suppress("DEPRECATION")
+    override fun parseExprNode(source: String): org.partiql.lang.ast.ExprNode {
         return parseAstStatement(source).toExprNode(ion)
     }
 
@@ -3178,6 +3178,7 @@ class SqlParser(
         return node.toAstStatement()
     }
 
+    @Suppress("DEPRECATION")
     override fun parse(source: String): IonSexp =
-        AstSerializer.serialize(parseExprNode(source), AstVersion.V0, ion)
+        org.partiql.lang.ast.AstSerializer.serialize(parseExprNode(source), AstVersion.V0, ion)
 }

--- a/lang/test/org/partiql/lang/TestBase.kt
+++ b/lang/test/org/partiql/lang/TestBase.kt
@@ -12,6 +12,8 @@
  *  language governing permissions and limitations under the License.
  */
 
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang
 
 import com.amazon.ion.Decimal
@@ -50,18 +52,14 @@ import kotlin.reflect.KClass
  * @param ex actual exception thrown by test
  * @param expectedValues expected values for errorContext
  */
-fun <T : SqlException> SoftAssertions.checkErrorAndErrorContext(errorCode: ErrorCode?, ex: T, expectedValues: Map<Property, Any>) {
-    if (ex.errorCode == null && errorCode != null) {
-        fail("Expected an error code but exception error code was null, message was: ${ex.message}")
-    } else {
-        this.assertThat(ex.errorCode).isEqualTo(errorCode)
-    }
+fun <T : SqlException> SoftAssertions.checkErrorAndErrorContext(errorCode: ErrorCode, ex: T, expectedValues: Map<Property, Any>) {
+
+    this.assertThat(ex.errorCode).isEqualTo(errorCode)
+
     val errorContext = ex.errorContext
 
-    if (errorCode != null) {
-        correctContextKeys(errorCode, errorContext)
-        correctContextValues(errorCode, errorContext, expectedValues)
-    }
+    correctContextKeys(errorCode, errorContext)
+    correctContextValues(errorCode, errorContext, expectedValues)
 }
 
 /**
@@ -129,7 +127,6 @@ private fun SoftAssertions.correctContextValues(errorCode: ErrorCode, errorConte
 }
 
 @RunWith(JUnitParamsRunner::class)
-@Deprecated("New test fixtures should not use this--inheritance is an anti-pattern in this case.")
 abstract class TestBase : Assert() {
 
     val ion: IonSystem = ION
@@ -211,7 +208,7 @@ abstract class TestBase : Assert() {
      * [expectErrorContextValues] match the expected values.
      */
     protected fun assertThrowsEvaluationException(
-        errorCode: ErrorCode? = null,
+        errorCode: ErrorCode,
         expectErrorContextValues: Map<Property, Any>,
         cause: KClass<out Throwable>? = null,
         block: () -> Unit

--- a/lang/test/org/partiql/lang/ast/AstNodeTest.kt
+++ b/lang/test/org/partiql/lang/ast/AstNodeTest.kt
@@ -1,3 +1,6 @@
+
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.ast
 
 import com.amazon.ion.IonSystem

--- a/lang/test/org/partiql/lang/ast/AstSerDeTests.kt
+++ b/lang/test/org/partiql/lang/ast/AstSerDeTests.kt
@@ -12,6 +12,8 @@
  *  language governing permissions and limitations under the License.
  */
 
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.ast
 
 import junitparams.Parameters

--- a/lang/test/org/partiql/lang/ast/IsIonLiteralMetaTest.kt
+++ b/lang/test/org/partiql/lang/ast/IsIonLiteralMetaTest.kt
@@ -24,6 +24,7 @@ class IsIonLiteralMetaTest {
     @Test
     fun testIonLiteralMetaPreserved() {
         val ion = IonSystemBuilder.standard().build()
+        @Suppress("DEPRECATION")
         val ionLiteral = SqlParser(ion).parseExprNode("`1.0`")
         Assert.assertTrue(ionLiteral.metas.hasMeta(IsIonLiteralMeta.TAG))
         val roundTrippedIonLiteral = ionLiteral.toAstStatement().toExprNode(ion)

--- a/lang/test/org/partiql/lang/ast/PathComponentExprTest.kt
+++ b/lang/test/org/partiql/lang/ast/PathComponentExprTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
+@Suppress("DEPRECATION")
 @RunWith(JUnitParamsRunner::class)
 class PathComponentExprTest {
     private val ion: IonSystem = IonSystemBuilder.standard().build()

--- a/lang/test/org/partiql/lang/ast/SerializationRoundTripTests.kt
+++ b/lang/test/org/partiql/lang/ast/SerializationRoundTripTests.kt
@@ -1,3 +1,6 @@
+
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.ast
 
 import org.junit.jupiter.api.assertDoesNotThrow

--- a/lang/test/org/partiql/lang/ast/SqlDataTypeTest.kt
+++ b/lang/test/org/partiql/lang/ast/SqlDataTypeTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert
 import org.junit.Test
 
 class SqlDataTypeTest {
+    @Suppress("SENSELESS_COMPARISON")
     @Test
     fun `accessing non-companion object should not cause NPE`() {
         // Accessing companion object to see if they are initialized properly.
@@ -41,6 +42,7 @@ class SqlDataTypeTest {
         }
     }
 
+    @Suppress("SENSELESS_COMPARISON")
     @Test
     fun sqlDataTypeAccessingCompanionTest() {
         // Accessing companion object should not cause any initialization

--- a/lang/test/org/partiql/lang/ast/VariableReferenceTest.kt
+++ b/lang/test/org/partiql/lang/ast/VariableReferenceTest.kt
@@ -18,6 +18,7 @@ import org.junit.Assert
 import org.junit.Test
 import kotlin.test.assertEquals
 
+@Suppress("DEPRECATION")
 class VariableReferenceTest {
 
     /**

--- a/lang/test/org/partiql/lang/ast/passes/AstRewriterBaseTest.kt
+++ b/lang/test/org/partiql/lang/ast/passes/AstRewriterBaseTest.kt
@@ -15,6 +15,7 @@ import org.partiql.lang.util.testdsl.ExprNodeTestCase
  * TODO:  when SqlParserTest case has been parameterized, include its test cases here too.
  */
 class AstRewriterBaseTest {
+    @Suppress("DEPRECATION")
     private val defaultRewriter = AstRewriterBase()
     @ParameterizedTest
     @ArgumentsSource(EvaluatorTestCasesAsExprNodeTestCases::class)

--- a/lang/test/org/partiql/lang/ast/passes/AstWalkerTests.kt
+++ b/lang/test/org/partiql/lang/ast/passes/AstWalkerTests.kt
@@ -12,6 +12,8 @@
  *  language governing permissions and limitations under the License.
  */
 
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.ast.passes
 
 import com.amazon.ion.system.IonSystemBuilder

--- a/lang/test/org/partiql/lang/ast/passes/RewriterTestBase.kt
+++ b/lang/test/org/partiql/lang/ast/passes/RewriterTestBase.kt
@@ -17,6 +17,7 @@ package org.partiql.lang.ast.passes
 import org.partiql.lang.syntax.SqlParserTestBase
 
 @Deprecated("New rewriters should implement PIG's PartiqlAst.VisitorTransform and use VisitorTransformTestBase to test")
+@Suppress("DEPRECATION")
 abstract class RewriterTestBase : SqlParserTestBase() {
 
     data class RewriterTestCase(val originalSql: String, val expectedSql: String)

--- a/lang/test/org/partiql/lang/domains/PartiqlAstToExprNodeRoundTripTests.kt
+++ b/lang/test/org/partiql/lang/domains/PartiqlAstToExprNodeRoundTripTests.kt
@@ -1,3 +1,6 @@
+
+@file:Suppress("DEPRECATION") // We don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.domains
 
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerSelectStarTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerSelectStarTests.kt
@@ -77,7 +77,7 @@ class EvaluatingCompilerSelectStarTests : EvaluatorTestBase() {
         )
 
     @Test
-    fun `select * over table with mixed types`() {
+    fun `select star over table with mixed types`() {
         runTestCaseInLegacyAndPermissiveModes(
             EvaluatorTestCase(
                 query = "select f.* from << { 'bar': 1 }, 10, << 11, 12 >> >> as f",

--- a/lang/test/org/partiql/lang/eval/EvaluatorErrorTestCase.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorErrorTestCase.kt
@@ -21,7 +21,7 @@ data class EvaluatorErrorTestCase(
     /**
      * The [ErrorCode] the query is to throw.
      */
-    val errorCode: ErrorCode? = null,
+    val errorCode: ErrorCode,
 
     /**
      * The error context the query throws is to match this mapping.
@@ -48,7 +48,7 @@ data class EvaluatorErrorTestCase(
 
     constructor(
         input: String,
-        errorCode: ErrorCode? = null,
+        errorCode: ErrorCode,
         expectErrorContextValues: Map<Property, Any>,
         cause: KClass<out Throwable>? = null,
         compOptions: CompOptions = CompOptions.STANDARD,

--- a/lang/test/org/partiql/lang/eval/EvaluatorTestBase.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTestBase.kt
@@ -12,6 +12,9 @@
  *  language governing permissions and limitations under the License.
  */
 
+// We don't need warnings about deprecated ExprNode.
+@file:Suppress("DEPRECATION")
+
 package org.partiql.lang.eval
 
 import com.amazon.ion.IonType
@@ -50,7 +53,6 @@ import kotlin.test.assertEquals
  *
  * As we parameterize PartiQL's other tests, we should migrate them away from using this base class as well.
  */
-@Deprecated("This class and everything in it should be considered deprecated.")
 abstract class EvaluatorTestBase : TestBase() {
 
     /**
@@ -422,7 +424,7 @@ abstract class EvaluatorTestBase : TestBase() {
 
     protected fun checkInputThrowingEvaluationException(
         input: String,
-        errorCode: ErrorCode? = null,
+        errorCode: ErrorCode,
         expectErrorContextValues: Map<Property, Any>,
         cause: KClass<out Throwable>? = null,
         expectedPermissiveModeResult: String? = null
@@ -440,7 +442,7 @@ abstract class EvaluatorTestBase : TestBase() {
     protected fun checkInputThrowingEvaluationException(
         input: String,
         session: EvaluationSession,
-        errorCode: ErrorCode? = null,
+        errorCode: ErrorCode,
         expectErrorContextValues: Map<Property, Any>,
         cause: KClass<out Throwable>? = null,
         expectedPermissiveModeResult: String? = null
@@ -498,7 +500,7 @@ abstract class EvaluatorTestBase : TestBase() {
                     }
                     // Return MISSING
                     ErrorBehaviorInPermissiveMode.RETURN_MISSING -> {
-                        if (tc.errorCode?.errorCategory() != ErrorCategory.SEMANTIC.toString()) {
+                        if (tc.errorCode.errorCategory() != ErrorCategory.SEMANTIC.toString()) {
                             assertNotNull("Required non null expectedPermissiveModeResult when ErrorCode.errorBehaviorInPermissiveMode is set to ErrorBehaviorInPermissiveMode.RETURN_MISSING", tc.expectedPermissiveModeResult)
                             val originalExprValueForPermissiveMode = evalForPermissiveMode(tc.sqlUnderTest, session = session)
                             val expectedExprValueForPermissiveMode = evalForPermissiveMode(tc.expectedPermissiveModeResult!!, session = session)

--- a/lang/test/org/partiql/lang/eval/ExprValueFactoryTest.kt
+++ b/lang/test/org/partiql/lang/eval/ExprValueFactoryTest.kt
@@ -164,6 +164,7 @@ class ExprValueFactoryTest {
                 assertEquals(expectedValue, tc.value.scalar.bytesValue())
                 assertNull(tc.value.scalar.timestampValue())
             }
+            else -> fail("Unexpected ExprValueType: ${tc.expectedType}")
         }
     }
 
@@ -264,6 +265,7 @@ class ExprValueFactoryTest {
                 assertEquals(tc.expectedIonValue, tc.value.ionValue)
                 assertEquivalentAfterConversionToIon(tc.value)
             }
+            else -> fail("Unexpected ExprValueType: ${tc.expectedType}")
         }
     }
 

--- a/lang/test/org/partiql/lang/eval/LikePredicateTest.kt
+++ b/lang/test/org/partiql/lang/eval/LikePredicateTest.kt
@@ -119,7 +119,7 @@ class LikePredicateTest : EvaluatorTestBase() {
             val query = "Select * From Object a Where " + whereClause
 
             softly.assertThatCode {
-                when (types.map { it.type }.minBy { it.precedence }) {
+                when (types.map { it.type }.minByOrNull { it.precedence }) {
                     NULL -> assertEval(query, "[]", session)
                     INT -> {
                         val ex = assertFailsWith<SqlException>(message = query) {

--- a/lang/test/org/partiql/lang/eval/io/CustomExceptionHandlerTest.kt
+++ b/lang/test/org/partiql/lang/eval/io/CustomExceptionHandlerTest.kt
@@ -11,7 +11,6 @@ import org.partiql.lang.eval.ThunkOptions
 import org.partiql.lang.types.FunctionSignature
 import org.partiql.lang.types.StaticType
 import kotlin.test.assertTrue
-import kotlin.test.fail
 
 class AlwaysThrowsFunc : ExprFunction {
 
@@ -34,7 +33,7 @@ class CustomExceptionHandlerTest {
                 CompileOptions.build {
                     thunkOptions(
                         ThunkOptions.build {
-                            handleExceptionForLegacyMode { throwable, sourceLocationMeta ->
+                            handleExceptionForLegacyMode { _, _ ->
                                 customHandlerWasInvoked = true
                                 throw IllegalStateException()
                             }
@@ -48,8 +47,6 @@ class CustomExceptionHandlerTest {
 
         try {
             expression.eval(EvaluationSession.standard())
-            throw IllegalStateException()
-            fail("IllegalStateException was not thrown.")
         } catch (e: IllegalStateException) {
             assertTrue(customHandlerWasInvoked, "Custom handler must be invoked")
         }
@@ -66,7 +63,7 @@ class CustomExceptionHandlerTest {
                 CompileOptions.builder()
                     .thunkOptions(
                         ThunkOptions.builder()
-                            .handleExceptionForLegacyMode { throwable, sourceLocationMeta ->
+                            .handleExceptionForLegacyMode { _, _ ->
                                 customHandlerWasInvoked = true
                                 throw IllegalStateException()
                             }
@@ -80,8 +77,6 @@ class CustomExceptionHandlerTest {
 
         try {
             expression.eval(EvaluationSession.standard())
-            throw IllegalStateException()
-            fail("IllegalStateException was not thrown.")
         } catch (e: IllegalStateException) {
             assertTrue(customHandlerWasInvoked, "Custom handler must be invoked")
         }

--- a/lang/test/org/partiql/lang/eval/visitors/StaticTypeVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/StaticTypeVisitorTransformTests.kt
@@ -856,7 +856,7 @@ class StaticTypeVisitorTransformTests : VisitorTransformTestBase() {
         StringWriter().use { sw ->
             PrintWriter(sw).use { pw ->
                 this.printStackTrace(pw)
-                return sw.toString()
+                sw.toString()
             }
         }
 

--- a/lang/test/org/partiql/lang/syntax/SqlParserCustomTypeCatalogTests.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserCustomTypeCatalogTests.kt
@@ -5,7 +5,6 @@ import com.amazon.ionelement.api.toIonElement
 import com.amazon.ionelement.api.toIonValue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.ast.toAstExpr
 import org.partiql.lang.ast.toExprNode
 import org.partiql.lang.domains.PartiqlAst
@@ -31,7 +30,8 @@ class SqlParserCustomTypeCatalogTests : SqlParserTestBase() {
         val newSerializedPigAst: String
     )
 
-    private fun deserialize(serializedSexp: String): ExprNode {
+    @Suppress("DEPRECATION")
+    private fun deserialize(serializedSexp: String): org.partiql.lang.ast.ExprNode {
         val sexp = ion.singleValue(serializedSexp).asIonSexp()
         val astExpr = PartiqlAst.transform(sexp.toIonElement()) as PartiqlAst.Expr
         val astStatement = PartiqlAst.build {

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -21,7 +21,6 @@ import com.amazon.ionelement.api.ionString
 import com.amazon.ionelement.api.loadSingleElement
 import org.junit.Ignore
 import org.junit.Test
-import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.ast.sourceLocation
 import org.partiql.lang.domains.PartiqlAst

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -12,6 +12,8 @@
  *  language governing permissions and limitations under the License.
  */
 
+@file:Suppress("DEPRECATION") // Don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.syntax
 
 import com.amazon.ion.IonSexp

--- a/lang/test/org/partiql/lang/thread/ThreadInterruptedTests.kt
+++ b/lang/test/org/partiql/lang/thread/ThreadInterruptedTests.kt
@@ -1,3 +1,6 @@
+
+@file:Suppress("DEPRECATION") // Don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.thread
 
 import com.amazon.ion.system.IonSystemBuilder

--- a/lang/test/org/partiql/lang/types/StaticTypeTests.kt
+++ b/lang/test/org/partiql/lang/types/StaticTypeTests.kt
@@ -118,7 +118,6 @@ class StaticTypeTests {
     class SequenceIsInstanceArguments : ArgumentsProviderBase() {
 
         override fun getParameters(): List<TestCase> {
-            val listType = ListType()
             return listOf(
                 // An empty list and an empty s-expression should be a list of s-exp of any type
                 StaticType.ALL_TYPES.map {

--- a/lang/test/org/partiql/lang/util/AssertionHelpers.kt
+++ b/lang/test/org/partiql/lang/util/AssertionHelpers.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.fail
  * to help them to be easier to read.
  */
 fun assertIonEquals(expectedResult: IonValue, actualResult: IonValue, message: String?) {
-    if (expectedResult != null && !actualResult.equals(expectedResult)) {
+    if (actualResult != expectedResult) {
         print("The actual value must match expected value")
         message?.let { print(it) }
         println()

--- a/lang/test/org/partiql/lang/util/BindingsExtensions.kt
+++ b/lang/test/org/partiql/lang/util/BindingsExtensions.kt
@@ -16,7 +16,7 @@ fun Bindings<ExprValue>.toTypedBindings() = this.let { valuedBindings ->
     object : Bindings<StaticType> {
         override fun get(bindingName: BindingName): StaticType? {
             val exprValue = valuedBindings[bindingName] ?: return null
-            return exprValue.type?.let { StaticType.fromExprValueType(it) }
+            return exprValue.type.let { StaticType.fromExprValueType(it) }
         }
     }
 }

--- a/lang/test/org/partiql/lang/util/SexpAstPrettyPrinter.kt
+++ b/lang/test/org/partiql/lang/util/SexpAstPrettyPrinter.kt
@@ -50,7 +50,7 @@ class SexpAstPrettyPrinter(val builder: StringBuilder = StringBuilder()) {
     var nestLevel = 0
 
     private fun nextLine() {
-        builder.appendln()
+        builder.appendLine()
         (1..nestLevel).forEach { builder.append("    ") }
     }
 

--- a/lang/test/org/partiql/lang/util/testdsl/ExprNodeTestCase.kt
+++ b/lang/test/org/partiql/lang/util/testdsl/ExprNodeTestCase.kt
@@ -1,3 +1,6 @@
+
+@file:Suppress("DEPRECATION") // Don't need warnings about ExprNode deprecation.
+
 package org.partiql.lang.util.testdsl
 
 import org.junit.jupiter.api.fail

--- a/lang/test/org/partiql/lang/util/testdsl/IonResultTestCase.kt
+++ b/lang/test/org/partiql/lang/util/testdsl/IonResultTestCase.kt
@@ -58,6 +58,7 @@ data class IonResultTestCase(
 
     fun toExprNodeTestCase(): ExprNodeTestCase =
         assertDoesNotThrow("IonResultTestCase ${toString()} should not throw when parsing") {
+            @Suppress("DEPRECATION")
             ExprNodeTestCase(name, SqlParser(ION).parseExprNode(sqlUnderTest))
         }
 }

--- a/testscript/test/org/partiql/testscript/SpecConverter.kt
+++ b/testscript/test/org/partiql/testscript/SpecConverter.kt
@@ -13,7 +13,7 @@ private val ion = IonSystemBuilder.standard().build()
 private val ptsParser = Parser(ion)
 private val ptsCompiler = Compiler(ion)
 
-fun main(args: Array<String>) {
+fun main() {
     val inputs = File("integration-test2/test-scripts")
         .listRecursive(ptsFileFilter)
         .map { file -> NamedInputStream(file.absolutePath, FileInputStream(file)) }


### PR DESCRIPTION
I've been doing some extensive work on this code base lately and the compiler warnings (which numbered ~900, IIRC) were driving me crazy since I couldn't tell if I was adding new warnings or not, so I decided to knock this out this morning.  It took only about 1.5 hours since most of them were related to `ExprNode` deprecation.  

In the future, it will be easy to tell if there are new warnings or not and we should consider a way of enforcing this.

This addresses #541 and all other warnings as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
