### PR TITLE
Minor GPML Match clause clean-up

### DIFF
--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -998,7 +998,7 @@ class SqlParser(
                     ParseType.MATCH_EXPR_EDGE -> parts.add(child.toGraphMatchEdge())
                     ParseType.MATCH_EXPR_QUANTIFIER -> quantifier = child.toGraphMatchQuantifier(quantifier)
                     ParseType.MATCH_EXPR_RESTRICTOR -> {
-                        restrictor = when (child.children[0].token!!.sourceText?.toUpperCase()) {
+                        restrictor = when (child.children[0].token!!.sourceText.toUpperCase()) {
                             "TRAIL" -> restrictorTrail()
                             "ACYCLIC" -> restrictorAcyclic()
                             "SIMPLE" -> restrictorSimple()
@@ -1042,7 +1042,7 @@ class SqlParser(
                     if (name != null) error("Invalid parse tree: name encountered more than once in MATCH")
                     val token = child.children[0].token!!
                     val nameText = when (token.type) {
-                        TokenType.KEYWORD -> token.sourceText!!
+                        TokenType.KEYWORD -> token.sourceText
                         else -> token.text!!
                     }
                     name = SymbolPrimitive(nameText, child.getMetas())
@@ -1050,7 +1050,7 @@ class SqlParser(
                 ParseType.MATCH_EXPR_LABEL -> {
                     val token = child.children[0].token!!
                     val labelText = when (token.type) {
-                        TokenType.KEYWORD -> token.sourceText!!
+                        TokenType.KEYWORD -> token.sourceText
                         else -> token.text!!
                     }
                     label.add(SymbolPrimitive(labelText, child.getMetas()))
@@ -1127,7 +1127,7 @@ class SqlParser(
                     if (name != null) error("Invalid parse tree: name encountered more than once in MATCH")
                     val token = child.children[0].token!!
                     val nameText = when (token.type) {
-                        TokenType.KEYWORD -> token.sourceText!!
+                        TokenType.KEYWORD -> token.sourceText
                         else -> token.text!!
                     }
                     name = SymbolPrimitive(nameText, child.getMetas())
@@ -1135,7 +1135,7 @@ class SqlParser(
                 ParseType.MATCH_EXPR_LABEL -> {
                     val token = child.children[0].token!!
                     val labelText = when (token.type) {
-                        TokenType.KEYWORD -> token.sourceText!!
+                        TokenType.KEYWORD -> token.sourceText
                         else -> token.text!!
                     }
                     label.add(SymbolPrimitive(labelText, child.getMetas()))
@@ -3502,7 +3502,7 @@ class SqlParser(
         fun consumeKW(keyword: String): Boolean {
             return when (rem.head?.type!!) {
                 TokenType.IDENTIFIER, TokenType.QUOTED_IDENTIFIER, TokenType.KEYWORD -> {
-                    if (rem.head!!.sourceText?.toUpperCase() == keyword) {
+                    if (rem.head!!.sourceText.toUpperCase() == keyword) {
                         rem = rem.tail
                         true
                     } else {
@@ -3522,7 +3522,7 @@ class SqlParser(
                 val startSpan = start.head!!.span
                 var last = startSpan
                 var len = 0L
-                for (next in start!!.tail.subList(0, count - 1)) {
+                for (next in start.tail.subList(0, count - 1)) {
                     if (next.span.line == last.line) {
                         len += (next.span.column - last.column)
                     } else {
@@ -3955,7 +3955,7 @@ class SqlParser(
         fun parseRestrictor(): ParseNode? {
             return when (rem.head?.type!!) {
                 TokenType.IDENTIFIER -> {
-                    if (rem.head!!.sourceText?.toUpperCase() in matchRestrictorKWs) {
+                    if (rem.head!!.sourceText.toUpperCase() in matchRestrictorKWs) {
                         val name = rem.atomFromHead()
                         rem = name.remaining
                         ParseNode(ParseType.MATCH_EXPR_RESTRICTOR, null, listOf(name), name.remaining)
@@ -3995,8 +3995,7 @@ class SqlParser(
                 rem = pattern.remaining
 
                 val predicate = if (rem.head?.keywordText == "where") {
-                    val rem = rem.tail
-                    rem.parseExpression()
+                    rem.tail.parseExpression()
                 } else {
                     null
                 }

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -3591,21 +3591,10 @@ class SqlParser(
         rem = selector?.remaining ?: rem
 
         val matches = ArrayList<ParseNode>()
-        var preComma = rem
         do {
-            try {
-                val pattern = rem.parseMatchPattern()
-                matches.add(pattern)
-                rem = pattern.remaining
-                preComma = rem
-            } catch (e: ParserException) {
-                if (matches.isEmpty()) {
-                    throw e
-                } else {
-                    rem = preComma
-                    break
-                }
-            }
+            val pattern = rem.parseMatchPattern()
+            matches.add(pattern)
+            rem = pattern.remaining
         } while (consume(TokenType.COMMA))
 
         return ParseNode(ParseType.MATCH, this.head, listOfNotNull(expr, selector) + matches, rem)

--- a/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
@@ -7,6 +7,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.domains.id
+import kotlin.test.assertFailsWith
 
 class SqlParserMatchTest : SqlParserTestBase() {
     @Test
@@ -977,10 +978,14 @@ class SqlParserMatchTest : SqlParserTestBase() {
     }
 
     @Test
-    fun matchAndJoinCommas() = assertExpressionNoRoundTrip(
-        "SELECT a,b,c, t1.x as x, t2.y as y FROM graph MATCH (a) -> (b), (a) -> (c), table1 as t1, table2 as t2",
-    ) {
-        joinedMatch()
+    fun matchAndJoinCommas() {
+        assertFailsWith<ParserException> {
+            assertExpressionNoRoundTrip(
+                "SELECT a,b,c, t1.x as x, t2.y as y FROM graph MATCH (a) -> (b), (a) -> (c), table1 as t1, table2 as t2",
+            ) {
+                joinedMatch()
+            }
+        }
     }
 
     // TODO label combinators


### PR DESCRIPTION
Minor clean-up after #652 and #658 :
- Clean up some linter warnings
- Require parentheses around implicitly joined (via comma) graph patterns in the MATCH clause.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
