### PR TITLE
[superceded] Partial support for INSERT and DELETE DML statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - path quantifiers  (section 4.4 of the GPML paper)
   - restrictors and selector  (section 5.1 of the GPML paper)
   - pre-filters and post-filters (section 5.2 of the GPML paper)
+- The `PlannerPipeline` API now has experimental and partial support for `INSERT` and `DELETE` DML statements.
+  Examples of supported statements include:
+  - `INSERT INTO foo << { 'id': 1, 'name': 'bob' }, { 'id': 2, 'name' : 'sue' } >>` (multi record insert)
+  - `INSERT INTO foo VALUE 1` (single record insert)
+  - `INSERT INTO foo SELECT c.id, c.name FROM customer AS c` (insert the results of a query into another table)
+  - `DELETE FROM foo` (delete all records in a table)
+  - `DELETE FROM foo AS f WHERE f.zipCode = '90210'` (delete all records matching a predicate)
 
 ### Changed
 

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -480,7 +480,7 @@ may then be further optimized by selecting better implementations of each operat
             // `DOUBLE_PRECISION`
             (double_precision_type)
 
-            // `DEICMAL[(<int> [, int])]`.  Elements are precision then scale.
+            // `DECIMAL[(<int> [, int])]`.  Elements are precision then scale.
             (decimal_type precision::(? int) scale::(? int))
 
             // `NUMERIC[(<int> [, int])]`.  Elements are precision then scale.
@@ -638,8 +638,8 @@ may then be further optimized by selecting better implementations of each operat
             // - The `AS`, `AT`, and `BY` sub-clauses in `FROM`
             // - The `AS` sub-clauses in within a `LET` clause.
             // - The `AS` and `AT` names specified with, `PIVOT`, i.e. `PIVOT x AS y AT z`
-            // Note that `AS` aliases specified in a select list (i.e. `SELECT x AS y` are *not* variables, they are
-            // fields.)
+            // Note that `AS` aliases specified in a select list (i.e. `SELECT x AS y`) are *not* variables, they are
+            // fields.
             // Modeling this with a separate node (as opposed to just a symbol) is beneficial because it is easy to
             // identify all variable declarations within a logical plan during tree traversal, and because in later
             // permuted domains we can add information to this type such as the variable's assigned index.
@@ -677,15 +677,46 @@ may then be further optimized by selecting better implementations of each operat
             )
         )
 
+        // DL TOOD: document everything
+        (include
+            (product dml_target
+                target::expr // permuted in resolved domain to be table uniqueid.
+            )
+
+            // Indicates kind of DML operation.
+            (sum dml_operation
+                // INSERT INTO
+                (dml_insert)
+
+                // DELETE FROM
+                (dml_delete)
+
+                // TODO:
+                // (dml_update)
+            )
+        )
+
+        // Redefine statement.dml to be a simple simple subset of the full DML functionality expressed with
+        // the PartiQL's DML syntax.  This is factored minimally to support `INSERT INTO` and
+        // `DELETE FROM ... [WHERE <predicate>]` but this may neeed refactoring when `FROM ... UPDATE` and
+        // `UPDATE` is supported later.
+        //need refactoring when PartiQL's `UPDATE` is supported later.
+        (with statement
+            (exclude dml)
+            (include
+                // A DML operation, such as `INSERT`, `UPDATE` or `DELETE`
+                (dml
+                    target::dml_target
+                    operation::dml_operation
+                    rows::expr
+                )
+            )
+        )
+
         // Nodes excluded below this line will eventually have a representation in the logical algebra, but not
         // initially.
 
-        (with statement
-            (exclude
-                dml
-                ddl
-            )
-        )
+        (with statement (exclude ddl))
 
         (exclude
             group_by
@@ -765,9 +796,9 @@ may then be further optimized by selecting better implementations of each operat
                 // - `uniqueId`: any Ion value that uniquely identifies the global variable, typically a storage
                 // defined UUID or the name of the table in its original letter case.
                 // The value of `uniqueId` is PartiQL integration defined and can be any symbol that uniquely
-                // identifies the global variable.  Examples include database object ids or the alphabetical case
-                // respecting table name found after case-insensitive lookup.
-                (global_id uniqueId::symbol case::case_sensitivity)
+                // identifies the global variable.  Examples include database object ids or the name of the variable
+                // in its the original letter case (as it was defined).
+                (global_id uniqueId::symbol)
             )
         )
     )
@@ -791,6 +822,18 @@ may then be further optimized by selecting better implementations of each operat
             // implementation.  These values are made available to the implementation at compile-time and evaluation
             // time.
             (product impl name::symbol static_args::(* ion 0))
+        )
+
+        // drop DML stuff added in partiql_logical (we expect these to be rewritten into pure bexprs by the time
+        // we transform a query to this domain).
+        (exclude dml_target dml_operation)
+        (with statement
+            (exclude dml query)
+
+            (include
+                // Include is_dml::bool in the query variant so that we know how to interpret the results of the
+                // query.
+                (query expr::expr is_dml::bool))
         )
 
         // Every variant of bexpr changes by adding an `impl` element in the physical algebra, so let's replace it
@@ -821,7 +864,6 @@ may then be further optimized by selecting better implementations of each operat
                     left::bexpr
                     right::bexpr
                     predicate::(? expr))
-
 
                 (offset i::impl row_count::expr source::bexpr)
                 (limit i::impl row_count::expr source::bexpr)

--- a/lang/src/org/partiql/lang/eval/Expression.kt
+++ b/lang/src/org/partiql/lang/eval/Expression.kt
@@ -14,10 +14,8 @@
 
 package org.partiql.lang.eval
 
