### PR TITLE
Add API to PlannerPipeline to allow custom passes over physical plans.

### DIFF
--- a/lang/src/org/partiql/lang/ast/SourceLocationMeta.kt
+++ b/lang/src/org/partiql/lang/ast/SourceLocationMeta.kt
@@ -82,6 +82,8 @@ data class SourceLocationMeta(val lineNum: Long, val charOffset: Long, val lengt
     }
 }
 
+val UNKNOWN_SOURCE_LOCATION = SourceLocationMeta(-1, -1, -1)
+
 val PartiQlMetaContainer.sourceLocation: SourceLocationMeta? get() = find(SourceLocationMeta.TAG) as SourceLocationMeta?
 val IonElementMetaContainer.sourceLocation: SourceLocationMeta? get() = metaOrNull(SourceLocationMeta.TAG) as SourceLocationMeta?
 

--- a/lang/src/org/partiql/lang/errors/ProblemHandler.kt
+++ b/lang/src/org/partiql/lang/errors/ProblemHandler.kt
@@ -5,7 +5,7 @@ import org.partiql.lang.ast.passes.SemanticException
 /**
  * Handles the encountered problem.
  */
-internal interface ProblemHandler {
+interface ProblemHandler {
     /** Handles a [problem] */
     fun handleProblem(problem: Problem)
 }

--- a/lang/src/org/partiql/lang/eval/physical/PhysicalExprToThunkConverterImpl.kt
+++ b/lang/src/org/partiql/lang/eval/physical/PhysicalExprToThunkConverterImpl.kt
@@ -20,6 +20,7 @@ import com.amazon.ion.Timestamp
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.toIonValue
 import org.partiql.lang.ast.SourceLocationMeta
+import org.partiql.lang.ast.UNKNOWN_SOURCE_LOCATION
 import org.partiql.lang.ast.sourceLocation
 import org.partiql.lang.ast.toPartiQlMetaContainer
 import org.partiql.lang.domains.PartiqlPhysical
@@ -72,6 +73,7 @@ import org.partiql.lang.eval.like.parsePattern
 import org.partiql.lang.eval.namedValue
 import org.partiql.lang.eval.numberValue
 import org.partiql.lang.eval.rangeOver
+import org.partiql.lang.eval.sourceLocationMeta
 import org.partiql.lang.eval.stringValue
 import org.partiql.lang.eval.syntheticColumnName
 import org.partiql.lang.eval.time.Time
@@ -1870,6 +1872,7 @@ internal class PhysicalExprToThunkConverterImpl(
 }
 
 internal val MetaContainer.sourceLocationMeta get() = this[SourceLocationMeta.TAG] as? SourceLocationMeta
+internal val MetaContainer.sourceLocationMetaOrUnknown get() = this.sourceLocationMeta ?: UNKNOWN_SOURCE_LOCATION
 
 internal fun StaticType.getTypes() = when (val flattened = this.flatten()) {
     is AnyOfType -> flattened.types

--- a/lang/src/org/partiql/lang/planner/PlannerPipeline.kt
+++ b/lang/src/org/partiql/lang/planner/PlannerPipeline.kt
@@ -61,7 +61,7 @@ import org.partiql.lang.types.CustomType
  *
  * - The passes may throw any exception, however these will always abort query planning and bypass the user-friendly
  * error reporting ([ProblemHandler]) mechanisms used for
- * [syntax and semantic errors](https://www.educative.io/edpresso/what-is-the-difference-between-syntax-and-semantic-errors))
+ * [syntax and semantic errors](https://www.educative.io/edpresso/what-is-the-difference-between-syntax-and-semantic-errors)
  * - Use the [ProblemHandler] to report semantic errors and warnings in the query to the query author.
  *
  * @see [ProblemHandler.handleProblem]

--- a/lang/test/org/partiql/lang/planner/PlannerPipelineSmokeTests.kt
+++ b/lang/test/org/partiql/lang/planner/PlannerPipelineSmokeTests.kt
@@ -1,13 +1,17 @@
 package org.partiql.lang.planner
 
-import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.ionString
 import com.amazon.ionelement.api.toIonValue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.partiql.lang.ION
+import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.errors.Problem
+import org.partiql.lang.errors.ProblemDetails
+import org.partiql.lang.errors.ProblemSeverity
+import org.partiql.lang.eval.physical.sourceLocationMetaOrUnknown
 import org.partiql.lang.planner.transforms.PLAN_VERSION_NUMBER
 import org.partiql.lang.planner.transforms.PlanningProblemDetails
 import org.partiql.lang.util.SexpAstPrettyPrinter
@@ -17,12 +21,15 @@ import org.partiql.lang.util.SexpAstPrettyPrinter
  * but it is still good to have a simple "smoke test" for the planner pipeline.
  */
 class PlannerPipelineSmokeTests {
-    private val ion = IonSystemBuilder.standard().build()
 
     @Suppress("DEPRECATION")
-    private fun createPlannerPipelineForTest(allowUndefinedVariables: Boolean) = PlannerPipeline.build(ion) {
+    private fun createPlannerPipelineForTest(
+        allowUndefinedVariables: Boolean,
+        block: PlannerPipeline.Builder.() -> Unit = { }
+    ) = PlannerPipeline.build(ION) {
         allowUndefinedVariables(allowUndefinedVariables)
         metadataResolver(createFakeMetadataResolver("Customer" to "fake_uid_for_Customer"))
+        block()
     }
 
     @Test
@@ -76,6 +83,80 @@ class PlannerPipelineSmokeTests {
                 listOf(problem(1, 8, PlanningProblemDetails.UndefinedVariable("undefined", caseSensitive = false)))
             ),
             result
+        )
+    }
+
+    @Test
+    fun `physical plan pass - happy path`() {
+        val qp = createPlannerPipelineForTest(allowUndefinedVariables = false) {
+            addPhysicalPlanPass { inputPlan, _ ->
+                // ensure we're getting the correct plan as input
+                assertEquals(createFakePlan(1), inputPlan)
+
+                // instead of doing something smart (this is after all a "smoke" test), just return a different
+                // plan entirely.
+                createFakePlan(2)
+            }
+            addPhysicalPlanPass { inputPlan, _ ->
+                // second pass should get the output of the first pass as input
+                assertEquals(createFakePlan(2), inputPlan)
+                createFakePlan(3)
+            }
+            addPhysicalPlanPass { inputPlan, _ ->
+                // third pass should get the output of the second pass as input
+                assertEquals(createFakePlan(3), inputPlan)
+                createFakePlan(4)
+            }
+        }
+        val actualPlanResult = qp.plan("1")
+
+        // final plan should be the output of the third pass.
+        assertEquals(PassResult.Success(createFakePlan(4), emptyList()), actualPlanResult)
+    }
+
+    private fun createFakePlan(number: Int) =
+        PartiqlPhysical.build {
+            plan(
+                stmt = query(lit(ionInt(number.toLong()))),
+                version = PLAN_VERSION_NUMBER
+            )
+        }
+
+    @Test
+    fun `physical plan pass - first user pass sends semantic error`() {
+        val qp = createPlannerPipelineForTest(allowUndefinedVariables = false) {
+            addPhysicalPlanPass { inputPlan, problemHandler ->
+                problemHandler.handleProblem(
+                    createFakeErrorProblem(inputPlan.stmt.metas.sourceLocationMetaOrUnknown)
+                )
+                inputPlan
+            }
+            addPhysicalPlanPass { _, _ ->
+                error(
+                    "This pass should not be reached due to an error being sent to to the problem handler " +
+                        "in the previous pass"
+                )
+            }
+        }
+        val expectedError = createFakeErrorProblem(SourceLocationMeta(1, 1, 57))
+
+        val actualPassResult = qp.plan(
+            // the actual expression doesn't matter as long as it doesn't have an error detected by a built-in pass
+            "'the meaning of life, the universe, and everything is 42'"
+        )
+
+        assertEquals(PassResult.Error<PartiqlPhysical.Plan>(listOf(expectedError)), actualPassResult)
+    }
+
+    private fun createFakeErrorProblem(sourceLocationMeta: SourceLocationMeta): Problem {
+        data class FakeProblemDetails(
+            override val severity: ProblemSeverity = ProblemSeverity.ERROR,
+            override val message: String = "Ack, the query author presented us with a logical conundrum!"
+        ) : ProblemDetails
+
+        return Problem(
+            sourceLocationMeta,
+            FakeProblemDetails()
         )
     }
 }


### PR DESCRIPTION
This PR will be merged to `main`.

This adds a new method to the `PlannerPipeline.Builder` class which allows customers to select optimal operator implementations and perform other custom rewrites on the physical algebra and also invokes these passes during plan-time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
