### PR TITLE
Add Equivalent Java Examples (#19)

### DIFF
--- a/examples/src/java/org/partiql/examples/CSVJavaExample.java
+++ b/examples/src/java/org/partiql/examples/CSVJavaExample.java
@@ -24,6 +24,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+/**
+ * This example executes a PartiQL query against CSV-formatted data.
+ */
 public class CSVJavaExample extends Example {
 
     public CSVJavaExample(@NotNull PrintStream out) {

--- a/examples/src/java/org/partiql/examples/EvaluationJavaExample.java
+++ b/examples/src/java/org/partiql/examples/EvaluationJavaExample.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.examples;
+
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.system.IonSystemBuilder;
+import kotlin.Unit;
+import org.jetbrains.annotations.NotNull;
+import org.partiql.examples.util.Example;
+import org.partiql.lang.CompilerPipeline;
+import org.partiql.lang.eval.Bindings;
+import org.partiql.lang.eval.EvaluationSession;
+import org.partiql.lang.eval.ExprValue;
+import org.partiql.lang.eval.Expression;
+
+import java.io.PrintStream;
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+
+/**
+ * This example demonstrates evaluating a PartiQL query against values defined in the global environment.
+ */
+public class EvaluationJavaExample extends Example {
+
+    public EvaluationJavaExample(@NotNull PrintStream out) {
+        super(out);
+    }
+
+    @Override
+    public void run() {
+
+        // A standard instance of [IonSystem], which is required by [CompilerPipeline].
+        final IonSystem ion = IonSystemBuilder.standard().build();
+
+        // An instance of [CompilerPipeline].
+        final CompilerPipeline pipeline = CompilerPipeline.standard(ion);
+
+        // Compiles a simple expression containing a reference to a global variable.
+        final String query = "'Hello, ' || user_name";
+        print("PartiQL query:", query);
+        final Expression e = pipeline.compile(query);
+
+        // This is the value of the global variable.
+        final String userName = "Homer Simpson";
+        final ExprValue usernameValue = pipeline.getValueFactory().newString(userName);
+
+        // [Bindings.ofMap] can be used to construct a [Bindings] instance of
+        // bindings with previously materialized values.
+        final Map<String, ExprValue> globals = singletonMap("user_name", usernameValue);
+        final Bindings<ExprValue> globalVariables = Bindings.ofMap(globals);
+        print("global variables:", globals);
+
+        // Include globalVariables when building the EvaluationSession.
+        final EvaluationSession session = EvaluationSession.Companion.build((builder) -> {
+            builder.globals(globalVariables);
+            return Unit.INSTANCE;
+        });
+
+        // Evaluate the compiled expression with the session containing the global variables.
+        final ExprValue result = e.eval(session);
+        print("result", result.toString());
+
+    }
+
+}

--- a/examples/src/java/org/partiql/examples/ParserJavaExample.java
+++ b/examples/src/java/org/partiql/examples/ParserJavaExample.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.examples;
+
+import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ion.system.IonTextWriterBuilder;
+import com.amazon.ionelement.api.SexpElement;
+import org.jetbrains.annotations.NotNull;
+import org.partiql.examples.util.Example;
+import org.partiql.lang.domains.PartiqlAst;
+import org.partiql.lang.syntax.SqlParser;
+
+import java.io.PrintStream;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * This example demonstrates producing a PartiQL AST from a PartiQL query.
+ */
+public class ParserJavaExample extends Example {
+
+    public ParserJavaExample(@NotNull PrintStream out) {
+        super(out);
+    }
+
+    @Override
+    public void run() {
+        // A standard instance of [IonSystem], which is required by [SqlParser].
+        final IonSystem ion = IonSystemBuilder.standard().build();
+
+        // An instance of [SqlParser].
+        final SqlParser parser = new SqlParser(ion, emptyList());
+
+        // A query in string format
+        final String query = "SELECT exampleField FROM exampleTable WHERE anotherField > 10";
+        print("PartiQL query", query);
+
+        // Use the SqlParser instance to parse the example query and get the AST as a PartiqlAst Statement.
+        final PartiqlAst.Statement ast = parser.parseAstStatement(query);
+
+        // We can transform the AST into SexpElement form to pretty print
+        final SexpElement elements = ast.toIonElement();
+
+        // Create an IonWriter to print the AST
+        final StringBuilder astString = new StringBuilder();
+        final IonWriter ionWriter = IonTextWriterBuilder.minimal().withPrettyPrinting().build(astString);
+
+        // Now use the IonWriter to write the SexpElement AST into the StringBuilder and pretty print it
+        elements.writeTo(ionWriter);
+        print("Serialized AST", astString.toString());
+
+        // We can also convert the SexpElement AST back into a PartiqlAst statement
+        final PartiqlAst.Statement roundTrippedStatement = (PartiqlAst.Statement) PartiqlAst.Companion.transform(elements);
+        // Verify that we have the original Partiql Ast statement
+        if (!ast.equals(roundTrippedStatement)) {
+            throw new RuntimeException("Expected statements to be the same");
+        }
+
+    }
+}

--- a/examples/src/java/org/partiql/examples/S3JavaExample.java
+++ b/examples/src/java/org/partiql/examples/S3JavaExample.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
 package org.partiql.examples;
 
 import com.amazon.ion.IonDatagram;
@@ -7,12 +21,10 @@ import com.amazon.ion.IonWriter;
 import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ion.system.IonSystemBuilder;
 import com.amazon.ion.system.IonTextWriterBuilder;
-
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
-
 import org.jetbrains.annotations.NotNull;
 import org.partiql.examples.util.Example;
 import org.partiql.lang.CompilerPipeline;
@@ -24,9 +36,12 @@ import org.partiql.lang.eval.Expression;
 import java.io.IOException;
 import java.io.PrintStream;
 
-public class S3Example extends Example {
+/**
+ * This example executes a PartiQL query against ION data stored as an object in S3.
+ */
+public class S3JavaExample extends Example {
 
-    public S3Example(@NotNull PrintStream out) {
+    public S3JavaExample(@NotNull PrintStream out) {
         super(out);
     }
 

--- a/examples/src/kotlin/org/partiql/examples/EvaluationWithBindings.kt
+++ b/examples/src/kotlin/org/partiql/examples/EvaluationWithBindings.kt
@@ -24,8 +24,9 @@ class EvaluationWithBindings(out: PrintStream) : Example(out) {
 
         // [Bindings.ofMap] can be used to construct a [Bindings] instance of
         // bindings with previously materialized values.
-        val globalVariables = Bindings.ofMap(mapOf("user_name" to usernameValue))
-        print("global variables:", "user_name => userName")
+        val globals = mapOf("user_name" to usernameValue)
+        val globalVariables = Bindings.ofMap(globals)
+        print("global variables:", globals)
 
         // Include globalVariables when building the EvaluationSession.
         val session = EvaluationSession.build { globals(globalVariables) }

--- a/examples/src/kotlin/org/partiql/examples/util/Example.kt
+++ b/examples/src/kotlin/org/partiql/examples/util/Example.kt
@@ -17,4 +17,13 @@ abstract class Example(val out: PrintStream) {
         out.println(label)
         out.println("    ${data.replace("\n", "\n    ")}")
     }
+
+    fun print(label: String, bindings: Map<String, ExprValue>) {
+        val data = buildString {
+            bindings.forEach { (k, v) ->
+                append(k).append(" => ").append(v).append('\n')
+            }
+        }.trimEnd()
+        print(label, data)
+    }
 }

--- a/examples/src/kotlin/org/partiql/examples/util/Main.kt
+++ b/examples/src/kotlin/org/partiql/examples/util/Main.kt
@@ -6,13 +6,15 @@ import org.partiql.examples.CSVJavaExample
 import org.partiql.examples.CsvExprValueExample
 import org.partiql.examples.CustomFunctionsExample
 import org.partiql.examples.CustomProceduresExample
+import org.partiql.examples.EvaluationJavaExample
 import org.partiql.examples.EvaluationWithBindings
 import org.partiql.examples.EvaluationWithLazyBindings
 import org.partiql.examples.ParserErrorExample
 import org.partiql.examples.ParserExample
+import org.partiql.examples.ParserJavaExample
 import org.partiql.examples.PartialEvaluationVisitorTransformExample
 import org.partiql.examples.PreventJoinVisitorExample
-import org.partiql.examples.S3Example
+import org.partiql.examples.S3JavaExample
 import org.partiql.examples.SimpleExpressionEvaluation
 import java.io.PrintStream
 import java.lang.RuntimeException
@@ -20,7 +22,9 @@ import java.lang.RuntimeException
 private val examples = mapOf(
     // Java Examples
     CSVJavaExample::class.java.simpleName to CSVJavaExample(System.out),
-    S3Example::class.java.simpleName to S3Example(System.out),
+    S3JavaExample::class.java.simpleName to S3JavaExample(System.out),
+    EvaluationJavaExample::class.java.simpleName to EvaluationJavaExample(System.out),
+    ParserJavaExample::class.java.simpleName to ParserJavaExample(System.out),
 
     // Kotlin Examples
     CsvExprValueExample::class.java.simpleName to CsvExprValueExample(System.out),

--- a/examples/test/org/partiql/examples/EvaluationJavaExampleTest.kt
+++ b/examples/test/org/partiql/examples/EvaluationJavaExampleTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.examples
+
+import org.partiql.examples.util.Example
+import java.io.PrintStream
+
+class EvaluationJavaExampleTest : BaseExampleTest() {
+    override fun example(out: PrintStream): Example = EvaluationJavaExample(out)
+
+    override val expected = """
+        |PartiQL query:
+        |    'Hello, ' || user_name
+        |global variables:
+        |    user_name => 'Homer Simpson'
+        |result
+        |    'Hello, Homer Simpson'
+        |
+    """.trimMargin()
+}

--- a/examples/test/org/partiql/examples/EvaluationWithBindingsTest.kt
+++ b/examples/test/org/partiql/examples/EvaluationWithBindingsTest.kt
@@ -10,7 +10,7 @@ class EvaluationWithBindingsTest : BaseExampleTest() {
         |PartiQL query:
         |    'Hello, ' || user_name
         |global variables:
-        |    user_name => userName
+        |    user_name => 'Homer Simpson'
         |result
         |    'Hello, Homer Simpson'
         |

--- a/examples/test/org/partiql/examples/ParserJavaExampleTest.kt
+++ b/examples/test/org/partiql/examples/ParserJavaExampleTest.kt
@@ -1,0 +1,80 @@
+package org.partiql.examples
+
+import org.partiql.examples.util.Example
+import java.io.PrintStream
+
+class ParserJavaExampleTest : BaseExampleTest() {
+    override fun example(out: PrintStream): Example = ParserJavaExample(out)
+
+    override val expected =
+"""PartiQL query
+    SELECT exampleField FROM exampleTable WHERE anotherField > 10
+Serialized AST
+    
+    (
+      query
+      (
+        select
+        (
+          project
+          (
+            project_list
+            (
+              project_expr
+              (
+                id
+                exampleField
+                (
+                  case_insensitive
+                )
+                (
+                  unqualified
+                )
+              )
+              null
+            )
+          )
+        )
+        (
+          from
+          (
+            scan
+            (
+              id
+              exampleTable
+              (
+                case_insensitive
+              )
+              (
+                unqualified
+              )
+            )
+            null
+            null
+            null
+          )
+        )
+        (
+          where
+          (
+            gt
+            (
+              id
+              anotherField
+              (
+                case_insensitive
+              )
+              (
+                unqualified
+              )
+            )
+            (
+              lit
+              10
+            )
+          )
+        )
+      )
+    )
+"""
+}


### PR DESCRIPTION
https://github.com/partiql/partiql-lang-kotlin/issues/19

*Description of changes:*
Adds an equivalent java example for ParserExample and EvaluationWithBindings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
