### PR TITLE
Fix ceil floor

### DIFF
--- a/lang/src/org/partiql/lang/eval/builtins/MathFunctions.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/MathFunctions.kt
@@ -1,16 +1,26 @@
 package org.partiql.lang.eval.builtins
 
+import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.errIntOverflow
+import org.partiql.lang.eval.errNoContext
 import org.partiql.lang.eval.numberValue
 import org.partiql.lang.types.FunctionSignature
 import org.partiql.lang.types.StaticType
+import org.partiql.lang.util.bigDecimalOf
+import org.partiql.lang.util.compareTo
+import org.partiql.lang.util.div
+import org.partiql.lang.util.plus
+import org.partiql.lang.util.times
+import org.partiql.lang.util.unaryMinus
 import java.lang.Double.NEGATIVE_INFINITY
 import java.lang.Double.NaN
 import java.lang.Double.POSITIVE_INFINITY
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.math.RoundingMode
 
 /**
@@ -45,25 +55,40 @@ private class UnaryNumeric(
         returnType = StaticType.NUMERIC,
     )
 
-    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
-        return when (val n = function.invoke(required.first().numberValue())) {
-            is Double, is Float -> valueFactory.newFloat(n.toDouble())
-            is Int -> valueFactory.newInt(n.toInt())
-            is Long -> valueFactory.newInt(n.toLong())
-            else -> valueFactory.newFloat(n.toDouble())
-        }
-    }
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue =
+        function.invoke(required.first().numberValue()).exprValue(valueFactory)
 }
 
 private fun ceil(n: Number): Number = when (n) {
     POSITIVE_INFINITY, NEGATIVE_INFINITY, NaN -> n
     // support for numbers that are larger than 64 bits.
-    is BigDecimal -> n.setScale(0, RoundingMode.CEILING).toInt()
-    else -> kotlin.math.ceil(n.toDouble()).toInt()
+    else -> transformIntType(bigDecimalOf(n).setScale(0, RoundingMode.CEILING).toBigIntegerExact())
 }
 
 private fun floor(n: Number): Number = when (n) {
     POSITIVE_INFINITY, NEGATIVE_INFINITY, NaN -> n
-    is BigDecimal -> n.setScale(0, RoundingMode.FLOOR).toInt()
-    else -> kotlin.math.floor(n.toDouble()).toInt()
+    else -> transformIntType(bigDecimalOf(n).setScale(0, RoundingMode.FLOOR).toBigIntegerExact())
+}
+
+// wrapper for transform function result to corresponding integer type
+private fun transformIntType(n: BigInteger): Number = when (n) {
+    in Int.MIN_VALUE.toBigInteger()..Int.MAX_VALUE.toBigInteger() -> n.toInt()
+    in Long.MIN_VALUE.toBigInteger()..Long.MAX_VALUE.toBigInteger() -> n.toLong()
+    /**
+     * currently kotlin-lang-ParitQL did not support integer value bigger than 64 bits.
+     */
+    else -> errIntOverflow(8)
+}
+
+// wrapper for converting result to expression value
+private fun Number.exprValue(valueFactory: ExprValueFactory): ExprValue = when (this) {
+    is Int -> valueFactory.newInt(this)
+    is Long -> valueFactory.newInt(this)
+    is Double, is Float -> valueFactory.newFloat(this.toDouble())
+    is BigDecimal -> valueFactory.newDecimal(this)
+    else -> errNoContext(
+        "Cannot convert number to expression value: $this",
+        errorCode = ErrorCode.EVALUATOR_INVALID_CONVERSION,
+        internal = true
+    )
 }

--- a/lang/src/org/partiql/lang/eval/builtins/MathFunctions.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/MathFunctions.kt
@@ -10,6 +10,8 @@ import org.partiql.lang.types.StaticType
 import java.lang.Double.NEGATIVE_INFINITY
 import java.lang.Double.NaN
 import java.lang.Double.POSITIVE_INFINITY
