### PR TITLE
Adds ktlint task dependency to enable execution optimizations

### DIFF
--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -109,6 +109,7 @@ sourceSets {
 }
 
 compileKotlin.dependsOn generatePigDomains
+runKtlintCheckOverMainSourceSet.dependsOn generatePigDomains
 
 ktlint {
     filter {


### PR DESCRIPTION
## Relevant Issue
Closes #618

## Description
- Sets an explicit dependency on generate PIG domains
- This enables execution optimizations and decreases the Total Build Time (excluding tests) by approx ~30% (~4s) after looking at preliminary results (6 runs) of `./gradlew --profile build` and cleaning prior to each run.
- Also removes the warning on each build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
