### PR TITLE
Cli add partiql input

### DIFF
--- a/cli/src/org/partiql/cli/Cli.kt
+++ b/cli/src/org/partiql/cli/Cli.kt
@@ -61,6 +61,11 @@ internal class Cli(
                 null -> Bindings.buildLazyBindings<ExprValue> {}.delegate(globals)
                 else -> getBindingsFromIonValue(valueFactory.newFromIonReader(reader))
             }
+            if (reader.next() != null) {
+                val message = "As of June 2022, PartiQL requires that Ion files contain only a single Ion value for " +
+                    "processing. Please consider wrapping multiple values in a list."
+                throw IllegalStateException(message)
+            }
             val result = compilerPipeline.compile(query).eval(EvaluationSession.build { globals(bindings) })
             outputResult(result)
         }

--- a/cli/src/org/partiql/cli/Cli.kt
+++ b/cli/src/org/partiql/cli/Cli.kt
@@ -60,7 +60,7 @@ internal class Cli(
                 else -> getBindingsFromIonValue(valueFactory.newFromIonReader(reader))
             }
             if (reader.next() != null) {
-                val message = "As of June 2022, PartiQL requires that Ion files contain only a single Ion value for " +
+                val message = "As of v0.7.0, PartiQL requires that Ion files contain only a single Ion value for " +
                     "processing. Please consider wrapping multiple values in a list."
                 throw IllegalStateException(message)
             }
@@ -70,9 +70,9 @@ internal class Cli(
     }
 
     private fun runWithPartiQLInput() {
-        val partiql =
+        val inputEnvironment =
             compilerPipeline.compile(input.readBytes().toString(Charsets.UTF_8)).eval(EvaluationSession.standard())
-        val bindings = getBindingsFromIonValue(partiql)
+        val bindings = getBindingsFromIonValue(inputEnvironment)
         val result = compilerPipeline.compile(query).eval(EvaluationSession.build { globals(bindings) })
         outputResult(result)
     }