+import java.math.BigDecimal
+import java.math.RoundingMode
 
 /**
  * A place to keep supported mathematical functions. We are missing many in comparison to PostgresQL.
@@ -55,10 +57,13 @@ private class UnaryNumeric(
 
 private fun ceil(n: Number): Number = when (n) {
     POSITIVE_INFINITY, NEGATIVE_INFINITY, NaN -> n
+    // support for numbers that are larger than 64 bits.
+    is BigDecimal -> n.setScale(0, RoundingMode.CEILING).toInt()
     else -> kotlin.math.ceil(n.toDouble()).toInt()
 }
 
 private fun floor(n: Number): Number = when (n) {
     POSITIVE_INFINITY, NEGATIVE_INFINITY, NaN -> n
+    is BigDecimal -> n.setScale(0, RoundingMode.FLOOR).toInt()
     else -> kotlin.math.floor(n.toDouble()).toInt()
 }

--- a/lang/test/org/partiql/lang/eval/builtins/functions/MathFunctionsTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/functions/MathFunctionsTest.kt
@@ -53,6 +53,10 @@ class MathFunctionsTest : EvaluatorTestBase() {
             ExprFunctionTestCase("floor(`+inf`)", "+inf"),
             ExprFunctionTestCase("floor(`-inf`)", "-inf"),
             ExprFunctionTestCase("floor(`nan`)", "nan"),
+            ExprFunctionTestCase("ceil(`1.00000000000000001`)", "2"),
+            ExprFunctionTestCase("ceil(1.00000000000000001)", "2"),
+            ExprFunctionTestCase("floor(`1.9999999999999999`)", "1"),
+            ExprFunctionTestCase("floor(1.99999999999999999999)", "1")
         )
     }
 

--- a/lang/test/org/partiql/lang/eval/builtins/functions/MathFunctionsTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/functions/MathFunctionsTest.kt
@@ -53,6 +53,7 @@ class MathFunctionsTest : EvaluatorTestBase() {
             ExprFunctionTestCase("floor(`+inf`)", "+inf"),
             ExprFunctionTestCase("floor(`-inf`)", "-inf"),
             ExprFunctionTestCase("floor(`nan`)", "nan"),
+            // test case for literal larger than 64 bits
             ExprFunctionTestCase("ceil(`1.00000000000000001`)", "2"),
             ExprFunctionTestCase("ceil(1.00000000000000001)", "2"),
             ExprFunctionTestCase("floor(`1.9999999999999999`)", "1"),

--- a/lang/test/org/partiql/lang/eval/builtins/functions/MathFunctionsTest.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/functions/MathFunctionsTest.kt
@@ -3,13 +3,27 @@ package org.partiql.lang.eval.builtins.functions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
+import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.eval.EvaluatorTestBase
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
 import org.partiql.lang.eval.builtins.checkInvalidArity
+import org.partiql.lang.eval.evaluatortestframework.EvaluatorErrorTestCase
+import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestTarget
 import org.partiql.lang.types.StaticType
 import org.partiql.lang.util.ArgumentsProviderBase
+import org.partiql.lang.util.div
+import org.partiql.lang.util.minus
+import org.partiql.lang.util.plus
+
+// constant that can be handy in testing
+private val MIN_INT2 = Short.MIN_VALUE
+private val MAX_INT2 = Short.MAX_VALUE
+private val MIN_INT4 = Int.MIN_VALUE
+private val MAX_INT4 = Int.MAX_VALUE
+private val MIN_INT8 = Long.MIN_VALUE
+private val MAX_INT8 = Long.MAX_VALUE
 
 class MathFunctionsTest : EvaluatorTestBase() {
 
@@ -23,7 +37,6 @@ class MathFunctionsTest : EvaluatorTestBase() {
     class MathFunctionsPassCases : ArgumentsProviderBase() {
 
         override fun getParameters(): List<Any> = listOf(
-            ExprFunctionTestCase("ceil(1)", "1"),
             ExprFunctionTestCase("ceil(1.0)", "1"),
             ExprFunctionTestCase("ceil(`1`)", "1"),
             ExprFunctionTestCase("ceil(1.0e0)", "1"),
@@ -57,7 +70,8 @@ class MathFunctionsTest : EvaluatorTestBase() {
             ExprFunctionTestCase("ceil(`1.00000000000000001`)", "2"),
             ExprFunctionTestCase("ceil(1.00000000000000001)", "2"),
             ExprFunctionTestCase("floor(`1.9999999999999999`)", "1"),
-            ExprFunctionTestCase("floor(1.99999999999999999999)", "1")
+            ExprFunctionTestCase("floor(1.99999999999999999999)", "1"),
+
         )
     }
 
@@ -90,5 +104,69 @@ class MathFunctionsTest : EvaluatorTestBase() {
         checkInvalidArity("ceil", 1, 1)
         checkInvalidArity("ceiling", 1, 1)
         checkInvalidArity("floor", 1, 1)
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(MathFunctionOverflowTest::class)
+    fun runOverflowTests(tc: EvaluatorErrorTestCase) = runEvaluatorErrorTestCase(
+        tc.query,
+        expectedErrorCode = tc.expectedErrorCode,
+        expectedPermissiveModeResult = tc.expectedPermissiveModeResult
+    )
+
+    class MathFunctionOverflowTest : ArgumentsProviderBase() {
+        override fun getParameters(): List<Any> = listOf(
+            // overflow caused by expression evaluation inside the function
+            EvaluatorErrorTestCase(
+                query = "floor($MAX_INT8+1)",
+                expectedErrorCode = ErrorCode.EVALUATOR_INTEGER_OVERFLOW,
+                expectedPermissiveModeResult = "MISSING"
+            ),
+            EvaluatorErrorTestCase(
+                query = "floor($MIN_INT8-1)",
+                expectedErrorCode = ErrorCode.EVALUATOR_INTEGER_OVERFLOW,
+                expectedPermissiveModeResult = "MISSING"
+            ),
+            EvaluatorErrorTestCase(
+                query = "ceil($MAX_INT8+1)",
+                expectedErrorCode = ErrorCode.EVALUATOR_INTEGER_OVERFLOW,
+                expectedPermissiveModeResult = "MISSING"
+            ),
+            EvaluatorErrorTestCase(
+                query = "ceil($MIN_INT8-1)",
+                expectedErrorCode = ErrorCode.EVALUATOR_INTEGER_OVERFLOW,
+                expectedPermissiveModeResult = "MISSING"
+            ),
+            // overflow caused by argument
+            EvaluatorErrorTestCase(
+                query = "floor(${MAX_INT8}1)",
+                expectedErrorCode = ErrorCode.SEMANTIC_LITERAL_INT_OVERFLOW,
+            ),
+            EvaluatorErrorTestCase(
+                query = "floor(${MIN_INT8}1)",
+                expectedErrorCode = ErrorCode.SEMANTIC_LITERAL_INT_OVERFLOW,
+            ),
+            EvaluatorErrorTestCase(
+                query = "CEIL(${MAX_INT8}1)",
+                expectedErrorCode = ErrorCode.SEMANTIC_LITERAL_INT_OVERFLOW,
+            ),
+            EvaluatorErrorTestCase(
+                query = "CEIL(${MIN_INT8}1)",
+                expectedErrorCode = ErrorCode.SEMANTIC_LITERAL_INT_OVERFLOW,
+            ),
+            // edge case, overflow caused by function evulation
+            EvaluatorErrorTestCase(
+                query = "ceil($MAX_INT8.1)",
+                expectedErrorCode = ErrorCode.EVALUATOR_INTEGER_OVERFLOW,
+                expectedPermissiveModeResult = "MISSING",
+                targetPipeline = EvaluatorTestTarget.ALL_PIPELINES
+            ),
+            EvaluatorErrorTestCase(
+                query = "floor($MIN_INT8.1)",
+                expectedErrorCode = ErrorCode.EVALUATOR_INTEGER_OVERFLOW,
+                expectedPermissiveModeResult = "MISSING",
+                targetPipeline = EvaluatorTestTarget.ALL_PIPELINES
+            ),
+        )
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

#661 CEIL And FLOOR Function behavior wrong when supplied with literal larger than 64 bits

*Description of changes:*

Adding support for larger literal for ``CEIL`` and ``FLOOR`` functions using ``BigDecimal``. Adding the corresponding test cases. 

*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes? (y/n), If not, please explain why:*

No.

*Does your PR include any backward-incompatible changes? (y/n), if yes, please explain the reason. In addition, please
 also mention any other alternatives you've considered and the reason they've been discarded?:*

```
For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in 
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base.
```

No.

*Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:*

No. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
