### PR TITLE
Upgrade dokka to 1.6.10, set org.gradle.jvmargs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.jvmargs=-Xmx4096M

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -23,7 +23,7 @@ plugins {
     id 'java-library'
     // https://docs.gradle.org/5.0/userguide/publishing_maven.html#header
     id 'maven-publish'
-    id 'org.jetbrains.dokka' version '0.9.18'
+    id 'org.jetbrains.dokka' version '1.6.10'
     id 'signing'
     id 'me.champeau.gradle.jmh' version '0.5.3'
 }
@@ -117,9 +117,9 @@ ktlint {
     }
 }
 
-dokka {
-    outputFormat = "html"
-    outputDirectory = "$buildDir/javadoc"
+tasks.dokkaHtml.configure {
+    dependsOn(generatePigDomains)
+    outputDirectory.set(file("$buildDir/javadoc"))
     //todo: includes = ["path/to/module.md"]
 }
 
@@ -129,8 +129,8 @@ task sourcesJar(type: Jar) {
 }
 
 task javadocJar(type: Jar) {
-    from dokka
-    classifier = "javadoc"
+    from dokkaHtml
+    archiveClassifier.set("javadoc")
 }
 
 publishing {


### PR DESCRIPTION
I wasn't able to publish to maven due to some incompatibilities between the gradle version and the older version of `dokka` we were using. Sample errors when trying to gradle publish:

```
> Task :lang:dokka FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Some problems were found with the configuration of task ':lang:dokka' (type 'DokkaTask').
  - In plugin 'org.jetbrains.dokka' type 'org.jetbrains.dokka.gradle.DokkaTask' property 'dokkaRuntime' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.4/userguide/validation_problems.html#missing_annotation for more details about this problem.
  - In plugin 'org.jetbrains.dokka' type 'org.jetbrains.dokka.gradle.DokkaTask' property 'outputDirectory' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.4/userguide/validation_problems.html#missing_annotation for more details about this problem.
  - In plugin 'org.jetbrains.dokka' type 'org.jetbrains.dokka.gradle.DokkaTask' property 'reportNotDocumented' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.4/userguide/validation_problems.html#missing_annotation for more details about this problem.
```

I encountered a similar problem when trying to publish the new version of PIG (https://github.com/partiql/partiql-ir-generator/pull/114). Applied a similar fix from that PR.

Tested by publishing to maven local:

```
❯ ./gradlew publishToMavenLocal

> Task :lang:generatePigDomains
pig: universe file: <path_to_domain_file>/partiql.ion
pig: parsing the universe...
pig: permuting domains...
pig: applying Kotlin pre-processing
pig: applying the Kotlin template once for each domain...
pig: universe generation complete!

BUILD SUCCESSFUL in 3s
13 actionable tasks: 6 executed, 7 up-to-date
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
