### PR TITLE
Exclude generated code from coverage report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,12 @@ subprojects {
                 html.required.set(true)
                 html.outputLocation.set(file("${buildDir}/reports/jacoco/html"))
             }
+            afterEvaluate {
+                classDirectories.setFrom(files(classDirectories.files.collect {
+                    // exclude PIG generated files.
+                    fileTree(dir: it, exclude: ["org/partiql/lang/domains/*.class"])
+                }))
+            }
         }
     }
 


### PR DESCRIPTION
Before this PR, the jacoco report showed test coverage to be about 74%, but that includes a lot of generated code that we're not covering.  This change excludes the generated code from the coverage report, which is IMHO, a fairer measure of code coverage.  This number is 84%.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
