### PR TITLE
Additional pipeline abstraction for test framework

### DIFF
--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerNAryIntOverflowTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerNAryIntOverflowTests.kt
@@ -158,6 +158,7 @@ class EvaluatingCompilerNAryIntOverflowTests : EvaluatorTestBase() {
         val etc = EvaluatorTestCase(
             query = tc.sqlUnderTest,
             expectedResult = tc.expectedPermissiveModeResult,
+            implicitPermissiveModeTest = false,
             compilerPipelineBuilderBlock = {
                 globalTypeBindings(defaultEnv.typeBindings)
                 compileOptions {

--- a/lang/test/org/partiql/lang/eval/EvaluatorStaticTypeTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorStaticTypeTests.kt
@@ -3,6 +3,7 @@ package org.partiql.lang.eval
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.partiql.lang.ION
+import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestTarget
 import org.partiql.lang.util.testdsl.IonResultTestCase
 import org.partiql.lang.util.testdsl.runTestCase
 
@@ -200,6 +201,7 @@ class EvaluatorStaticTypeTests {
         tc.runTestCase(
             valueFactory = valueFactory,
             db = mockDb,
+            target = EvaluatorTestTarget.COMPILER_PIPELINE,
             // Enable the static type inferencer for this
             compilerPipelineBuilderBlock = { this.globalTypeBindings(mockDb.typeBindings) }
         )

--- a/lang/test/org/partiql/lang/eval/EvaluatorTestBase.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTestBase.kt
@@ -26,15 +26,17 @@ import org.partiql.lang.SqlException
 import org.partiql.lang.TestBase
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.PropertyValueMap
-import org.partiql.lang.eval.evaluatortestframework.AstEvaluatorTestAdapter
 import org.partiql.lang.eval.evaluatortestframework.AstRewriterBaseTestAdapter
+import org.partiql.lang.eval.evaluatortestframework.CompilerPipelineFactory
 import org.partiql.lang.eval.evaluatortestframework.EvaluatorErrorTestCase
 import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestAdapter
 import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestCase
+import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestTarget
 import org.partiql.lang.eval.evaluatortestframework.ExpectedResultFormat
 import org.partiql.lang.eval.evaluatortestframework.LegacySerializerTestAdapter
 import org.partiql.lang.eval.evaluatortestframework.MultipleTestAdapter
 import org.partiql.lang.eval.evaluatortestframework.PartiqlAstExprNodeRoundTripAdapter
+import org.partiql.lang.eval.evaluatortestframework.PipelineEvaluatorTestAdapter
 import org.partiql.lang.util.asSequence
 import org.partiql.lang.util.newFromIonText
 
@@ -44,7 +46,8 @@ import org.partiql.lang.util.newFromIonText
 abstract class EvaluatorTestBase : TestBase() {
     private val testHarness: EvaluatorTestAdapter = MultipleTestAdapter(
         listOf(
-            AstEvaluatorTestAdapter(),
+            PipelineEvaluatorTestAdapter(CompilerPipelineFactory()),
+            // TODO: PipelineEvaluatorTestAdapter(PlannerPipelineFactory()),
             PartiqlAstExprNodeRoundTripAdapter(),
             LegacySerializerTestAdapter(),
             AstRewriterBaseTestAdapter()
@@ -71,6 +74,7 @@ abstract class EvaluatorTestBase : TestBase() {
         excludeLegacySerializerAssertions: Boolean = false,
         expectedResultFormat: ExpectedResultFormat = ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS,
         includePermissiveModeTest: Boolean = true,
+        target: EvaluatorTestTarget = EvaluatorTestTarget.ALL_PIPELINES,
         compileOptionsBuilderBlock: CompileOptions.Builder.() -> Unit = { },
         compilerPipelineBuilderBlock: CompilerPipeline.Builder.() -> Unit = { },
         extraResultAssertions: (ExprValue) -> Unit = { }
@@ -82,6 +86,7 @@ abstract class EvaluatorTestBase : TestBase() {
             expectedResultFormat = expectedResultFormat,
             excludeLegacySerializerAssertions = excludeLegacySerializerAssertions,
             implicitPermissiveModeTest = includePermissiveModeTest,
+            target = target,
             compileOptionsBuilderBlock = compileOptionsBuilderBlock,
             compilerPipelineBuilderBlock = compilerPipelineBuilderBlock,
             extraResultAssertions = extraResultAssertions
@@ -112,6 +117,7 @@ abstract class EvaluatorTestBase : TestBase() {
         compileOptionsBuilderBlock: CompileOptions.Builder.() -> Unit = { },
         addtionalExceptionAssertBlock: (SqlException) -> Unit = { },
         implicitPermissiveModeTest: Boolean = true,
+        target: EvaluatorTestTarget = EvaluatorTestTarget.ALL_PIPELINES,
         session: EvaluationSession = EvaluationSession.standard()
     ) {
         val tc = EvaluatorErrorTestCase(
@@ -121,9 +127,10 @@ abstract class EvaluatorTestBase : TestBase() {
             expectedInternalFlag = expectedInternalFlag,
             expectedPermissiveModeResult = expectedPermissiveModeResult,
             excludeLegacySerializerAssertions = excludeLegacySerializerAssertions,
+            implicitPermissiveModeTest = implicitPermissiveModeTest,
+            target = target,
             compileOptionsBuilderBlock = compileOptionsBuilderBlock,
             compilerPipelineBuilderBlock = compilerPipelineBuilderBlock,
-            implicitPermissiveModeTest = implicitPermissiveModeTest,
             additionalExceptionAssertBlock = addtionalExceptionAssertBlock,
         )
 

--- a/lang/test/org/partiql/lang/eval/EvaluatorTestBase.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTestBase.kt
@@ -128,7 +128,7 @@ abstract class EvaluatorTestBase : TestBase() {
             expectedPermissiveModeResult = expectedPermissiveModeResult,
             excludeLegacySerializerAssertions = excludeLegacySerializerAssertions,
             implicitPermissiveModeTest = implicitPermissiveModeTest,
-            target = target,
+            targetPipeline = target,
             compileOptionsBuilderBlock = compileOptionsBuilderBlock,
             compilerPipelineBuilderBlock = compilerPipelineBuilderBlock,
             additionalExceptionAssertBlock = addtionalExceptionAssertBlock,

--- a/lang/test/org/partiql/lang/eval/EvaluatorTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTests.kt
@@ -17,6 +17,7 @@ package org.partiql.lang.eval
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.partiql.lang.ION
+import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestTarget
 import org.partiql.lang.util.testdsl.IonResultTestCase
 import org.partiql.lang.util.testdsl.runTestCase
 
@@ -62,5 +63,5 @@ class EvaluatorTests {
 
     @ParameterizedTest
     @MethodSource("evaluatorTests")
-    fun allTests(tc: IonResultTestCase) = tc.runTestCase(valueFactory, mockDb)
+    fun allTests(tc: IonResultTestCase) = tc.runTestCase(valueFactory, mockDb, EvaluatorTestTarget.COMPILER_PIPELINE)
 }

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/AbstractPipeline.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/AbstractPipeline.kt
@@ -1,0 +1,15 @@
+package org.partiql.lang.eval.evaluatortestframework
+
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.TypingMode
+
+/**
+ * Represents an abstract pipeline (either [org.partiql.lang.CompilerPipeline] or
+ * [org.partiql.lang.planner.PlannerPipeline]) so that [PipelineEvaluatorTestAdapter] can work with either.
+ *
+ * Includes only those properties and methods that are required for testing purposes.
+ */
+interface AbstractPipeline {
+    val typingMode: TypingMode
+    fun evaluate(query: String): ExprValue
+}

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/Assertions.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/Assertions.kt
@@ -1,0 +1,40 @@
+package org.partiql.lang.eval.evaluatortestframework
+
+import org.partiql.lang.SqlException
+
+internal fun assertEquals(
+    expected: Any?,
+    actual: Any?,
+    reason: EvaluatorTestFailureReason,
+    detailsBlock: () -> String
+) {
+    if (expected != actual) {
+        throw EvaluatorAssertionFailedError(reason, detailsBlock())
+    }
+}
+
+internal fun <T> assertDoesNotThrow(
+    reason: EvaluatorTestFailureReason,
+    detailsBlock: () -> String,
+    block: () -> T
+): T {
+    try {
+        return block()
+    } catch (ex: Throwable) {
+        throw EvaluatorAssertionFailedError(reason, detailsBlock(), ex)
+    }
+}
+
+internal inline fun assertThrowsSqlException(
+    reason: EvaluatorTestFailureReason,
+    detailsBlock: () -> String,
+    block: () -> Unit
+): SqlException {
+    try {
+        block()
+        // if we made it here, the test failed.
+        throw EvaluatorAssertionFailedError(reason, detailsBlock())
+    } catch (ex: SqlException) {
+        return ex
+    }
+}

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/CompilerPipelineFactory.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/CompilerPipelineFactory.kt
@@ -1,0 +1,51 @@
+package org.partiql.lang.eval.evaluatortestframework
+
+import org.partiql.lang.CompilerPipeline
+import org.partiql.lang.ION
+import org.partiql.lang.eval.CompileOptions
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.TypingMode
+
+internal class CompilerPipelineFactory : PipelineFactory {
+    override val pipelineName: String
+        get() = "CompilerPipeline (AST Evaluator)"
+
+    override val target: EvaluatorTestTarget
+        get() = EvaluatorTestTarget.COMPILER_PIPELINE
+
+    override fun createPipeline(
+        evaluatorTestDefinition: EvaluatorTestDefinition,
+        session: EvaluationSession,
+        forcePermissiveMode: Boolean
+    ): AbstractPipeline {
+        val concretePipeline = evaluatorTestDefinition.createCompilerPipeline(forcePermissiveMode)
+
+        return object : AbstractPipeline {
+            override val typingMode: TypingMode
+                get() = concretePipeline.compileOptions.typingMode
+
+            override fun evaluate(query: String): ExprValue =
+                concretePipeline.compile(query).eval(session)
+        }
+    }
+}
+
+internal fun EvaluatorTestDefinition.createCompilerPipeline(forcePermissiveMode: Boolean): CompilerPipeline {
+
+    val compileOptions = CompileOptions.build(compileOptionsBuilderBlock).let { co ->
+        if (forcePermissiveMode) {
+            CompileOptions.build(co) {
+                typingMode(TypingMode.PERMISSIVE)
+            }
+        } else {
+            co
+        }
+    }
+
+    val concretePipeline = CompilerPipeline.build(ION) {
+        compileOptions(compileOptions)
+        this@createCompilerPipeline.compilerPipelineBuilderBlock(this)
+    }
+    return concretePipeline
+}

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorErrorTestCase.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorErrorTestCase.kt
@@ -56,6 +56,17 @@ data class EvaluatorErrorTestCase(
     override val implicitPermissiveModeTest: Boolean = true,
 
     /**
+     * This will be executed to perform additional exceptions on the resulting exception.
+     */
+    val additionalExceptionAssertBlock: (SqlException) -> Unit = { },
+
+    /**
+     * Determines which pipeline this test should run against; the [CompilerPipeline],
+     * [org.partiql.lang.planner.PlannerPipeline] or both.
+     */
+    override val target: EvaluatorTestTarget = EvaluatorTestTarget.ALL_PIPELINES,
+
+    /**
      * Builder block for building [CompileOptions].
      */
     override val compileOptionsBuilderBlock: CompileOptions.Builder.() -> Unit = { },
@@ -65,15 +76,42 @@ data class EvaluatorErrorTestCase(
      */
     override val compilerPipelineBuilderBlock: CompilerPipeline.Builder.() -> Unit = { },
 
-    /**
-     * This will be executed to perform additional exceptions on the resulting exception.
-     */
-    val additionalExceptionAssertBlock: (SqlException) -> Unit = { }
 ) : EvaluatorTestDefinition {
 
     /** This will show up in the IDE's test runner. */
     override fun toString(): String {
         val groupNameString = if (groupName == null) "" else "$groupName"
         return "$groupNameString $query : $expectedErrorCode : $expectedErrorContext"
+    }
+
+    /** A generated and human-readable description of this test case for display in assertion failure messages. */
+    fun testDetails(
+        note: String,
+        actualErrorCode: ErrorCode? = null,
+        actualErrorContext: PropertyValueMap? = null,
+        actualPermissiveModeResult: String? = null,
+        actualInternalFlag: Boolean? = null,
+    ): String {
+        val b = StringBuilder()
+        b.appendLine("Note                           : $note")
+        b.appendLine("Group name                     : $groupName")
+        b.appendLine("Query                          : $query")
+        b.appendLine("Expected error code            : $expectedErrorCode")
+        if (actualErrorCode != null) {
+            b.appendLine("Actual error code              : $actualErrorCode")
+        }
+        b.appendLine("Expected error context         : $expectedErrorContext")
+        if (actualErrorContext != null) {
+            b.appendLine("Actual error context           : $actualErrorContext")
+        }
+        b.appendLine("Expected internal flag         : $expectedInternalFlag")
+        if (actualErrorContext != null) {
+            b.appendLine("Actual internal flag           : $actualInternalFlag")
+        }
+        b.appendLine("Expected permissive mode result: $expectedPermissiveModeResult")
+        if (actualPermissiveModeResult != null) {
+            b.appendLine("Actual permissive mode result  : $actualPermissiveModeResult")
+        }
+        return b.toString()
     }
 }

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorErrorTestCase.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorErrorTestCase.kt
@@ -64,7 +64,7 @@ data class EvaluatorErrorTestCase(
      * Determines which pipeline this test should run against; the [CompilerPipeline],
      * [org.partiql.lang.planner.PlannerPipeline] or both.
      */
-    override val target: EvaluatorTestTarget = EvaluatorTestTarget.ALL_PIPELINES,
+    override val targetPipeline: EvaluatorTestTarget = EvaluatorTestTarget.ALL_PIPELINES,
 
     /**
      * Builder block for building [CompileOptions].
@@ -96,6 +96,7 @@ data class EvaluatorErrorTestCase(
         b.appendLine("Note                           : $note")
         b.appendLine("Group name                     : $groupName")
         b.appendLine("Query                          : $query")
+        b.appendLine("Target pipeline                : $targetPipeline")
         b.appendLine("Expected error code            : $expectedErrorCode")
         if (actualErrorCode != null) {
             b.appendLine("Actual error code              : $actualErrorCode")

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestCase.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestCase.kt
@@ -60,7 +60,11 @@ data class EvaluatorTestCase(
      */
     override val implicitPermissiveModeTest: Boolean = true,
 
-    override val target: EvaluatorTestTarget = EvaluatorTestTarget.ALL_PIPELINES,
+    /**
+     * Determines which pipeline this test should run against; the [CompilerPipeline],
+     * [org.partiql.lang.planner.PlannerPipeline] or both.
+     */
+    override val targetPipeline: EvaluatorTestTarget = EvaluatorTestTarget.ALL_PIPELINES,
 
     /**
      * Builder block for building [CompileOptions].
@@ -93,7 +97,7 @@ data class EvaluatorTestCase(
         expectedResultFormat = expectedResultFormat,
         excludeLegacySerializerAssertions = excludeLegacySerializerAssertions,
         implicitPermissiveModeTest = implicitPermissiveModeTest,
-        target = target,
+        targetPipeline = target,
         compileOptionsBuilderBlock = compileOptionsBuilderBlock,
         compilerPipelineBuilderBlock = compilerPipelineBuilderBlock,
         extraResultAssertions = extraResultAssertions
@@ -111,6 +115,8 @@ data class EvaluatorTestCase(
         b.appendLine("Note            : $note")
         b.appendLine("Group name      : $groupName")
         b.appendLine("Query           : $query")
+        b.appendLine("Target pipeline : $targetPipeline")
+
         b.appendLine("Expected result : $expectedResult")
         if (actualResult != null) {
             b.appendLine("Actual result   : $actualResult")

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestCase.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestCase.kt
@@ -59,6 +59,9 @@ data class EvaluatorTestCase(
      * `false`.  Note that, when `false`, [expectedPermissiveModeResult] is ignored.
      */
     override val implicitPermissiveModeTest: Boolean = true,
+
+    override val target: EvaluatorTestTarget = EvaluatorTestTarget.ALL_PIPELINES,
+
     /**
      * Builder block for building [CompileOptions].
      */
@@ -78,6 +81,7 @@ data class EvaluatorTestCase(
         expectedResultFormat: ExpectedResultFormat = ExpectedResultFormat.PARTIQL,
         excludeLegacySerializerAssertions: Boolean = false,
         implicitPermissiveModeTest: Boolean = true,
+        target: EvaluatorTestTarget = EvaluatorTestTarget.ALL_PIPELINES,
         compileOptionsBuilderBlock: CompileOptions.Builder.() -> Unit = { },
         compilerPipelineBuilderBlock: CompilerPipeline.Builder.() -> Unit = { },
         extraResultAssertions: (ExprValue) -> Unit = { },
@@ -89,6 +93,7 @@ data class EvaluatorTestCase(
         expectedResultFormat = expectedResultFormat,
         excludeLegacySerializerAssertions = excludeLegacySerializerAssertions,
         implicitPermissiveModeTest = implicitPermissiveModeTest,
+        target = target,
         compileOptionsBuilderBlock = compileOptionsBuilderBlock,
         compilerPipelineBuilderBlock = compilerPipelineBuilderBlock,
         extraResultAssertions = extraResultAssertions
@@ -97,6 +102,21 @@ data class EvaluatorTestCase(
     /** This will show up in the IDE's test runner. */
     override fun toString() = when {
         groupName != null -> "$groupName : $query"
-        else -> "$query"
+        else -> query
+    }
+
+    /** A generated and human-readable description of this test case for display in assertion failure messages. */
+    fun testDetails(note: String, actualResult: String? = null): String {
+        val b = StringBuilder()
+        b.appendLine("Note            : $note")
+        b.appendLine("Group name      : $groupName")
+        b.appendLine("Query           : $query")
+        b.appendLine("Expected result : $expectedResult")
+        if (actualResult != null) {
+            b.appendLine("Actual result   : $actualResult")
+        }
+        b.appendLine("Result format   : $expectedResultFormat")
+
+        return b.toString()
     }
 }

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestDefinition.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestDefinition.kt
@@ -40,7 +40,7 @@ interface EvaluatorTestDefinition {
      * Determines which pipeline this test should run against; the [CompilerPipeline],
      * [org.partiql.lang.planner.PlannerPipeline] or both.
      */
-    val target: EvaluatorTestTarget
+    val targetPipeline: EvaluatorTestTarget
 
     /**
      * Builder block for building [CompileOptions].

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestDefinition.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestDefinition.kt
@@ -37,6 +37,12 @@ interface EvaluatorTestDefinition {
     val implicitPermissiveModeTest: Boolean
 
     /**
+     * Determines which pipeline this test should run against; the [CompilerPipeline],
+     * [org.partiql.lang.planner.PlannerPipeline] or both.
+     */
+    val target: EvaluatorTestTarget
+
+    /**
      * Builder block for building [CompileOptions].
      */
     val compileOptionsBuilderBlock: CompileOptions.Builder.() -> Unit

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestTarget.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestTarget.kt
@@ -1,0 +1,7 @@
+package org.partiql.lang.eval.evaluatortestframework
+
+enum class EvaluatorTestTarget {
+    ALL_PIPELINES,
+    COMPILER_PIPELINE,
+    PLANNER_PIPELINE
+}

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestTarget.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestTarget.kt
@@ -1,7 +1,26 @@
 package org.partiql.lang.eval.evaluatortestframework
 
+/**
+ * An indicator of which pipeline(s) each test case should be run against.  Useful when one pipeline supports
+ * a feature that the other one doesn't.
+ */
 enum class EvaluatorTestTarget {
+    /**
+     * Run the test on all pipelines.
+     *
+     * Set this option when both pipelines support all features utilized in the test case.
+     * */
     ALL_PIPELINES,
+
+    /**
+     * Run the test only on [org.partiql.lang.CompilerPipeline]. Set this when the test case covers features not yet
+     * supported by [org.partiql.lang.planner.PlannerPipeline] or when testing features unique to the former.
+     */
     COMPILER_PIPELINE,
+
+    /**
+     * Run the test only on [org.partiql.lang.planner.PlannerPipeline]. Set this when the test case covers features not
+     * supported by [org.partiql.lang.CompilerPipeline], or when testing features unique to the former.
+     */
     PLANNER_PIPELINE
 }

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/PipelineEvaluatorTestAdapter.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/PipelineEvaluatorTestAdapter.kt
@@ -1,136 +1,31 @@
 package org.partiql.lang.eval.evaluatortestframework
 
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
-import org.partiql.lang.CompilerPipeline
 import org.partiql.lang.ION
-import org.partiql.lang.SqlException
 import org.partiql.lang.errors.ErrorBehaviorInPermissiveMode
-import org.partiql.lang.errors.ErrorCode
-import org.partiql.lang.errors.PropertyValueMap
-import org.partiql.lang.eval.CompileOptions
 import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.TypingMode
 import org.partiql.lang.eval.cloneAndRemoveBagAndMissingAnnotations
 import org.partiql.lang.eval.exprEquals
-import kotlin.test.assertNotEquals
 
-private fun EvaluatorTestDefinition.createPipeline(forcePermissiveMode: Boolean = false): CompilerPipeline {
-    val compileOptions = CompileOptions.build(this@createPipeline.compileOptionsBuilderBlock).let { co ->
-        if (forcePermissiveMode) {
-            CompileOptions.build(co) {
-                typingMode(TypingMode.PERMISSIVE)
-            }
-        } else {
-            co
-        }
-    }
-
-    return CompilerPipeline.build(ION) {
-        compileOptions(compileOptions)
-        this@createPipeline.compilerPipelineBuilderBlock(this)
-    }
-}
-
-/** A generated and human readable description of this test case for display in assertion failure messages. */
-fun EvaluatorTestCase.testDetails(note: String, actualResult: String? = null): String {
-    val b = StringBuilder()
-    b.appendLine("Note            : $note")
-    b.appendLine("Group name      : $groupName")
-    b.appendLine("Query           : $query")
-    b.appendLine("Expected result : $expectedResult")
-    if (actualResult != null) {
-        b.appendLine("Actual result   : $actualResult")
-    }
-    b.appendLine("Result format   : $expectedResultFormat")
-
-    return b.toString()
-}
-
-/** A generated and human readable description of this test case for display in assertion failure messages. */
-fun EvaluatorErrorTestCase.testDetails(
-    note: String,
-    actualErrorCode: ErrorCode? = null,
-    actualErrorContext: PropertyValueMap? = null,
-    actualPermissiveModeResult: String? = null,
-    actualInternalFlag: Boolean? = null,
-): String {
-    val b = StringBuilder()
-    b.appendLine("Note                           : $note")
-    b.appendLine("Group name                     : $groupName")
-    b.appendLine("Query                          : $query")
-    b.appendLine("Expected error code            : $expectedErrorCode")
-    if (actualErrorCode != null) {
-        b.appendLine("Actual error code              : $actualErrorCode")
-    }
-    b.appendLine("Expected error context         : $expectedErrorContext")
-    if (actualErrorContext != null) {
-        b.appendLine("Actual error context           : $actualErrorContext")
-    }
-    b.appendLine("Expected internal flag         : $expectedInternalFlag")
-    if (actualErrorContext != null) {
-        b.appendLine("Actual internal flag           : $actualInternalFlag")
-    }
-    b.appendLine("Expected permissive mode result: $expectedPermissiveModeResult")
-    if (actualPermissiveModeResult != null) {
-        b.appendLine("Actual permissive mode result  : $actualPermissiveModeResult")
-    }
-    return b.toString()
-}
-
-private fun assertEquals(
-    expected: Any?,
-    actual: Any?,
-    reason: EvaluatorTestFailureReason,
-    detailsBlock: () -> String
-) {
-    if (expected != actual) {
-        throw EvaluatorAssertionFailedError(reason, detailsBlock())
-    }
-}
-
-private fun <T> assertDoesNotThrow(
-    reason: EvaluatorTestFailureReason,
-    detailsBlock: () -> String,
-    block: () -> T
-): T {
-    try {
-        return block()
-    } catch (ex: Throwable) {
-        throw EvaluatorAssertionFailedError(reason, detailsBlock(), ex.cause)
-    }
-}
-
-private inline fun assertThrowsSqlException(
-    reason: EvaluatorTestFailureReason,
-    detailsBlock: () -> String,
-    block: () -> Unit
-): SqlException {
-    try {
-        block()
-        // if we made it here, the test failed.
-        throw EvaluatorAssertionFailedError(reason, detailsBlock())
-    } catch (ex: SqlException) {
-        return ex
-    }
-}
-
-class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
+internal class PipelineEvaluatorTestAdapter(
+    private val pipelineFactory: PipelineFactory
+) : EvaluatorTestAdapter {
 
     override fun runEvaluatorTestCase(tc: EvaluatorTestCase, session: EvaluationSession) {
-        if (tc.implicitPermissiveModeTest) {
-            val testOpts = CompileOptions.build { tc.compileOptionsBuilderBlock(this) }
-            assertNotEquals(
-                TypingMode.PERMISSIVE, testOpts.typingMode,
-                "Setting TypingMode.PERMISSIVE when implicit permissive mode testing is enabled is redundant"
-            )
+        if (tc.target != EvaluatorTestTarget.ALL_PIPELINES && pipelineFactory.target != tc.target) {
+            return
         }
+        checkRedundantPermissiveMode(tc)
 
         // Compile options unmodified... This covers [TypingMode.LEGACY], unless the test explicitly
         // sets the typing mode.
-        privateRunEvaluatorTestCase(tc, session, "compile options unaltered")
+        privateRunEvaluatorTestCase(tc, session, "${pipelineFactory.pipelineName} (compile options unaltered)")
 
-        // Unless the tests disable it, run again in permissive mode.
+        // Unless the test disables it, run again in permissive mode.
         if (tc.implicitPermissiveModeTest) {
             privateRunEvaluatorTestCase(
                 tc.copy(
@@ -140,7 +35,7 @@ class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
                     }
                 ),
                 session,
-                "compile options forced to PERMISSIVE mode"
+                "${pipelineFactory.pipelineName} (compile options forced to PERMISSIVE mode)"
             )
         }
     }
@@ -153,17 +48,17 @@ class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
         session: EvaluationSession,
         note: String,
     ) {
-        val pipeline = tc.createPipeline()
+        val pipeline = pipelineFactory.createPipeline(tc, session)
 
-        val actualExprValueResult = assertDoesNotThrow(
+        val actualExprValueResult: ExprValue = assertDoesNotThrow(
             EvaluatorTestFailureReason.FAILED_TO_EVALUATE_QUERY,
             { tc.testDetails(note = note) }
         ) {
-            pipeline.compile(tc.query).eval(session)
+            pipeline.evaluate(tc.query)
         }
 
         val (expectedResult, unexpectedResultErrorCode) =
-            when (pipeline.compileOptions.typingMode) {
+            when (pipeline.typingMode) {
                 TypingMode.LEGACY -> tc.expectedResult to EvaluatorTestFailureReason.UNEXPECTED_QUERY_RESULT
                 TypingMode.PERMISSIVE -> tc.expectedPermissiveModeResult to EvaluatorTestFailureReason.UNEXPECTED_PERMISSIVE_MODE_RESULT
             }
@@ -194,7 +89,7 @@ class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
                     EvaluatorTestFailureReason.FAILED_TO_EVALUATE_PARTIQL_EXPECTED_RESULT,
                     { tc.testDetails(note = note) }
                 ) {
-                    pipeline.compile(expectedResult).eval(session)
+                    pipeline.evaluate(expectedResult)
                 }
 
                 if (!expectedExprValueResult.exprEquals(actualExprValueResult)) {
@@ -223,7 +118,7 @@ class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
         session: EvaluationSession,
         note: String
     ) {
-        val compilerPipeline = tc.createPipeline()
+        val pipeline = pipelineFactory.createPipeline(tc, session)
 
         val ex = assertThrowsSqlException(
             EvaluatorTestFailureReason.EXPECTED_SQL_EXCEPTION_BUT_THERE_WAS_NONE,
@@ -234,10 +129,8 @@ class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
             // .compile OR in .eval.  We currently don't make a distinction, so tests cannot assert that certain
             // errors are compile-time and others are evaluation-time.  We really aught to create a way for tests to
             // indicate when the exception should be thrown.  This is undone.
-            val expression = compilerPipeline.compile(tc.query)
-
-            // The call to .ionValue is important since query execution won't actually begin otherwise.
-            expression.eval(session).ionValue
+            // The call to .ionValue below is important since query execution won't actually begin otherwise.
+            pipeline.evaluate(tc.query).ionValue
         }
 
         assertEquals(
@@ -266,14 +159,11 @@ class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
     }
 
     override fun runEvaluatorErrorTestCase(tc: EvaluatorErrorTestCase, session: EvaluationSession) {
-        if (tc.implicitPermissiveModeTest) {
-            val testOpts = CompileOptions.build { tc.compileOptionsBuilderBlock(this) }
-            assertNotEquals(
-                TypingMode.PERMISSIVE,
-                testOpts.typingMode,
-                "Setting TypingMode.PERMISSIVE when implicit permissive mode testing is enabled is redundant"
-            )
+        if (tc.target != EvaluatorTestTarget.ALL_PIPELINES && pipelineFactory.target != tc.target) {
+            return
         }
+
+        checkRedundantPermissiveMode(tc)
 
         // Run the query once with compile options unmodified.
         privateRunEvaluatorErrorTestCase(
@@ -284,7 +174,7 @@ class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
                 }
             ),
             session = session,
-            note = "Typing mode forced to LEGACY"
+            note = "${pipelineFactory.pipelineName} (Typing mode forced to LEGACY)"
         )
 
         when (tc.expectedErrorCode.errorBehaviorInPermissiveMode) {
@@ -305,7 +195,7 @@ class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
                         }
                     ),
                     session,
-                    note = "Typing mode forced to PERMISSIVE"
+                    note = "${pipelineFactory.pipelineName} (typing mode forced to PERMISSIVE)"
                 )
             }
             ErrorBehaviorInPermissiveMode.RETURN_MISSING -> {
@@ -319,14 +209,14 @@ class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
                 )
 
                 // Compute the expected return value
-                val permissiveModePipeline = tc.createPipeline(forcePermissiveMode = true)
+                val permissiveModePipeline = pipelineFactory.createPipeline(evaluatorTestDefinition = tc, session, forcePermissiveMode = true)
 
                 val expectedExprValueForPermissiveMode =
                     assertDoesNotThrow(
                         EvaluatorTestFailureReason.FAILED_TO_EVALUATE_PARTIQL_EXPECTED_RESULT,
                         { tc.testDetails(note = "Evaluating expected permissive mode result") }
                     ) {
-                        permissiveModePipeline.compile(tc.expectedPermissiveModeResult!!).eval(session)
+                        permissiveModePipeline.evaluate(tc.expectedPermissiveModeResult!!)
                     }
 
                 val actualReturnValueForPermissiveMode =
@@ -338,7 +228,7 @@ class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
                             )
                         }
                     ) {
-                        permissiveModePipeline.compile(tc.query).eval(session)
+                        permissiveModePipeline.evaluate(tc.query)
                     }
 
                 if (!expectedExprValueForPermissiveMode.exprEquals(actualReturnValueForPermissiveMode)) {
@@ -351,6 +241,17 @@ class AstEvaluatorTestAdapter : EvaluatorTestAdapter {
                     )
                 }
             }
+        }
+    }
+
+    private fun checkRedundantPermissiveMode(tc: EvaluatorTestDefinition) {
+        if (tc.implicitPermissiveModeTest) {
+            val pipeline = pipelineFactory.createPipeline(tc, EvaluationSession.standard())
+            assertNotEquals(
+                TypingMode.PERMISSIVE,
+                pipeline.typingMode,
+                "Setting TypingMode.PERMISSIVE when implicit permissive mode testing is enabled is redundant"
+            )
         }
     }
 }

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/PipelineEvaluatorTestAdapter.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/PipelineEvaluatorTestAdapter.kt
@@ -16,7 +16,8 @@ internal class PipelineEvaluatorTestAdapter(
 ) : EvaluatorTestAdapter {
 
     override fun runEvaluatorTestCase(tc: EvaluatorTestCase, session: EvaluationSession) {
-        if (tc.target != EvaluatorTestTarget.ALL_PIPELINES && pipelineFactory.target != tc.target) {
+        // Skip execution of this test case if it does not apply to the pipeline supplied by pipelineFactory.
+        if (tc.targetPipeline != EvaluatorTestTarget.ALL_PIPELINES && pipelineFactory.target != tc.targetPipeline) {
             return
         }
         checkRedundantPermissiveMode(tc)
@@ -159,7 +160,8 @@ internal class PipelineEvaluatorTestAdapter(
     }
 
     override fun runEvaluatorErrorTestCase(tc: EvaluatorErrorTestCase, session: EvaluationSession) {
-        if (tc.target != EvaluatorTestTarget.ALL_PIPELINES && pipelineFactory.target != tc.target) {
+        // Skip execution of this test case if it does not apply to the pipeline supplied by pipelineFactory.
+        if (tc.targetPipeline != EvaluatorTestTarget.ALL_PIPELINES && pipelineFactory.target != tc.targetPipeline) {
             return
         }
 

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/PipelineFactory.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/PipelineFactory.kt
@@ -3,7 +3,7 @@ package org.partiql.lang.eval.evaluatortestframework
 import org.partiql.lang.eval.EvaluationSession
 
 /**
- * The implementation of this interface passed to the constructor of [PipelineEvaluatorTestAdapter].  Determines
+ * The implementation of this interface is passed to the constructor of [PipelineEvaluatorTestAdapter].  Determines
  * which pipeline (either [org.partiql.lang.CompilerPipeline] or [org.partiql.lang.planner.PlannerPipeline]) will be
  * tested.
  */

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/PipelineFactory.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/PipelineFactory.kt
@@ -1,0 +1,19 @@
+package org.partiql.lang.eval.evaluatortestframework
+
+import org.partiql.lang.eval.EvaluationSession
+
+/**
+ * The implementation of this interface passed to the constructor of [PipelineEvaluatorTestAdapter].  Determines
+ * which pipeline (either [org.partiql.lang.CompilerPipeline] or [org.partiql.lang.planner.PlannerPipeline]) will be
+ * tested.
+ */
+internal interface PipelineFactory {
+    val pipelineName: String
+    val target: EvaluatorTestTarget
+
+    fun createPipeline(
+        evaluatorTestDefinition: EvaluatorTestDefinition,
+        session: EvaluationSession,
+        forcePermissiveMode: Boolean = false,
+    ): AbstractPipeline
+}

--- a/lang/test/org/partiql/lang/util/testdsl/IonResultTestCase.kt
+++ b/lang/test/org/partiql/lang/util/testdsl/IonResultTestCase.kt
@@ -9,10 +9,11 @@ import org.partiql.lang.eval.EVALUATOR_TEST_SUITE
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
-import org.partiql.lang.eval.evaluatortestframework.AstEvaluatorTestAdapter
-import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestAdapter
+import org.partiql.lang.eval.evaluatortestframework.CompilerPipelineFactory
 import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestCase
+import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestTarget
 import org.partiql.lang.eval.evaluatortestframework.ExpectedResultFormat
+import org.partiql.lang.eval.evaluatortestframework.PipelineEvaluatorTestAdapter
 import org.partiql.lang.mockdb.MockDb
 import org.partiql.lang.syntax.SqlParser
 
@@ -71,9 +72,16 @@ data class IonResultTestCase(
 internal fun IonResultTestCase.runTestCase(
     valueFactory: ExprValueFactory,
     db: MockDb,
+    target: EvaluatorTestTarget,
     compilerPipelineBuilderBlock: CompilerPipeline.Builder.() -> Unit = { }
 ) {
-    val harness: EvaluatorTestAdapter = AstEvaluatorTestAdapter()
+    val adapter = PipelineEvaluatorTestAdapter(
+        when (target) {
+            EvaluatorTestTarget.COMPILER_PIPELINE -> CompilerPipelineFactory()
+            EvaluatorTestTarget.PLANNER_PIPELINE -> TODO("PlannerPipelineFactory()")
+            EvaluatorTestTarget.ALL_PIPELINES -> error("May only test one pipeline at a time with IonResultTestCase")
+        }
+    )
 
     val session = EvaluationSession.build {
         globals(db.valueBindings)
@@ -94,13 +102,13 @@ internal fun IonResultTestCase.runTestCase(
     )
 
     if (!this.expectFailure) {
-        harness.runEvaluatorTestCase(tc, session)
+        adapter.runEvaluatorTestCase(tc, session)
     } else {
         val message = "We expect test \"${this.name}\" to fail, but it did not. This check exists to ensure the " +
             "failing list is up to date."
 
         assertThrows<Throwable>(message) {
-            harness.runEvaluatorTestCase(tc, session)
+            adapter.runEvaluatorTestCase(tc, session)
         }
     }
 }

--- a/lang/test/org/partiql/lang/util/testdsl/IonResultTestCase.kt
+++ b/lang/test/org/partiql/lang/util/testdsl/IonResultTestCase.kt
@@ -79,7 +79,10 @@ internal fun IonResultTestCase.runTestCase(
         when (target) {
             EvaluatorTestTarget.COMPILER_PIPELINE -> CompilerPipelineFactory()
             EvaluatorTestTarget.PLANNER_PIPELINE -> TODO("PlannerPipelineFactory()")
-            EvaluatorTestTarget.ALL_PIPELINES -> error("May only test one pipeline at a time with IonResultTestCase")
+            EvaluatorTestTarget.ALL_PIPELINES ->
+                // We don't support ALL_PIPELINES here because each pipeline needs a separate skip list, which
+                // is decided by the caller of this function.
+                error("May only test one pipeline at a time with IonResultTestCase")
         }
     )
 


### PR DESCRIPTION
Since #582 is too big to review, it's being split up into a few smaller PRs.  This is the first.  Note that this PR will be merged to the `physical-plan-staging` branch, which will later be merged to `main`.

The test framework introduced in #573 and #579 includes `AstEvaluatorTestAdapter` which is tightly coupled to `CompilerPipeline` and therefore `EvaluatingCompiler` (the AST evaluator).  `AstEvaluatorTestAdapter` also contains all of the logic needed for running an individual test.  This PR moves all of that logic to `PipelineEvaluatorTestAdapter` and introduces an abstraction around pipelines to allow the logic to be used with other pipelines such as `PlannerPipeline` (which is being introduced in #592).

Additionally, the test framework currently lacks a mechanism to exclude one of the evaluators from certain test cases such as would be needed if one of the evaluators does not support all PartiQL language features (as is the case with the new plan evaluator).   The enum `EvaluatorTestTarget` was introduced to serve this need.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