--- a/cli/src/org/partiql/cli/Cli.kt
+++ b/cli/src/org/partiql/cli/Cli.kt
@@ -73,7 +73,7 @@ internal class Cli(
 
     private fun runWithPartiQLInput() {
         val partiql =
-            compilerPipeline.compile(input.readAllBytes().toString(Charsets.UTF_8)).eval(EvaluationSession.standard())
+            compilerPipeline.compile(input.readBytes().toString(Charsets.UTF_8)).eval(EvaluationSession.standard())
         val bindings = getBindingsFromIonValue(partiql)
         val result = compilerPipeline.compile(query).eval(EvaluationSession.build { globals(bindings) })
         outputResult(result)

--- a/cli/src/org/partiql/cli/functions/ReadFile.kt
+++ b/cli/src/org/partiql/cli/functions/ReadFile.kt
@@ -15,6 +15,7 @@
 package org.partiql.cli.functions
 
 import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonReaderBuilder
 import org.apache.commons.csv.CSVFormat
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
@@ -65,13 +66,25 @@ internal class ReadFile(valueFactory: ExprValueFactory) : BaseFunction(valueFact
             .let { if (record != null) it.withRecordSeparator(record) else it }
             .let { if (escape != null) it.withEscape(escape) else it }
             .let { if (quote != null) it.withQuote(quote) else it }
-
-        DelimitedValues.exprValue(valueFactory, reader, csvFormatWithOptions, conversionModeFor(conversion))
+        val seq = Sequence {
+            DelimitedValues.exprValue(valueFactory, reader, csvFormatWithOptions, conversionModeFor(conversion)).iterator()
+        }
+        valueFactory.newBag(seq)
     }
 
     private fun ionReadHandler(): (InputStream, IonStruct) -> ExprValue = { input, _ ->
-        @Suppress("DEPRECATION")
-        valueFactory.newBag(valueFactory.ion.iterate(input).asSequence().map { valueFactory.newFromIonValue(it) })
+        IonReaderBuilder.standard().build(input).use { reader ->
+            val value = when (reader.next()) {
+                null -> valueFactory.missingValue
+                else -> valueFactory.newFromIonReader(reader)
+            }
+            if (reader.next() != null) {
+                val message = "As of June 2022, PartiQL requires that Ion files contain only a single Ion value for " +
+                    "processing. Please consider wrapping multiple values in a list."
+                throw IllegalStateException(message)
+            }
+            value
+        }
     }
 
     private val readHandlers = mapOf(
@@ -89,13 +102,10 @@ internal class ReadFile(valueFactory: ExprValueFactory) : BaseFunction(valueFact
         val fileName = required[0].stringValue()
         val fileType = "ion"
         val handler = readHandlers[fileType] ?: throw IllegalArgumentException("Unknown file type: $fileType")
-        val seq = Sequence {
-            // TODO we should take care to clean up this `FileInputStream` properly
-            //  https://github.com/partiql/partiql-lang-kotlin/issues/518
-            val fileInput = FileInputStream(fileName)
-            handler(fileInput, valueFactory.ion.newEmptyStruct()).iterator()
-        }
-        return valueFactory.newBag(seq)
+        // TODO we should take care to clean up this `FileInputStream` properly
+        //  https://github.com/partiql/partiql-lang-kotlin/issues/518
+        val fileInput = FileInputStream(fileName)
+        return handler(fileInput, valueFactory.ion.newEmptyStruct())
     }
 
     override fun callWithOptional(session: EvaluationSession, required: List<ExprValue>, opt: ExprValue): ExprValue {
@@ -103,12 +113,9 @@ internal class ReadFile(valueFactory: ExprValueFactory) : BaseFunction(valueFact
         val fileName = required[0].stringValue()
         val fileType = options["type"]?.stringValue() ?: "ion"
         val handler = readHandlers[fileType] ?: throw IllegalArgumentException("Unknown file type: $fileType")
-        val seq = Sequence {
-            // TODO we should take care to clean up this `FileInputStream` properly
-            //  https://github.com/partiql/partiql-lang-kotlin/issues/518
-            val fileInput = FileInputStream(fileName)
-            handler(fileInput, options).iterator()
-        }
-        return valueFactory.newBag(seq)
+        // TODO we should take care to clean up this `FileInputStream` properly
+        //  https://github.com/partiql/partiql-lang-kotlin/issues/518
+        val fileInput = FileInputStream(fileName)
+        return handler(fileInput, options)
     }
 }

--- a/cli/src/org/partiql/cli/functions/ReadFile.kt
+++ b/cli/src/org/partiql/cli/functions/ReadFile.kt
@@ -79,7 +79,7 @@ internal class ReadFile(valueFactory: ExprValueFactory) : BaseFunction(valueFact
                 else -> valueFactory.newFromIonReader(reader)
             }
             if (reader.next() != null) {
-                val message = "As of June 2022, PartiQL requires that Ion files contain only a single Ion value for " +
+                val message = "As of v0.7.0, PartiQL requires that Ion files contain only a single Ion value for " +
                     "processing. Please consider wrapping multiple values in a list."
                 throw IllegalStateException(message)
             }

--- a/cli/src/org/partiql/cli/functions/WriteFile.kt
+++ b/cli/src/org/partiql/cli/functions/WriteFile.kt
@@ -41,7 +41,7 @@ internal class WriteFile(valueFactory: ExprValueFactory) : BaseFunction(valueFac
     companion object {
         @JvmStatic private val PRETTY_ION_WRITER: (ExprValue, OutputStream, IonStruct) -> Unit = { results, out, _ ->
             IonTextWriterBuilder.pretty().build(out).use { w ->
-                results.forEach { it.ionValue.writeTo(w) }
+                results.ionValue.writeTo(w)
             }
         }
     }

--- a/cli/src/org/partiql/cli/main.kt
+++ b/cli/src/org/partiql/cli/main.kt
@@ -104,6 +104,9 @@ private val inputFormatOpt = optParser.acceptsAll(listOf("input-format", "if"), 
     .describedAs("(${InputFormat.values().joinToString("|")})")
     .defaultsTo(InputFormat.ION)
 
+private val wrapIonOpt = optParser.acceptsAll(listOf("wrap-ion", "w"), "wraps Ion input file values in a bag, requires the input format to be ION, requires the query option")
+    .availableIf(queryOpt)
+
 private val outputFileOpt = optParser.acceptsAll(listOf("output", "o"), "output file, requires the query option (default: stdout)")
     .availableIf(queryOpt)
     .withRequiredArg()
@@ -131,6 +134,7 @@ private val outputFormatOpt = optParser.acceptsAll(listOf("output-format", "of")
  *      * -q --query: PartiQL query
  *      * -i --input: input file
  *      * -if --input-format: (default: ION) [ION, PARTIQL]
+ *      * -w --wrap-ion: wraps Ion input file values in a bag, requires the input format to be ION, requires the query option
  *      * -o --output: output file (default: STDOUT)
  *      * -of --output-format: (default: PARTIQL) [ION_TEXT, ION_BINARY, PARTIQL, PARTIQL_PRETTY]
  */
@@ -206,11 +210,13 @@ private fun runCli(environment: Bindings<ExprValue>, optionSet: OptionSet, compi
     val inputFormat = optionSet.valueOf(inputFormatOpt)
     val outputFormat = optionSet.valueOf(outputFormatOpt)
 
+    val wrapIon = optionSet.has(wrapIonOpt)
+
     val query = optionSet.valueOf(queryOpt)
 
     input.use {
         output.use {
-            Cli(valueFactory, input, inputFormat, output, outputFormat, compilerPipeline, environment, query).run()
+            Cli(valueFactory, input, inputFormat, output, outputFormat, compilerPipeline, environment, query, wrapIon).run()
         }
     }
 }

--- a/cli/src/org/partiql/cli/main.kt
+++ b/cli/src/org/partiql/cli/main.kt
@@ -97,7 +97,7 @@ private val inputFileOpt = optParser.acceptsAll(listOf("input", "i"), "input fil
     .withRequiredArg()
     .ofType(File::class.java)
 
-private val inputFormatOpt = optParser.acceptsAll(listOf("input-format", "if"), "output format, requires the query option")
+private val inputFormatOpt = optParser.acceptsAll(listOf("input-format", "if"), "input format, requires the query option")
     .availableIf(queryOpt)
     .withRequiredArg()
     .ofType(InputFormat::class.java)
@@ -129,10 +129,10 @@ private val outputFormatOpt = optParser.acceptsAll(listOf("output-format", "of")
  * mismatches)
  * * Non interactive only:
  *      * -q --query: PartiQL query
- *      * -i --input: input file, default STDIN
- *      * -if --input-format: ION_TEXT (default), ION_BINARY, PARTIQL
- *      * -o --output: output file, default STDOUT
- *      * -of --output-format: ION_TEXT, ION_BINARY, PARTIQL (default), PARTIQL_PRETTY
+ *      * -i --input: input file
+ *      * -if --input-format: (default: ION) [ION, PARTIQL]
+ *      * -o --output: output file (default: STDOUT)
+ *      * -of --output-format: (default: PARTIQL) [ION_TEXT, ION_BINARY, PARTIQL, PARTIQL_PRETTY]
  */
 fun main(args: Array<String>) = try {
     optParser.formatHelpWith(formatter)

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -17,6 +17,7 @@ package org.partiql.cli
 import com.amazon.ion.system.IonSystemBuilder
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 import org.partiql.lang.CompilerPipeline
@@ -84,6 +85,14 @@ class CliTest {
         val actual = subject.runAndOutput()
 
         assertAsIon("{a: 1}", actual)
+    }
+
+    @Test
+    fun runQueryOnBadValue() {
+        val subject = makeCli("SELECT * FROM input_data", "1 2")
+        assertThrows(IllegalStateException::class.java) {
+            subject.runAndOutput()
+        }
     }
 
     @Test

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -17,24 +17,18 @@ package org.partiql.cli
 import com.amazon.ion.system.IonSystemBuilder
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThrows
 import org.junit.Before
 import org.junit.Test
 import org.partiql.lang.CompilerPipeline
-import org.partiql.lang.eval.Bindings
 import org.partiql.lang.eval.EvaluationException
-import org.partiql.lang.eval.ExprValue
-import org.partiql.lang.eval.ExprValueFactory
 import org.partiql.lang.eval.TypingMode
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
-import java.io.OutputStream
 import java.nio.file.Files
 
 class CliTest {
     private val ion = IonSystemBuilder.standard().build()
-    private val valueFactory = ExprValueFactory.standard(ion)
     private val output = ByteArrayOutputStream()
     private val testFile = File("test.ion")
     private val partiqlBagAnnotation = "\$partiql_bag::"
@@ -49,141 +43,142 @@ class CliTest {
         Files.deleteIfExists(testFile.toPath())
     }
 
-    private fun makeCli(
-        query: String,
-        input: String? = null,
-        bindings: Bindings<ExprValue> = Bindings.empty(),
-        outputFormat: OutputFormat = OutputFormat.ION_TEXT,
-        output: OutputStream = this.output,
-        compilerPipeline: CompilerPipeline = CompilerPipeline.standard(ion)
-    ) =
-        Cli(
-            valueFactory,
-            input?.byteInputStream(Charsets.UTF_8) ?: EmptyInputStream(),
-            InputFormat.ION,
-            output,
-            outputFormat,
-            compilerPipeline,
-            bindings,
-            query
-        )
-
-    private fun Cli.runAndOutput(): String {
-        run()
-        return output.toString(Charsets.UTF_8.name())
-    }
-
-    private fun String.singleIonExprValue() = valueFactory.newFromIonValue(ion.singleValue(this))
-    private fun Map<String, String>.asBinding() =
-        Bindings.ofMap(this.mapValues { it.value.singleIonExprValue() })
-
-    private fun assertAsIon(expected: String, actual: String) =
-        assertEquals(ion.loader.load(expected), ion.loader.load(actual))
-
     @Test
     fun runQueryOnSingleValue() {
-        val subject = makeCli("SELECT * FROM input_data", "[{a: 1}]")
-        val actual = subject.runAndOutput()
+        val query = "SELECT * FROM input_data"
+        val input = "[{'a': 1}]"
         val expected = "$partiqlBagAnnotation[{a: 1}]"
 
-        assertAsIon(expected, actual)
+        val ionInputResult = makeCliAndGetResult(query, input, inputFormat = InputFormat.ION)
+        val partiqlInputResult = makeCliAndGetResult(query, input, inputFormat = InputFormat.PARTIQL)
+
+        assertAsIon(expected, ionInputResult)
+        assertAsIon(expected, partiqlInputResult)
     }
 
-    @Test
+    @Test(expected = java.lang.IllegalStateException::class)
     fun runQueryOnBadValue() {
-        val subject = makeCli("SELECT * FROM input_data", "1 2")
-        assertThrows(IllegalStateException::class.java) {
-            subject.runAndOutput()
-        }
+        val query = "SELECT * FROM input_data"
+        val input = "1 2"
+        makeCliAndGetResult(query, input)
     }
 
     @Test
     fun runQueryOnMultipleValues() {
-        val subject = makeCli("SELECT * FROM input_data", "[{a: 1},{a: 2},{a: 3}]")
-        val actual = subject.runAndOutput()
+        val query = "SELECT * FROM input_data"
+        val input = "[{'a': 1},{'a': 2},{'a': 3}]"
         val expected = "$partiqlBagAnnotation[{a: 1},{a: 2},{a: 3}]"
 
-        assertAsIon(expected, actual)
+        val ionInputResult = makeCliAndGetResult(query, input, inputFormat = InputFormat.ION)
+        val partiqlInputResult = makeCliAndGetResult(query, input, inputFormat = InputFormat.PARTIQL)
+
+        assertAsIon(expected, ionInputResult)
+        assertAsIon(expected, partiqlInputResult)
     }
 
     @Test
     fun caseInsensitiveBindingName() {
-        val subject = makeCli("SELECT * FROM input_DAta", "[{a: 1}]")
-        val actual = subject.runAndOutput()
+        val query = "SELECT * FROM input_dAta"
+        val input = "[{'a': 1}]"
         val expected = "$partiqlBagAnnotation[{a: 1}]"
 
-        assertAsIon(expected, actual)
+        val ionInputResult = makeCliAndGetResult(query, input, inputFormat = InputFormat.ION)
+        val partiqlInputResult = makeCliAndGetResult(query, input, inputFormat = InputFormat.PARTIQL)
+
+        assertAsIon(expected, ionInputResult)
+        assertAsIon(expected, partiqlInputResult)
     }
 
     @Test
     fun withBinding() {
-        val subject = makeCli("SELECT v, d FROM bound_value v, input_data d", "[{a: 1}]", mapOf("bound_value" to "{b: 1}").asBinding())
-        val actual = subject.runAndOutput()
+        val query = "SELECT v, d FROM bound_value v, input_data d"
+        val input = "[{'a': 1}]"
+        val bindings = mapOf("bound_value" to "{b: 1}").asBinding()
         val expected = "$partiqlBagAnnotation[{v: {b: 1}, d: {a: 1}}]"
 
-        assertAsIon(expected, actual)
+        val ionInputResult = makeCliAndGetResult(query, input, bindings = bindings, inputFormat = InputFormat.ION)
+        val partiqlInputResult = makeCliAndGetResult(query, input, bindings = bindings, inputFormat = InputFormat.PARTIQL)
+
+        assertAsIon(expected, ionInputResult)
+        assertAsIon(expected, partiqlInputResult)
     }
 
     @Test
     fun withShadowingBinding() {
-        val subject = makeCli("SELECT * FROM input_data", "[{a: 1}]", mapOf("input_data" to "{b: 1}").asBinding())
-        val actual = subject.runAndOutput()
+        val query = "SELECT * FROM input_data"
+        val input = "[{'a': 1}]"
+        val bindings = mapOf("input_data" to "{b: 1}").asBinding()
         val expected = "$partiqlBagAnnotation[{a: 1}]"
 
-        assertAsIon(expected, actual)
+        val ionInputResult = makeCliAndGetResult(query, input, bindings = bindings, inputFormat = InputFormat.ION)
+        val partiqlInputResult = makeCliAndGetResult(query, input, bindings = bindings, inputFormat = InputFormat.PARTIQL)
+
+        assertAsIon(expected, ionInputResult)
+        assertAsIon(expected, partiqlInputResult)
     }
 
     @Test
     fun withPartiQLOutput() {
-        val subject = makeCli("SELECT * FROM input_data", "[{a: 1}]", outputFormat = OutputFormat.PARTIQL)
-        val actual = subject.runAndOutput()
+        val query = "SELECT * FROM input_data"
+        val input = "[{a: 1}]"
+        val expected = "<<{'a': 1}>>"
 
-        assertEquals("<<{'a': 1}>>", actual)
+        val actual = makeCliAndGetResult(query, input, inputFormat = InputFormat.ION, outputFormat = OutputFormat.PARTIQL)
+
+        assertEquals(expected, actual)
     }
 
     @Test
     fun withPartiQLPrettyOutput() {
-        val subject = makeCli("SELECT * FROM input_data", "[{a: 1, b: 2}]", outputFormat = OutputFormat.PARTIQL_PRETTY)
-        val actual = subject.runAndOutput()
+        val query = "SELECT * FROM input_data"
+        val input = "[{a: 1, b: 2}]"
+        val expected = "<<\n  {\n    'a': 1,\n    'b': 2\n  }\n>>"
 
-        assertEquals("<<\n  {\n    'a': 1,\n    'b': 2\n  }\n>>", actual)
+        val actual = makeCliAndGetResult(query, input, inputFormat = InputFormat.ION, outputFormat = OutputFormat.PARTIQL_PRETTY)
+
+        assertEquals(expected, actual)
     }
 
     @Test
     fun withIonTextOutput() {
-        val subject = makeCli("SELECT * FROM input_data", "[{a: 1}, {b: 1}]", outputFormat = OutputFormat.ION_TEXT)
-        val actual = subject.runAndOutput()
+        val query = "SELECT * FROM input_data"
+        val input = "[{a: 1}, {b: 1}]"
         val expected = "$partiqlBagAnnotation[{a:1}\n,{b:1}\n]"
+
+        val actual = makeCliAndGetResult(query, input, inputFormat = InputFormat.ION, outputFormat = OutputFormat.ION_TEXT)
 
         assertAsIon(expected, actual)
     }
 
     @Test
     fun withIonTextOutputToFile() {
-        makeCli(
-            "SELECT * FROM input_data",
-            "[{a: 1}, {b: 1}]",
-            output = FileOutputStream(testFile),
-            outputFormat = OutputFormat.ION_TEXT
-        ).run()
-        val actual = testFile.bufferedReader().use { it.readText() }
+        val query = "SELECT * FROM input_data"
+        val input = "[{'a': 1}, {'b': 1}]"
         val expected = "$partiqlBagAnnotation[{a:1}\n,{b:1}\n]"
 
-        assertAsIon(expected, actual)
+        makeCliAndGetResult(query, input, inputFormat = InputFormat.ION, outputFormat = OutputFormat.ION_TEXT, output = FileOutputStream(testFile))
+        val ionInputResult = testFile.bufferedReader().use { it.readText() }
+        assertAsIon(expected, ionInputResult)
+
+        makeCliAndGetResult(query, input, inputFormat = InputFormat.PARTIQL, outputFormat = OutputFormat.ION_TEXT, output = FileOutputStream(testFile))
+        val partiqlInputResult = testFile.bufferedReader().use { it.readText() }
+        assertAsIon(expected, partiqlInputResult)
     }
 
     @Test
     fun withoutInput() {
-        val subject = makeCli("1")
-        val actual = subject.runAndOutput()
+        val query = "1"
         val expected = "1"
+
+        val actual = makeCliAndGetResult(query)
 
         assertAsIon(expected, actual)
     }
 
     @Test(expected = EvaluationException::class)
     fun withoutInputWithInputDataBindingThrowsException() {
-        makeCli("SELECT * FROM input_data").runAndOutput()
+        val query = "SELECT * FROM input_data"
+        makeCliAndGetResult(query)
     }
 
     @Test
@@ -193,8 +188,8 @@ class CliTest {
                 typingMode(TypingMode.PERMISSIVE)
             }
         }
-        val subject = makeCli("1 + 'foo'", compilerPipeline = permissiveModeCP)
-        val actual = subject.runAndOutput()
+        val query = "1 + 'foo'"
+        val actual = makeCliAndGetResult(query, compilerPipeline = permissiveModeCP)
 
         assertAsIon("\$partiql_missing::null", actual)
     }

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -14,6 +14,7 @@
 
 package org.partiql.cli
 
+import com.amazon.ion.IonException
 import com.amazon.ion.system.IonSystemBuilder
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -192,5 +193,23 @@ class CliTest {
         val actual = makeCliAndGetResult(query, compilerPipeline = permissiveModeCP)
 
         assertAsIon("\$partiql_missing::null", actual)
+    }
+
+    @Test
+    fun partiqlInputSuccess() {
+        val query = "SELECT * FROM input_data"
+        val input = "<<{'a': 1}, {'b': 1}>>"
+        val expected = "$partiqlBagAnnotation[{a:1}\n,{b:1}\n]"
+
+        val partiqlInputResult = makeCliAndGetResult(query, input, inputFormat = InputFormat.PARTIQL)
+        assertAsIon(expected, partiqlInputResult)
+    }
+
+    @Test(expected = IonException::class)
+    fun partiqlInputFailure() {
+        val query = "SELECT * FROM input_data"
+        val input = "<<{'a': 1}, {'b': 1}>>"
+
+        makeCliAndGetResult(query, input, inputFormat = InputFormat.ION)
     }
 }

--- a/cli/test/org/partiql/cli/CliTest.kt
+++ b/cli/test/org/partiql/cli/CliTest.kt
@@ -58,6 +58,7 @@ class CliTest {
         Cli(
             valueFactory,
             input?.byteInputStream(Charsets.UTF_8) ?: EmptyInputStream(),
+            InputFormat.ION,
             output,
             outputFormat,
             compilerPipeline,
@@ -79,7 +80,7 @@ class CliTest {
 
     @Test
     fun runQueryOnSingleValue() {
-        val subject = makeCli("SELECT * FROM input_data", "{a: 1}")
+        val subject = makeCli("SELECT * FROM input_data", "[{a: 1}]")
         val actual = subject.runAndOutput()
 
         assertAsIon("{a: 1}", actual)
@@ -87,7 +88,7 @@ class CliTest {
 
     @Test
     fun runQueryOnMultipleValues() {
-        val subject = makeCli("SELECT * FROM input_data", "{a: 1}{a: 2}{a: 3}")
+        val subject = makeCli("SELECT * FROM input_data", "[{a: 1},{a: 2},{a: 3}]")
         val actual = subject.runAndOutput()
 
         assertAsIon("{a: 1} {a: 2} {a: 3}", actual)
@@ -95,7 +96,7 @@ class CliTest {
 
     @Test
     fun caseInsensitiveBindingName() {
-        val subject = makeCli("SELECT * FROM input_DAta", "{a: 1}")
+        val subject = makeCli("SELECT * FROM input_DAta", "[{a: 1}]")
         val actual = subject.runAndOutput()
 
         assertAsIon("{a: 1}", actual)
@@ -103,7 +104,7 @@ class CliTest {
 
     @Test
     fun withBinding() {
-        val subject = makeCli("SELECT v, d FROM bound_value v, input_data d", "{a: 1}", mapOf("bound_value" to "{b: 1}").asBinding())
+        val subject = makeCli("SELECT v, d FROM bound_value v, input_data d", "[{a: 1}]", mapOf("bound_value" to "{b: 1}").asBinding())
         val actual = subject.runAndOutput()
 
         assertAsIon("{v: {b: 1}, d: {a: 1}}", actual)
@@ -111,7 +112,7 @@ class CliTest {
 
     @Test
     fun withShadowingBinding() {
-        val subject = makeCli("SELECT * FROM input_data", "{a: 1}", mapOf("input_data" to "{b: 1}").asBinding())
+        val subject = makeCli("SELECT * FROM input_data", "[{a: 1}]", mapOf("input_data" to "{b: 1}").asBinding())
 
         val actual = subject.runAndOutput()
 
@@ -120,7 +121,7 @@ class CliTest {
 
     @Test
     fun withPartiQLOutput() {
-        val subject = makeCli("SELECT * FROM input_data", "{a: 1}", outputFormat = OutputFormat.PARTIQL)
+        val subject = makeCli("SELECT * FROM input_data", "[{a: 1}]", outputFormat = OutputFormat.PARTIQL)
         val actual = subject.runAndOutput()
 
         assertEquals("<<{'a': 1}>>", actual)
@@ -128,7 +129,7 @@ class CliTest {
 
     @Test
     fun withPartiQLPrettyOutput() {
-        val subject = makeCli("SELECT * FROM input_data", "{a: 1, b: 2}", outputFormat = OutputFormat.PARTIQL_PRETTY)
+        val subject = makeCli("SELECT * FROM input_data", "[{a: 1, b: 2}]", outputFormat = OutputFormat.PARTIQL_PRETTY)
         val actual = subject.runAndOutput()
 
         assertEquals("<<\n  {\n    'a': 1,\n    'b': 2\n  }\n>>", actual)
@@ -136,7 +137,7 @@ class CliTest {
 
     @Test
     fun withIonTextOutput() {
-        val subject = makeCli("SELECT * FROM input_data", "{a: 1} {b: 1}", outputFormat = OutputFormat.ION_TEXT)
+        val subject = makeCli("SELECT * FROM input_data", "[{a: 1}, {b: 1}]", outputFormat = OutputFormat.ION_TEXT)
         val actual = subject.runAndOutput()
 
         assertEquals("{a:1}\n{b:1}\n", actual)
@@ -146,7 +147,7 @@ class CliTest {
     fun withIonTextOutputToFile() {
         makeCli(
             "SELECT * FROM input_data",
-            "{a: 1} {b: 1}",
+            "[{a: 1}, {b: 1}]",
             output = FileOutputStream(testFile),
             outputFormat = OutputFormat.ION_TEXT
         ).run()

--- a/cli/test/org/partiql/cli/CliTestUtility.kt
+++ b/cli/test/org/partiql/cli/CliTestUtility.kt
@@ -22,7 +22,8 @@ fun makeCliAndGetResult(
     output: OutputStream = ByteArrayOutputStream(),
     ion: IonSystem = IonSystemBuilder.standard().build(),
     compilerPipeline: CompilerPipeline = CompilerPipeline.standard(ion),
-    valueFactory: ExprValueFactory = ExprValueFactory.standard(ion)
+    valueFactory: ExprValueFactory = ExprValueFactory.standard(ion),
+    wrapIon: Boolean = false
 ): String {
     val cli = Cli(
         valueFactory,
@@ -32,7 +33,8 @@ fun makeCliAndGetResult(
         outputFormat,
         compilerPipeline,
         bindings,
-        query
+        query,
+        wrapIon
     )
     cli.run()
     return output.toString()

--- a/cli/test/org/partiql/cli/CliTestUtility.kt
+++ b/cli/test/org/partiql/cli/CliTestUtility.kt
@@ -16,6 +16,7 @@ import java.io.OutputStream
 fun makeCliAndGetResult(
     query: String,
     input: String? = null,
+    inputFormat: InputFormat = InputFormat.ION,
     bindings: Bindings<ExprValue> = Bindings.empty(),
     outputFormat: OutputFormat = OutputFormat.ION_TEXT,
     output: OutputStream = ByteArrayOutputStream(),
@@ -26,7 +27,7 @@ fun makeCliAndGetResult(
     val cli = Cli(
         valueFactory,
         input?.byteInputStream(Charsets.UTF_8) ?: EmptyInputStream(),
-        InputFormat.ION,
+        inputFormat,
         output,
         outputFormat,
         compilerPipeline,
@@ -50,3 +51,7 @@ fun assertAsIon(expected: String, actual: String) {
  */
 fun assertAsIon(ion: IonSystem, expected: String, actual: String) =
     Assert.assertEquals(ion.loader.load(expected), ion.loader.load(actual))
+
+fun String.singleIonExprValue(ion: IonSystem = IonSystemBuilder.standard().build(), valueFactory: ExprValueFactory = ExprValueFactory.standard(ion)) = valueFactory.newFromIonValue(ion.singleValue(this))
+fun Map<String, String>.asBinding() =
+    Bindings.ofMap(this.mapValues { it.value.singleIonExprValue() })

--- a/cli/test/org/partiql/cli/CliTestUtility.kt
+++ b/cli/test/org/partiql/cli/CliTestUtility.kt
@@ -26,6 +26,7 @@ fun makeCliAndGetResult(
     val cli = Cli(
         valueFactory,
         input?.byteInputStream(Charsets.UTF_8) ?: EmptyInputStream(),
+        InputFormat.ION,
         output,
         outputFormat,
         compilerPipeline,

--- a/cli/test/org/partiql/cli/functions/ReadFileTest.kt
+++ b/cli/test/org/partiql/cli/functions/ReadFileTest.kt
@@ -19,13 +19,12 @@ import com.amazon.ion.IonValue
 import com.amazon.ion.system.IonSystemBuilder
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertSame
+import org.junit.Assert.assertThrows
 import org.junit.BeforeClass
 import org.junit.Test
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
-import org.partiql.lang.eval.ExprValueType
 import org.partiql.lang.util.asSequence
 import java.io.File
 
@@ -83,13 +82,12 @@ class ReadFileTest {
     private fun assertValues(expectedIon: String, value: ExprValue) {
         val expectedValues = ion.singleValue(expectedIon)
 
-        assertSame(ExprValueType.BAG, value.type)
         assertEquals(expectedValues, value.ionValue.cloneAndRemoveAnnotations())
     }
 
     @Test
     fun readIonAsDefault() {
-        writeFile("data.ion", "1 2")
+        writeFile("data.ion", "[1, 2]")
 
         val args = listOf("\"${dirPath("data.ion")}\"").map { it.exprValue() }
         val actual = function.callWithRequired(session, args)
@@ -100,7 +98,7 @@ class ReadFileTest {
 
     @Test
     fun readIon() {
-        writeFile("data.ion", "1 2")
+        writeFile("data.ion", "[1, 2]")
 
         val args = listOf("\"${dirPath("data.ion")}\"").map { it.exprValue() }
         val additionalOptions = "{type:\"ion\"}".exprValue()
@@ -108,6 +106,17 @@ class ReadFileTest {
         val expected = "[1, 2]"
 
         assertValues(expected, actual)
+    }
+
+    @Test
+    fun readBadIon() {
+        writeFile("data.ion", "1 2")
+
+        val args = listOf("\"${dirPath("data.ion")}\"").map { it.exprValue() }
+        val additionalOptions = "{type:\"ion\"}".exprValue()
+        assertThrows(IllegalStateException::class.java) {
+            function.callWithOptional(session, args, additionalOptions)
+        }
     }
 
     @Test

--- a/cli/test/org/partiql/cli/functions/WriteFileTest.kt
+++ b/cli/test/org/partiql/cli/functions/WriteFileTest.kt
@@ -209,18 +209,19 @@ class WriteFileTest {
     }
 
     @Test
-    fun integration_fail_nestedValueBag() {
+    fun integration_success_nestedValueBag() {
         // Arrange
         val filePath = createRandomTmpFilePath()
         val query = "write_file('$filePath', SELECT VALUE a.b FROM input_data)"
-        val input = "{a: {b: << 1, 2 >>}}"
-        val expected = "<< 1, 2 >>"
+        val input = "[{a: {b: \$partiql_bag::[ 1, 2 ] }}]"
+        val expected = "\$partiql_bag::[1,2]"
 
         // Act
         val cliResponse =
             makeCliAndGetResult(query = query, input = input, output = outputStream, compilerPipeline = pipeline)
 
         // Assert
-        assertAsIon(FALSE_STRING, cliResponse)
+        assertAsIon(TRUE_STRING, cliResponse)
+        Assert.assertEquals(ion.loader.load(expected), ion.loader.load(readFileFromPath(filePath)))
     }
 }

--- a/cli/test/org/partiql/cli/functions/WriteFileTest.kt
+++ b/cli/test/org/partiql/cli/functions/WriteFileTest.kt
@@ -52,7 +52,6 @@ class WriteFileTest {
 
     companion object {
         private const val TRUE_STRING: String = "true"
-        private const val FALSE_STRING: String = "false"
     }
 
     /**
@@ -83,7 +82,7 @@ class WriteFileTest {
         val args = listOf("\"$filePath\"", "[1, 2]").map { it.exprValue() }
         function.callWithRequired(session, args).ionValue
 
-        val expected = "1 2"
+        val expected = "[1, 2]"
 
         Assert.assertEquals(ion.loader.load(expected), ion.loader.load(readFileFromPath(filePath)))
     }
@@ -95,7 +94,7 @@ class WriteFileTest {
         val additionalOptions = """{type: "ion"}""".exprValue()
         function.callWithOptional(session, args, additionalOptions).ionValue
 
-        val expected = "1 2"
+        val expected = "[1, 2]"
 
         Assert.assertEquals(ion.loader.load(expected), ion.loader.load(readFileFromPath(filePath)))
     }
@@ -112,7 +111,7 @@ class WriteFileTest {
         val filePath = createRandomTmpFilePath()
         val query = "write_file('$filePath', SELECT * FROM input_data)"
         val input = "{a: 1}"
-        val expected = "{a: 1}"
+        val expected = "\$partiql_bag::[{a: 1}]"
 
         // Act
         val cliResponse =
@@ -129,7 +128,7 @@ class WriteFileTest {
         val filePath = createRandomTmpFilePath()
         val query = "write_file('$filePath', SELECT a.b FROM input_data)"
         val input = "{a: {b: 1}}"
-        val expected = "{b: 1}"
+        val expected = "\$partiql_bag::[{b: 1}]"
 
         // Act
         val cliResponse =
@@ -146,7 +145,7 @@ class WriteFileTest {
         val filePath = createRandomTmpFilePath()
         val query = "write_file('$filePath', SELECT VALUE a FROM input_data)"
         val input = "{a: {b: 1}}"
-        val expected = "{b: 1}"
+        val expected = "\$partiql_bag::[{b: 1}]"
 
         // Act
         val cliResponse =
@@ -163,7 +162,7 @@ class WriteFileTest {
         val filePath = createRandomTmpFilePath()
         val query = "write_file('$filePath', SELECT VALUE a.b FROM input_data)"
         val input = "{a: {b: 1}}"
-        val expected = "1"
+        val expected = "\$partiql_bag::[1]"
 
         // Act
         val cliResponse =
@@ -180,7 +179,7 @@ class WriteFileTest {
         val filePath = createRandomTmpFilePath()
         val query = "write_file('$filePath', SELECT VALUE a.b FROM input_data)"
         val input = "{a: {b: [ 1, 2 ]}}"
-        val expected = "[ 1, 2 ]"
+        val expected = "\$partiql_bag::[[ 1, 2 ]]"
 
         // Act
         val cliResponse =
@@ -197,7 +196,7 @@ class WriteFileTest {
         val filePath = createRandomTmpFilePath()
         val query = "write_file('$filePath', SELECT VALUE a FROM input_data)"
         val input = "{a : 5}"
-        val expected = "5"
+        val expected = "\$partiql_bag::[5]"
 
         // Act
         val cliResponse =
@@ -213,8 +212,8 @@ class WriteFileTest {
         // Arrange
         val filePath = createRandomTmpFilePath()
         val query = "write_file('$filePath', SELECT VALUE a.b FROM input_data)"
-        val input = "[{a: {b: \$partiql_bag::[ 1, 2 ] }}]"
-        val expected = "\$partiql_bag::[1,2]"
+        val input = "[{a: {b: [ 1, 2 ] }}]"
+        val expected = "\$partiql_bag::[[1,2]]"
 
         // Act
         val cliResponse =

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,10 @@
-# Contents 
+# PartiQL Documents
 
-The two subfolders 
+# Contents
 
-* [dev](dev) 
-* [user](user) 
+The two sub-folders:
 
-contain the source for generating the developer's guide and the user's
-guide repsectively.
+- [dev/](dev) contains the source for generating the developer's guide
+- [user/](user) contains the source for generating the user's guide
 
-For instructions on how to contribute or build the documentation see the corresponding `README` and `README-AUTHORS` files. 
+For instructions on how to contribute to the documentation, reference the [README-AUTHORS](./README-AUTHORS.md) file.

--- a/docs/user/CLI.md
+++ b/docs/user/CLI.md
@@ -24,6 +24,7 @@ Option                                Description
 -h, --help                            prints this help
 -i, --input <File>                    input file, requires the query option (optional)
 -if, --input-format <InputFormat>     input format, requires the query option (default: ION) [ION, PARTIQL]
+-w, --wrap-ion                        wraps Ion input file values in a bag, requires the input format to be ION, requires the query option
 -o, --output <File>                   output file, requires the query option (default: stdout)
 -of, --output-format <OutputFormat>   output format, requires the query option (default: PARTIQL) [PARTIQL, PARTIQL_PRETTY, ION_TEXT, ION_BINARY]
 -p, --permissive                      run the PartiQL query in PERMISSIVE typing mode

--- a/docs/user/CLI.md
+++ b/docs/user/CLI.md
@@ -23,7 +23,7 @@ Option                                Description
 -e, --environment <File>              initial global environment (optional)
 -h, --help                            prints this help
 -i, --input <File>                    input file, requires the query option (optional)
--if, --input-format <InputFormat>     input format, requires the query option -- [PARTIQL (default), ION]
+-if, --input-format <InputFormat>     input format, requires the query option -- [ION (default), PARTIQL]
 -o, --output <File>                   output file, requires the query option (default: stdout)
 -of, --output-format <OutputFormat>   output format, requires the query option [PARTIQL (default), PARTIQL_PRETTY, ION_TEXT, ION_BINARY]
 -p, --permissive                      run the PartiQL query in PERMISSIVE typing mode
@@ -80,7 +80,7 @@ At this point, you can type in valid SQL/PartiQL and press enter *twice* to exec
 ```shell
 PartiQL> SELECT id FROM `[{id: 5, name:"bill"}, {id: 6, name:"bob"}]` WHERE name = 'bob';
 ```
-```ion
+```partiql
 <<
   {
     'id': 6
@@ -92,7 +92,7 @@ Alternatively, you can denote the end of a query using a semi-colon:
 ```shell
 PartiQL> SELECT id FROM `[{id: 5, name:"bill"}, {id: 6, name:"bob"}]` WHERE name = 'bob';
 ```
-```ion
+```partiql
 <<
   {
     'id': 6
@@ -106,7 +106,7 @@ expressions based on the last one.
 ```shell
 PartiQL> SELECT id + 4 AS name FROM _;
 ```
-```ion
+```partiql
 <<
   {
     'name': 10
@@ -157,7 +157,7 @@ single `struct` containing the initial *global environment*.
 
 For example, a file named `config.env` contains the following:
 
-```ion
+```partiql
 {
   'animals':[
     {'name': 'Kumo', 'type': 'dog'},
@@ -192,7 +192,7 @@ Expressions can then use the environment defined by `config.env`:
 ```shell
 PartiQL> SELECT name, type, is_magic FROM animals, types WHERE type = id
 ```
-```ion
+```partiql
 <<
   {
     'name': 'Kumo',
@@ -217,7 +217,7 @@ To see the current REPL environment you can use `!global_env`, for example for t
 ```shell
 PartiQL> !global_env;
 ```
-```ion
+```partiql
 {
   'types': [
     {
@@ -256,7 +256,7 @@ example below replaces the value bound to `types`
 ```shell
 PartiQL> !add_to_global_env {'types': []};
 ```
-```ion
+```partiql
 {
   'types': []
 }
@@ -265,7 +265,7 @@ Let's look at what has changed:
 ```shell
 PartiQL> !global_env
 ```
-```ion
+```partiql
 {
   'types': [],
   'animals': [
@@ -289,7 +289,7 @@ PartiQL> !global_env
 
 Let's consider the following initial environment:
 
-```ion
+```partiql
 {
   'stores':[
     {
@@ -321,7 +321,7 @@ If we wanted to find all books *as their own rows* with a price greater than `7`
 ```shell
 PartiQL> SELECT * FROM stores[*].books[*] AS b WHERE b.price > 7;
 ```
-```ion
+```partiql
 <<
   {
     'title': 'D',
@@ -353,7 +353,7 @@ If you wanted to also de-normalize the store ID and title into the above rows:
 ```shell
 PartiQL> SELECT s.id AS store, b.title AS title FROM stores AS s, @s.books AS b WHERE b.price > 7;
 ```
-```ion
+```partiql
 <<
   {
     'store': 5,
@@ -380,7 +380,7 @@ PartiQL> SELECT * FROM stores AS s
    |    SELECT * FROM @s.books AS b WHERE b.price > 9.5
    | );
 ```
-```ion
+```partiql
 <<
   {
     'id': 6,
@@ -432,7 +432,7 @@ To select the cities that are in `HI` and `NY` states:
 ```shell
 PartiQL> SELECT city FROM read_file('data.ion') AS c, `["HI", "NY"]` AS s WHERE c.state = s;
 ```
-```ion
+```partiql
 <<
   {
     'city': 'Honolulu'
@@ -451,7 +451,7 @@ PartiQL> write_file('out.ion', SELECT * FROM _);
 
 A file called `out.ion` will be created in the `cli` directory with the following contents:
 ```ion
-[
+$partiql_bag::[
     {
         city: Honolulu
     },
@@ -460,6 +460,9 @@ A file called `out.ion` will be created in the `cli` directory with the followin
     }
 ]
 ```
+
+Notice that PartiQL added the annotation of `$partiql_bag` to the Ion list. This is how Ion represents PartiQL 
+`BAGs`.
 
 Functions and expressions can be used in the *global configuration* as well.  Consider
 the following `config.ion`:
@@ -475,7 +478,7 @@ The `data` variable will now be bound to file containing Ion:
 ```shell
 PartiQL> SELECT * FROM data;
 ```
-```ion
+```partiql
 <<
     {
       'city': 'Seattle',
@@ -518,7 +521,7 @@ You can read the file with the following CLI command:
 ```shell
 PartiQL> read_file('simple.csv', {'type':'csv'});
 ```
-```ion
+```partiql
 <<
     {
       _0:'title',
@@ -549,7 +552,7 @@ column names with the `header` field.
 ```shell
 PartiQL> read_file('simple.csv', {'type': 'csv', 'header': true});
 ```
-```ion
+```partiql
 <<
     {
       'title': 'harry potter',
@@ -574,7 +577,7 @@ Auto-conversion for numeric and timestamp values can also be specified as follow
 ```shell
 PartiQL> read_file('simple.csv', {'type':'csv', 'header':true, 'conversion':'auto'});
 ```
-```ion
+```partiql
 <<
     {
       'title':' harry potter',

--- a/docs/user/CLI.md
+++ b/docs/user/CLI.md
@@ -23,9 +23,9 @@ Option                                Description
 -e, --environment <File>              initial global environment (optional)
 -h, --help                            prints this help
 -i, --input <File>                    input file, requires the query option (optional)
--if, --input-format <InputFormat>     input format, requires the query option -- [ION (default), PARTIQL]
+-if, --input-format <InputFormat>     input format, requires the query option (default: ION) [ION, PARTIQL]
 -o, --output <File>                   output file, requires the query option (default: stdout)
--of, --output-format <OutputFormat>   output format, requires the query option [PARTIQL (default), PARTIQL_PRETTY, ION_TEXT, ION_BINARY]
+-of, --output-format <OutputFormat>   output format, requires the query option (default: PARTIQL) [PARTIQL, PARTIQL_PRETTY, ION_TEXT, ION_BINARY]
 -p, --permissive                      run the PartiQL query in PERMISSIVE typing mode
 -q, --query <String>                  PartiQL query, triggers non interactive mode
 ```
@@ -51,9 +51,7 @@ The following command will build any dependencies before starting the CLI.
 ./gradlew :cli:run -q --args="<command line arguments>"
 ```
 
-The CLI can be run in two manners, non-interactive (conventional) and interactive (REPL).
-
-
+The CLI can be run in two manners, non-interactive and interactive (REPL).
 
 ## REPL
 
@@ -118,7 +116,7 @@ Press control-D to exit the REPL.
 
 ### Advanced REPL Features
 
-To view the AST of a PartiQL statement, type one and press enter only *once*, then type `!!` and press enter:
+To view the AST of a PartiQL statement, type the statement and press enter only *once*, then type `!!` and press enter:
 
 ```shell
 PartiQL> 1 + 1
@@ -415,7 +413,9 @@ PartiQL> SELECT * FROM stores AS s
 
 ## Reading/Writing Files
 The REPL provides the `read_file` function to stream data from a file. The files need to be placed in the folder `cli`, 
-and they must contain only a single Ion value (typically a list).
+and, if using the default file type (Ion), they must contain only a single Ion value (typically a list).
+
+**Note**: Later on, we will introduce reading different file types, but we will first focus on the default (Ion).
 
 For example, create a file called `data.ion` in the `cli` folder with the following contents
 ```ion
@@ -461,8 +461,8 @@ $partiql_bag::[
 ]
 ```
 
-Notice that PartiQL added the annotation of `$partiql_bag` to the Ion list. This is how Ion represents PartiQL 
-`BAGs`.
+Notice that PartiQL added the annotation of `$partiql_bag` to the Ion list. When outputting to Ion, we use type 
+annotations to represent some PartiQL values/types not in Ion.
 
 Functions and expressions can be used in the *global configuration* as well.  Consider
 the following `config.ion`:

--- a/docs/user/GettingStarted.md
+++ b/docs/user/GettingStarted.md
@@ -96,7 +96,7 @@ PartiQL> SELECT * FROM [1,2,3]
 
 and press `ENTER` *twice*. The output should look similar to: 
 
-```ion
+```partiql
 <<
   {
     '_1': 1
@@ -137,7 +137,7 @@ the **special** REPL command `!global_env`, i.e.,
 ```shell
 PartiQL> !global_env;
 ```
-```ion
+```partiql
 {
   'hr': {
     'employees': <<

--- a/docs/user/GettingStarted.md
+++ b/docs/user/GettingStarted.md
@@ -69,7 +69,7 @@ form. The subfolder `code` contains 3 types of files:
 Run (double click on) `partiql.bat`. This should open a command-line
 prompt and start the PartiQL REPL which displays:
 
-```
+```shell
 Welcome to the PartiQL REPL!
 PartiQL> 
 ```
@@ -81,7 +81,7 @@ PartiQL>
 
 [^foldername]: The folder name will have the PartiQL version as a suffix, i.e., `partiql-cli-0.1.0`.
 
-```
+```shell
 Welcome to the PartiQL REPL!
 PartiQL>
 ```
@@ -90,16 +90,13 @@ PartiQL>
 
 Let's write a simple query to verify that our PartiQL REPL is working. At the `PartiQL>` prompt type: 
 
-```
+```shell
 PartiQL> SELECT * FROM [1,2,3]
 ```
 
 and press `ENTER` *twice*. The output should look similar to: 
 
-```
-PartiQL> SELECT * FROM [1,2,3]
-   | 
-===' 
+```ion
 <<
   {
     '_1': 1
@@ -111,9 +108,6 @@ PartiQL> SELECT * FROM [1,2,3]
     '_1': 3
   }
 >>
---- 
-OK!
-PartiQL> 
 ```
 
 Congratulations! You successfully installed and run the PartiQL REPL.
@@ -133,19 +127,17 @@ An easy way to load the necessary data into the REPL
 is use the `-e` switch when starting the REPL
 and provide the name of a file that contains your data.
 
-
-```
+```shell
 ./bin/partiql  -e Tutorial/code/q1.env
 ```
 
 You can then see what is loaded in the REPL's global environment using
 the **special** REPL command `!global_env`, i.e.,
 
-``` 
-Welcome to the PartiQL REPL!
-PartiQL> !global_env
-   | 
-===' 
+```shell
+PartiQL> !global_env;
+```
+```ion
 {
   'hr': {
     'employees': <<
@@ -167,7 +159,4 @@ PartiQL> !global_env
     >>
   }
 }
---- 
-OK!
-
 ```


### PR DESCRIPTION
## Description of Changes
- Adds the `--input-format` flag to the CLI
- Adds the ability to handle PartiQL data format for input (before was only Ion)
- Modifies the `--input` flag for CLI to not loop through the sequence of Ion values. Expect a single Ion value. (For the Ion input format)
- Modifies the `--output-format` option ION_TEXT to output the real value of the results (not loop through the bag)
- Updates the `read_file` function to read in a single Ion value
   - Before, the `read_file` function used to loop through the values of an Ion file and place all values within a bag. This limits our ability to differentiate between different Ion values. See the next bullet-point for more information.
- Updates the `write_file` function to write the actual result.
  - Before, the `write_file` function used to loop through the values within a bag/list and print those values. This would not allow for printing expressions like literals.
- Updates the documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
