### PR TITLE
Rename `UniqueIdResolver` to `MetadataResolver`

### DIFF
--- a/lang/src/org/partiql/lang/planner/MetadataResolver.kt
+++ b/lang/src/org/partiql/lang/planner/MetadataResolver.kt
@@ -62,4 +62,4 @@ private val EMPTY: MetadataResolver = object : MetadataResolver {
 }
 
 /** Convenience function for obtaining an instance of [MetadataResolver] with no defined variables. */
-fun emptySchemaResolver(): MetadataResolver = EMPTY
+fun emptyMetadataResolver(): MetadataResolver = EMPTY

--- a/lang/src/org/partiql/lang/planner/MetadataResolver.kt
+++ b/lang/src/org/partiql/lang/planner/MetadataResolver.kt
@@ -8,6 +8,9 @@ sealed class ResolutionResult {
     /**
      * A success case, indicates the [uniqueId] of the match to the [BindingName] in the global scope.
      * Typically, this is defined by the storage layer.
+     *
+     * In the future, this will likely contain much more than just a unique id.  It might include detailed schema
+     * information about global variables.
      */
     data class GlobalVariable(val uniqueId: String) : ResolutionResult()
 
@@ -22,9 +25,19 @@ sealed class ResolutionResult {
     object Undefined : ResolutionResult()
 }
 
-fun interface UniqueIdResolver {
+/**
+ * Supplies the query planner with metadata about the current database.  Meant to be implemented by the application
+ * embedding PartiQL.
+ *
+ * Metadata is associated with global variables.  Global variables can be tables or (less commonly) any other
+ * application specific global variable.
+ *
+ * In the future, new methods could be added which expose information about other types of database metadata such as
+ * available indexes and table statistics.
+ */
+interface MetadataResolver {
     /**
-     * Implementations try to resolve a global variable which is typically a database table to a unique identifier
+     * Implementations try to resolve a variable which is typically a database table to a schema
      * using [bindingName].  [bindingName] includes both the name as specified by the query author and a [BindingCase]
      * which indicates if query author included double quotes (") which mean the lookup should be case-sensitive.
      *
@@ -41,10 +54,12 @@ fun interface UniqueIdResolver {
      * Note that while [ResolutionResult.LocalVariable] exists, it is intentionally marked `internal` and cannot
      * be used by outside this project.
      */
-    fun resolve(bindingName: BindingName): ResolutionResult
+    fun resolveVariable(bindingName: BindingName): ResolutionResult
 }
 
-private val EMPTY = UniqueIdResolver { ResolutionResult.Undefined }
+private val EMPTY: MetadataResolver = object : MetadataResolver {
+    override fun resolveVariable(bindingName: BindingName): ResolutionResult = ResolutionResult.Undefined
+}
 
-/** Convenience function for obtaining an instance of [UniqueIdResolver] with no defined variables. */
-fun emptyUniqueIdResolver(): UniqueIdResolver = EMPTY
+/** Convenience function for obtaining an instance of [MetadataResolver] with no defined variables. */
+fun emptySchemaResolver(): MetadataResolver = EMPTY

--- a/lang/test/org/partiql/lang/planner/Util.kt
+++ b/lang/test/org/partiql/lang/planner/Util.kt
@@ -3,18 +3,21 @@ package org.partiql.lang.planner
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.errors.Problem
 import org.partiql.lang.errors.ProblemDetails
+import org.partiql.lang.eval.BindingName
 
 /**
- * Creates a fake implementation of [UniqueIdResolver] with the specified [globalVariableNames].
+ * Creates a fake implementation of [MetadataResolver] with the specified [globalVariableNames].
  *
  * The fake unique identifier of bound variables is computed to be `fake_uid_for_${globalVariableName}`.
  */
-fun createFakeGlobalBindings(vararg globalVariableNames: Pair<String, String>) =
-    UniqueIdResolver { bindingName ->
-        val matches = globalVariableNames.filter { bindingName.isEquivalentTo(it.first) }
-        when (matches.size) {
-            0 -> ResolutionResult.Undefined
-            else -> ResolutionResult.GlobalVariable(matches.first().second)
+fun createFakeMetadataResolver(vararg globalVariableNames: Pair<String, String>) =
+    object : MetadataResolver {
+        override fun resolveVariable(bindingName: BindingName): ResolutionResult {
+            val matches = globalVariableNames.filter { bindingName.isEquivalentTo(it.first) }
+            return when (matches.size) {
+                0 -> ResolutionResult.Undefined
+                else -> ResolutionResult.GlobalVariable(matches.first().second)
+            }
         }
     }
 

--- a/lang/test/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransformTests.kt
@@ -14,7 +14,7 @@ import org.partiql.lang.errors.ProblemCollector
 import org.partiql.lang.eval.BindingCase
 import org.partiql.lang.eval.builtins.DYNAMIC_LOOKUP_FUNCTION_NAME
 import org.partiql.lang.eval.sourceLocationMeta
-import org.partiql.lang.planner.createFakeGlobalBindings
+import org.partiql.lang.planner.createFakeMetadataResolver
 import org.partiql.lang.planner.problem
 import org.partiql.lang.syntax.SqlParser
 import org.partiql.lang.util.ArgumentsProviderBase
@@ -91,7 +91,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
     }
 
     /** Mock table resolver. That can resolve f, foo, or UPPERCASE_FOO, while respecting case-sensitivity. */
-    private val globalBindings = createFakeGlobalBindings(
+    private val globalBindings = createFakeMetadataResolver(
         *listOf(
             "shadow",
             "foo",


### PR DESCRIPTION
#588 introduces `UniqueIdResolver`.  While that name does accurately reflect what it currently does, in the future it will be expanded to cover much more than unique Ids.  Therefore, I have decided that `MetadataResolver` is a much better name.

I would like to merge this to `physical-plan-staging` before #590 and #592 are merged so as to reduce PR churn.  Thanks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
