### PR TITLE
Fixed compile error introduced by PR 650

### DIFF
--- a/lang/src/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
+++ b/lang/src/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
@@ -676,6 +676,7 @@ class ASTPrettyPrinter {
                     if (node.byAlias == null) it else { it.plusElement(toRecursionTree(node.byAlias, attrOfParent = "by")) }
                 }
             )
+            else -> TODO("Unsupported FROM AST node")
         }
 
     private fun toRecursionTree(node: PartiqlAst.Let, attrOfParent: String? = null): RecursionTree =


### PR DESCRIPTION
*Description of changes:*
A new AST node was introduced before PR 650 got merged, so the compile after PR 650 got merged failed. This PR fixes the compile problem. 