-import com.amazon.ion.IonValue
-
 /**
- * An expression that can be evaluated to [IonValue].
+ * An expression that can be evaluated to [ExprValue].
  */
 interface Expression {
 

--- a/lang/src/org/partiql/lang/eval/physical/PhysicalExprToThunkConverterImpl.kt
+++ b/lang/src/org/partiql/lang/eval/physical/PhysicalExprToThunkConverterImpl.kt
@@ -32,6 +32,7 @@ import org.partiql.lang.errors.PropertyValueMap
 import org.partiql.lang.eval.AnyOfCastTable
 import org.partiql.lang.eval.Arguments
 import org.partiql.lang.eval.BaseExprValue
+import org.partiql.lang.eval.BindingCase
 import org.partiql.lang.eval.BindingName
 import org.partiql.lang.eval.CastFunc
 import org.partiql.lang.eval.DEFAULT_COMPARATOR
@@ -900,9 +901,11 @@ internal class PhysicalExprToThunkConverterImpl(
         thunkFactory.thunkEnv(metas) { valueFactory.missingValue }
 
     private fun compileGlobalId(expr: PartiqlPhysical.Expr.GlobalId): PhysicalPlanThunk {
-        val bindingCase = expr.case.toBindingCase()
+        // TODO: we really should consider using something other than `Bindings<ExprValue>` for global variables
+        // with the physical plan evaluator because `Bindings<ExprValue>.get()` accepts a `BindingName` instance
+        // which contains the `case` property which is always set to `SENSITIVE` and is therefore redundant.
+        val bindingName = BindingName(expr.uniqueId.text, BindingCase.SENSITIVE)
         return thunkFactory.thunkEnv(expr.metas) { env ->
-            val bindingName = BindingName(expr.uniqueId.text, bindingCase)
             env.session.globals[bindingName] ?: throwUndefinedVariableException(bindingName, expr.metas)
         }
     }

--- a/lang/src/org/partiql/lang/planner/QueryPlan.kt
+++ b/lang/src/org/partiql/lang/planner/QueryPlan.kt
@@ -1,0 +1,105 @@
+package org.partiql.lang.planner
+
+import org.partiql.lang.eval.BindingCase
+import org.partiql.lang.eval.BindingName
+import org.partiql.lang.eval.Bindings
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueType
+
+/** A query plan that has been compiled and is ready to be evaluated. */
+fun interface QueryPlan {
+    /**
+     * Evaluates the query plan with the given Session.
+     */
+    fun eval(session: EvaluationSession): QueryResult
+}
+
+sealed class QueryResult {
+    /**
+     * The result of an SFW query, arbitrary expression, or `EXEC` stored procedure call.
+     */
+    class Value(val value: ExprValue) : QueryResult()
+
+    /**
+     * The result of a INSERT or DELETE statement.  (UPDATE is out of scope for now.)
+     *
+     * Each instance of a DML command denotes an operation to be performed by the embedding PartiQL application
+     * to effect the writes specified by a DML operation.
+     *
+     * The primary benefit of this class is that it ensures that the [rows] property is evaluated lazily.  It also
+     * provides a cleaner API that is easier to work with for PartiQL embedders.  Without this, the user would have to
+     * consume the [ExprValue] directly and use code similar to that in [toDmlCommand] or convert it to Ion.  Neither
+     * option is particularly developer friendly, efficient or maintainable.
+     *
+     * This is currently only factored to support `INSERT INTO` and `DELETE FROM` as `UPDATE` and `FROM ... UPDATE` is
+     * out of scope for the current effort.
+     */
+    data class DmlCommand(
+        /** Identifies the action to take. */
+        val action: DmlAction,
+        /** The unique identifier of the table targed by the DML statement. */
+        val targetUniqueId: String,
+        /**
+         * The rows to be inserted or deleted.
+         *
+         * In the case of delete, the rows must contain at least the fields which comprise the primary key.
+         */
+        val rows: Iterable<ExprValue>
+    ) : QueryResult()
+}
+
+/** Identifies the action to take. */
+enum class DmlAction { INSERT, DELETE }
+
+internal const val DML_COMMAND_FIELD_ACTION = "action"
+internal const val DML_COMMAND_FIELD_TARGET_UNIQUE_ID = "target_unique_id"
+internal const val DML_COMMAND_FIELD_ROWS = "rows"
+
+private operator fun Bindings<ExprValue>.get(fieldName: String): ExprValue? =
+    this[BindingName(fieldName, BindingCase.SENSITIVE)]
+
+private fun errMissing(fieldName: String): Nothing =
+    error("'$fieldName' missing from DML command struct or has incorrect Ion type")
+
+/**
+ * Converts an [ExprValue] which is the result of a DML query to an instance of [DmlCommand].
+ *
+ * Format of a DML command:
+ *
+ * ```
+ * {
+ *     'action': <action>,
+ *     'target_unique_id': <unique_id>
+ *     'rows': <rows>
+ * }
+ * ```
+ *
+ * Where:
+ *  - `<action>` is either `insert` or `delete`
+ *  - `<target_unique_id>` is a string or symbol containing the unique identifier of the table to be effected
+ *  by the DML statement.
+ *  - `<rows>` is a list of bag containing the rows (structs) effected by the DML statement.
+ *      - When `<action>` is `insert` this is the rows to be inserted.
+ *      - When `<action>` is `delete` this is the rows to be deleted.  Non-primary key fields may be elided, but the
+ *      default behavior is to include all fields because PartiQL does not yet know about primary keys.
+ */
+internal fun ExprValue.toDmlCommand(): QueryResult.DmlCommand {
+    require(this.type == ExprValueType.STRUCT) { "'row' must be a struct" }
+
+    val actionString = this.bindings[DML_COMMAND_FIELD_ACTION]?.scalar?.stringValue()?.toUpperCase()
+        ?: errMissing(DML_COMMAND_FIELD_ACTION)
+
+    val dmlAction = DmlAction.values().firstOrNull { it.name == actionString }
+        ?: error("Unknown DmlAction in DML command struct: '$actionString'")
+
+    val targetUniqueId = this.bindings[DML_COMMAND_FIELD_TARGET_UNIQUE_ID]?.scalar?.stringValue()
+        ?: errMissing(DML_COMMAND_FIELD_TARGET_UNIQUE_ID)
+
+    val rows = this.bindings[DML_COMMAND_FIELD_ROWS] ?: errMissing(DML_COMMAND_FIELD_ROWS)
+    if (!rows.type.isSequence) {
+        error("DML command struct '$DML_COMMAND_FIELD_ROWS' field must be a bag or list")
+    }
+
+    return QueryResult.DmlCommand(dmlAction, targetUniqueId, rows)
+}

--- a/lang/src/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransform.kt
@@ -1,8 +1,13 @@
 package org.partiql.lang.planner.transforms
 
+import com.amazon.ionelement.api.ionSymbol
 import org.partiql.lang.domains.PartiqlLogicalResolved
 import org.partiql.lang.domains.PartiqlLogicalResolvedToPartiqlPhysicalVisitorTransform
 import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.planner.DML_COMMAND_FIELD_ACTION
+import org.partiql.lang.planner.DML_COMMAND_FIELD_ROWS
+import org.partiql.lang.planner.DML_COMMAND_FIELD_TARGET_UNIQUE_ID
+import org.partiql.lang.planner.DmlAction
 
 /**
  * Transforms an instance of [PartiqlLogicalResolved.Statement] to [PartiqlPhysical.Statement],
@@ -13,6 +18,12 @@ internal fun PartiqlLogicalResolved.Plan.toDefaultPhysicalPlan() =
 
 internal const val DEFAULT_IMPL_NAME = "default"
 internal val DEFAULT_IMPL = PartiqlPhysical.build { impl(DEFAULT_IMPL_NAME) }
+
+internal fun PartiqlPhysical.Builder.structField(name: String, value: String) =
+    structField(lit(ionSymbol(name)), lit(ionSymbol(value)))
+
+internal fun PartiqlPhysical.Builder.structField(name: String, value: PartiqlPhysical.Expr) =
+    structField(lit(ionSymbol(name)), value)
 
 internal class LogicalResolvedToDefaultPhysicalVisitorTransform : PartiqlLogicalResolvedToPartiqlPhysicalVisitorTransform() {
 
@@ -88,8 +99,48 @@ internal class LogicalResolvedToDefaultPhysicalVisitorTransform : PartiqlLogical
             let(
                 i = DEFAULT_IMPL,
                 source = thiz.transformBexpr(node.source),
-                bindings = node.bindings.map { transformLetBinding(it) }
+                bindings = node.bindings.map { transformLetBinding(it) },
+                metas = node.metas
             )
         }
     }
+
+    private fun PartiqlLogicalResolved.DmlTarget.asActionTarget(): PartiqlPhysical.Expr.Lit =
+        when (val target = this.target) {
+            is PartiqlLogicalResolved.Expr.GlobalId ->
+                PartiqlPhysical.build {
+                    lit(ionSymbol(target.uniqueId.text))
+                }
+            else ->
+                TODO("User-friendly error for invalid data manipulation target: $target")
+        }
+
+    override fun transformStatementDml(node: PartiqlLogicalResolved.Statement.Dml): PartiqlPhysical.Statement {
+        val action = when (node.operation) {
+            is PartiqlLogicalResolved.DmlOperation.DmlInsert -> DmlAction.INSERT
+            is PartiqlLogicalResolved.DmlOperation.DmlDelete -> DmlAction.DELETE
+        }.name.toLowerCase()
+
+        return PartiqlPhysical.build {
+            query(
+                expr = struct(
+                    structField(DML_COMMAND_FIELD_ACTION, action),
+                    structField(DML_COMMAND_FIELD_TARGET_UNIQUE_ID, node.target.asActionTarget()),
+                    structField(DML_COMMAND_FIELD_ROWS, transformExpr(node.rows)),
+                    metas = node.metas
+                ),
+                isDml = true,
+                metas = node.metas
+            )
+        }
+    }
+
+    override fun transformStatementQuery(node: PartiqlLogicalResolved.Statement.Query): PartiqlPhysical.Statement =
+        PartiqlPhysical.build {
+            query(
+                transformExpr(node.expr),
+                isDml = false, // DML is handled in transformStatementDml
+                metas = node.metas
+            )
+        }
 }

--- a/lang/src/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
@@ -138,7 +138,6 @@ private data class LogicalToLogicalResolvedVisitorTransform(
         PartiqlLogicalResolved.build {
             globalId_(
                 uniqueId = uniqueId.asPrimitive(),
-                case = this@LogicalToLogicalResolvedVisitorTransform.transformCaseSensitivity(this@asGlobalId.case),
                 metas = this@asGlobalId.metas
             )
         }

--- a/lang/test/org/partiql/lang/eval/EvaluatorTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTests.kt
@@ -105,6 +105,10 @@ class EvaluatorTests {
             "undefinedUnqualifiedVariableIsNullExprWithUndefinedVariableBehaviorMissing",
             "undefinedUnqualifiedVariableIsMissingExprWithUndefinedVariableBehaviorMissing",
             "undefinedUnqualifiedVariableInSelectWithUndefinedVariableBehaviorMissing",
+
+            // we are currently not plumbed to be able to return the original letter casing of global variables.
+            // (there are other tests in LogicalToLogicalResolvedVisitorTransform which cover this case)
+            "identifierCaseMismatch"
         )
 
         @JvmStatic

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/PlannerPipelineFactory.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/PlannerPipelineFactory.kt
@@ -11,6 +11,7 @@ import org.partiql.lang.planner.EvaluatorOptions
 import org.partiql.lang.planner.MetadataResolver
 import org.partiql.lang.planner.PassResult
 import org.partiql.lang.planner.PlannerPipeline
+import org.partiql.lang.planner.QueryResult
 import org.partiql.lang.planner.ResolutionResult
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
@@ -94,8 +95,8 @@ internal class PlannerPipelineFactory : PipelineFactory {
                             // There is no way to tell the actual name of the global variable as it exists
                             // in session.globals (case may differ).  For now we simply have to use binding.name
                             // as the uniqueId of the variable, however, this is not desirable in production
-                            // scenarios.  At minimum, the name of the variable in its original letter-case should be
-                            // used.
+                            // scenarios.  Ideally the name of the variable in the letter case of its declaration
+                            // should be used.
                             ResolutionResult.GlobalVariable(bindingName.name)
                         } else {
                             ResolutionResult.Undefined
@@ -115,7 +116,10 @@ internal class PlannerPipelineFactory : PipelineFactory {
                         fail("Query compilation unexpectedly failed: ${planningResult.errors}")
                     }
                     is PassResult.Success -> {
-                        return planningResult.result.eval(session)
+                        when (val queryResult = planningResult.result.eval(session)) {
+                            is QueryResult.DmlCommand -> error("DML is not supported by test suite")
+                            is QueryResult.Value -> return queryResult.value
+                        }
                     }
                 }
             }

--- a/lang/test/org/partiql/lang/planner/DmlIntegrationTests.kt
+++ b/lang/test/org/partiql/lang/planner/DmlIntegrationTests.kt
@@ -1,0 +1,76 @@
+package org.partiql.lang.planner
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.partiql.lang.ION
+import org.partiql.lang.eval.ExprValueFactory
+
+class DmlIntegrationTests {
+    val valueFactory = ExprValueFactory.standard(ION)
+
+    private val database = InMemoryDatabase(
+        listOf(InMemoryTable("customer", listOf("id"), valueFactory))
+    )
+
+    // DL TOOD: include test for INSERT/SELECT
+
+    @Test
+    fun `insert, select and delete`() {
+        val customerTbl = database.tables["customer"]!!
+        assertEquals(0, customerTbl.size)
+
+        // DL TODO: DML queries return { rows_effected: n } we should assert on that.
+
+        // start by inserting 4 rows
+        database.executeQuery("INSERT INTO customer VALUE { 'id': 1, 'name': 'bob' }")
+        database.executeQuery("INSERT INTO customer VALUE { 'id': 2, 'name': 'jane' }")
+        database.executeQuery("INSERT INTO customer VALUE { 'id': 3, 'name': 'moe' }")
+        database.executeQuery("INSERT INTO customer VALUE { 'id': 4, 'name': 'sue' }")
+
+        // assert each of the rows is present in the actual table.
+        assertEquals(4, customerTbl.size)
+        assertTrue(customerTbl.containsKey(intKey(1)))
+        assertTrue(customerTbl.containsKey(intKey(2)))
+        assertTrue(customerTbl.containsKey(intKey(3)))
+        assertTrue(customerTbl.containsKey(intKey(4)))
+
+        // run some simple SFW queries DL TODO: could DRY a little here.
+        assertEquals(
+            ION.singleValue("\$partiql_bag::[{ name: \"bob\"}]"),
+            database.executeQuery("SELECT c.name FROM customer AS c where c.id = 1").ionValue
+        )
+        assertEquals(
+            ION.singleValue("\$partiql_bag::[{ name: \"jane\"}]"),
+            database.executeQuery("SELECT c.name FROM customer AS c where c.id = 2").ionValue
+        )
+        assertEquals(
+            ION.singleValue("\$partiql_bag::[{ name: \"moe\"}]"),
+            database.executeQuery("SELECT c.name FROM customer AS c where c.id = 3").ionValue
+        )
+        // run some simple SFW queries
+        assertEquals(
+            ION.singleValue("\$partiql_bag::[{ name: \"sue\"}]"),
+            database.executeQuery("SELECT c.name FROM customer AS c where c.id = 4").ionValue
+        )
+
+        // now delete 2 rows and assert that they are no longer present (test DELETE FROM with WHERE predicate)
+
+        database.executeQuery("DELETE FROM customer AS c WHERE c.id = 2")
+        assertEquals(3, customerTbl.size)
+        assertFalse(customerTbl.containsKey(intKey(2)))
+
+        database.executeQuery("DELETE FROM customer AS c WHERE c.id = 4")
+        assertFalse(customerTbl.containsKey(intKey(4)))
+
+        // finally, delete all remaining rows (test DELETE FROM without WHERE predicate)
+
+        database.executeQuery("DELETE FROM customer")
+        assertEquals(0, customerTbl.size)
+        assertFalse(customerTbl.containsKey(intKey(1)))
+        assertFalse(customerTbl.containsKey(intKey(3)))
+    }
+
+    private fun intKey(value: Int) = valueFactory.newList(listOf(valueFactory.newInt(value)))
+}

--- a/lang/test/org/partiql/lang/planner/InMemoryDatabase.kt
+++ b/lang/test/org/partiql/lang/planner/InMemoryDatabase.kt
@@ -1,0 +1,103 @@
+package org.partiql.lang.planner
+
+import org.partiql.lang.ION
+import org.partiql.lang.eval.BindingCase
+import org.partiql.lang.eval.BindingName
+import org.partiql.lang.eval.Bindings
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.StructOrdering
+import org.partiql.lang.eval.namedValue
+
+/**
+ * This is an extremely simple in-memory "database" for the purposes of demonstrating PartiQL's DML functionality
+ * in the simplest manner possible.
+ *
+ * This database supports basic SFW and DML operations.
+ */
+class InMemoryDatabase(
+    /**
+     * A list of tables that will be in the in-memory database.
+     * Names of the tables should be unique.
+     */
+    theTables: List<InMemoryTable>
+) {
+    val valueFactory = ExprValueFactory.standard(ION)
+    val tables = theTables.associateBy { it.name }
+
+    // planner needs to resolve global variables (i.e. tables)
+    private val resolver = object : MetadataResolver {
+        override fun resolveVariable(bindingName: BindingName): ResolutionResult {
+            return when (bindingName.bindingCase) {
+                BindingCase.SENSITIVE -> tables[bindingName.name]
+                BindingCase.INSENSITIVE -> tables.entries.firstOrNull { it.key.compareTo(bindingName.name) == 0 }?.value
+            }?.let {
+                // Note that the name we pass here becomes the case-sensitive lookup into global bindings, below.
+                // Therefore it is important to use the defined name of the table and *not* the name of the
+                // variable, which might vary by letter case.
+                // DL TODO: the above may not be true (see dl todo comments in the `binding` declaration below
+                ResolutionResult.GlobalVariable(it.name)
+            } ?: ResolutionResult.Undefined
+        }
+    }
+
+    val bindings = object : Bindings<ExprValue> {
+        override fun get(bindingName: BindingName): ExprValue? {
+            // The need to assert this is one of the reasons why we should consider using something other
+            // than Bindings<ExprValue>
+            require(bindingName.bindingCase == BindingCase.SENSITIVE) {
+                "the planner should never set bindingName.bindingCase to INSENSITIVE"
+            }
+            val table: InMemoryTable = tables[bindingName.name] ?: return null
+            return valueFactory.newBag(table)
+        }
+    }
+
+    private val planner = PlannerPipeline.build(valueFactory) {
+        metadataResolver(resolver)
+    }
+
+    // planner API changes:
+    // need a way to indicate if the query planned is DML or not
+    fun executeQuery(sql: String): ExprValue {
+        when (val plan = planner.planAndCompile(sql)) {
+            is PassResult.Error -> error(plan)
+            is PassResult.Success -> {
+                val session = EvaluationSession.build {
+                    globals(bindings)
+                }
+
+                return when (val queryResult = plan.result.eval(session)) {
+                    is QueryResult.Value -> queryResult.value
+                    is QueryResult.DmlCommand -> {
+                        // find the target table
+                        val targetTable = tables[queryResult.targetUniqueId] ?: error(
+                            "Planned query for some reason allowed a reference to a " +
+                                "non-existing table '$queryResult.target.uniqueId' to pass unnoticed!"
+                        )
+
+                        var rowsEffected = 0L
+                        // now perform the action.
+                        when (queryResult.action) {
+                            DmlAction.INSERT -> queryResult.rows.forEach {
+                                targetTable.insert(it)
+                                rowsEffected++
+                            }
+                            DmlAction.DELETE -> queryResult.rows.forEach {
+                                targetTable.delete(it)
+                                rowsEffected++
+                            }
+                        }
+
+                        // returns `{ rows_effected: $rowsEffected }`
+                        valueFactory.newStruct(
+                            listOf(valueFactory.newInt(rowsEffected).namedValue(valueFactory.newString("rows_effected"))),
+                            StructOrdering.UNORDERED
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/lang/test/org/partiql/lang/planner/InMemoryTable.kt
+++ b/lang/test/org/partiql/lang/planner/InMemoryTable.kt
@@ -1,0 +1,68 @@
+package org.partiql.lang.planner
+
+import org.partiql.lang.eval.BindingCase
+import org.partiql.lang.eval.BindingName
+import org.partiql.lang.eval.DEFAULT_COMPARATOR
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.ExprValueType
+import java.util.TreeMap
+
+/**
+ * An extermely simple in-memory table, to be used with [InMemoryDatabase].
+ */
+class InMemoryTable(
+    val name: String,
+    primaryKeyFields: List<String>,
+    private val valueFactory: ExprValueFactory
+) : Iterable<ExprValue> {
+    private val rows = TreeMap<ExprValue, ExprValue>(DEFAULT_COMPARATOR)
+
+    private val primaryKeyBindingNames = primaryKeyFields.map { BindingName(it, BindingCase.SENSITIVE) }
+
+    private fun ExprValue.extractPrimaryKey(): ExprValue =
+        valueFactory.newList(
+            primaryKeyBindingNames.map {
+                this.bindings[it] ?: error("Row missing primary key field '${it.name}' (case: ${it.bindingCase})")
+            }.asIterable()
+        )
+
+    fun containsKey(key: ExprValue): Boolean {
+        require(key.type == ExprValueType.LIST) { "Primary key value must be a list" }
+        return rows.containsKey(key)
+    }
+
+    val size: Int get() = rows.size
+
+    fun insert(row: ExprValue) {
+        require(row.type == ExprValueType.STRUCT) { "Row to be inserted must be a struct" }
+
+        val primaryKeyExprValue = row.extractPrimaryKey()
+
+        if (rows.containsKey(primaryKeyExprValue)) {
+            error("Table '$name' already contains a row with the specified primary key ")
+        } else {
+            // We have to detatch the ExprValue from any lazily evaluated query that may get invoked
+            // whenever the value is accessed.  To do this we convert to Ion, which forces full materialization,
+            // and then create a new ExprValue based off the Ion.
+            val rowStruct = row.ionValue
+            rows[primaryKeyExprValue] = valueFactory.newFromIonValue(rowStruct)
+        }
+    }
+
+    /**
+     * Deletes a row from the table.  [row] should at least contain all the fields which make up the
+     * primary key of the table, but may also contain additional rows, which are ignored.
+     */
+    fun delete(row: ExprValue) {
+        require(row.type == ExprValueType.STRUCT) { "Row to be deleted must be a struct" }
+        val primaryKey = row.extractPrimaryKey()
+        rows.remove(primaryKey)
+    }
+
+    override fun iterator(): Iterator<ExprValue> =
+        // the call to .toList below is important to allow the table contents to be modified during query
+        // execution.  (Otherwise we will hit a ConcurrentModificationException in the case a DELETE FROM statement
+        // is executed)
+        rows.values.toList().iterator()
+}

--- a/lang/test/org/partiql/lang/planner/PlannerPipelineSmokeTests.kt
+++ b/lang/test/org/partiql/lang/planner/PlannerPipelineSmokeTests.kt
@@ -65,11 +65,12 @@ class PlannerPipelineSmokeTests {
                                     ),
                                     source = scan(
                                         i = impl("default"),
-                                        expr = globalId("fake_uid_for_Customer", caseInsensitive()),
+                                        expr = globalId("fake_uid_for_Customer"),
                                         asDecl = varDecl(0)
                                     )
                                 )
-                            )
+                            ),
+                            isDml = false
                         ),
                         locals = listOf(localVariable("c", 0)),
                         version = PLAN_VERSION_NUMBER
@@ -123,7 +124,7 @@ class PlannerPipelineSmokeTests {
     private fun createFakePlan(number: Int) =
         PartiqlPhysical.build {
             plan(
-                stmt = query(lit(ionInt(number.toLong()))),
+                stmt = query(lit(ionInt(number.toLong())), isDml = false),
                 version = PLAN_VERSION_NUMBER
             )
         }

--- a/lang/test/org/partiql/lang/planner/operators/CustomOperatorFactoryTests.kt
+++ b/lang/test/org/partiql/lang/planner/operators/CustomOperatorFactoryTests.kt
@@ -127,7 +127,7 @@ class CustomOperatorFactoryTests {
 
         private fun PartiqlPhysical.Builder.defaultScan() = scan(
             DEFAULT_IMPL,
-            globalId("whatever", caseInsensitive()), varDecl(0)
+            globalId("whatever"), varDecl(0)
         )
 
         private fun <T : PartiqlPhysical.Bexpr> createTestCase(
@@ -139,9 +139,10 @@ class CustomOperatorFactoryTests {
                 plan(
                     stmt = query(
                         bindingsToValues(
-                            globalId("whatever", caseInsensitive()),
+                            globalId("whatever"),
                             this.block()
-                        )
+                        ),
+                        isDml = false
                     ),
                     version = PLAN_VERSION_NUMBER
                 )

--- a/lang/test/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransformTests.kt
@@ -1,28 +1,34 @@
 package org.partiql.lang.planner.transforms
 
 import com.amazon.ionelement.api.ionBool
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.ionSymbol
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.domains.PartiqlLogicalResolved
 import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.planner.DML_COMMAND_FIELD_ACTION
+import org.partiql.lang.planner.DML_COMMAND_FIELD_ROWS
+import org.partiql.lang.planner.DML_COMMAND_FIELD_TARGET_UNIQUE_ID
 import org.partiql.lang.util.ArgumentsProviderBase
+import kotlin.test.fail
 
 class LogicalResolvedToDefaultPhysicalVisitorTransformTests {
-    data class TestCase(val input: PartiqlLogicalResolved.Bexpr, val expected: PartiqlPhysical.Bexpr)
+    data class BexprTestCase(val input: PartiqlLogicalResolved.Bexpr, val expected: PartiqlPhysical.Bexpr)
 
     @ParameterizedTest
     @ArgumentsSource(ArgumentsForToPhysicalTests::class)
-    fun `to physical`(tc: TestCase) {
+    fun `relational operators`(tc: BexprTestCase) {
         assertEquals(tc.expected, LogicalResolvedToDefaultPhysicalVisitorTransform().transformBexpr(tc.input))
     }
 
     class ArgumentsForToPhysicalTests : ArgumentsProviderBase() {
         override fun getParameters() = listOf(
-            TestCase(
+            BexprTestCase(
                 PartiqlLogicalResolved.build {
                     scan(
-                        expr = globalId("foo", caseInsensitive()),
+                        expr = globalId("foo"),
                         asDecl = varDecl(0),
                         atDecl = varDecl(1),
                         byDecl = varDecl(2)
@@ -31,19 +37,19 @@ class LogicalResolvedToDefaultPhysicalVisitorTransformTests {
                 PartiqlPhysical.build {
                     scan(
                         i = DEFAULT_IMPL,
-                        expr = globalId("foo", caseInsensitive()),
+                        expr = globalId("foo"),
                         asDecl = varDecl(0),
                         atDecl = varDecl(1),
                         byDecl = varDecl(2)
                     )
                 }
             ),
-            TestCase(
+            BexprTestCase(
                 PartiqlLogicalResolved.build {
                     filter(
                         predicate = lit(ionBool(true)),
                         source = scan(
-                            expr = globalId("foo", caseInsensitive()),
+                            expr = globalId("foo"),
                             asDecl = varDecl(0),
                             atDecl = varDecl(1),
                             byDecl = varDecl(2)
@@ -56,7 +62,7 @@ class LogicalResolvedToDefaultPhysicalVisitorTransformTests {
                         predicate = lit(ionBool(true)),
                         source = scan(
                             i = DEFAULT_IMPL,
-                            expr = globalId("foo", caseInsensitive()),
+                            expr = globalId("foo"),
                             asDecl = varDecl(0),
                             atDecl = varDecl(1),
                             byDecl = varDecl(2)
@@ -64,6 +70,150 @@ class LogicalResolvedToDefaultPhysicalVisitorTransformTests {
                     )
                 }
             )
+        )
+    }
+
+    data class DmlTestCase(val input: PartiqlLogicalResolved.Statement, val expected: PartiqlPhysical.Statement)
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgumentsForToDMLTests::class)
+    fun `DML to query`(tc: DmlTestCase) {
+        val actual = LogicalResolvedToDefaultPhysicalVisitorTransform().transformStatement(tc.input)
+        if (actual != tc.expected) {
+            fail("Expected and actual values must match!\nExpected: ${tc.expected}\nActual  : $actual")
+        }
+    }
+
+    class ArgumentsForToDMLTests : ArgumentsProviderBase() {
+        override fun getParameters() = listOf(
+            DmlTestCase(
+                // INSERT INTO foo VALUE 1
+                PartiqlLogicalResolved.build {
+                    dml(
+                        dmlTarget(globalId("foo")),
+                        dmlInsert(),
+                        bag(lit(ionInt(1)))
+                    )
+                },
+                PartiqlPhysical.build {
+                    query(
+                        struct(
+                            structField(DML_COMMAND_FIELD_ACTION, "insert"),
+                            structField(DML_COMMAND_FIELD_TARGET_UNIQUE_ID, lit(ionSymbol("foo"))),
+                            structField(DML_COMMAND_FIELD_ROWS, bag(lit(ionInt(1))))
+                        ),
+                        isDml = true
+                    )
+                }
+            ),
+            DmlTestCase(
+                // INSERT INTO foo SELECT x.* FROM 1 AS x
+                PartiqlLogicalResolved.build {
+                    dml(
+                        dmlTarget(globalId("foo")),
+                        dmlInsert(),
+                        bindingsToValues(
+                            struct(structFields(localId(0))),
+                            scan(lit(ionInt(1)), varDecl(0))
+                        )
+                    )
+                },
+                PartiqlPhysical.build {
+                    query(
+                        struct(
+                            structField(DML_COMMAND_FIELD_ACTION, "insert"),
+                            structField(DML_COMMAND_FIELD_TARGET_UNIQUE_ID, lit(ionSymbol("foo"))),
+                            structField(
+                                DML_COMMAND_FIELD_ROWS,
+                                bindingsToValues(
+                                    struct(structFields(localId(0))),
+                                    scan(
+                                        i = DEFAULT_IMPL,
+                                        expr = lit(ionInt(1)),
+                                        asDecl = varDecl(0)
+                                    )
+                                )
+                            )
+                        ),
+                        isDml = true
+                    )
+                }
+            ),
+            DmlTestCase(
+                // DELETE FROM y AS y
+                PartiqlLogicalResolved.build {
+                    dml(
+                        dmlTarget(globalId("foo")),
+                        dmlDelete(),
+                        bindingsToValues(
+                            localId(0),
+                            scan(globalId("y"), varDecl(0))
+                        )
+                    )
+                },
+                PartiqlPhysical.build {
+                    query(
+                        struct(
+                            structField(DML_COMMAND_FIELD_ACTION, "delete"),
+                            structField(DML_COMMAND_FIELD_TARGET_UNIQUE_ID, lit(ionSymbol("foo"))),
+                            structField(
+                                DML_COMMAND_FIELD_ROWS,
+                                bindingsToValues(
+                                    localId(0),
+                                    scan(
+                                        i = DEFAULT_IMPL,
+                                        expr = globalId("y"),
+                                        asDecl = varDecl(0)
+                                    )
+                                )
+                            )
+                        ),
+                        isDml = true
+                    )
+                }
+            ),
+            DmlTestCase(
+                // DELETE FROM y AS y WHERE 1=1
+                PartiqlLogicalResolved.build {
+                    dml(
+                        dmlTarget(globalId("y")),
+                        dmlDelete(),
+                        bindingsToValues(
+                            localId(0),
+                            // this logical plan is same as previous but includes this filter
+                            filter(
+                                eq(lit(ionInt(1)), lit(ionInt(1))),
+                                scan(globalId("y"), varDecl(0))
+                            )
+                        )
+                    )
+                },
+                PartiqlPhysical.build {
+                    query(
+                        struct(
+                            structField(DML_COMMAND_FIELD_ACTION, "delete"),
+                            structField(DML_COMMAND_FIELD_TARGET_UNIQUE_ID, lit(ionSymbol("y"))),
+                            structField(
+                                DML_COMMAND_FIELD_ROWS,
+                                bindingsToValues(
+                                    localId(0),
+                                    // this logical plan is same as previous but includes this filter
+                                    filter(
+                                        i = DEFAULT_IMPL,
+                                        eq(lit(ionInt(1)), lit(ionInt(1))),
+                                        scan(
+                                            i = DEFAULT_IMPL,
+                                            expr = globalId("y"),
+                                            asDecl = varDecl(0)
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                        isDml = true
+                    )
+                }
+            ),
         )
     }
 }

--- a/lang/test/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransformTests.kt
@@ -202,17 +202,17 @@ class LogicalToLogicalResolvedVisitorTransformTests {
             TestCase(
                 // all uppercase
                 sql = "FOO",
-                expectation = Expectation.Success(ResolvedId(1, 1) { globalId("fake_uid_for_foo", caseInsensitive()) })
+                expectation = Expectation.Success(ResolvedId(1, 1) { globalId("fake_uid_for_foo") })
             ),
             TestCase(
                 // all lower case
                 "foo",
-                Expectation.Success(ResolvedId(1, 1) { globalId("fake_uid_for_foo", caseInsensitive()) })
+                Expectation.Success(ResolvedId(1, 1) { globalId("fake_uid_for_foo") })
             ),
             TestCase(
                 // mixed case
                 "fOo",
-                Expectation.Success(ResolvedId(1, 1) { globalId("fake_uid_for_foo", caseInsensitive()) })
+                Expectation.Success(ResolvedId(1, 1) { globalId("fake_uid_for_foo") })
             ),
             TestCase(
                 // undefined
@@ -233,7 +233,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 // In this case, we resolve to the first matching binding.  This is consistent with Postres 9.6.
                 Expectation.Success(
                     ResolvedId(1, 1) {
-                        globalId("fake_uid_for_case_AMBIGUOUS_foo", caseInsensitive())
+                        globalId("fake_uid_for_case_AMBIGUOUS_foo")
                     }
                 )
             ),
@@ -244,7 +244,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 "UPPERCASE_FOO",
                 Expectation.Success(
                     ResolvedId(1, 1) {
-                        globalId("fake_uid_for_UPPERCASE_FOO", caseInsensitive())
+                        globalId("fake_uid_for_UPPERCASE_FOO")
                     }
                 )
             ),
@@ -253,7 +253,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 "uppercase_foo",
                 Expectation.Success(
                     ResolvedId(1, 1) {
-                        globalId("fake_uid_for_UPPERCASE_FOO", caseInsensitive())
+                        globalId("fake_uid_for_UPPERCASE_FOO")
                     }
                 )
             ),
@@ -262,7 +262,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 "UpPeRcAsE_fOo",
                 Expectation.Success(
                     ResolvedId(1, 1) {
-                        globalId("fake_uid_for_UPPERCASE_FOO", caseInsensitive())
+                        globalId("fake_uid_for_UPPERCASE_FOO")
                     }
                 )
             ),
@@ -301,7 +301,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
             TestCase(
                 // all lowercase
                 "\"foo\"",
-                Expectation.Success(ResolvedId(1, 1) { globalId("fake_uid_for_foo", caseSensitive()) })
+                Expectation.Success(ResolvedId(1, 1) { globalId("fake_uid_for_foo") })
             ),
             TestCase(
                 // mixed
@@ -321,9 +321,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 "\"UPPERCASE_FOO\"",
                 Expectation.Success(
                     ResolvedId(1, 1) {
-                        globalId(
-                            "fake_uid_for_UPPERCASE_FOO", caseSensitive()
-                        )
+                        globalId("fake_uid_for_UPPERCASE_FOO")
                     }
                 )
             ),
@@ -346,7 +344,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 "\"case_AMBIGUOUS_foo\"",
                 Expectation.Success(
                     ResolvedId(1, 1) {
-                        globalId("fake_uid_for_case_AMBIGUOUS_foo", caseSensitive())
+                        globalId("fake_uid_for_case_AMBIGUOUS_foo")
                     }
                 )
             ),
@@ -355,7 +353,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 "\"case_ambiguous_FOO\"",
                 Expectation.Success(
                     ResolvedId(1, 1) {
-                        globalId("fake_uid_for_case_ambiguous_FOO", caseSensitive())
+                        globalId("fake_uid_for_case_ambiguous_FOO")
                     }
                 )
             ),
@@ -370,7 +368,6 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                     )
                 )
             ),
-
             TestCase(
                 // undefined allowed (case-sensitive)
                 "\"some_undefined\"",
@@ -536,7 +533,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 "SELECT $varName.* FROM foo AS a AT b BY c",
                 Expectation.Success(
                     ResolvedId(1, 8) { localId(expectedIndex.toLong()) },
-                    ResolvedId(1, 17) { globalId("fake_uid_for_foo", caseInsensitive()) }
+                    ResolvedId(1, 17) { globalId("fake_uid_for_foo") }
                 ).withLocals(localVariable("a", 0), localVariable("b", 1), localVariable("c", 2))
             )
 
@@ -553,7 +550,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 "SELECT b.* FROM bar AS b WHERE b.primaryKey = 42",
                 Expectation.Success(
                     ResolvedId(1, 8) { localId(0) },
-                    ResolvedId(1, 17) { globalId("fake_uid_for_bar", caseInsensitive()) },
+                    ResolvedId(1, 17) { globalId("fake_uid_for_bar") },
                     ResolvedId(1, 32) { localId(0) },
                 ).withLocals(localVariable("b", 0))
             ),
@@ -563,7 +560,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 "SELECT shadow.* FROM shadow AS shadow", // `shadow` defined here shadows the global `shadow`
                 Expectation.Success(
                     ResolvedId(1, 8) { localId(0) },
-                    ResolvedId(1, 22) { globalId("fake_uid_for_shadow", caseInsensitive()) }
+                    ResolvedId(1, 22) { globalId("fake_uid_for_shadow") }
                 ).withLocals(localVariable("shadow", 0))
             ),
 


### PR DESCRIPTION
#### Description of Changes

This PR adds support to PartiQL for DML statements taking the following forms:

- `INSERT INTO foo << { 'id': 1, 'name': 'bob' }, { 'id': 2, 'name' : 'sue' } >>` (multi record insert)
- `INSERT INTO foo VALUE 1` (single record insert)
- `INSERT INTO foo SELECT c.id, c.name FROM customer AS c` (insert the results of a query into another table)
- `DELETE FROM foo` (delete all records in a table)
- `DELETE FROM foo AS f WHERE f.zipCode = '90210'` (delete all records matching a predicate)

This is accomplished by rewriting DML statements into standard queries and enhancing the API of `PlannerPipeline` to better support execution of these queries.  For details on the rewrites, see changes to `LogicalResolvedToDefaultPhysicalVisitorTransform` and its tests to see how this works.

---

This PR is still in WIP!  This PR has been completed enough to verify that all of the above DML statements work, however, the following must be completed before this may be merged:

- [ ] Address those `TODO` comments and function calls (those that are within the scope described above, that is).
- [ ] Throw/handle proper exceptions & error messaging.
- [ ] Additional unit testing (particularly surrounding error cases)
- [x] Update `CHANGELOG.md`

#### Backward Incompatible Changes

The API of `PlannerPipeline` (an experimental API that few, if anybody, is using) changes.  Namely, the result of compilation is now a `QueryPlan` which is analogous to the previous `Expression` interface but returns `QueryResult` instead of `ExprValue`.  `QueryResult` is a sealed class that may be one of `QueryResult.Value` (the result of an SFW query or other expression and contains an `ExprValue`) or `QueryResult.DmlCommand`, which is the result of a DML operation and contains a series of "commands" which must be applied by the application embedding PartiQL to effect the DML.

#### Dependencies 

> *Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:*

No new dependencies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


