### PR TITLE
Parse expectedResult instead of query fixing a bug in the evaluator test framework

### DIFF
--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/AstEvaluatorTestAdapter.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/AstEvaluatorTestAdapter.kt
@@ -117,7 +117,7 @@ class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
             }
             ExpectedResultFormat.PARTIQL -> {
                 val expected = try {
-                    pipeline.compile(tc.query).eval(session)
+                    pipeline.compile(expectedResult).eval(session)
                 } catch (e: Throwable) {
                     showTestCase()
                     e.printStackTrace()


### PR DESCRIPTION
Glad I caught this right away, could have been very confusing.  This makes me realize that my next PR should be some additional for the new evaluator test framework.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
