### PR TITLE
Add experimental draft support for GPML-style graph query

### DIFF
--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -219,23 +219,6 @@ may then be further optimized by selecting better implementations of each operat
         // Indicates the logical type of join.
         (sum join_type (inner) (left) (right) (full))
 
-        // A quantifier for graph edges or patterns. (e.g., the `{2,5}` in `MATCH (x)->{2,5}->(y)`)
-        (product graph_match_quantifier lower::int upper::(? int))
-
-        // A single node in a graph pattern.
-        (product graph_match_node
-                 predicate::(? expr)   // an optional node pre-filter
-                 variable::(? symbol)  // the optional element variable of the node match
-                 label::(* symbol 0))  // the optional label(s) to match for the node
-
-        // A single edge in a graph pattern.
-        (product graph_match_edge
-                 direction::graph_match_direction       // edge direction
-                 quantifier::(? graph_match_quantifier) // an optional quantifier for the edge match
-                 predicate::(? expr)   // an optional edge pre-filter
-                 variable::(? symbol)  // the optional element variable of the edge match
-                 label::(* symbol 0))  // the optional label(s) to match for the edge
-
         // The direction of an edge
         (sum graph_match_direction
              (edge_left)
@@ -246,10 +229,25 @@ may then be further optimized by selecting better implementations of each operat
              (edge_left_or_right)
              (edge_left_or_undirected_or_right))
 
+        // A part of a graph pattern
         (sum graph_match_pattern_part
-             (node node::graph_match_node)
-             (edge edge::graph_match_edge)
+             // A single node in a graph pattern.
+             (node
+                 predicate::(? expr)   // an optional node pre-filter
+                 variable::(? symbol)  // the optional element variable of the node match
+                 label::(* symbol 0))  // the optional label(s) to match for the node
+             // A single edge in a graph pattern.
+             (edge
+                 direction::graph_match_direction       // edge direction
+                 quantifier::(? graph_match_quantifier) // an optional quantifier for the edge match
+                 predicate::(? expr)   // an optional edge pre-filter
+                 variable::(? symbol)  // the optional element variable of the edge match
+                 label::(* symbol 0))  // the optional label(s) to match for the edge
+             // A sub-pattern.
              (pattern pattern::graph_match_pattern))
+
+        // A quantifier for graph edges or patterns. (e.g., the `{2,5}` in `MATCH (x)->{2,5}->(y)`)
+        (product graph_match_quantifier lower::int upper::(? int))
 
         // A single graph match pattern.
         (product graph_match_pattern

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -220,6 +220,18 @@ may then be further optimized by selecting better implementations of each operat
         (sum join_type (inner) (left) (right) (full))
 
         // The direction of an edge
+        // | Orientation               | Edge pattern | Abbreviation |
+        // |---------------------------+--------------+--------------|
+        // | Pointing left             | <−[ spec ]−  | <−           |
+        // | Undirected                | ~[ spec ]~   | ~            |
+        // | Pointing right            | −[ spec ]−>  | −>           |
+        // | Left or undirected        | <~[ spec ]~  | <~           |
+        // | Undirected or right       | ~[ spec ]~>  | ~>           |
+        // | Left or right             | <−[ spec ]−> | <−>          |
+        // | Left, undirected or right | −[ spec ]−   | −            |
+        //
+        // Fig. 5. Table of edge patterns:
+        // https://arxiv.org/abs/2112.06217
         (sum graph_match_direction
              (edge_left)
              (edge_undirected)
@@ -233,20 +245,21 @@ may then be further optimized by selecting better implementations of each operat
         (sum graph_match_pattern_part
              // A single node in a graph pattern.
              (node
-                 predicate::(? expr)   // an optional node pre-filter
-                 variable::(? symbol)  // the optional element variable of the node match
-                 label::(* symbol 0))  // the optional label(s) to match for the node
+                 predicate::(? expr)   // an optional node pre-filter, e.g.: `WHERE c.name='Alarm'` in `MATCH (c WHERE c.name='Alarm')`
+                 variable::(? symbol)  // the optional element variable of the node match, e.g.: `x` in `MATCH (x)`
+                 label::(* symbol 0))  // the optional label(s) to match for the node, e.g.: `Entity` in `MATCH (x:Entity)`
+
              // A single edge in a graph pattern.
              (edge
                  direction::graph_match_direction       // edge direction
                  quantifier::(? graph_match_quantifier) // an optional quantifier for the edge match
-                 predicate::(? expr)   // an optional edge pre-filter
-                 variable::(? symbol)  // the optional element variable of the edge match
-                 label::(* symbol 0))  // the optional label(s) to match for the edge
+                 predicate::(? expr)   // an optional edge pre-filter, e.g.: `WHERE t.capacity>100` in `MATCH −[t:hasSupply WHERE t.capacity>100]−>`
+                 variable::(? symbol)  // the optional element variable of the edge match, e.g.: `t` in `MATCH −[t]−>`
+                 label::(* symbol 0))  // the optional label(s) to match for the edge. e.g.: `Target` in `MATCH −[t:Target]−>`
              // A sub-pattern.
              (pattern pattern::graph_match_pattern))
 
-        // A quantifier for graph edges or patterns. (e.g., the `{2,5}` in `MATCH (x)->{2,5}->(y)`)
+        // A quantifier for graph edges or patterns. (e.g., the `{2,5}` in `MATCH (x)->{2,5}(y)`)
         (product graph_match_quantifier lower::int upper::(? int))
 
         // A single graph match pattern.
@@ -254,7 +267,8 @@ may then be further optimized by selecting better implementations of each operat
                  quantifier::(? graph_match_quantifier) // an optional quantifier for the entire pattern match
                  parts::(* graph_match_pattern_part 1)) // the ordered pattern parts
 
-        // A graph match clause.
+        // A graph match clause as defined in GPML
+        // See https://arxiv.org/abs/2112.06217
         (product graph_match_expr patterns::(*graph_match_pattern 1))
 
 

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -210,11 +210,55 @@ may then be further optimized by selecting better implementations of each operat
             // UNPIVOT <expr> [AS <id>] [AT <id>] [BY <id>]
             (unpivot expr::expr as_alias::(? symbol) at_alias::(? symbol) by_alias::(? symbol))
 
