### PR TITLE
Add code coverage xml target, add extensions to codecov, upgrade codecov GH actions version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,35 +34,41 @@ jobs:
         with:
           java-version: 11
       - name: Generate test coverage report
-        run: ./gradlew build jacocoTestReport
+        run: ./gradlew jacocoTestReport
 
       # Upload coverage for CLI, LANG, PTS, TEST_SCRIPT, and EXAMPLES
       - name: Upload CLI coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          directory: cli/build/reports
+          file: cli/build/reports/jacoco/test/jacocoTestReport.xml
           flags: CLI
 
       - name: Upload LANG coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          directory: lang/build/reports
+          file: lang/build/reports/jacoco/test/jacocoTestReport.xml
           flags: LANG
 
       - name: Upload PTS coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          directory: pts/build/reports
+          file: pts/build/reports/jacoco/test/jacocoTestReport.xml
           flags: PTS
 
       - name: Upload TEST_SCRIPT coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          directory: testscript/build/reports
+          file: testscript/build/reports/jacoco/test/jacocoTestReport.xml
           flags: TEST_SCRIPT
 
       - name: Upload EXAMPLES coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          directory: examples/build/reports
+          file: examples/build/reports/jacoco/test/jacocoTestReport.xml
           flags: EXAMPLES
+
+      - name: Upload EXTENSIONS coverage
+        uses: codecov/codecov-action@v3
+        with:
+          file: extensions/build/reports/jacoco/test/jacocoTestReport.xml
+          flags: EXTENSIONS

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ subprojects {
         useJUnitPlatform()
         jacocoTestReport {
             reports {
+                xml.required.set(true)
                 html.required.set(true)
                 html.outputLocation.set(file("${buildDir}/reports/jacoco/html"))
             }


### PR DESCRIPTION
Closes #659.

*Description of changes:* 
- Fixes code coverage report generation by adding a code coverage xml target
- Also adds `extensions` package to codecov
- Upgrades codecov GH actions version from v1 -> v3

*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes? (y/n), If not, please explain why:*

No, will update when PR is ready to review. For now, just checking if codecov works properly.

*Does your PR include any backward-incompatible changes? (y/n), if yes, please explain the reason. In addition, please
 also mention any other alternatives you've considered and the reason they've been discarded?:*

No.

*Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:*

No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
