### PR TITLE
Change some namings of OTS interfaces

### DIFF
--- a/lang/src/org/partiql/lang/typesystem/interfaces/function/SqlFunction.kt
+++ b/lang/src/org/partiql/lang/typesystem/interfaces/function/SqlFunction.kt
@@ -1,8 +1,8 @@
 package org.partiql.lang.typesystem.interfaces.function
 
 import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.typesystem.interfaces.type.CompileTimeType
 import org.partiql.lang.typesystem.interfaces.type.SqlType
-import org.partiql.lang.typesystem.interfaces.type.SqlTypeWithParameters
 import org.partiql.lang.typesystem.interfaces.type.TypeParameters
 
 /**
@@ -34,7 +34,7 @@ interface SqlFunction {
      *
      * [argsTypeParameters] represents type parameters of arguments passed to this function during compile time.
      */
-    fun inferReturnType(argsTypeParameters: List<TypeParameters>): SqlTypeWithParameters
+    fun inferReturnType(argsTypeParameters: List<TypeParameters>): CompileTimeType
 
     /**
      * Function evaluation

--- a/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/BetweenOp.kt
+++ b/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/BetweenOp.kt
@@ -3,8 +3,8 @@ package org.partiql.lang.typesystem.interfaces.operator.operators
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.typesystem.interfaces.operator.OpAlias
 import org.partiql.lang.typesystem.interfaces.operator.SqlOperator
+import org.partiql.lang.typesystem.interfaces.type.CompileTimeType
 import org.partiql.lang.typesystem.interfaces.type.SqlType
-import org.partiql.lang.typesystem.interfaces.type.SqlTypeWithParameters
 import org.partiql.lang.typesystem.interfaces.type.TypeParameters
 
 /**
@@ -34,7 +34,7 @@ abstract class BetweenOp : SqlOperator {
      *
      * [paramRegistry] is the registry of type parameters of operands.
      */
-    abstract fun inferReturnType(paramRegistry: ParameterRegistry): SqlTypeWithParameters
+    abstract fun inferReturnType(paramRegistry: ParameterRegistry): CompileTimeType
 
     /**
      * Evaluation

--- a/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/BinaryOps.kt
+++ b/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/BinaryOps.kt
@@ -3,8 +3,8 @@ package org.partiql.lang.typesystem.interfaces.operator.operators
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.typesystem.interfaces.operator.OpAlias
 import org.partiql.lang.typesystem.interfaces.operator.SqlOperator
+import org.partiql.lang.typesystem.interfaces.type.CompileTimeType
 import org.partiql.lang.typesystem.interfaces.type.SqlType
-import org.partiql.lang.typesystem.interfaces.type.SqlTypeWithParameters
 import org.partiql.lang.typesystem.interfaces.type.TypeParameters
 
 sealed class BinaryOp(override val operatorAlias: OpAlias) : SqlOperator {
@@ -23,7 +23,7 @@ sealed class BinaryOp(override val operatorAlias: OpAlias) : SqlOperator {
      *
      * [paramRegistry] is the registry of type parameters of operands.
      */
-    abstract fun inferReturnType(paramRegistry: ParameterRegistry): SqlTypeWithParameters
+    abstract fun inferReturnType(paramRegistry: ParameterRegistry): CompileTimeType
 
     /**
      * Evaluation

--- a/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/CastOps.kt
+++ b/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/CastOps.kt
@@ -3,8 +3,8 @@ package org.partiql.lang.typesystem.interfaces.operator.operators
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.typesystem.interfaces.operator.OpAlias
 import org.partiql.lang.typesystem.interfaces.operator.SqlOperator
+import org.partiql.lang.typesystem.interfaces.type.CompileTimeType
 import org.partiql.lang.typesystem.interfaces.type.SqlType
-import org.partiql.lang.typesystem.interfaces.type.SqlTypeWithParameters
 import org.partiql.lang.typesystem.interfaces.type.TypeParameters
 
 sealed class AbstractCastOp(override val operatorAlias: OpAlias) : SqlOperator {
@@ -23,7 +23,7 @@ sealed class AbstractCastOp(override val operatorAlias: OpAlias) : SqlOperator {
      *
      * [paramRegistry] is the registry of type parameters of operands.
      */
-    abstract fun inferReturnType(paramRegistry: ParameterRegistry): SqlTypeWithParameters
+    abstract fun inferReturnType(paramRegistry: ParameterRegistry): CompileTimeType
 
     /**
      * Evaluation

--- a/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/InOp.kt
+++ b/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/InOp.kt
@@ -3,8 +3,8 @@ package org.partiql.lang.typesystem.interfaces.operator.operators
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.typesystem.interfaces.operator.OpAlias
 import org.partiql.lang.typesystem.interfaces.operator.SqlOperator
+import org.partiql.lang.typesystem.interfaces.type.CompileTimeType
 import org.partiql.lang.typesystem.interfaces.type.SqlType
-import org.partiql.lang.typesystem.interfaces.type.SqlTypeWithParameters
 import org.partiql.lang.typesystem.interfaces.type.TypeParameters
 
 /**
@@ -29,7 +29,7 @@ abstract class InOp : SqlOperator {
      *
      * [paramRegistry] is the registry of type parameters.
      */
