### PR TITLE
[DRAFT/EXPERIMENT] Add ability to specify custom operator "mini-compilers"

### DIFF
--- a/lang/src/org/partiql/lang/eval/physical/EvaluatorState.kt
+++ b/lang/src/org/partiql/lang/eval/physical/EvaluatorState.kt
@@ -24,12 +24,21 @@ import org.partiql.lang.eval.ExprValue
  * Since the elements of [registers] are mutable, when/if we decide to make query execution multi-threaded, we'll have
  * to take care to not share [EvaluatorState] instances among different threads.
  *
+ * This class must be public because it has to be accessible to custom physical operator implementations.
+ *
  * @param session The evaluation session.
  * @param registers An array of registers containing [ExprValue]s needed during query execution.  Generally, there is
  * one register per local variable.  This is an array (and not a [List]) because its semantics match exactly what we
  * need: fixed length but mutable elements.
  */
-internal class EvaluatorState(
+class EvaluatorState(
     val session: EvaluationSession,
-    val registers: Array<ExprValue>
+    /**
+     * The current state of all variables during query execution.  This is marked as `internal` because there is no
+     * reasonable use-case for applications embedding PartiQL to either read or write directly to this state.  Doing
+     * so is very dangerous. Modification of this state by applications embedding PartiQL should be considered
+     * prohibited, except through [org.partiql.lang.eval.physical.SetVariableFunc] arguments to certain custom physical
+     * operators.
+     */
+    internal val registers: Array<ExprValue>
 )

--- a/lang/src/org/partiql/lang/eval/physical/PhysicalBexprToThunkConverter.kt
+++ b/lang/src/org/partiql/lang/eval/physical/PhysicalBexprToThunkConverter.kt
@@ -1,335 +1,63 @@
 package org.partiql.lang.eval.physical
 
-import com.amazon.ionelement.api.BoolElement
-import com.amazon.ionelement.api.MetaContainer
 import org.partiql.lang.domains.PartiqlPhysical
-import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
-import org.partiql.lang.eval.ExprValueType
 import org.partiql.lang.eval.Thunk
 import org.partiql.lang.eval.ThunkValue
-import org.partiql.lang.eval.address
-import org.partiql.lang.eval.booleanValue
-import org.partiql.lang.eval.isUnknown
-import org.partiql.lang.eval.name
-import org.partiql.lang.eval.relation.RelationIterator
-import org.partiql.lang.eval.relation.RelationScope
-import org.partiql.lang.eval.relation.RelationType
-import org.partiql.lang.eval.relation.relation
-import org.partiql.lang.eval.sourceLocationMeta
-import org.partiql.lang.eval.unnamedValue
-import org.partiql.lang.util.toIntExact
+import org.partiql.lang.eval.physical.operators.DEFAULT_OPERATOR_COMPILERS
+import org.partiql.lang.eval.physical.operators.ThunkConverter
 
-private val DEFAULT_IMPL = PartiqlPhysical.build { impl("default") }
+// DL TOOD: relocate this--doesn't really belong here anymore.
+const val DEFAULT_IMPL_NAME = "default"
 
-/** A specialization of [Thunk] that we use for evaluation of physical plans. */
-internal typealias PhysicalPlanThunk = Thunk<EvaluatorState>
+/** A specialization of [Thunk] that we use for evaluation of value expressions physical plans. */
+typealias ExprThunkEnv = Thunk<EvaluatorState>
 
 /** A specialization of [ThunkValue] that we use for evaluation of physical plans. */
-internal typealias PhysicalPlanThunkValue<T> = ThunkValue<EvaluatorState, T>
+internal typealias ExprThunkValue<T> = ThunkValue<EvaluatorState, T>
 
 internal class PhysicalBexprToThunkConverter(
     private val exprConverter: PhysicalExprToThunkConverter,
     private val valueFactory: ExprValueFactory,
 ) : PartiqlPhysical.Bexpr.Converter<RelationThunkEnv> {
 
-    private fun blockNonDefaultImpl(i: PartiqlPhysical.Impl) {
-        if (i != DEFAULT_IMPL) {
-            TODO("Support non-default operator implementations")
-        }
+    // DL TODO: make constructor argument.
+    private val operators = DEFAULT_OPERATOR_COMPILERS
+
+    private val compiler = object : ThunkConverter {
+        override fun compile(bexpr: PartiqlPhysical.Bexpr): RelationThunkEnv =
+            this@PhysicalBexprToThunkConverter.convert(bexpr)
+
+        override fun compile(expr: PartiqlPhysical.Expr): ExprThunkEnv =
+            this@PhysicalBexprToThunkConverter.exprConverter.convert(expr)
     }
 
-    override fun convertProject(node: PartiqlPhysical.Bexpr.Project): RelationThunkEnv {
-        TODO("not implemented")
-    }
-
-    override fun convertScan(node: PartiqlPhysical.Bexpr.Scan): RelationThunkEnv {
-        blockNonDefaultImpl(node.i)
-
-        val exprThunk = exprConverter.convert(node.expr)
-        val asIndex = node.asDecl.index.value.toIntExact()
-        val atIndex = node.atDecl?.index?.value?.toIntExact() ?: -1
-        val byIndex = node.byDecl?.index?.value?.toIntExact() ?: -1
-
-        return relationThunk(node.metas) { env ->
-            val valueToScan = exprThunk.invoke(env)
-
-            // coerces non-collection types to a singleton Sequence<>.
-            val rows: Sequence<ExprValue> = when (valueToScan.type) {
-                ExprValueType.LIST, ExprValueType.BAG -> valueToScan.asSequence()
-                else -> sequenceOf(valueToScan)
-            }
-
-            relation(RelationType.BAG) {
-                var rowsIter: Iterator<ExprValue> = rows.iterator()
-                while (rowsIter.hasNext()) {
-                    val item = rowsIter.next()
-                    env.registers[asIndex] = item.unnamedValue() // Remove any ordinal (output is a bag)
-
-                    if (atIndex >= 0) {
-                        env.registers[atIndex] = item.name ?: valueFactory.missingValue
-                    }
-
-                    if (byIndex >= 0) {
-                        env.registers[byIndex] = item.address ?: valueFactory.missingValue
-                    }
-                    yield()
-                }
-            }
-        }
-    }
-
-    override fun convertFilter(node: PartiqlPhysical.Bexpr.Filter): RelationThunkEnv {
-        blockNonDefaultImpl(node.i)
-
-        val predicateThunk = exprConverter.convert(node.predicate)
-        val sourceThunk = this.convert(node.source)
-
-        return relationThunk(node.metas) { env ->
-            val sourceToFilter = sourceThunk(env)
-            createFilterRelItr(sourceToFilter, predicateThunk, env)
-        }
-    }
-
-    override fun convertJoin(node: PartiqlPhysical.Bexpr.Join): RelationThunkEnv {
-        blockNonDefaultImpl(node.i)
-
-        val leftThunk = this.convert(node.left)
-        val rightThunk = this.convert(node.right)
-        val predicateThunk = node.predicate?.let { exprConverter.convert(it).takeIf { !node.predicate.isLitTrue() } }
-
-        return when (node.joinType) {
-            is PartiqlPhysical.JoinType.Inner -> {
-                createInnerJoinThunk(node.metas, leftThunk, rightThunk, predicateThunk)
-            }
-            is PartiqlPhysical.JoinType.Left -> {
-                val rightVariableIndexes = node.right.extractAccessibleVarDecls().map { it.index.value.toIntExact() }
-                createLeftJoinThunk(
-                    joinMetas = node.metas,
-                    leftThunk = leftThunk,
-                    rightThunk = rightThunk,
-                    rightVariableIndexes = rightVariableIndexes,
-                    predicateThunk = predicateThunk
-                )
-            }
-            is PartiqlPhysical.JoinType.Right -> {
-                // Note that this is the same as the left join but the right and left sides are swapped.
-                val leftVariableIndexes = node.left.extractAccessibleVarDecls().map { it.index.value.toIntExact() }
-                createLeftJoinThunk(
-                    joinMetas = node.metas,
-                    leftThunk = rightThunk,
-                    rightThunk = leftThunk,
-                    rightVariableIndexes = leftVariableIndexes,
-                    predicateThunk = predicateThunk
-                )
-            }
-            is PartiqlPhysical.JoinType.Full -> TODO("Full join")
-        }
-    }
-
-    private fun createInnerJoinThunk(
-        joinMetas: MetaContainer,
-        leftThunk: RelationThunkEnv,
-        rightThunk: RelationThunkEnv,
-        predicateThunk: PhysicalPlanThunk?
-    ) = if (predicateThunk == null) {
-        relationThunk(joinMetas) { env ->
-            createCrossJoinRelItr(leftThunk, rightThunk, env)
-        }
-    } else {
-        relationThunk(joinMetas) { env ->
-            val crossJoinRelItr = createCrossJoinRelItr(leftThunk, rightThunk, env)
-            createFilterRelItr(crossJoinRelItr, predicateThunk, env)
-        }
-    }
-
-    private fun createCrossJoinRelItr(
-        leftThunk: RelationThunkEnv,
-        rightThunk: RelationThunkEnv,
-        env: EvaluatorState
-    ): RelationIterator {
-        return relation(RelationType.BAG) {
-            val leftItr = leftThunk(env)
-            while (leftItr.nextRow()) {
-                val rightItr = rightThunk(env)
-                while (rightItr.nextRow()) {
-                    yield()
-                }
-            }
-        }
-    }
-
-    private fun createLeftJoinThunk(
-        joinMetas: MetaContainer,
-        leftThunk: RelationThunkEnv,
-        rightThunk: RelationThunkEnv,
-        rightVariableIndexes: List<Int>,
-        predicateThunk: PhysicalPlanThunk?
+    private fun <T : PartiqlPhysical.Bexpr> compileOperator(
+        implementationName: String,
+        operatorClass: Class<T>,
+        node: T
     ) =
-        relationThunk(joinMetas) { env ->
-            createLeftJoinRelItr(leftThunk, rightThunk, rightVariableIndexes, predicateThunk, env)
-        }
+        operators.getOperator(implementationName, operatorClass)
+            .compile(node, compiler, valueFactory)
 
-    /**
-     * Like [createCrossJoinRelItr], but the right-hand relation is padded with unknown values in the event
-     * that it is empty or that the predicate does not match.
-     */
-    private fun createLeftJoinRelItr(
-        leftThunk: RelationThunkEnv,
-        rightThunk: RelationThunkEnv,
-        rightVariableIndexes: List<Int>,
-        predicateThunk: PhysicalPlanThunk?,
-        env: EvaluatorState
-    ): RelationIterator {
-        return if (predicateThunk == null) {
-            relation(RelationType.BAG) {
-                val leftItr = leftThunk(env)
-                while (leftItr.nextRow()) {
-                    val rightItr = rightThunk(env)
-                    // if the rightItr does has a row...
-                    if (rightItr.nextRow()) {
-                        yield() // yield current row
-                        yieldAll(rightItr) // yield remaining rows
-                    } else {
-                        // no row--yield padded row
-                        yieldPaddedUnknowns(rightVariableIndexes, env)
-                    }
-                }
-            }
-        } else {
-            relation(RelationType.BAG) {
-                val leftItr = leftThunk(env)
-                while (leftItr.nextRow()) {
-                    val rightItr = rightThunk(env)
-                    var yieldedSomething = false
-                    while (rightItr.nextRow()) {
-                        if (coercePredicateResult(predicateThunk(env))) {
-                            yield()
-                            yieldedSomething = true
-                        }
-                    }
-                    // If we still haven't yielded anything, we still need to emit a row with right-hand side variables
-                    // padded with unknowns.
-                    if (!yieldedSomething) {
-                        yieldPaddedUnknowns(rightVariableIndexes, env)
-                    }
-                }
-            }
-        }
-    }
+    override fun convertProject(node: PartiqlPhysical.Bexpr.Project): RelationThunkEnv =
+        compileOperator(node.i.name.text, PartiqlPhysical.Bexpr.Project::class.java, node)
 
-    private suspend fun RelationScope.yieldPaddedUnknowns(
-        rightVariableIndexes: List<Int>,
-        env: EvaluatorState
-    ) {
-        rightVariableIndexes.forEach { env.registers[it] = valueFactory.nullValue }
-        yield()
-    }
+    override fun convertScan(node: PartiqlPhysical.Bexpr.Scan): RelationThunkEnv =
+        compileOperator(node.i.name.text, PartiqlPhysical.Bexpr.Scan::class.java, node)
 
-    private fun PartiqlPhysical.Bexpr.extractAccessibleVarDecls(): List<PartiqlPhysical.VarDecl> =
-        // This fold traverses a [PartiqlPhysical.Bexpr] node and extracts all variable declarations within
-        // It avoids recursing into sub-queries.
-        object : PartiqlPhysical.VisitorFold<List<PartiqlPhysical.VarDecl>>() {
-            override fun visitVarDecl(
-                node: PartiqlPhysical.VarDecl,
-                accumulator: List<PartiqlPhysical.VarDecl>
-            ): List<PartiqlPhysical.VarDecl> = accumulator + node
+    override fun convertFilter(node: PartiqlPhysical.Bexpr.Filter): RelationThunkEnv =
+        compileOperator(node.i.name.text, PartiqlPhysical.Bexpr.Filter::class.java, node)
 
-            /**
-             * Avoids recursion into expressions, since these may contain sub-queries with other var-decls that we don't
-             * care about here.
-             */
-            override fun walkExpr(
-                node: PartiqlPhysical.Expr,
-                accumulator: List<PartiqlPhysical.VarDecl>
-            ): List<PartiqlPhysical.VarDecl> {
-                return accumulator
-            }
-        }.walkBexpr(this, emptyList())
+    override fun convertJoin(node: PartiqlPhysical.Bexpr.Join): RelationThunkEnv =
+        compileOperator(node.i.name.text, PartiqlPhysical.Bexpr.Join::class.java, node)
 
-    private fun createFilterRelItr(
-        relItr: RelationIterator,
-        predicateThunk: PhysicalPlanThunk,
-        env: EvaluatorState
-    ) = relation(RelationType.BAG) {
-        while (true) {
-            if (!relItr.nextRow()) {
-                break
-            } else {
-                val matches = predicateThunk(env)
-                if (coercePredicateResult(matches)) {
-                    yield()
-                }
-            }
-        }
-    }
+    override fun convertOffset(node: PartiqlPhysical.Bexpr.Offset): RelationThunkEnv =
+        compileOperator(node.i.name.text, PartiqlPhysical.Bexpr.Offset::class.java, node)
 
-    private fun coercePredicateResult(value: ExprValue): Boolean =
-        when {
-            value.isUnknown() -> false
-            else -> value.booleanValue() // <-- throws if [value] is not a boolean.
-        }
+    override fun convertLimit(node: PartiqlPhysical.Bexpr.Limit): RelationThunkEnv =
+        compileOperator(node.i.name.text, PartiqlPhysical.Bexpr.Limit::class.java, node)
 
-    override fun convertOffset(node: PartiqlPhysical.Bexpr.Offset): RelationThunkEnv {
-        val rowCountThunk = exprConverter.convert(node.rowCount)
-        val sourceThunk = this.convert(node.source)
-        val rowCountLocation = node.rowCount.metas.sourceLocationMeta
-        return relationThunk(node.metas) { env ->
-            val skipCount: Long = evalOffsetRowCount(rowCountThunk, env, rowCountLocation)
-            relation(RelationType.BAG) {
-                val sourceRel = sourceThunk(env)
-                var rowCount = 0L
-                while (rowCount++ < skipCount) {
-                    // stop iterating if we finish run out of rows before we hit the offset.
-                    if (!sourceRel.nextRow()) {
-                        return@relation
-                    }
-                }
-
-                yieldAll(sourceRel)
-            }
-        }
-    }
-
-    override fun convertLimit(node: PartiqlPhysical.Bexpr.Limit): RelationThunkEnv {
-        val rowCountThunk = exprConverter.convert(node.rowCount)
-        val sourceThunk = this.convert(node.source)
-        val rowCountLocation = node.rowCount.metas.sourceLocationMeta
-        return relationThunk(node.metas) { env ->
-            val limitCount = evalLimitRowCount(rowCountThunk, env, rowCountLocation)
-            val rowIter = sourceThunk(env)
-            relation(RelationType.BAG) {
-                var rowCount = 0L
-                while (rowCount++ < limitCount && rowIter.nextRow()) {
-                    yield()
-                }
-            }
-        }
-    }
-
-    override fun convertLet(node: PartiqlPhysical.Bexpr.Let): RelationThunkEnv {
-        val sourceThunk = this.convert(node.source)
-        class CompiledBinding(val index: Int, val valueThunk: PhysicalPlanThunk)
-        val compiledBindings = node.bindings.map {
-            CompiledBinding(
-                it.decl.index.value.toIntExact(),
-                exprConverter.convert(it.value)
-            )
-        }
-        return relationThunk(node.metas) { env ->
-            val sourceItr = sourceThunk(env)
-
-            relation(sourceItr.relType) {
-                while (sourceItr.nextRow()) {
-                    compiledBindings.forEach {
-                        env.registers[it.index] = it.valueThunk(env)
-                    }
-                    yield()
-                }
-            }
-        }
-    }
+    override fun convertLet(node: PartiqlPhysical.Bexpr.Let): RelationThunkEnv =
+        compileOperator(node.i.name.text, PartiqlPhysical.Bexpr.Let::class.java, node)
 }
-
-private fun PartiqlPhysical.Expr.isLitTrue() =
-    this is PartiqlPhysical.Expr.Lit && this.value is BoolElement && this.value.booleanValue

--- a/lang/src/org/partiql/lang/eval/physical/PhysicalExprToThunkConverter.kt
+++ b/lang/src/org/partiql/lang/eval/physical/PhysicalExprToThunkConverter.kt
@@ -3,11 +3,11 @@ package org.partiql.lang.eval.physical
 import org.partiql.lang.domains.PartiqlPhysical
 
 /**
- * Simple API that defines a method to convert a [PartiqlPhysical.Expr] to a [PhysicalPlanThunk].
+ * Simple API that defines a method to convert a [PartiqlPhysical.Expr] to a [ExprThunkEnv].
  *
  * Intended to prevent [PhysicalBexprToThunkConverter] from having to take a direct dependency on
  * [org.partiql.lang.eval.EvaluatingCompiler].
  */
 internal interface PhysicalExprToThunkConverter {
-    fun convert(expr: PartiqlPhysical.Expr): PhysicalPlanThunk
+    fun convert(expr: PartiqlPhysical.Expr): ExprThunkEnv
 }

--- a/lang/src/org/partiql/lang/eval/physical/RelationThunk.kt
+++ b/lang/src/org/partiql/lang/eval/physical/RelationThunk.kt
@@ -11,7 +11,7 @@ import org.partiql.lang.eval.fillErrorContext
 import org.partiql.lang.eval.relation.RelationIterator
 
 /** A thunk that returns a [RelationIterator], which is the result of evaluating a relational operator. */
-internal typealias RelationThunkEnv = (EvaluatorState) -> RelationIterator
+typealias RelationThunkEnv = (EvaluatorState) -> RelationIterator
 
 /**
  * Invokes [t] with error handling like is supplied by [ThunkFactory].
@@ -19,7 +19,7 @@ internal typealias RelationThunkEnv = (EvaluatorState) -> RelationIterator
  * This function is not currently in [ThunkFactory] to avoid complicating it further.  If a need arises, it could be
  * moved.
  */
-internal inline fun relationThunk(metas: MetaContainer, crossinline t: RelationThunkEnv): RelationThunkEnv {
+inline fun relationThunk(metas: MetaContainer, crossinline t: RelationThunkEnv): RelationThunkEnv {
     val sourceLocationMeta = metas[SourceLocationMeta.TAG] as? SourceLocationMeta
     return { env: EvaluatorState ->
         try {

--- a/lang/src/org/partiql/lang/eval/physical/SetVariableFunc.kt
+++ b/lang/src/org/partiql/lang/eval/physical/SetVariableFunc.kt
@@ -1,0 +1,39 @@
+package org.partiql.lang.eval.physical
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.util.toIntExact
+
+/**
+ * Sets the value of a variable which is stored in an [EvaluatorState].
+ *
+ * To obtain an instance of [SetVariableFunc] that sets a specific variable, see [toSetVariableFunc].
+ *
+ * [EvaluatorState.registers] contains the current value of all variables in an SFW query.  As such, allowing
+ * direct access to the registers is very risky--for example, if the wrong register is set the query will have
+ * the incorrect result or trigger an evaluation-time exception.
+ *
+ * To mitigate this risk, [EvaluatorState.registers] is set to `internal` to avoid exposing it publicly and
+ * [SetVariableFunc] is provided.
+ *
+ * Parameters:
+ *
+ * - [EvaluatorState] - The object containing the current state of the evaluator and current values of the variables.
+ * - [ExprValue] - The value to set.
+ */
+typealias SetVariableFunc = (EvaluatorState, ExprValue) -> Unit
+
+/**
+ * Creates a [SetVariableFunc] tied to the variable identified in the [PartiqlPhysical.VarDecl] receiver object that
+ * can be used to set the value of the variable at evaluation time.  This method is considerably safer than direct
+ * access to the [EvaluatorState.registers] array, which is marked as `internal` to reduce the likelihood of being
+ * clobbered by custom operator implementations.
+ *
+ * Of course, it is still possible to circumvent this safety by constructing [PartiqlPhysical.VarDecl] with an
+ * arbitrary index, but doing this in a way that avoids introducing evaluation-time bugs could be challenging.  In
+ * general, it is safest to not manipulate register indexes assigned to [PartiqlPhysical.VarDecl] by the query planner
+ * (the [org.partiql.lang.planner.transforms.LogicalToLogicalResolvedVisitorTransform] pass specifically).  If these
+ * index values must be manipulated, it must be done with extreme care and thorough testing.
+ */
+fun PartiqlPhysical.VarDecl.toSetVariableFunc(): SetVariableFunc =
+    { state, value -> state.registers[this.index.value.toIntExact()] = value }

--- a/lang/src/org/partiql/lang/eval/physical/operators/DefaultOperatorCompilers.kt
+++ b/lang/src/org/partiql/lang/eval/physical/operators/DefaultOperatorCompilers.kt
@@ -1,0 +1,298 @@
+package org.partiql.lang.eval.physical.operators
+
+import coercePredicateResult
+import com.amazon.ionelement.api.BoolElement
+import com.amazon.ionelement.api.MetaContainer
+import createFilterRelItr
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.ExprValueType
+import org.partiql.lang.eval.address
+import org.partiql.lang.eval.name
+import org.partiql.lang.eval.physical.DEFAULT_IMPL_NAME
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.physical.ExprThunkEnv
+import org.partiql.lang.eval.physical.RelationThunkEnv
+import org.partiql.lang.eval.physical.evalLimitRowCount
+import org.partiql.lang.eval.physical.evalOffsetRowCount
+import org.partiql.lang.eval.physical.relationThunk
+import org.partiql.lang.eval.physical.toSetVariableFunc
+import org.partiql.lang.eval.relation.RelationIterator
+import org.partiql.lang.eval.relation.RelationScope
+import org.partiql.lang.eval.relation.RelationType
+import org.partiql.lang.eval.relation.relation
+import org.partiql.lang.eval.sourceLocationMeta
+import org.partiql.lang.eval.unnamedValue
+import org.partiql.lang.util.toIntExact
+
+// DL TODO: terminology everywhere.  For instance, I don't know if I like the term operator "compiler" applied here
+
+val DEFAULT_OPERATOR_COMPILERS = OperatorCompilerCatalog(
+    listOf(
+        createPhysicalOperatorCompiler<PartiqlPhysical.Bexpr.Scan>(DEFAULT_IMPL_NAME) { node, compiler, valueFactory ->
+            val exprThunk = compiler.compile(node.expr)
+
+            val asIndexSetter = node.asDecl.toSetVariableFunc()
+            val atIndexSetter = node.atDecl?.toSetVariableFunc()
+            val byIndexSetter = node.byDecl?.toSetVariableFunc()
+
+            relationThunk(node.metas) { state ->
+                val valueToScan = exprThunk.invoke(state)
+
+                // coerces non-collection types to a singleton Sequence<>.
+                val rows: Sequence<ExprValue> = when (valueToScan.type) {
+                    ExprValueType.LIST, ExprValueType.BAG -> valueToScan.asSequence()
+                    else -> sequenceOf(valueToScan)
+                }
+
+                relation(RelationType.BAG) {
+                    val rowsIter: Iterator<ExprValue> = rows.iterator()
+                    while (rowsIter.hasNext()) {
+                        val item = rowsIter.next()
+
+                        // Note that although we could access [EvaluatorState.registers] directly within relationThunk,
+                        // we don't as a means to demonstrate the proper way that custom operator implementations should
+                        // set the values of variables.  See [toSetFunc] and [SetVarFunc] for more info.
+                        asIndexSetter(state, item.unnamedValue()) // Remove any ordinal (output is a bag)
+
+                        if (atIndexSetter != null) {
+                            atIndexSetter(state, item.name ?: valueFactory.missingValue)
+                        }
+
+                        if (byIndexSetter != null) {
+                            byIndexSetter(state, item.address ?: valueFactory.missingValue)
+                        }
+                        yield()
+                    }
+                }
+            }
+        },
+        createPhysicalOperatorCompiler<PartiqlPhysical.Bexpr.Filter>(DEFAULT_IMPL_NAME) { node, compiler, _ ->
+            val predicateThunk = compiler.compile(node.predicate)
+            val sourceThunk = compiler.compile(node.source)
+
+            relationThunk(node.metas) { env ->
+                val sourceToFilter = sourceThunk(env)
+                createFilterRelItr(sourceToFilter, predicateThunk, env)
+            }
+        },
+        createPhysicalOperatorCompiler<PartiqlPhysical.Bexpr.Join>(DEFAULT_IMPL_NAME) { node, compiler, valueFactory ->
+            val leftThunk = compiler.compile(node.left)
+            val rightThunk = compiler.compile(node.right)
+            val predicateThunk = node.predicate?.let { compiler.compile(it).takeIf { !node.predicate.isLitTrue() } }
+
+            when (node.joinType) {
+                is PartiqlPhysical.JoinType.Inner -> {
+                    createInnerJoinThunk(node.metas, leftThunk, rightThunk, predicateThunk)
+                }
+                is PartiqlPhysical.JoinType.Left -> {
+                    val rightVariableIndexes = node.right.extractAccessibleVarDecls().map { it.index.value.toIntExact() }
+                    createLeftJoinThunk(
+                        joinMetas = node.metas,
+                        leftThunk = leftThunk,
+                        rightThunk = rightThunk,
+                        rightVariableIndexes = rightVariableIndexes,
+                        predicateThunk = predicateThunk,
+                        valueFactory = valueFactory
+                    )
+                }
+                is PartiqlPhysical.JoinType.Right -> {
+                    // Note that this is the same as the left join but the right and left sides are swapped.
+                    val leftVariableIndexes = node.left.extractAccessibleVarDecls().map { it.index.value.toIntExact() }
+                    createLeftJoinThunk(
+                        joinMetas = node.metas,
+                        leftThunk = rightThunk,
+                        rightThunk = leftThunk,
+                        rightVariableIndexes = leftVariableIndexes,
+                        predicateThunk = predicateThunk,
+                        valueFactory = valueFactory
+                    )
+                }
+                is PartiqlPhysical.JoinType.Full -> TODO("Full join")
+            }
+        },
+        createPhysicalOperatorCompiler<PartiqlPhysical.Bexpr.Offset>(DEFAULT_IMPL_NAME) { node, compiler, _ ->
+            val rowCountThunk = compiler.compile(node.rowCount)
+            val sourceThunk = compiler.compile(node.source)
+            val rowCountLocation = node.rowCount.metas.sourceLocationMeta
+            relationThunk(node.metas) { env ->
+                val skipCount: Long = evalOffsetRowCount(rowCountThunk, env, rowCountLocation)
+                relation(RelationType.BAG) {
+                    val sourceRel = sourceThunk(env)
+                    var rowCount = 0L
+                    while (rowCount++ < skipCount) {
+                        // stop iterating if we finish run out of rows before we hit the offset.
+                        if (!sourceRel.nextRow()) {
+                            return@relation
+                        }
+                    }
+                    yieldAll(sourceRel)
+                }
+            }
+        },
+        createPhysicalOperatorCompiler<PartiqlPhysical.Bexpr.Limit>(DEFAULT_IMPL_NAME) { node, compiler, _ ->
+            val rowCountThunk = compiler.compile(node.rowCount)
+            val sourceThunk = compiler.compile(node.source)
+            val rowCountLocation = node.rowCount.metas.sourceLocationMeta
+            relationThunk(node.metas) { env ->
+                val limitCount = evalLimitRowCount(rowCountThunk, env, rowCountLocation)
+                val rowIter = sourceThunk(env)
+                relation(RelationType.BAG) {
+                    var rowCount = 0L
+                    while (rowCount++ < limitCount && rowIter.nextRow()) {
+                        yield()
+                    }
+                }
+            }
+        },
+        createPhysicalOperatorCompiler<PartiqlPhysical.Bexpr.Let>(DEFAULT_IMPL_NAME) { node, compiler, _ ->
+            val sourceThunk = compiler.compile(node.source)
+            class CompiledBinding(val index: Int, val valueThunk: ExprThunkEnv)
+            val compiledBindings = node.bindings.map {
+                CompiledBinding(
+                    it.decl.index.value.toIntExact(),
+                    compiler.compile(it.value)
+                )
+            }
+            relationThunk(node.metas) { env ->
+                val sourceItr = sourceThunk(env)
+
+                relation(sourceItr.relType) {
+                    while (sourceItr.nextRow()) {
+                        compiledBindings.forEach {
+                            env.registers[it.index] = it.valueThunk(env)
+                        }
+                        yield()
+                    }
+                }
+            }
+        }
+    )
+) // end of default operator implementations
+
+private fun createInnerJoinThunk(
+    joinMetas: MetaContainer,
+    leftThunk: RelationThunkEnv,
+    rightThunk: RelationThunkEnv,
+    predicateThunk: ExprThunkEnv?
+) = if (predicateThunk == null) {
+    relationThunk(joinMetas) { env ->
+        createCrossJoinRelItr(leftThunk, rightThunk, env)
+    }
+} else {
+    relationThunk(joinMetas) { env ->
+        val crossJoinRelItr = createCrossJoinRelItr(leftThunk, rightThunk, env)
+        createFilterRelItr(crossJoinRelItr, predicateThunk, env)
+    }
+}
+
+private fun createCrossJoinRelItr(
+    leftThunk: RelationThunkEnv,
+    rightThunk: RelationThunkEnv,
+    env: EvaluatorState
+): RelationIterator {
+    return relation(RelationType.BAG) {
+        val leftItr = leftThunk(env)
+        while (leftItr.nextRow()) {
+            val rightItr = rightThunk(env)
+            while (rightItr.nextRow()) {
+                yield()
+            }
+        }
+    }
+}
+
+private fun createLeftJoinThunk(
+    joinMetas: MetaContainer,
+    leftThunk: RelationThunkEnv,
+    rightThunk: RelationThunkEnv,
+    rightVariableIndexes: List<Int>,
+    predicateThunk: ExprThunkEnv?,
+    valueFactory: ExprValueFactory
+) =
+    relationThunk(joinMetas) { env ->
+        createLeftJoinRelItr(leftThunk, rightThunk, rightVariableIndexes, predicateThunk, env, valueFactory)
+    }
+
+/**
+ * Like [createCrossJoinRelItr], but the right-hand relation is padded with unknown values in the event
+ * that it is empty or that the predicate does not match.
+ */
+private fun createLeftJoinRelItr(
+    leftThunk: RelationThunkEnv,
+    rightThunk: RelationThunkEnv,
+    rightVariableIndexes: List<Int>,
+    predicateThunk: ExprThunkEnv?,
+    state: EvaluatorState,
+    valueFactory: ExprValueFactory
+): RelationIterator {
+    return if (predicateThunk == null) {
+        relation(RelationType.BAG) {
+            val leftItr = leftThunk(state)
+            while (leftItr.nextRow()) {
+                val rightItr = rightThunk(state)
+                // if the rightItr does has a row...
+                if (rightItr.nextRow()) {
+                    yield() // yield current row
+                    yieldAll(rightItr) // yield remaining rows
+                } else {
+                    // no row--yield padded row
+                    yieldPaddedUnknowns(rightVariableIndexes, state, valueFactory)
+                }
+            }
+        }
+    } else {
+        relation(RelationType.BAG) {
+            val leftItr = leftThunk(state)
+            while (leftItr.nextRow()) {
+                val rightItr = rightThunk(state)
+                var yieldedSomething = false
+                while (rightItr.nextRow()) {
+                    if (coercePredicateResult(predicateThunk(state))) {
+                        yield()
+                        yieldedSomething = true
+                    }
+                }
+                // If we still haven't yielded anything, we still need to emit a row with right-hand side variables
+                // padded with unknowns.
+                if (!yieldedSomething) {
+                    yieldPaddedUnknowns(rightVariableIndexes, state, valueFactory)
+                }
+            }
+        }
+    }
+}
+
+private fun PartiqlPhysical.Bexpr.extractAccessibleVarDecls(): List<PartiqlPhysical.VarDecl> =
+// This fold traverses a [PartiqlPhysical.Bexpr] node and extracts all variable declarations within
+    // It avoids recursing into sub-queries.
+    object : PartiqlPhysical.VisitorFold<List<PartiqlPhysical.VarDecl>>() {
+        override fun visitVarDecl(
+            node: PartiqlPhysical.VarDecl,
+            accumulator: List<PartiqlPhysical.VarDecl>
+        ): List<PartiqlPhysical.VarDecl> = accumulator + node
+
+        /**
+         * Avoids recursion into expressions, since these may contain sub-queries with other var-decls that we don't
+         * care about here.
+         */
+        override fun walkExpr(
+            node: PartiqlPhysical.Expr,
+            accumulator: List<PartiqlPhysical.VarDecl>
+        ): List<PartiqlPhysical.VarDecl> {
+            return accumulator
+        }
+    }.walkBexpr(this, emptyList())
+
+private suspend fun RelationScope.yieldPaddedUnknowns(
+    rightVariableIndexes: List<Int>,
+    state: EvaluatorState,
+    valueFactory: ExprValueFactory
+) {
+    rightVariableIndexes.forEach { state.registers[it] = valueFactory.nullValue }
+    yield()
+}
+
+private fun PartiqlPhysical.Expr.isLitTrue() =
+    this is PartiqlPhysical.Expr.Lit && this.value is BoolElement && this.value.booleanValue

--- a/lang/src/org/partiql/lang/eval/physical/operators/OffsetLimitHelpers.kt
+++ b/lang/src/org/partiql/lang/eval/physical/operators/OffsetLimitHelpers.kt
@@ -13,7 +13,7 @@ import org.partiql.lang.eval.numberValue
 // The functions in this file look very similar and so the temptation to DRY is quite strong....
 // However, there are enough subtle differences between them that avoiding the duplication isn't worth it.
 
-internal fun evalLimitRowCount(rowCountThunk: PhysicalPlanThunk, env: EvaluatorState, limitLocationMeta: SourceLocationMeta?): Long {
+internal fun evalLimitRowCount(rowCountThunk: ExprThunkEnv, env: EvaluatorState, limitLocationMeta: SourceLocationMeta?): Long {
     val limitExprValue = rowCountThunk(env)
 
     if (limitExprValue.type != ExprValueType.INT) {
@@ -60,7 +60,7 @@ internal fun evalLimitRowCount(rowCountThunk: PhysicalPlanThunk, env: EvaluatorS
     return limitValue
 }
 
-internal fun evalOffsetRowCount(rowCountThunk: PhysicalPlanThunk, env: EvaluatorState, offsetLocationMeta: SourceLocationMeta?): Long {
+internal fun evalOffsetRowCount(rowCountThunk: ExprThunkEnv, env: EvaluatorState, offsetLocationMeta: SourceLocationMeta?): Long {
     val offsetExprValue = rowCountThunk(env)
 
     if (offsetExprValue.type != ExprValueType.INT) {

--- a/lang/src/org/partiql/lang/eval/physical/operators/PhysicalOperatorCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/physical/operators/PhysicalOperatorCompiler.kt
@@ -1,0 +1,58 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.physical.ExprThunkEnv
+import org.partiql.lang.eval.physical.RelationThunkEnv
+
+data class OperatorCompilerId(
+    val implementationName: String,
+    val implementsClass: Class<*>
+)
+
+class OperatorCompilerCatalog(operatorList: List<PhysicalOperatorCompiler<*>>) {
+    private val operatorMap = operatorList.associateBy { it.id }
+
+    fun <T : PartiqlPhysical.Bexpr> getOperator(
+        implementationName: String,
+        operatorClass: Class<T>
+    ): PhysicalOperatorCompiler<T> {
+        val id = OperatorCompilerId(implementationName, operatorClass)
+        @Suppress("UNCHECKED_CAST")
+        return operatorMap[id] as? PhysicalOperatorCompiler<T>
+            ?: error("Could not locate compiler for operator '$operatorClass' named '$implementationName'")
+    }
+}
+
+// DL TODO: rename
+interface ThunkConverter {
+    // DL TODO: rename, kdoc
+    fun compile(bexpr: PartiqlPhysical.Bexpr): RelationThunkEnv
+    // DL TODO: rename, kdoc
+    fun compile(expr: PartiqlPhysical.Expr): ExprThunkEnv
+}
+
+// DL TODO: rename, kdoc
+interface PhysicalOperatorCompiler<TOperator : PartiqlPhysical.Bexpr> {
+    val id: OperatorCompilerId
+    fun compile(operator: TOperator, compiler: ThunkConverter, valueFactory: ExprValueFactory): RelationThunkEnv
+}
+
+/**
+ * Reduces some syntactic overhead of creating physical operator compilers.
+ */
+inline fun <reified TOperator : PartiqlPhysical.Bexpr> createPhysicalOperatorCompiler(
+    implementationName: String,
+    crossinline compileBlock: (TOperator, ThunkConverter, ExprValueFactory) -> RelationThunkEnv
+): PhysicalOperatorCompiler<TOperator> =
+    object : PhysicalOperatorCompiler<TOperator> {
+
+        override fun compile(
+            operator: TOperator,
+            compiler: ThunkConverter,
+            valueFactory: ExprValueFactory
+        ): RelationThunkEnv =
+            compileBlock(operator, compiler, valueFactory)
+
+        override val id: OperatorCompilerId get() = OperatorCompilerId(implementationName, TOperator::class.java)
+    }

--- a/lang/src/org/partiql/lang/eval/physical/operators/Util.kt
+++ b/lang/src/org/partiql/lang/eval/physical/operators/Util.kt
@@ -1,0 +1,31 @@
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.booleanValue
+import org.partiql.lang.eval.isUnknown
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.physical.ExprThunkEnv
+import org.partiql.lang.eval.relation.RelationIterator
+import org.partiql.lang.eval.relation.RelationType
+import org.partiql.lang.eval.relation.relation
+
+internal fun createFilterRelItr(
+    relItr: RelationIterator,
+    predicateThunk: ExprThunkEnv,
+    env: EvaluatorState
+) = relation(RelationType.BAG) {
+    while (true) {
+        if (!relItr.nextRow()) {
+            break
+        } else {
+            val matches = predicateThunk(env)
+            if (coercePredicateResult(matches)) {
+                yield()
+            }
+        }
+    }
+}
+
+internal fun coercePredicateResult(value: ExprValue): Boolean =
+    when {
+        value.isUnknown() -> false
+        else -> value.booleanValue() // <-- throws if [value] is not a boolean.
+    }

--- a/lang/src/org/partiql/lang/eval/relation/Relation.kt
+++ b/lang/src/org/partiql/lang/eval/relation/Relation.kt
@@ -13,7 +13,7 @@ import kotlin.coroutines.resume
  *
  * This is inspired heavily by Kotlin's [sequence] but for [RelationIterator] instead of [Sequence].
  */
-internal fun relation(
+fun relation(
     seqType: RelationType,
     block: suspend RelationScope.() -> Unit
 ): RelationIterator {
@@ -28,7 +28,7 @@ annotation class RelationDsl
 
 /** Defines functions within a block supplied to [relation]. */
 @RelationDsl
-internal interface RelationScope {
+interface RelationScope {
     /** Suspends the coroutine.  Should be called after processing the current row of the relation. */
     suspend fun yield()
 

--- a/lang/src/org/partiql/lang/eval/relation/RelationIterator.kt
+++ b/lang/src/org/partiql/lang/eval/relation/RelationIterator.kt
@@ -24,7 +24,7 @@ enum class RelationType { BAG, LIST }
  * including filters and joins that requires advancing through possibly all remaining rows to see if any remaining row
  * matches the predicate.  This is awkward to implement and would force eager evaluation of the [Iterator].
  */
-internal interface RelationIterator {
+interface RelationIterator {
     val relType: RelationType
 
     /**


### PR DESCRIPTION
## Superceded by #636

Publishing this to get it before PartiQL devs eyes and collect initial thoughts on the approach.

Still TODO before this can be merged:

- [ ] Sign off of PartiQL developers on basic approach.
- [ ] Add additional tests with some custom operators (currently all tests use the default operators which prove this works but still should try a custom operator implementation in a test or three)
- [ ] Add `PlannerPipeline` function to add additional operator implementations.

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