-            // <from_source> JOIN [INNER | LEFT | RIGHT | FULL] <from_source> ON <expr>
-            (join type::join_type left::from_source right::from_source predicate::(? expr)))
+             // <from_source> JOIN [INNER | LEFT | RIGHT | FULL] <from_source> ON <expr>
+             (join type::join_type left::from_source right::from_source predicate::(? expr))
+
+             // <expr> MATCH <graph_pattern>
+             (graph_match expr::expr graph_expr::graph_match_expr))
 
         // Indicates the logical type of join.
         (sum join_type (inner) (left) (right) (full))
+
+        // A quantifier for graph edges or patterns. (e.g., the `{2,5}` in `MATCH (x)->{2,5}->(y)`)
+        (product graph_match_quantifier lower::int upper::(? int))
+
+        // A single node in a graph pattern.
+        (product graph_match_node
+                 predicate::(? expr)   // an optional node pre-filter
+                 variable::(? symbol)  // the optional element variable of the node match
+                 label::(* symbol 0))  // the optional label(s) to match for the node
+
+        // A single edge in a graph pattern.
+        (product graph_match_edge
+                 direction::graph_match_direction       // edge direction
+                 quantifier::(? graph_match_quantifier) // an optional quantifier for the edge match
+                 predicate::(? expr)   // an optional edge pre-filter
+                 variable::(? symbol)  // the optional element variable of the edge match
+                 label::(* symbol 0))  // the optional label(s) to match for the edge
+
+        // The direction of an edge
+        (sum graph_match_direction
+             (edge_left)
+             (edge_undirected)
+             (edge_right)
+             (edge_left_or_undirected)
+             (edge_undirected_or_right)
+             (edge_left_or_right)
+             (edge_left_or_undirected_or_right))
+
+        (sum graph_match_pattern_part
+             (node node::graph_match_node)
+             (edge edge::graph_match_edge)
+             (pattern pattern::graph_match_pattern))
+
+        // A single graph match pattern.
+        (product graph_match_pattern
+                 quantifier::(? graph_match_quantifier) // an optional quantifier for the entire pattern match
+                 parts::(* graph_match_pattern_part 1)) // the ordered pattern parts
+
+        // A graph match clause.
+        (product graph_match_expr patterns::(*graph_match_pattern 1))
+
 
         // A generic pair of expressions.  Used in the `struct`, `searched_case` and `simple_case` expr variants above.
         (product expr_pair first::expr second::expr)

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -266,6 +266,7 @@ private class StatementTransformer(val ion: IonSystem) {
                     condition = predicate?.toExprNode() ?: Literal(ion.newBool(true), metaContainerOf(StaticTypeMeta(StaticType.BOOL))),
                     metas = metas
                 )
+            is PartiqlAst.FromSource.GraphMatch -> error("$this node has no representation in prior ASTs.")
         }
     }
 

--- a/lang/src/org/partiql/lang/errors/ErrorCode.kt
+++ b/lang/src/org/partiql/lang/errors/ErrorCode.kt
@@ -393,6 +393,42 @@ enum class ErrorCode(
         "expected identifier for alias"
     ),
 
+    PARSE_EXPECTED_IDENT_FOR_MATCH(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "expected identifier for match"
+    ),
+
+    PARSE_EXPECTED_LEFT_PAREN_FOR_MATCH_NODE(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "expected left parenthesis for match node"
+    ),
+
+    PARSE_EXPECTED_RIGHT_PAREN_FOR_MATCH_NODE(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "expected right parenthesis for match node"
+    ),
+
+    PARSE_EXPECTED_LEFT_BRACKET_FOR_MATCH_EDGE(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "expected left bracket for match edge"
+    ),
+
+    PARSE_EXPECTED_RIGHT_BRACKET_FOR_MATCH_EDGE(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "expected right bracket for match edge"
+    ),
+
+    PARSE_EXPECTED_EDGE_PATTERN_MATCH_EDGE(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "expected edge pattern for match edge"
+    ),
+
     PARSE_EXPECTED_AS_FOR_LET(
         ErrorCategory.PARSER,
         LOC_TOKEN,

--- a/lang/src/org/partiql/lang/eval/visitors/GroupByPathExpressionVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/GroupByPathExpressionVisitorTransform.kt
@@ -76,6 +76,9 @@ class GroupByPathExpressionVisitorTransform(
 
                 is PartiqlAst.FromSource.Unpivot ->
                     listOfNotNull(fromSource.asAlias?.text, fromSource.atAlias?.text)
+
+                is PartiqlAst.FromSource.GraphMatch ->
+                    TODO("Handle MATCH for GROUP BY")
             }
     }
 

--- a/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -165,4 +165,8 @@ private object FromSourceToBexpr : PartiqlAst.FromSource.Converter<PartiqlLogica
                 node.metas
             )
         }
+
+    override fun convertGraphMatch(node: PartiqlAst.FromSource.GraphMatch): PartiqlLogical.Bexpr {
+        TODO("Support for MATCH")
+    }
 }

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -500,14 +500,19 @@ internal val DATE_TIME_PART_KEYWORDS: Set<String> = DateTimePart.values()
 )
 
 /** All operators with special parsing rules. */
+@JvmField internal val MATCH_OPERATORS = setOf(
+    "~"
+)
+
+/** All operators with special parsing rules. */
 @JvmField internal val SPECIAL_OPERATORS = SPECIAL_INFIX_OPERATORS + setOf(
     "@"
 )
 
 @JvmField internal val ALL_SINGLE_LEXEME_OPERATORS =
-    SINGLE_LEXEME_BINARY_OPERATORS + UNARY_OPERATORS + SPECIAL_OPERATORS
+    SINGLE_LEXEME_BINARY_OPERATORS + UNARY_OPERATORS + SPECIAL_OPERATORS + MATCH_OPERATORS
 @JvmField internal val ALL_OPERATORS =
