### PR TITLE
Add EvaluationSession.contextVariables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - path quantifiers  (section 4.4 of the GPML paper)
   - restrictors and selector  (section 5.1 of the GPML paper)
   - pre-filters and post-filters (section 5.2 of the GPML paper)
+- Added EvaluatonSession.contextVariables: A string-keyed map of arbitrary data which provides a way to make  
+session state such as current user and transaction details available to custom [ExprFunction] implementations 
+and custom physical operator implementations.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - path quantifiers  (section 4.4 of the GPML paper)
   - restrictors and selector  (section 5.1 of the GPML paper)
   - pre-filters and post-filters (section 5.2 of the GPML paper)
-- Added EvaluatonSession.contextVariables: A string-keyed map of arbitrary data which provides a way to make  
+- Added EvaluatonSession.context: A string-keyed map of arbitrary values which provides a way to make  
 session state such as current user and transaction details available to custom [ExprFunction] implementations 
 and custom physical operator implementations.
 

--- a/lang/src/org/partiql/lang/eval/EvaluationSession.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluationSession.kt
@@ -22,13 +22,18 @@ import com.amazon.ion.Timestamp
  *
  * @property globals The global bindings. Defaults to [Bindings.empty]
  * @property parameters List of parameters to be substituted for positional placeholders
+ * @property contextVariables A string-keyed map of arbitrary data associated with this [EvaluationSession].  This
+ * provides a way to make custom session state such as current user and transaction details available to
+ * custom [ExprFunction] implementations and custom physical operator implementations.
  * @property now Timestamp to consider as the current time, used by functions like `utcnow()` and `now()`. Defaults to [Timestamp.nowZ]
  */
 class EvaluationSession private constructor(
     val globals: Bindings<ExprValue>,
     val parameters: List<ExprValue>,
+    val contextVariables: Map<String, Any>,
     val now: Timestamp
 ) {
+
     companion object {
         /**
          * Java style builder to construct a new [EvaluationSession]. Uses the default value for any non specified field
@@ -70,9 +75,16 @@ class EvaluationSession private constructor(
             return this
         }
 
+        private val contextVariables = HashMap<String, Any>()
+        fun withContextVariable(name: String, value: Any): Builder {
+            contextVariables[name] = value
+            return this
+        }
+
         fun build(): EvaluationSession = EvaluationSession(
             now = now ?: Timestamp.nowZ(),
             parameters = parameters,
+            contextVariables = contextVariables,
             globals = globals
         )
     }

--- a/lang/src/org/partiql/lang/eval/EvaluationSession.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluationSession.kt
@@ -22,7 +22,7 @@ import com.amazon.ion.Timestamp
  *
  * @property globals The global bindings. Defaults to [Bindings.empty]
  * @property parameters List of parameters to be substituted for positional placeholders
- * @property contextVariables A string-keyed map of arbitrary data associated with this [EvaluationSession].  This
+ * @property context A string-keyed map of arbitrary data associated with this [EvaluationSession].  This
  * provides a way to make custom session state such as current user and transaction details available to
  * custom [ExprFunction] implementations and custom physical operator implementations.
  * @property now Timestamp to consider as the current time, used by functions like `utcnow()` and `now()`. Defaults to [Timestamp.nowZ]
@@ -30,7 +30,7 @@ import com.amazon.ion.Timestamp
 class EvaluationSession private constructor(
     val globals: Bindings<ExprValue>,
     val parameters: List<ExprValue>,
-    val contextVariables: Map<String, Any>,
+    val context: Map<String, Any>,
     val now: Timestamp
 ) {
 
@@ -84,7 +84,7 @@ class EvaluationSession private constructor(
         fun build(): EvaluationSession = EvaluationSession(
             now = now ?: Timestamp.nowZ(),
             parameters = parameters,
-            contextVariables = contextVariables,
+            context = contextVariables,
             globals = globals
         )
     }

--- a/lang/test/org/partiql/lang/eval/EvaluationSessionTest.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluationSessionTest.kt
@@ -60,6 +60,17 @@ class EvaluationSessionTest {
     }
 
     @Test
+    fun canSetContextVariables() {
+        val session = EvaluationSession.build {
+            withContextVariable("meaning", 42)
+            withContextVariable("captain", "Picard")
+        }
+        assertEquals(2, session.contextVariables.size)
+        assertEquals(42, session.contextVariables["meaning"])
+        assertEquals("Picard", session.contextVariables["captain"])
+    }
+
+    @Test
     fun settingNow() {
         val now = Timestamp.forMillis(10, 0)
         val session = EvaluationSession.build { now(now) }

--- a/lang/test/org/partiql/lang/eval/EvaluationSessionTest.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluationSessionTest.kt
@@ -65,9 +65,9 @@ class EvaluationSessionTest {
             withContextVariable("meaning", 42)
             withContextVariable("captain", "Picard")
         }
-        assertEquals(2, session.contextVariables.size)
-        assertEquals(42, session.contextVariables["meaning"])
-        assertEquals("Picard", session.contextVariables["captain"])
+        assertEquals(2, session.context.size)
+        assertEquals(42, session.context["meaning"])
+        assertEquals("Picard", session.context["captain"])
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*

This provides a way for embedding PartiQL applications to pass session context such as current user information and transaction state to their custom `ExprFunction` and physical operator implementations.

*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes? (y/n), If not, please explain why:*

yes, see the diff.

*Does your PR include any backward-incompatible changes? (y/n), if yes, please explain the reason. In addition, please
 also mention any other alternatives you've considered and the reason they've been discarded?:*

Changes are backward compatible.

*Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:*

No new dependencies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