-    abstract fun inferReturnType(paramRegistry: ParameterRegistry): SqlTypeWithParameters
+    abstract fun inferReturnType(paramRegistry: ParameterRegistry): CompileTimeType
 
     /**
      * Evaluation

--- a/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/IsOp.kt
+++ b/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/IsOp.kt
@@ -3,8 +3,8 @@ package org.partiql.lang.typesystem.interfaces.operator.operators
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.typesystem.interfaces.operator.OpAlias
 import org.partiql.lang.typesystem.interfaces.operator.SqlOperator
+import org.partiql.lang.typesystem.interfaces.type.CompileTimeType
 import org.partiql.lang.typesystem.interfaces.type.SqlType
-import org.partiql.lang.typesystem.interfaces.type.SqlTypeWithParameters
 import org.partiql.lang.typesystem.interfaces.type.TypeParameters
 
 /**
@@ -29,7 +29,7 @@ abstract class IsOp : SqlOperator {
      *
      * [paramRegistry] is the registry of type parameters.
      */
-    abstract fun inferReturnType(paramRegistry: ParameterRegistry): SqlTypeWithParameters
+    abstract fun inferReturnType(paramRegistry: ParameterRegistry): CompileTimeType
 
     /**
      * Evaluation

--- a/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/LikeOp.kt
+++ b/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/LikeOp.kt
@@ -3,8 +3,8 @@ package org.partiql.lang.typesystem.interfaces.operator.operators
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.typesystem.interfaces.operator.OpAlias
 import org.partiql.lang.typesystem.interfaces.operator.SqlOperator
+import org.partiql.lang.typesystem.interfaces.type.CompileTimeType
 import org.partiql.lang.typesystem.interfaces.type.SqlType
-import org.partiql.lang.typesystem.interfaces.type.SqlTypeWithParameters
 import org.partiql.lang.typesystem.interfaces.type.TypeParameters
 
 /**
@@ -34,7 +34,7 @@ abstract class LikeOp : SqlOperator {
      *
      * [paramRegistry] is the registry of type parameters.
      */
-    abstract fun inferReturnType(paramRegistry: ParameterRegistry): SqlTypeWithParameters
+    abstract fun inferReturnType(paramRegistry: ParameterRegistry): CompileTimeType
 
     /**
      * Evaluation

--- a/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/UnaryOps.kt
+++ b/lang/src/org/partiql/lang/typesystem/interfaces/operator/operators/UnaryOps.kt
@@ -3,8 +3,8 @@ package org.partiql.lang.typesystem.interfaces.operator.operators
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.typesystem.interfaces.operator.OpAlias
 import org.partiql.lang.typesystem.interfaces.operator.SqlOperator
+import org.partiql.lang.typesystem.interfaces.type.CompileTimeType
 import org.partiql.lang.typesystem.interfaces.type.SqlType
-import org.partiql.lang.typesystem.interfaces.type.SqlTypeWithParameters
 import org.partiql.lang.typesystem.interfaces.type.TypeParameters
 
 sealed class UnaryOp(override val operatorAlias: OpAlias) : SqlOperator {
@@ -18,7 +18,7 @@ sealed class UnaryOp(override val operatorAlias: OpAlias) : SqlOperator {
      *
      * [typeParametersOfExpr] is type parameters of the operand passed to this operator at compile time.
      */
-    abstract fun inferReturnType(typeParametersOfExpr: TypeParameters): List<SqlTypeWithParameters>
+    abstract fun inferReturnType(typeParametersOfExpr: TypeParameters): List<CompileTimeType>
 
     /**
      * Evaluation

--- a/lang/src/org/partiql/lang/typesystem/interfaces/type/TypeExtension.kt
+++ b/lang/src/org/partiql/lang/typesystem/interfaces/type/TypeExtension.kt
@@ -3,22 +3,24 @@ package org.partiql.lang.typesystem.interfaces.type
 import org.partiql.lang.eval.ExprValue
 
 /**
- * A sql type with actual parameters. If it is a non-parametric type, [parameters] should be an empty list.
+ * A sql type at compile time, during which type parameters are known.
+ *
+ * [parameters] should be an empty list for non-parametric types.
  */
-data class SqlTypeWithParameters(
+data class CompileTimeType(
     val type: SqlType,
     val parameters: TypeParameters = emptyList()
 )
 
 /**
- * A value with a sql type
+ * A type parameter. The value of type parameter must be known at compile time.
  */
-data class ValueWithType(
+data class TypeParameter(
     val value: ExprValue,
-    val typeWithParameters: SqlTypeWithParameters
+    val typeWithParameters: CompileTimeType
 )
 
 /**
  * Parameters of a parametric type
  */
-typealias TypeParameters = List<ValueWithType>
+typealias TypeParameters = List<TypeParameter>


### PR DESCRIPTION
*Description of changes:*
1. Changed `SqlTypeWithParameters` into `CompileTimeType`
2. Changed `ValueWithType` into `TypeParameter`