-    BINARY_OPERATORS + UNARY_OPERATORS + SPECIAL_OPERATORS
+    BINARY_OPERATORS + UNARY_OPERATORS + SPECIAL_OPERATORS + MATCH_OPERATORS
 
 /**
  * Operator precedence groups
@@ -585,7 +590,7 @@ internal const val DIGIT_CHARS = "0" + NON_ZERO_DIGIT_CHARS
 
 @JvmField internal val E_NOTATION_CHARS = allCase("E")
 
-internal const val NON_OVERLOADED_OPERATOR_CHARS = "^%=@+"
+internal const val NON_OVERLOADED_OPERATOR_CHARS = "^%=@+~"
 internal const val OPERATOR_CHARS = NON_OVERLOADED_OPERATOR_CHARS + "-*/<>|!"
 
 @JvmField internal val ALPHA_CHARS = allCase("ABCDEFGHIJKLMNOPQRSTUVWXYZ")

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -499,7 +499,7 @@ internal val DATE_TIME_PART_KEYWORDS: Set<String> = DateTimePart.values()
     "+", "-", "not"
 )
 
-/** All operators with special parsing rules. */
+/** Operators specific to the `MATCH` clause. */
 @JvmField internal val MATCH_OPERATORS = setOf(
     "~"
 )

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -963,8 +963,8 @@ class SqlParser(
         val metas = getMetas()
 
         var name: SymbolPrimitive? = null
-        var label = mutableListOf<SymbolPrimitive>()
-        var predicate = null
+        val label = mutableListOf<SymbolPrimitive>()
+        val predicate = null
 
         for (child in children) {
             when (child.type) {
@@ -996,8 +996,8 @@ class SqlParser(
 
         var direction: PartiqlAst.GraphMatchDirection? = null
         var name: SymbolPrimitive? = null
-        var label = mutableListOf<SymbolPrimitive>()
-        var predicate = null
+        val label = mutableListOf<SymbolPrimitive>()
+        val predicate = null
 
         for (child in children) {
             when (child.type) {
@@ -3284,7 +3284,7 @@ class SqlParser(
             )
 
     private fun List<Token>.parseOptionalMatchClause(child: ParseNode): ParseNode {
-        var rem = this
+        val rem = this
         return when (rem.head?.keywordText) {
             "match" -> {
                 rem.parseMatch(child)
@@ -3401,6 +3401,7 @@ class SqlParser(
             }
         }
 
+        // 'consume' a single token matching the specified type and optionally matching a specified keyword
         fun consume(type: TokenType, keywordText: String? = null): Boolean {
             if (rem.head?.type == type) {
                 if (keywordText == null || rem.head?.keywordText == keywordText) {
@@ -3411,7 +3412,8 @@ class SqlParser(
             return false
         }
 
-        fun expect1(type: TokenType, errorCode: ErrorCode, errorMsg: String) {
+        // `consume` a single token matching the specified type or throw an error if not possible
+        fun expect(type: TokenType, errorCode: ErrorCode, errorMsg: String) {
             if (!consume(type)) {
                 rem.head.err(
                     "Expected ${type.name} for $errorMsg", errorCode
@@ -3420,12 +3422,12 @@ class SqlParser(
         }
 
         fun parseNode(): ParseNode {
-            expect1(TokenType.LEFT_PAREN, ErrorCode.PARSE_EXPECTED_LEFT_PAREN_FOR_MATCH_NODE, "match node")
+            expect(TokenType.LEFT_PAREN, ErrorCode.PARSE_EXPECTED_LEFT_PAREN_FOR_MATCH_NODE, "match node")
             val name = parseName()
             rem = name?.remaining ?: rem
             val label = parseLabel()
             rem = label?.remaining ?: rem
-            expect1(TokenType.RIGHT_PAREN, ErrorCode.PARSE_EXPECTED_RIGHT_PAREN_FOR_MATCH_NODE, "match node")
+            expect(TokenType.RIGHT_PAREN, ErrorCode.PARSE_EXPECTED_RIGHT_PAREN_FOR_MATCH_NODE, "match node")
 
             return ParseNode(ParseType.MATCH_EXPR_NODE, null, listOfNotNull(name, label), rem)
         }
@@ -3506,12 +3508,12 @@ class SqlParser(
         // https://arxiv.org/abs/2112.06217
         fun parseEdgeWithSpec(): ParseNode {
             val dir1 = parseLeftEdgePattern()
-            expect1(TokenType.LEFT_BRACKET, ErrorCode.PARSE_EXPECTED_LEFT_BRACKET_FOR_MATCH_EDGE, "match edge")
+            expect(TokenType.LEFT_BRACKET, ErrorCode.PARSE_EXPECTED_LEFT_BRACKET_FOR_MATCH_EDGE, "match edge")
             val name = parseName()
             rem = name?.remaining ?: rem
             val label = parseLabel()
             rem = label?.remaining ?: rem
-            expect1(TokenType.RIGHT_BRACKET, ErrorCode.PARSE_EXPECTED_RIGHT_BRACKET_FOR_MATCH_EDGE, "match edge")
+            expect(TokenType.RIGHT_BRACKET, ErrorCode.PARSE_EXPECTED_RIGHT_BRACKET_FOR_MATCH_EDGE, "match edge")
             val dir2 = parseRightEdgePattern()
 
             val dir = dir1.combine(dir2)

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -946,12 +946,8 @@ class SqlParser(
         return PartiqlAst.build {
             val parts = children.map {
                 when (it.type) {
-                    ParseType.MATCH_EXPR_NODE -> {
-                        PartiqlAst.GraphMatchPatternPart.Node(it.toGraphMatchNode(), it.getMetas())
-                    }
-                    ParseType.MATCH_EXPR_EDGE -> {
-                        PartiqlAst.GraphMatchPatternPart.Edge(it.toGraphMatchEdge(), it.getMetas())
-                    }
+                    ParseType.MATCH_EXPR_NODE -> it.toGraphMatchNode()
+                    ParseType.MATCH_EXPR_EDGE -> it.toGraphMatchEdge()
                     else -> {
                         TODO("Handle pattern part other than node&edge")
                     }
@@ -963,7 +959,7 @@ class SqlParser(
         }
     }
 
-    private fun ParseNode.toGraphMatchNode(): PartiqlAst.GraphMatchNode {
+    private fun ParseNode.toGraphMatchNode(): PartiqlAst.GraphMatchPatternPart.Node {
         val metas = getMetas()
 
         var name: SymbolPrimitive? = null
@@ -986,7 +982,7 @@ class SqlParser(
         }
 
         return PartiqlAst.build {
-            PartiqlAst.GraphMatchNode(
+            PartiqlAst.GraphMatchPatternPart.Node(
                 variable = name,
                 label = label,
                 predicate = predicate,
@@ -995,7 +991,7 @@ class SqlParser(
         }
     }
 
-    private fun ParseNode.toGraphMatchEdge(): PartiqlAst.GraphMatchEdge {
+    private fun ParseNode.toGraphMatchEdge(): PartiqlAst.GraphMatchPatternPart.Edge {
         val metas = getMetas()
 
         var direction: PartiqlAst.GraphMatchDirection? = null
@@ -1036,7 +1032,7 @@ class SqlParser(
 
         // TODO quantifier
         return PartiqlAst.build {
-            PartiqlAst.GraphMatchEdge(
+            PartiqlAst.GraphMatchPatternPart.Edge(
                 direction = direction,
                 quantifier = null,
                 variable = name,

--- a/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
@@ -7,6 +7,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.domains.id
+import org.partiql.pig.runtime.asPrimitive
 
 class SqlParserMatchTest : SqlParserTestBase() {
     @Test
@@ -20,7 +21,13 @@ class SqlParserMatchTest : SqlParserTestBase() {
                 graphExpr = graphMatchExpr(
                     patterns = listOf(
                         graphMatchPattern(
-                            parts = listOf(PartiqlAst.GraphMatchPatternPart.Node((graphMatchNode())))
+                            parts = listOf(
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    predicate = null,
+                                    variable = null,
+                                    label = listOf()
+                                )
+                            )
                         )
                     )
                 )
@@ -40,7 +47,13 @@ class SqlParserMatchTest : SqlParserTestBase() {
                 graphExpr = graphMatchExpr(
                     patterns = listOf(
                         graphMatchPattern(
-                            parts = listOf(PartiqlAst.GraphMatchPatternPart.Node((graphMatchNode())))
+                            parts = listOf(
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    predicate = null,
+                                    variable = null,
+                                    label = listOf()
+                                )
+                            )
                         )
                     )
                 )
@@ -65,7 +78,13 @@ class SqlParserMatchTest : SqlParserTestBase() {
                 graphExpr = graphMatchExpr(
                     patterns = listOf(
                         graphMatchPattern(
-                            parts = listOf(PartiqlAst.GraphMatchPatternPart.Node((graphMatchNode(variable = "x"))))
+                            parts = listOf(
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    predicate = null,
+                                    variable = "x".asPrimitive(),
+                                    label = listOf()
+                                )
+                            )
                         )
                     )
                 )
@@ -90,10 +109,9 @@ class SqlParserMatchTest : SqlParserTestBase() {
                         graphMatchPattern(
                             parts = listOf(
                                 PartiqlAst.GraphMatchPatternPart.Node(
-                                    graphMatchNode(
-                                        variable = "x",
-                                        label = listOf("Label")
-                                    )
+                                    predicate = null,
+                                    variable = "x".asPrimitive(),
+                                    label = listOf("Label".asPrimitive())
                                 )
                             )
                         )
@@ -120,7 +138,15 @@ class SqlParserMatchTest : SqlParserTestBase() {
                 graphExpr = graphMatchExpr(
                     patterns = listOf(
                         graphMatchPattern(
-                            parts = listOf(PartiqlAst.GraphMatchPatternPart.Edge((graphMatchEdge(direction = edgeRight()))))
+                            parts = listOf(
+                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                    direction = edgeRight(),
+                                    quantifier = null,
+                                    predicate = null,
+                                    variable = null,
+                                    label = listOf()
+                                )
+                            )
                         )
                     )
                 )
@@ -140,23 +166,21 @@ class SqlParserMatchTest : SqlParserTestBase() {
                             graphMatchPattern(
                                 parts = listOf(
                                     PartiqlAst.GraphMatchPatternPart.Node(
-                                        graphMatchNode(
-                                            variable = "a",
-                                            label = listOf("A")
-                                        )
+                                        predicate = null,
+                                        variable = "a".asPrimitive(),
+                                        label = listOf("A".asPrimitive())
                                     ),
                                     PartiqlAst.GraphMatchPatternPart.Edge(
-                                        graphMatchEdge(
-                                            direction = direction,
-                                            variable = variable,
-                                            label = label ?: emptyList()
-                                        )
+                                        direction = direction,
+                                        quantifier = null,
+                                        predicate = null,
+                                        variable = variable?.asPrimitive(),
+                                        label = label?.map { it.asPrimitive() } ?: emptyList()
                                     ),
                                     PartiqlAst.GraphMatchPatternPart.Node(
-                                        graphMatchNode(
-                                            variable = "b",
-                                            label = listOf("B")
-                                        )
+                                        predicate = null,
+                                        variable = "b".asPrimitive(),
+                                        label = listOf("B".asPrimitive())
                                     ),
                                 )
                             )
@@ -288,23 +312,21 @@ class SqlParserMatchTest : SqlParserTestBase() {
                         graphMatchPattern(
                             parts = listOf(
                                 PartiqlAst.GraphMatchPatternPart.Node(
-                                    graphMatchNode(
-                                        variable = "the_a",
-                                        label = listOf("a")
-                                    )
+                                    predicate = null,
+                                    variable = "the_a".asPrimitive(),
+                                    label = listOf("a".asPrimitive())
                                 ),
                                 PartiqlAst.GraphMatchPatternPart.Edge(
-                                    graphMatchEdge(
-                                        direction = edgeRight(),
-                                        variable = "the_y",
-                                        label = listOf("y")
-                                    )
+                                    direction = edgeRight(),
+                                    quantifier = null,
+                                    predicate = null,
+                                    variable = "the_y".asPrimitive(),
+                                    label = listOf("y".asPrimitive())
                                 ),
                                 PartiqlAst.GraphMatchPatternPart.Node(
-                                    graphMatchNode(
-                                        variable = "the_b",
-                                        label = listOf("b")
-                                    )
+                                    predicate = null,
+                                    variable = "the_b".asPrimitive(),
+                                    label = listOf("b".asPrimitive())
                                 ),
                             )
                         )
@@ -335,26 +357,44 @@ class SqlParserMatchTest : SqlParserTestBase() {
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
-                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode(variable = "a")),
-                                PartiqlAst.GraphMatchPatternPart.Edge(
-                                    graphMatchEdge(
-                                        direction = edgeRight(),
-                                        label = listOf("has")
-                                    )
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    predicate = null,
+                                    variable = "a".asPrimitive(),
+                                    label = listOf()
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode(variable = "x")),
+                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                    direction = edgeRight(),
+                                    quantifier = null,
+                                    predicate = null,
+                                    variable = null,
+                                    label = listOf("has".asPrimitive())
+                                ),
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    predicate = null,
+                                    variable = "x".asPrimitive(),
+                                    label = listOf()
+                                ),
                             )
                         ),
                         graphMatchPattern(
                             parts = listOf(
-                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode(variable = "x")),
-                                PartiqlAst.GraphMatchPatternPart.Edge(
-                                    graphMatchEdge(
-                                        direction = edgeRight(),
-                                        label = listOf("contains")
-                                    )
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    predicate = null,
+                                    variable = "x".asPrimitive(),
+                                    label = listOf()
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode(variable = "b")),
+                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                    direction = edgeRight(),
+                                    quantifier = null,
+                                    predicate = null,
+                                    variable = null,
+                                    label = listOf("contains".asPrimitive())
+                                ),
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    predicate = null,
+                                    variable = "b".asPrimitive(),
+                                    label = listOf()
+                                ),
                             )
                         )
                     )
@@ -378,21 +418,35 @@ class SqlParserMatchTest : SqlParserTestBase() {
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
-                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode(variable = "a")),
-                                PartiqlAst.GraphMatchPatternPart.Edge(
-                                    graphMatchEdge(
-                                        direction = edgeRight(),
-                                        label = listOf("has")
-                                    )
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    predicate = null,
+                                    variable = "a".asPrimitive(),
+                                    label = listOf()
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode()),
                                 PartiqlAst.GraphMatchPatternPart.Edge(
-                                    graphMatchEdge(
-                                        direction = edgeRight(),
-                                        label = listOf("contains")
-                                    )
+                                    direction = edgeRight(),
+                                    quantifier = null,
+                                    predicate = null,
+                                    variable = null,
+                                    label = listOf("has".asPrimitive())
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode(variable = "b")),
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    predicate = null,
+                                    variable = null,
+                                    label = listOf()
+                                ),
+                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                    direction = edgeRight(),
+                                    quantifier = null,
+                                    predicate = null,
+                                    variable = null,
+                                    label = listOf("contains".asPrimitive())
+                                ),
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    predicate = null,
+                                    variable = "b".asPrimitive(),
+                                    label = listOf()
+                                ),
                             )
                         )
                     )

--- a/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
@@ -1,0 +1,462 @@
+package org.partiql.lang.syntax
+
+import com.amazon.ionelement.api.ionBool
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.ionString
+import org.junit.Ignore
+import org.junit.Test
+import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.id
+
+class SqlParserMatchTest : SqlParserTestBase() {
+    @Test
+    fun allNodesNoLabel() = assertExpressionNoRoundTrip(
+        "SELECT 1 FROM my_graph MATCH ()"
+    ) {
+        select(
+            project = projectList(projectExpr(lit(ionInt(1)))),
+            from = graphMatch(
+                expr = id("my_graph"),
+                graphExpr = graphMatchExpr(
+                    patterns = listOf(
+                        graphMatchPattern(
+                            parts = listOf(PartiqlAst.GraphMatchPatternPart.Node((graphMatchNode())))
+                        )
+                    )
+                )
+            ),
+            where = null
+        )
+    }
+
+    @Test
+    fun allNodesNoLabelFilter() = assertExpressionNoRoundTrip(
+        "SELECT 1 FROM my_graph MATCH () WHERE contains_value('1')",
+    ) {
+        select(
+            project = projectList(projectExpr(lit(ionInt(1)))),
+            from = graphMatch(
+                expr = id("my_graph"),
+                graphExpr = graphMatchExpr(
+                    patterns = listOf(
+                        graphMatchPattern(
+                            parts = listOf(PartiqlAst.GraphMatchPatternPart.Node((graphMatchNode())))
+                        )
+                    )
+                )
+            ),
+            where = call(funcName = "contains_value", args = listOf(lit(ionString("1"))))
+        )
+    }
+
+    @Test
+    fun allNodes() = assertExpressionNoRoundTrip(
+        "SELECT x.info AS info FROM my_graph MATCH (x) WHERE x.name LIKE 'foo'",
+    ) {
+        select(
+            project = projectList(
+                projectExpr(
+                    expr = path(id("x"), pathExpr(lit(ionString("info")), caseInsensitive())),
+                    asAlias = "info"
+                )
+            ),
+            from = graphMatch(
+                expr = id("my_graph"),
+                graphExpr = graphMatchExpr(
+                    patterns = listOf(
+                        graphMatchPattern(
+                            parts = listOf(PartiqlAst.GraphMatchPatternPart.Node((graphMatchNode(variable = "x"))))
+                        )
+                    )
+                )
+            ),
+            where = like(
+                value = path(id("x"), pathExpr(lit(ionString("name")), caseInsensitive())),
+                pattern = lit(ionString("foo"))
+            )
+        )
+    }
+
+    @Test
+    fun labelledNodes() = assertExpressionNoRoundTrip(
+        "SELECT x AS target FROM my_graph MATCH (x:Label) WHERE x.has_data = true",
+    ) {
+        select(
+            project = projectList(projectExpr(expr = id("x"), asAlias = "target")),
+            from = graphMatch(
+                expr = id("my_graph"),
+                graphExpr = graphMatchExpr(
+                    patterns = listOf(
+                        graphMatchPattern(
+                            parts = listOf(
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    graphMatchNode(
+                                        variable = "x",
+                                        label = listOf("Label")
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            where = eq(
+                listOf(
+                    path(id("x"), pathExpr(lit(ionString("has_data")), caseInsensitive())),
+                    lit(ionBool(true))
+                )
+            )
+        )
+    }
+
+    @Test
+    fun allEdges() = assertExpressionNoRoundTrip(
+        "SELECT 1 FROM g MATCH -[]-> ",
+    ) {
+        select(
+            project = projectList(projectExpr(lit(ionInt(1)))),
+            from = graphMatch(
+                expr = id("g"),
+                graphExpr = graphMatchExpr(
+                    patterns = listOf(
+                        graphMatchPattern(
+                            parts = listOf(PartiqlAst.GraphMatchPatternPart.Edge((graphMatchEdge(direction = edgeRight()))))
+                        )
+                    )
+                )
+            ),
+            where = null
+        )
+    }
+
+    val simpleGraphAST = { direction: PartiqlAst.GraphMatchDirection, variable: String?, label: List<String>? ->
+        PartiqlAst.build {
+            select(
+                project = projectList(projectExpr(id("a")), projectExpr(id("b"))),
+                from = graphMatch(
+                    expr = id("g"),
+                    graphExpr = graphMatchExpr(
+                        patterns = listOf(
+                            graphMatchPattern(
+                                parts = listOf(
+                                    PartiqlAst.GraphMatchPatternPart.Node(
+                                        graphMatchNode(
+                                            variable = "a",
+                                            label = listOf("A")
+                                        )
+                                    ),
+                                    PartiqlAst.GraphMatchPatternPart.Edge(
+                                        graphMatchEdge(
+                                            direction = direction,
+                                            variable = variable,
+                                            label = label ?: emptyList()
+                                        )
+                                    ),
+                                    PartiqlAst.GraphMatchPatternPart.Node(
+                                        graphMatchNode(
+                                            variable = "b",
+                                            label = listOf("B")
+                                        )
+                                    ),
+                                )
+                            )
+                        )
+                    )
+                ),
+                where = null
+            )
+        }
+    }
+
+    @Test
+    fun rightDirected() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) -[e:E]-> (b:B)",
+    ) {
+        simpleGraphAST(edgeRight(), "e", listOf("E"))
+    }
+
+    @Test
+    fun rightDirectedAbbreviated() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) -> (b:B)",
+    ) {
+        simpleGraphAST(edgeRight(), null, null)
+    }
+
+    @Test
+    fun leftDirected() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) <-[e:E]- (b:B)",
+    ) {
+        simpleGraphAST(edgeLeft(), "e", listOf("E"))
+    }
+
+    @Test
+    fun leftDirectedAbbreviated() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) <- (b:B)",
+    ) {
+        simpleGraphAST(edgeLeft(), null, null)
+    }
+
+    @Test
+    fun undirected() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) ~[e:E]~ (b:B)",
+    ) {
+        simpleGraphAST(edgeUndirected(), "e", listOf("E"))
+    }
+
+    @Test
+    fun undirectedAbbreviated() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) ~ (b:B)",
+    ) {
+        simpleGraphAST(edgeUndirected(), null, null)
+    }
+
+    @Test
+    fun rightOrUnDirected() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) ~[e:E]~> (b:B)",
+    ) {
+        simpleGraphAST(edgeUndirectedOrRight(), "e", listOf("E"))
+    }
+
+    @Test
+    fun rightOrUnDirectedAbbreviated() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) ~> (b:B)",
+    ) {
+        simpleGraphAST(edgeUndirectedOrRight(), null, null)
+    }
+
+    @Test
+    fun leftOrUnDirected() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) <~[e:E]~ (b:B)",
+    ) {
+        simpleGraphAST(edgeLeftOrUndirected(), "e", listOf("E"))
+    }
+
+    @Test
+    fun leftOrUnDirectedAbbreviated() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) <~ (b:B)",
+    ) {
+        simpleGraphAST(edgeLeftOrUndirected(), null, null)
+    }
+
+    @Test
+    fun leftOrRight() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) <-[e:E]-> (b:B)",
+    ) {
+        simpleGraphAST(edgeLeftOrRight(), "e", listOf("E"))
+    }
+
+    @Test
+    fun leftOrRightAbbreviated() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) <-> (b:B)",
+    ) {
+        simpleGraphAST(edgeLeftOrRight(), null, null)
+    }
+
+    @Test
+    fun leftOrRightOrUndirected() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) -[e:E]- (b:B)",
+    ) {
+        simpleGraphAST(edgeLeftOrUndirectedOrRight(), "e", listOf("E"))
+    }
+
+    @Test
+    fun leftOrRightOrUndirectedAbbreviated() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a:A) - (b:B)",
+    ) {
+        simpleGraphAST(edgeLeftOrUndirectedOrRight(), null, null)
+    }
+
+    @Test
+    fun singleEdgeMatch() = assertExpressionNoRoundTrip(
+        "SELECT the_a.name AS src, the_b.name AS dest FROM my_graph MATCH (the_a:a) -[the_y:y]-> (the_b:b) WHERE the_y.score > 10",
+    ) {
+        select(
+            project = projectList(
+                projectExpr(
+                    expr = path(id("the_a"), pathExpr(lit(ionString("name")), caseInsensitive())),
+                    asAlias = "src"
+                ),
+                projectExpr(
+                    expr = path(id("the_b"), pathExpr(lit(ionString("name")), caseInsensitive())),
+                    asAlias = "dest"
+                )
+            ),
+            from = graphMatch(
+                expr = id("my_graph"),
+                graphExpr = graphMatchExpr(
+                    patterns = listOf(
+                        graphMatchPattern(
+                            parts = listOf(
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    graphMatchNode(
+                                        variable = "the_a",
+                                        label = listOf("a")
+                                    )
+                                ),
+                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                    graphMatchEdge(
+                                        direction = edgeRight(),
+                                        variable = "the_y",
+                                        label = listOf("y")
+                                    )
+                                ),
+                                PartiqlAst.GraphMatchPatternPart.Node(
+                                    graphMatchNode(
+                                        variable = "the_b",
+                                        label = listOf("b")
+                                    )
+                                ),
+                            )
+                        )
+                    )
+                )
+            ),
+            where = gt(
+                listOf(
+                    path(id("the_y"), pathExpr(lit(ionString("score")), caseInsensitive())),
+                    lit(ionInt(10))
+                )
+            )
+        )
+    }
+
+    @Test
+    fun twoHopTriples() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a) -[:has]-> (x), (x)-[:contains]->(b)",
+    ) {
+        select(
+            project = projectList(
+                projectExpr(expr = id("a")),
+                projectExpr(expr = id("b"))
+            ),
+            from = graphMatch(
+                expr = id("g"),
+                graphExpr = graphMatchExpr(
+                    patterns = listOf(
+                        graphMatchPattern(
+                            parts = listOf(
+                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode(variable = "a")),
+                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                    graphMatchEdge(
+                                        direction = edgeRight(),
+                                        label = listOf("has")
+                                    )
+                                ),
+                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode(variable = "x")),
+                            )
+                        ),
+                        graphMatchPattern(
+                            parts = listOf(
+                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode(variable = "x")),
+                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                    graphMatchEdge(
+                                        direction = edgeRight(),
+                                        label = listOf("contains")
+                                    )
+                                ),
+                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode(variable = "b")),
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun twoHopPattern() = assertExpressionNoRoundTrip(
+        "SELECT a,b FROM g MATCH (a)-[:has]->()-[:contains]->(b)",
+    ) {
+        select(
+            project = projectList(
+                projectExpr(expr = id("a")),
+                projectExpr(expr = id("b"))
+            ),
+            from = graphMatch(
+                expr = id("g"),
+                graphExpr = graphMatchExpr(
+                    patterns = listOf(
+                        graphMatchPattern(
+                            parts = listOf(
+                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode(variable = "a")),
+                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                    graphMatchEdge(
+                                        direction = edgeRight(),
+                                        label = listOf("has")
+                                    )
+                                ),
+                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode()),
+                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                    graphMatchEdge(
+                                        direction = edgeRight(),
+                                        label = listOf("contains")
+                                    )
+                                ),
+                                PartiqlAst.GraphMatchPatternPart.Node(graphMatchNode(variable = "b")),
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    // TODO prefilters
+    @Test
+    @Ignore
+    fun prefilters() = assertExpressionNoRoundTrip(
+        "SELECT u as banCandidate FROM g MATCH (p:Post Where p.isFlagged = true) ~[ep:createdPost]~ (u:User WHERE u.isBanned = false AND u.karma < 20) -[ec:createdComment]->(c:Comment WHERE c.isFlagged = true)",
+    ) {
+        TODO()
+    }
+
+    // TODO label combinators
+    @Test
+    @Ignore
+    fun labelDisjunction() = assertExpressionNoRoundTrip(
+        "SELECT x FROM g MATCH (x:Label|OtherLabel)",
+    ) {
+        TODO()
+    }
+
+    @Test
+    @Ignore
+    fun labelConjunction() = assertExpressionNoRoundTrip(
+        "SELECT x FROM g MATCH (x:Label&OtherLabel)",
+    ) {
+        TODO()
+    }
+
+    @Test
+    @Ignore
+    fun labelNegation() = assertExpressionNoRoundTrip(
+        "SELECT x FROM g MATCH (x:!Label)",
+    ) {
+        TODO()
+    }
+
+    @Test
+    @Ignore
+    fun labelWildcard() = assertExpressionNoRoundTrip(
+        "SELECT x FROM g MATCH (x:%)",
+    ) {
+        TODO()
+    }
+
+    @Test
+    @Ignore
+    fun labelCombo() = assertExpressionNoRoundTrip(
+        "SELECT x FROM g MATCH (x: L1|L2&L3|!L4|(L5&%)",
+    ) {
+        TODO()
+    }
+
+    // TODO path variable (e.g., `MATCH p = (x) -> (y)`
+    // TODO quantifiers (e.g., `MATCH (a:Node)−[:Edge]−>{2,5}(b:Node)`,  `*`, `+`)
+    // TODO group variables (e.g., `MATCH ... WHERE SUM()...`)
+    // TODO union & multiset (e.g., `MATCH (a:Label) | (a:Label2)` , `MATCH (a:Label) |+| (a:Label2)`
+    // TODO conditional variables
+    // TODO graphical predicates (i.e., `IS DIRECTED`, `IS SOURCE OF`, `IS DESTINATION OF`, `SAME`, `ALL DIFFERENT`)
+    // TODO restrictors & selectors (i.e., `TRAIL`|`ACYCLIC`|`SIMPLE`  & ANY SHORTEST, ALL SHORTEST, ANY, ANY k, SHORTEST k, SHORTEST k GROUP)
+    // TODO selector filters
+}

--- a/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
@@ -7,7 +7,6 @@ import org.junit.Ignore
 import org.junit.Test
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.domains.id
-import org.partiql.pig.runtime.asPrimitive
 
 class SqlParserMatchTest : SqlParserTestBase() {
     @Test
@@ -22,7 +21,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
                                     variable = null,
                                     label = listOf()
@@ -48,7 +47,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
                                     variable = null,
                                     label = listOf()
@@ -79,9 +78,9 @@ class SqlParserMatchTest : SqlParserTestBase() {
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
-                                    variable = "x".asPrimitive(),
+                                    variable = "x",
                                     label = listOf()
                                 )
                             )
@@ -108,10 +107,10 @@ class SqlParserMatchTest : SqlParserTestBase() {
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
-                                    variable = "x".asPrimitive(),
-                                    label = listOf("Label".asPrimitive())
+                                    variable = "x",
+                                    label = listOf("Label")
                                 )
                             )
                         )
@@ -139,7 +138,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
-                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                edge(
                                     direction = edgeRight(),
                                     quantifier = null,
                                     predicate = null,
@@ -164,23 +163,24 @@ class SqlParserMatchTest : SqlParserTestBase() {
                     graphExpr = graphMatchExpr(
                         patterns = listOf(
                             graphMatchPattern(
+                                quantifier = null,
                                 parts = listOf(
-                                    PartiqlAst.GraphMatchPatternPart.Node(
+                                    node(
                                         predicate = null,
-                                        variable = "a".asPrimitive(),
-                                        label = listOf("A".asPrimitive())
+                                        variable = "a",
+                                        label = listOf("A")
                                     ),
-                                    PartiqlAst.GraphMatchPatternPart.Edge(
+                                    edge(
                                         direction = direction,
                                         quantifier = null,
                                         predicate = null,
-                                        variable = variable?.asPrimitive(),
-                                        label = label?.map { it.asPrimitive() } ?: emptyList()
+                                        variable = variable,
+                                        label = label ?: emptyList()
                                     ),
-                                    PartiqlAst.GraphMatchPatternPart.Node(
+                                    node(
                                         predicate = null,
-                                        variable = "b".asPrimitive(),
-                                        label = listOf("B".asPrimitive())
+                                        variable = "b",
+                                        label = listOf("B")
                                     ),
                                 )
                             )
@@ -311,22 +311,22 @@ class SqlParserMatchTest : SqlParserTestBase() {
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
-                                    variable = "the_a".asPrimitive(),
-                                    label = listOf("a".asPrimitive())
+                                    variable = "the_a",
+                                    label = listOf("a")
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                edge(
                                     direction = edgeRight(),
                                     quantifier = null,
                                     predicate = null,
-                                    variable = "the_y".asPrimitive(),
-                                    label = listOf("y".asPrimitive())
+                                    variable = "the_y",
+                                    label = listOf("y")
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
-                                    variable = "the_b".asPrimitive(),
-                                    label = listOf("b".asPrimitive())
+                                    variable = "the_b",
+                                    label = listOf("b")
                                 ),
                             )
                         )
@@ -357,42 +357,42 @@ class SqlParserMatchTest : SqlParserTestBase() {
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
-                                    variable = "a".asPrimitive(),
+                                    variable = "a",
                                     label = listOf()
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                edge(
                                     direction = edgeRight(),
                                     quantifier = null,
                                     predicate = null,
                                     variable = null,
-                                    label = listOf("has".asPrimitive())
+                                    label = listOf("has")
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
-                                    variable = "x".asPrimitive(),
+                                    variable = "x",
                                     label = listOf()
                                 ),
                             )
                         ),
                         graphMatchPattern(
                             parts = listOf(
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
-                                    variable = "x".asPrimitive(),
+                                    variable = "x",
                                     label = listOf()
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                edge(
                                     direction = edgeRight(),
                                     quantifier = null,
                                     predicate = null,
                                     variable = null,
-                                    label = listOf("contains".asPrimitive())
+                                    label = listOf("contains")
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
-                                    variable = "b".asPrimitive(),
+                                    variable = "b",
                                     label = listOf()
                                 ),
                             )
@@ -418,33 +418,33 @@ class SqlParserMatchTest : SqlParserTestBase() {
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
-                                    variable = "a".asPrimitive(),
+                                    variable = "a",
                                     label = listOf()
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                edge(
                                     direction = edgeRight(),
                                     quantifier = null,
                                     predicate = null,
                                     variable = null,
-                                    label = listOf("has".asPrimitive())
+                                    label = listOf("has")
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
                                     variable = null,
                                     label = listOf()
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Edge(
+                                edge(
                                     direction = edgeRight(),
                                     quantifier = null,
                                     predicate = null,
                                     variable = null,
-                                    label = listOf("contains".asPrimitive())
+                                    label = listOf("contains")
                                 ),
-                                PartiqlAst.GraphMatchPatternPart.Node(
+                                node(
                                     predicate = null,
-                                    variable = "b".asPrimitive(),
+                                    variable = "b",
                                     label = listOf()
                                 ),
                             )

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -114,7 +114,7 @@ abstract class SqlParserTestBase : TestBase() {
         val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
 
         // Refer to comments inside the main body of the following function to see what checks are performed.
-        assertExpression(source, expectedPigAst, true)
+        assertExpression(source, expectedPigAst, roundTrip = true)
     }
 
     /**

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -99,7 +99,7 @@ abstract class SqlParserTestBase : TestBase() {
         val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
 
         // Refer to comments inside the main body of the following function to see what checks are performed.
-        assertExpression(source, expectedPigAst, false)
+        assertExpression(source, expectedPigAst, roundTrip = false)
     }
 
     /**

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -66,7 +66,8 @@ abstract class SqlParserTestBase : TestBase() {
      */
     protected fun assertExpression(
         source: String,
-        expectedPigAst: String
+        expectedPigAst: String,
+        roundTrip: Boolean = true,
     ) {
         val actualStatement = parse(source)
         val expectedIonSexp = loadIonSexp(expectedPigAst)
@@ -80,7 +81,25 @@ abstract class SqlParserTestBase : TestBase() {
         pigDomainAssert(actualStatement, expectedElement)
 
         // Check equals for actual value after round trip transformation: astStatement -> ExprNode -> astStatement
-        assertRoundTripPigAstToExprNode(actualStatement)
+        if (roundTrip) {
+            assertRoundTripPigAstToExprNode(actualStatement)
+        }
+    }
+
+    /**
+     * This method is used by test cases for parsing a string.
+     * The test are performed with only PIG AST.
+     * The expected PIG AST is a PIG builder.
+     * No ExprNode <-> PIG AST round trip is performed.
+     */
+    protected fun assertExpressionNoRoundTrip(
+        source: String,
+        expectedPigBuilder: PartiqlAst.Builder.() -> PartiqlAst.PartiqlAstNode
+    ) {
+        val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
+
+        // Refer to comments inside the main body of the following function to see what checks are performed.
+        assertExpression(source, expectedPigAst, false)
     }
 
     /**
@@ -95,7 +114,7 @@ abstract class SqlParserTestBase : TestBase() {
         val expectedPigAst = PartiqlAst.build { expectedPigBuilder() }.toIonElement().toString()
 
         // Refer to comments inside the main body of the following function to see what checks are performed.
-        assertExpression(source, expectedPigAst)
+        assertExpression(source, expectedPigAst, true)
     }
 
     /**


### PR DESCRIPTION
This adds draft parser/AST support for a subset of GPML as outlined by [Graph Pattern Matching in GQL and SQL/PGQ](https://arxiv.org/abs/2112.06217). The use within the grammar is based on the assumption of a new graph data type being added to the specification of data types within PartiQL, and should be considered experimental until the semantics of the graph data type are specified.


This adds support for parsing:
- basic and abbreviated node and edge patterns (section 4.1 of the GPML paper)
- concatenated path patterns  (section 4.2 of the GPML paper)
- graph patterns (i.e., comma separated path patterns)  (section 4.3 of the GPML paper)
- AST support for path quantifiers  (section 4.4 of the GPML paper)
- AST support for pre-filters (section 5.2 of the GPML paper)


TODO:
- path variables  (section 4.2 of the GPML paper)
- parsing support for path quantifiers and group variables  (section 4.4 of the GPML paper)
- path pattern union and multiset  (section 4.5 of the GPML paper)
- conditional variables  (section 4.6 of the GPML paper)
- graphical predicates  (section 4.7 of the GPML paper)
- restrictors and selector  (section 5.1 of the GPML paper)
- pre-filters and post-filters (section 5.2 of the GPML paper)
- aggregats of unbounded variables (section 5.3 of the GPML paper)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
