### PR TITLE
Specifies tests to be of locale en_US

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ configure(subprojects.findAll { it.name != 'example' }) {
 subprojects {
     apply plugin: "org.jetbrains.kotlin.jvm"
     tasks.withType(Test) {
+        jvmArgs += ['-Duser.language=en', '-Duser.country=US']
         maxHeapSize = "4g"
         testLogging {
             events "failed"


### PR DESCRIPTION
## Relevant Issue
Closes #457

## Description
- Since we do not have locale-specific tests, this PR adds a flag to test with en_US
- This allows developers of other locales to build/test without a need to change their laptop's settings
- See the issue above for manual testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.