### PR TITLE
Adds metas to ORDER BY clause

### DIFF
--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -591,7 +591,8 @@ class SqlParser(
                                     3 -> sortSpec(it.children[0].toAstExpr(), it.children[1].toOrderingSpec(), it.children[2].toNullsSpec())
                                     else -> errMalformedParseTree("Invalid ordering expressions syntax")
                                 }
-                            }
+                            },
+                            it.getMetas()
                         )
                     }
 
@@ -2289,13 +2290,14 @@ class SqlParser(
         parseOptionalSingleExpressionClause(ParseType.HAVING)
 
         if (rem.head?.keywordText == "order") {
+            val orderToken = rem.head
             rem = rem.tail.tailExpectedToken(TokenType.BY)
 
             val orderByChildren = listOf(rem.parseOrderByArgList())
             rem = orderByChildren.first().remaining
 
             children.add(
-                ParseNode(type = ParseType.ORDER_BY, token = null, children = orderByChildren, remaining = rem)
+                ParseNode(type = ParseType.ORDER_BY, token = orderToken, children = orderByChildren, remaining = rem)
             )
         }
 

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -4268,4 +4268,26 @@ class SqlParserTest : SqlParserTestBase() {
             System.currentTimeMillis() - startTime < maxParseTime
         )
     }
+
+    @Test
+    fun testMetas() {
+        // Arrange
+        val query = "SELECT * FROM << { 'x': 2 } >> ORDER BY x"
+        val expected = SourceLocationMeta(1, 32, 5)
+
+        // Act
+        val stmt = parser.parseAstStatement(query)
+
+        // Gather Metas and Assert
+        val expr = when (stmt) {
+            is PartiqlAst.Statement.Query -> stmt.expr
+            else -> throw AssertionError()
+        }
+        val orderExpr = when (expr) {
+            is PartiqlAst.Expr.Select -> expr.order
+            else -> throw AssertionError()
+        }
+        val metas = orderExpr?.metas ?: throw AssertionError()
+        assertEquals(expected, metas.sourceLocation)
+    }
 }


### PR DESCRIPTION
## Relevant Issue
Closes #516 

## Description
- Adds the metas to the appropriate token
- Adds a test to verify the meta's existence
- Also manually checked the old test to verify that it works by throwing an unsupported exception as before. See the issue for reference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
