### PR TITLE
Run ktlintCheck before tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,10 @@ subprojects {
                 }))
             }
         }
+
+        // Make the ktlinCheck task run *before* unit tests--faster failure here means we won't need to re-run the
+        // tests (which can take several minutes) after applying formatting fixes.
+        dependsOn.add(ktlintCheck)
     }
 
     plugins.withId('java', { _ ->


### PR DESCRIPTION
Implements #580.  This surfaces formatting problems identified by `ktlintCheck` earlier in the build, so long parts of the build like the unit tests don't need to be re-executed after applying formatting fixes.  

I also considered doing this before compilation, but `ktlinCheck`'s error messages are not at all helpful when it fails to parse some file... so it is better to compile, run ktlint, then run the tests...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
