### PR TITLE
Adds OUTER set operators to parser and type domain

### DIFF
--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -130,6 +130,9 @@ may then be further optimized by selecting better implementations of each operat
             (union setq::set_quantifier operands::(* expr 2))
             (except setq::set_quantifier operands::(* expr 2))
             (intersect setq::set_quantifier operands::(* expr 2))
+            (outer_union setq::set_quantifier operands::(* expr 2))
+            (outer_except setq::set_quantifier operands::(* expr 2))
+            (outer_intersect setq::set_quantifier operands::(* expr 2))
 
             // Other expression types
             (path root::expr steps::(* path_step 1))

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -1,4 +1,3 @@
-
 // We don't need warnings about deprecated ExprNode.
 @file: Suppress("DEPRECATION")
 
@@ -95,7 +94,12 @@ fun ExprNode.toAstExpr(): PartiqlAst.Expr {
         when (node) {
             is Literal -> lit(node.ionValue.toIonElement(), metas)
             is LiteralMissing -> missing(metas)
-            is VariableReference -> id(node.id, node.case.toAstCaseSensitivity(), node.scopeQualifier.toAstScopeQualifier(), metas)
+            is VariableReference -> id(
+                node.id,
+                node.case.toAstCaseSensitivity(),
+                node.scopeQualifier.toAstScopeQualifier(),
+                metas
+            )
             is Parameter -> parameter(node.position.toLong(), metas)
             is NAry -> {
                 val args = node.args.map { it.toAstExpr() }
@@ -135,12 +139,18 @@ fun ExprNode.toAstExpr(): PartiqlAst.Expr {
                         // TODO:  we are losing case-sensitivity of the function name here.  Do we care?
                         call(idArg.name.text, args.drop(1), metas)
                     }
+                    NAryOp.UNION -> union(distinct(), args, metas)
+                    NAryOp.UNION_ALL -> union(all(), args, metas)
                     NAryOp.INTERSECT -> intersect(distinct(), args, metas)
                     NAryOp.INTERSECT_ALL -> intersect(all(), args, metas)
                     NAryOp.EXCEPT -> except(distinct(), args, metas)
                     NAryOp.EXCEPT_ALL -> except(all(), args, metas)
-                    NAryOp.UNION -> union(distinct(), args, metas)
-                    NAryOp.UNION_ALL -> union(all(), args, metas)
+                    NAryOp.OUTER_UNION -> outerUnion(distinct(), args, metas)
+                    NAryOp.OUTER_UNION_ALL -> outerUnion(all(), args, metas)
+                    NAryOp.OUTER_INTERSECT -> outerIntersect(distinct(), args, metas)
+                    NAryOp.OUTER_INTERSECT_ALL -> outerIntersect(all(), args, metas)
+                    NAryOp.OUTER_EXCEPT -> outerExcept(distinct(), args, metas)
+                    NAryOp.OUTER_EXCEPT_ALL -> outerExcept(all(), args, metas)
                 }
             }
             is CallAgg -> {
@@ -230,7 +240,13 @@ private fun OrderBy.toAstOrderBySpec(): PartiqlAst.OrderBy {
     val thiz = this
     return PartiqlAst.build {
         orderBy(
-            thiz.sortSpecItems.map { sortSpec(it.expr.toAstExpr(), it.orderingSpec?.toAstOrderSpec(), it.nullsSpec?.toAstNullsSpec()) }
+            thiz.sortSpecItems.map {
+                sortSpec(
+                    it.expr.toAstExpr(),
+                    it.orderingSpec?.toAstOrderSpec(),
+                    it.nullsSpec?.toAstNullsSpec()
+                )
+            }
         )
     }
 }
@@ -313,19 +329,31 @@ private fun SelectProjection.toAstSelectProject(): PartiqlAst.Projection {
                     if (thiz.items.size > 1) error("More than one select item when SELECT * was present.")
                     val metas = (thiz.items[0] as SelectListItemStar).metas.toIonElementMetaContainer()
                     projectStar(metas)
-                } else
+                } else {
                     projectList(
                         thiz.items.map {
                             when (it) {
-                                is SelectListItemExpr -> projectExpr_(it.expr.toAstExpr(), it.asName?.toPrimitive(), it.expr.metas.toIonElementMetaContainer())
-                                is SelectListItemProjectAll -> projectAll(it.expr.toAstExpr(), it.expr.metas.toIonElementMetaContainer())
+                                is SelectListItemExpr -> projectExpr_(
+                                    it.expr.toAstExpr(),
+                                    it.asName?.toPrimitive(),
+                                    it.expr.metas.toIonElementMetaContainer()
+                                )
+                                is SelectListItemProjectAll -> projectAll(
+                                    it.expr.toAstExpr(),
+                                    it.expr.metas.toIonElementMetaContainer()
+                                )
                                 is SelectListItemStar -> error("this should happen due to `when` branch above.")
                             }
                         },
                         metas = thiz.metas.toIonElementMetaContainer()
                     )
+                }
             }
-            is SelectProjectionPivot -> projectPivot(thiz.nameExpr.toAstExpr(), thiz.valueExpr.toAstExpr(), thiz.metas.toIonElementMetaContainer())
+            is SelectProjectionPivot -> projectPivot(
+                thiz.nameExpr.toAstExpr(),
+                thiz.valueExpr.toAstExpr(),
+                thiz.metas.toIonElementMetaContainer()
+            )
         }
     }
 }
@@ -425,6 +453,7 @@ private fun DmlOpList.toAstDmlOps(dml: DataManipulation): PartiqlAst.DmlOpList =
             metas = dml.metas.toIonElementMetaContainer()
         )
     }
+
 private fun DataManipulationOperation.toAstDmlOp(dml: DataManipulation): PartiqlAst.DmlOp =
     PartiqlAst.build {
         when (val thiz = this@toAstDmlOp) {

--- a/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
+++ b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt
@@ -145,12 +145,6 @@ fun ExprNode.toAstExpr(): PartiqlAst.Expr {
                     NAryOp.INTERSECT_ALL -> intersect(all(), args, metas)
                     NAryOp.EXCEPT -> except(distinct(), args, metas)
                     NAryOp.EXCEPT_ALL -> except(all(), args, metas)
-                    NAryOp.OUTER_UNION -> outerUnion(distinct(), args, metas)
-                    NAryOp.OUTER_UNION_ALL -> outerUnion(all(), args, metas)
-                    NAryOp.OUTER_INTERSECT -> outerIntersect(distinct(), args, metas)
-                    NAryOp.OUTER_INTERSECT_ALL -> outerIntersect(all(), args, metas)
-                    NAryOp.OUTER_EXCEPT -> outerExcept(distinct(), args, metas)
-                    NAryOp.OUTER_EXCEPT_ALL -> outerExcept(all(), args, metas)
                 }
             }
             is CallAgg -> {

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -111,33 +111,9 @@ private class StatementTransformer(val ion: IonSystem) {
                     operands.toExprNodeList(),
                     metas
                 )
-            is PartiqlAst.Expr.OuterUnion ->
-                NAry(
-                    when (setq) {
-                        is PartiqlAst.SetQuantifier.Distinct -> NAryOp.OUTER_UNION
-                        is PartiqlAst.SetQuantifier.All -> NAryOp.OUTER_UNION_ALL
-                    },
-                    operands.toExprNodeList(),
-                    metas
-                )
-            is PartiqlAst.Expr.OuterIntersect ->
-                NAry(
-                    when (setq) {
-                        is PartiqlAst.SetQuantifier.Distinct -> NAryOp.OUTER_INTERSECT
-                        is PartiqlAst.SetQuantifier.All -> NAryOp.OUTER_INTERSECT_ALL
-                    },
-                    operands.toExprNodeList(),
-                    metas
-                )
-            is PartiqlAst.Expr.OuterExcept ->
-                NAry(
-                    when (setq) {
-                        is PartiqlAst.SetQuantifier.Distinct -> NAryOp.OUTER_EXCEPT
-                        is PartiqlAst.SetQuantifier.All -> NAryOp.OUTER_EXCEPT_ALL
-                    },
-                    operands.toExprNodeList(),
-                    metas
-                )
+            is PartiqlAst.Expr.OuterUnion,
+            is PartiqlAst.Expr.OuterIntersect,
+            is PartiqlAst.Expr.OuterExcept -> error("$this node has no representation in prior ASTs.")
             is PartiqlAst.Expr.Like -> NAry(NAryOp.LIKE, listOfNotNull(value.toExprNode(), pattern.toExprNode(), escape?.toExprNode()), metas)
             is PartiqlAst.Expr.Between -> NAry(NAryOp.BETWEEN, listOf(value.toExprNode(), from.toExprNode(), to.toExprNode()), metas)
             is PartiqlAst.Expr.InCollection -> NAry(NAryOp.IN, operands.toExprNodeList(), metas)

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -114,8 +114,8 @@ private class StatementTransformer(val ion: IonSystem) {
             is PartiqlAst.Expr.OuterUnion ->
                 NAry(
                     when (setq) {
-                        is PartiqlAst.SetQuantifier.Distinct -> NAryOp.UNION
-                        is PartiqlAst.SetQuantifier.All -> NAryOp.UNION_ALL
+                        is PartiqlAst.SetQuantifier.Distinct -> NAryOp.OUTER_UNION
+                        is PartiqlAst.SetQuantifier.All -> NAryOp.OUTER_UNION_ALL
                     },
                     operands.toExprNodeList(),
                     metas
@@ -123,8 +123,8 @@ private class StatementTransformer(val ion: IonSystem) {
             is PartiqlAst.Expr.OuterIntersect ->
                 NAry(
                     when (setq) {
-                        is PartiqlAst.SetQuantifier.Distinct -> NAryOp.INTERSECT
-                        is PartiqlAst.SetQuantifier.All -> NAryOp.INTERSECT_ALL
+                        is PartiqlAst.SetQuantifier.Distinct -> NAryOp.OUTER_INTERSECT
+                        is PartiqlAst.SetQuantifier.All -> NAryOp.OUTER_INTERSECT_ALL
                     },
                     operands.toExprNodeList(),
                     metas
@@ -132,8 +132,8 @@ private class StatementTransformer(val ion: IonSystem) {
             is PartiqlAst.Expr.OuterExcept ->
                 NAry(
                     when (setq) {
-                        is PartiqlAst.SetQuantifier.Distinct -> NAryOp.EXCEPT
-                        is PartiqlAst.SetQuantifier.All -> NAryOp.EXCEPT_ALL
+                        is PartiqlAst.SetQuantifier.Distinct -> NAryOp.OUTER_EXCEPT
+                        is PartiqlAst.SetQuantifier.All -> NAryOp.OUTER_EXCEPT_ALL
                     },
                     operands.toExprNodeList(),
                     metas

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -84,7 +84,6 @@ private class StatementTransformer(val ion: IonSystem) {
             is PartiqlAst.Expr.Gte -> NAry(NAryOp.GTE, operands.toExprNodeList(), metas)
             is PartiqlAst.Expr.Lt -> NAry(NAryOp.LT, operands.toExprNodeList(), metas)
             is PartiqlAst.Expr.Lte -> NAry(NAryOp.LTE, operands.toExprNodeList(), metas)
-
             is PartiqlAst.Expr.Union ->
                 NAry(
                     when (setq) {
@@ -104,6 +103,33 @@ private class StatementTransformer(val ion: IonSystem) {
                     metas
                 )
             is PartiqlAst.Expr.Except ->
+                NAry(
+                    when (setq) {
+                        is PartiqlAst.SetQuantifier.Distinct -> NAryOp.EXCEPT
+                        is PartiqlAst.SetQuantifier.All -> NAryOp.EXCEPT_ALL
+                    },
+                    operands.toExprNodeList(),
+                    metas
+                )
+            is PartiqlAst.Expr.OuterUnion ->
+                NAry(
+                    when (setq) {
+                        is PartiqlAst.SetQuantifier.Distinct -> NAryOp.UNION
+                        is PartiqlAst.SetQuantifier.All -> NAryOp.UNION_ALL
+                    },
+                    operands.toExprNodeList(),
+                    metas
+                )
+            is PartiqlAst.Expr.OuterIntersect ->
+                NAry(
+                    when (setq) {
+                        is PartiqlAst.SetQuantifier.Distinct -> NAryOp.INTERSECT
+                        is PartiqlAst.SetQuantifier.All -> NAryOp.INTERSECT_ALL
+                    },
+                    operands.toExprNodeList(),
+                    metas
+                )
+            is PartiqlAst.Expr.OuterExcept ->
                 NAry(
                     when (setq) {
                         is PartiqlAst.SetQuantifier.Distinct -> NAryOp.EXCEPT

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -1005,13 +1005,7 @@ enum class NAryOp(val arityRange: IntRange, val symbol: String, val textName: St
     EXCEPT(2..Int.MAX_VALUE, "except"),
     EXCEPT_ALL(2..Int.MAX_VALUE, "except_all"),
     UNION(2..Int.MAX_VALUE, "union"),
-    UNION_ALL(2..Int.MAX_VALUE, "union_all"),
-    OUTER_INTERSECT(2..Int.MAX_VALUE, "outer_intersect"),
-    OUTER_INTERSECT_ALL(2..Int.MAX_VALUE, "outer_intersect_all"),
-    OUTER_EXCEPT(2..Int.MAX_VALUE, "outer_except"),
-    OUTER_EXCEPT_ALL(2..Int.MAX_VALUE, "outer_except_all"),
-    OUTER_UNION(2..Int.MAX_VALUE, "outer_union"),
-    OUTER_UNION_ALL(2..Int.MAX_VALUE, "outer_union_all");
+    UNION_ALL(2..Int.MAX_VALUE, "union_all");
 
     companion object {
         /** Map of [NAryOp] keyed by the operation's text. */

--- a/lang/src/org/partiql/lang/ast/ast.kt
+++ b/lang/src/org/partiql/lang/ast/ast.kt
@@ -1005,7 +1005,13 @@ enum class NAryOp(val arityRange: IntRange, val symbol: String, val textName: St
     EXCEPT(2..Int.MAX_VALUE, "except"),
     EXCEPT_ALL(2..Int.MAX_VALUE, "except_all"),
     UNION(2..Int.MAX_VALUE, "union"),
-    UNION_ALL(2..Int.MAX_VALUE, "union_all");
+    UNION_ALL(2..Int.MAX_VALUE, "union_all"),
+    OUTER_INTERSECT(2..Int.MAX_VALUE, "outer_intersect"),
+    OUTER_INTERSECT_ALL(2..Int.MAX_VALUE, "outer_intersect_all"),
+    OUTER_EXCEPT(2..Int.MAX_VALUE, "outer_except"),
+    OUTER_EXCEPT_ALL(2..Int.MAX_VALUE, "outer_except_all"),
+    OUTER_UNION(2..Int.MAX_VALUE, "outer_union"),
+    OUTER_UNION_ALL(2..Int.MAX_VALUE, "outer_union_all");
 
     companion object {
         /** Map of [NAryOp] keyed by the operation's text. */

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -84,7 +84,6 @@ import java.util.LinkedList
 import java.util.Stack
 import java.util.TreeSet
 import java.util.regex.Pattern
-import kotlin.Comparator
 
 /**
  * A thunk with no parameters other than the current environment.
@@ -440,9 +439,12 @@ internal class EvaluatingCompiler(
             is PartiqlAst.Expr.Bag -> compileSeq(ExprValueType.BAG, expr.values, metas)
 
             // set operators
-            is PartiqlAst.Expr.Intersect,
             is PartiqlAst.Expr.Union,
-            is PartiqlAst.Expr.Except -> {
+            is PartiqlAst.Expr.Intersect,
+            is PartiqlAst.Expr.Except,
+            is PartiqlAst.Expr.OuterUnion,
+            is PartiqlAst.Expr.OuterIntersect,
+            is PartiqlAst.Expr.OuterExcept -> {
                 err(
                     "${expr.javaClass.canonicalName} is not yet supported",
                     ErrorCode.EVALUATOR_FEATURE_NOT_SUPPORTED_YET,
@@ -752,7 +754,8 @@ internal class EvaluatingCompiler(
         val leftThunk = compileAstExpr(args[0])
         val rightOp = args[1]
 
-        fun isOptimizedCase(values: List<PartiqlAst.Expr>): Boolean = values.all { it is PartiqlAst.Expr.Lit && !it.value.isNull }
+        fun isOptimizedCase(values: List<PartiqlAst.Expr>): Boolean =
+            values.all { it is PartiqlAst.Expr.Lit && !it.value.isNull }
 
         fun optimizedCase(values: List<PartiqlAst.Expr>): ThunkEnv {
             // Put all the literals in the sequence into a pre-computed map to be checked later by the thunk.

--- a/lang/src/org/partiql/lang/eval/physical/PhysicalExprToThunkConverterImpl.kt
+++ b/lang/src/org/partiql/lang/eval/physical/PhysicalExprToThunkConverterImpl.kt
@@ -260,9 +260,12 @@ internal class PhysicalExprToThunkConverterImpl(
             is PartiqlPhysical.Expr.Bag -> compileSeq(ExprValueType.BAG, expr.values, metas)
 
             // set operators
-            is PartiqlPhysical.Expr.Intersect,
             is PartiqlPhysical.Expr.Union,
-            is PartiqlPhysical.Expr.Except -> {
+            is PartiqlPhysical.Expr.Intersect,
+            is PartiqlPhysical.Expr.Except,
+            is PartiqlPhysical.Expr.OuterUnion,
+            is PartiqlPhysical.Expr.OuterIntersect,
+            is PartiqlPhysical.Expr.OuterExcept -> {
                 err(
                     "${expr.javaClass.canonicalName} is not yet supported",
                     ErrorCode.EVALUATOR_FEATURE_NOT_SUPPORTED_YET,

--- a/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -6,7 +6,7 @@ import org.partiql.lang.domains.PartiqlLogical
 
 /**
  * Transforms an instance of [PartiqlAst.Statement] to [PartiqlLogical.Statement].  This representation of the query
- * expresses the intent of the query author in terms of PartiQL's relational algebra instead of it its AST.
+ * expresses the intent of the query author in terms of PartiQL's relational algebra instead of its AST.
  *
  * Performs no semantic checks.
  *

--- a/lang/src/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
+++ b/lang/src/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
@@ -399,13 +399,28 @@ class ASTPrettyPrinter {
                 attrOfParent = attrOfParent,
                 children = toRecursionTreeList(node.operands)
             )
+            is PartiqlAst.Expr.Intersect -> RecursionTree(
+                astType = "Intersect",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
             is PartiqlAst.Expr.Except -> RecursionTree(
                 astType = "Except",
                 attrOfParent = attrOfParent,
                 children = toRecursionTreeList(node.operands)
             )
-            is PartiqlAst.Expr.Intersect -> RecursionTree(
-                astType = "Intersect",
+            is PartiqlAst.Expr.OuterUnion -> RecursionTree(
+                astType = "OuterUnion",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.OuterIntersect -> RecursionTree(
+                astType = "OuterIntersect",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.operands)
+            )
+            is PartiqlAst.Expr.OuterExcept -> RecursionTree(
+                astType = "OuterExcept",
                 attrOfParent = attrOfParent,
                 children = toRecursionTreeList(node.operands)
             )

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -445,14 +445,19 @@ internal val DATE_TIME_PART_KEYWORDS: Set<String> = DateTimePart.values()
     listOf("union", "all") to ("union_all" to OPERATOR),
     listOf("intersect", "all") to ("intersect_all" to OPERATOR),
     listOf("except", "all") to ("except_all" to OPERATOR),
+    listOf("union", "distinct") to ("union_distinct" to OPERATOR),
+    listOf("intersect", "distinct") to ("intersect_distinct" to OPERATOR),
+    listOf("except", "distinct") to ("except_distinct" to OPERATOR),
+
     listOf("outer", "union") to ("outer_union" to OPERATOR),
     listOf("outer", "intersect") to ("outer_intersect" to OPERATOR),
     listOf("outer", "except") to ("outer_except" to OPERATOR),
-
-    // tomfoolery with multi lexeme token folding
-    listOf("outer_intersect", "all") to ("outer_intersect_all" to OPERATOR),
     listOf("outer_union", "all") to ("outer_union_all" to OPERATOR),
+    listOf("outer_intersect", "all") to ("outer_intersect_all" to OPERATOR),
     listOf("outer_except", "all") to ("outer_except_all" to OPERATOR),
+    listOf("outer_union", "distinct") to ("outer_union_distinct" to OPERATOR),
+    listOf("outer_intersect", "distinct") to ("outer_intersect_distinct" to OPERATOR),
+    listOf("outer_except", "distinct") to ("outer_except_distinct" to OPERATOR),
 
     listOf("character", "varying") to ("character_varying" to KEYWORD),
     listOf("double", "precision") to ("double_precision" to KEYWORD),

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -441,9 +441,19 @@ internal val DATE_TIME_PART_KEYWORDS: Set<String> = DateTimePart.values()
     listOf("not", "in") to ("not_in" to OPERATOR),
     listOf("is", "not") to ("is_not" to OPERATOR),
     listOf("not", "between") to ("not_between" to OPERATOR),
+
+    listOf("union", "all") to ("union_all" to OPERATOR),
     listOf("intersect", "all") to ("intersect_all" to OPERATOR),
     listOf("except", "all") to ("except_all" to OPERATOR),
-    listOf("union", "all") to ("union_all" to OPERATOR),
+    listOf("outer", "union") to ("outer_union" to OPERATOR),
+    listOf("outer", "intersect") to ("outer_intersect" to OPERATOR),
+    listOf("outer", "except") to ("outer_except" to OPERATOR),
+
+    // tomfoolery with multi lexeme token folding
+    listOf("outer_intersect", "all") to ("outer_intersect_all" to OPERATOR),
+    listOf("outer_union", "all") to ("outer_union_all" to OPERATOR),
+    listOf("outer_except", "all") to ("outer_except_all" to OPERATOR),
+
     listOf("character", "varying") to ("character_varying" to KEYWORD),
     listOf("double", "precision") to ("double_precision" to KEYWORD),
     listOf("not", "like") to ("not_like" to OPERATOR),
@@ -535,12 +545,18 @@ enum class OperatorPrecedenceGroups(val precedence: Int) {
  */
 @JvmField internal val OPERATOR_PRECEDENCE = mapOf(
     // set operator group
+    "union" to OperatorPrecedenceGroups.SET.precedence,
+    "union_all" to OperatorPrecedenceGroups.SET.precedence,
     "intersect" to OperatorPrecedenceGroups.SET.precedence,
     "intersect_all" to OperatorPrecedenceGroups.SET.precedence,
     "except" to OperatorPrecedenceGroups.SET.precedence,
     "except_all" to OperatorPrecedenceGroups.SET.precedence,
-    "union" to OperatorPrecedenceGroups.SET.precedence,
-    "union_all" to OperatorPrecedenceGroups.SET.precedence,
+    "outer_union" to OperatorPrecedenceGroups.SET.precedence,
+    "outer_union_all" to OperatorPrecedenceGroups.SET.precedence,
+    "outer_intersect" to OperatorPrecedenceGroups.SET.precedence,
+    "outer_intersect_all" to OperatorPrecedenceGroups.SET.precedence,
+    "outer_except" to OperatorPrecedenceGroups.SET.precedence,
+    "outer_except_all" to OperatorPrecedenceGroups.SET.precedence,
 
     // logical group
     "or" to OperatorPrecedenceGroups.LOGICAL_OR.precedence,

--- a/lang/src/org/partiql/lang/syntax/LexerConstants.kt
+++ b/lang/src/org/partiql/lang/syntax/LexerConstants.kt
@@ -551,16 +551,22 @@ enum class OperatorPrecedenceGroups(val precedence: Int) {
 @JvmField internal val OPERATOR_PRECEDENCE = mapOf(
     // set operator group
     "union" to OperatorPrecedenceGroups.SET.precedence,
+    "union_distinct" to OperatorPrecedenceGroups.SET.precedence,
     "union_all" to OperatorPrecedenceGroups.SET.precedence,
     "intersect" to OperatorPrecedenceGroups.SET.precedence,
+    "intersect_distinct" to OperatorPrecedenceGroups.SET.precedence,
     "intersect_all" to OperatorPrecedenceGroups.SET.precedence,
     "except" to OperatorPrecedenceGroups.SET.precedence,
+    "except_distinct" to OperatorPrecedenceGroups.SET.precedence,
     "except_all" to OperatorPrecedenceGroups.SET.precedence,
     "outer_union" to OperatorPrecedenceGroups.SET.precedence,
+    "outer_union_distinct" to OperatorPrecedenceGroups.SET.precedence,
     "outer_union_all" to OperatorPrecedenceGroups.SET.precedence,
     "outer_intersect" to OperatorPrecedenceGroups.SET.precedence,
+    "outer_intersect_distinct" to OperatorPrecedenceGroups.SET.precedence,
     "outer_intersect_all" to OperatorPrecedenceGroups.SET.precedence,
     "outer_except" to OperatorPrecedenceGroups.SET.precedence,
+    "outer_except_distinct" to OperatorPrecedenceGroups.SET.precedence,
     "outer_except_all" to OperatorPrecedenceGroups.SET.precedence,
 
     // logical group

--- a/lang/src/org/partiql/lang/syntax/SqlLexer.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlLexer.kt
@@ -624,6 +624,13 @@ class SqlLexer(private val ion: IonSystem) : Lexer {
         return tokens
     }
 
+    /**
+     * For a given token x, and lexer token list [ ..., a, b, c, d ], we attempt to look back and find the longest
+     * string "a_b_c_d_x" that appears in the multi lexeme map. If a match is found, we replace the previous matching
+     * tokens with a single "merged" token.
+     *
+     * For example, "UNION ALL" -(lex)-> [ Token(union) ].addOrMerge(Token(all)) -> [ Token(union_all) ]
+     */
     private fun MutableList<Token>.addOrMerge(token: Token) {
         var newToken = token
 

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -888,12 +888,18 @@ class SqlParser(
                     // TODO:  we are losing case-sensitivity of the function name here.  Do we care?
                     call(idArg.name.text, args.drop(1), metas)
                 }
+                "union" -> union(distinct(), args, metas)
+                "union_all" -> union(all(), args, metas)
                 "intersect" -> intersect(distinct(), args, metas)
                 "intersect_all" -> intersect(all(), args, metas)
                 "except" -> except(distinct(), args, metas)
                 "except_all" -> except(all(), args, metas)
-                "union" -> union(distinct(), args, metas)
-                "union_all" -> union(all(), args, metas)
+                "outer_union" -> outerUnion(distinct(), args, metas)
+                "outer_union_all" -> outerUnion(all(), args, metas)
+                "outer_intersect" -> outerIntersect(distinct(), args, metas)
+                "outer_intersect_all" -> outerIntersect(all(), args, metas)
+                "outer_except_outer" -> outerExcept(distinct(), args, metas)
+                "outer_except_outer_all" -> outerExcept(all(), args, metas)
                 else -> throw IllegalArgumentException("Unsupported operator: ${this@toOperator}")
             }
         }

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -888,18 +888,24 @@ class SqlParser(
                     // TODO:  we are losing case-sensitivity of the function name here.  Do we care?
                     call(idArg.name.text, args.drop(1), metas)
                 }
-                "union" -> union(distinct(), args, metas)
+                "union",
+                "union_distinct" -> union(distinct(), args, metas)
                 "union_all" -> union(all(), args, metas)
-                "intersect" -> intersect(distinct(), args, metas)
+                "intersect",
+                "intersect_distinct" -> intersect(distinct(), args, metas)
                 "intersect_all" -> intersect(all(), args, metas)
-                "except" -> except(distinct(), args, metas)
+                "except",
+                "except_distinct" -> except(distinct(), args, metas)
                 "except_all" -> except(all(), args, metas)
-                "outer_union" -> outerUnion(distinct(), args, metas)
+                "outer_union",
+                "outer_union_distinct" -> outerUnion(distinct(), args, metas)
                 "outer_union_all" -> outerUnion(all(), args, metas)
-                "outer_intersect" -> outerIntersect(distinct(), args, metas)
+                "outer_intersect",
+                "outer_intersect_distinct" -> outerIntersect(distinct(), args, metas)
                 "outer_intersect_all" -> outerIntersect(all(), args, metas)
-                "outer_except_outer" -> outerExcept(distinct(), args, metas)
-                "outer_except_outer_all" -> outerExcept(all(), args, metas)
+                "outer_except",
+                "outer_except_distinct" -> outerExcept(distinct(), args, metas)
+                "outer_except_all" -> outerExcept(all(), args, metas)
                 else -> throw IllegalArgumentException("Unsupported operator: ${this@toOperator}")
             }
         }

--- a/lang/test/org/partiql/lang/syntax/SqlLexerTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlLexerTest.kt
@@ -216,13 +216,22 @@ class SqlLexerTest : TestBase() {
     }
 
     @Test
-    fun multiLexemeOperators() = assertTokens(
-        "UNION ALL IS NOT union_all is_not",
-        token(TokenType.OPERATOR, "union_all", "UNION ALL", 1, 1, 5),
-        token(TokenType.OPERATOR, "is_not", "IS NOT", 1, 11, 2),
-        token(TokenType.IDENTIFIER, "union_all", "union_all", 1, 18, 9),
-        token(TokenType.IDENTIFIER, "is_not", "is_not", 1, 28, 6)
-    )
+    fun multiLexemeOperators() {
+        assertTokens(
+            "UNION ALL IS NOT union_all is_not",
+            token(TokenType.OPERATOR, "union_all", "UNION ALL", 1, 1, 5),
+            token(TokenType.OPERATOR, "is_not", "IS NOT", 1, 11, 2),
+            token(TokenType.IDENTIFIER, "union_all", "union_all", 1, 18, 9),
+            token(TokenType.IDENTIFIER, "is_not", "is_not", 1, 28, 6)
+        )
+        assertTokens(
+            "OUTER UNION ALL IS NOT outer_union_all is_not",
+            token(TokenType.OPERATOR, "outer_union_all", "OUTER UNION ALL", 1, 1, 5),
+            token(TokenType.OPERATOR, "is_not", "IS NOT", 1, 17, 2),
+            token(TokenType.IDENTIFIER, "outer_union_all", "outer_union_all", 1, 24, 15),
+            token(TokenType.IDENTIFIER, "is_not", "is_not", 1, 40, 6)
+        )
+    }
 
     @Test
     fun multiLexemeKeywords() = assertTokens(

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3939,13 +3939,6 @@ class SqlParserTest : SqlParserTestBase() {
     )
 
     @Test
-    fun union() = assertExpression(
-        "a UNION b",
-        "(union (id a case_insensitive) (id b case_insensitive))",
-        "(union (distinct) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
-    )
-
-    @Test
     fun unionSelectPrecedence() = assertExpression(
         "SELECT * FROM foo UNION SELECT * FROM bar",
         """
@@ -3988,60 +3981,121 @@ class SqlParserTest : SqlParserTestBase() {
     )
 
     @Test
+    fun union() = assertExpression(
+        "a UNION b"
+    ) {
+        this.union(
+            setq = PartiqlAst.SetQuantifier.Distinct(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
+
+    @Test
     fun unionDistinct() = assertExpression(
-        "a UNION DISTINCT b",
-        "(union (id a case_insensitive) (id b case_insensitive))",
-        "(union (distinct) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
-    )
+        "a UNION DISTINCT b"
+    ) {
+        this.union(
+            setq = PartiqlAst.SetQuantifier.Distinct(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
 
     @Test
     fun unionAll() = assertExpression(
-        "a UNION ALL b",
-        "(union_all (id a case_insensitive) (id b case_insensitive))",
-        "(union (all) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
-    )
-
-    @Test
-    fun except() = assertExpression(
-        "a EXCEPT b",
-        "(except (id a case_insensitive) (id b case_insensitive))",
-        "(except (distinct) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
-    )
-
-    @Test
-    fun exceptDistinct() = assertExpression(
-        "a EXCEPT DISTINCT b",
-        "(except (id a case_insensitive) (id b case_insensitive))",
-        "(except (distinct) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
-    )
-
-    @Test
-    fun exceptAll() = assertExpression(
-        "a EXCEPT ALL b",
-        "(except_all (id a case_insensitive) (id b case_insensitive))",
-        "(except (all) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
-    )
+        "a UNION ALL b"
+    ) {
+        this.union(
+            setq = PartiqlAst.SetQuantifier.All(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
 
     @Test
     fun intersect() = assertExpression(
-        "a INTERSECT b",
-        "(intersect (id a case_insensitive) (id b case_insensitive))",
-        "(intersect (distinct) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
-    )
+        "a INTERSECT b"
+    ) {
+        this.intersect(
+            setq = PartiqlAst.SetQuantifier.Distinct(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
 
     @Test
     fun intersectDistinct() = assertExpression(
-        "a INTERSECT DISTINCT b",
-        "(intersect (id a case_insensitive) (id b case_insensitive))",
-        "(intersect (distinct) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
-    )
+        "a INTERSECT DISTINCT b"
+    ) {
+        this.intersect(
+            setq = PartiqlAst.SetQuantifier.Distinct(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
 
     @Test
     fun intersectAll() = assertExpression(
-        "a INTERSECT ALL b",
-        "(intersect_all (id a case_insensitive) (id b case_insensitive))",
-        "(intersect (all) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
-    )
+        "a INTERSECT ALL b"
+    ) {
+        this.intersect(
+            setq = PartiqlAst.SetQuantifier.All(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
+
+    @Test
+    fun except() = assertExpression(
+        "a EXCEPT b"
+    ) {
+        this.except(
+            setq = PartiqlAst.SetQuantifier.Distinct(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
+
+    @Test
+    fun exceptDistinct() = assertExpression(
+        "a EXCEPT DISTINCT b"
+    ) {
+        this.except(
+            setq = PartiqlAst.SetQuantifier.Distinct(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
+
+    @Test
+    fun exceptAll() = assertExpression(
+        "a EXCEPT ALL b"
+    ) {
+        this.except(
+            setq = PartiqlAst.SetQuantifier.All(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
 
     @Test
     fun outerUnion() = assertExpressionNoRoundTrip(

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -3988,6 +3988,13 @@ class SqlParserTest : SqlParserTestBase() {
     )
 
     @Test
+    fun unionDistinct() = assertExpression(
+        "a UNION DISTINCT b",
+        "(union (id a case_insensitive) (id b case_insensitive))",
+        "(union (distinct) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+    )
+
+    @Test
     fun unionAll() = assertExpression(
         "a UNION ALL b",
         "(union_all (id a case_insensitive) (id b case_insensitive))",
@@ -3997,6 +4004,13 @@ class SqlParserTest : SqlParserTestBase() {
     @Test
     fun except() = assertExpression(
         "a EXCEPT b",
+        "(except (id a case_insensitive) (id b case_insensitive))",
+        "(except (distinct) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+    )
+
+    @Test
+    fun exceptDistinct() = assertExpression(
+        "a EXCEPT DISTINCT b",
         "(except (id a case_insensitive) (id b case_insensitive))",
         "(except (distinct) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
@@ -4016,11 +4030,135 @@ class SqlParserTest : SqlParserTestBase() {
     )
 
     @Test
+    fun intersectDistinct() = assertExpression(
+        "a INTERSECT DISTINCT b",
+        "(intersect (id a case_insensitive) (id b case_insensitive))",
+        "(intersect (distinct) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+    )
+
+    @Test
     fun intersectAll() = assertExpression(
         "a INTERSECT ALL b",
         "(intersect_all (id a case_insensitive) (id b case_insensitive))",
         "(intersect (all) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
+
+    @Test
+    fun outerUnion() = assertExpressionNoRoundTrip(
+        "a OUTER UNION b"
+    ) {
+        this.outerUnion(
+            setq = PartiqlAst.SetQuantifier.Distinct(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
+
+    @Test
+    fun outerUnionDistinct() = assertExpressionNoRoundTrip(
+        "a OUTER UNION DISTINCT b"
+    ) {
+        this.outerUnion(
+            setq = PartiqlAst.SetQuantifier.Distinct(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
+
+    @Test
+    fun outerUnionAll() = assertExpressionNoRoundTrip(
+        "a OUTER UNION ALL b"
+    ) {
+        this.outerUnion(
+            setq = PartiqlAst.SetQuantifier.All(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
+
+    @Test
+    fun outerIntersect() = assertExpressionNoRoundTrip(
+        "a OUTER INTERSECT b"
+    ) {
+        this.outerIntersect(
+            setq = PartiqlAst.SetQuantifier.Distinct(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
+
+    @Test
+    fun outerIntersectDistinct() = assertExpressionNoRoundTrip(
+        "a OUTER INTERSECT DISTINCT b"
+    ) {
+        this.outerIntersect(
+            setq = PartiqlAst.SetQuantifier.Distinct(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
+
+    @Test
+    fun outerIntersectAll() = assertExpressionNoRoundTrip(
+        "a OUTER INTERSECT ALL b"
+    ) {
+        this.outerIntersect(
+            setq = PartiqlAst.SetQuantifier.All(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
+
+    @Test
+    fun outerExcept() = assertExpressionNoRoundTrip(
+        "a OUTER EXCEPT b"
+    ) {
+        this.outerExcept(
+            setq = PartiqlAst.SetQuantifier.Distinct(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
+
+    @Test
+    fun outerExceptDistinct() = assertExpressionNoRoundTrip(
+        "a OUTER EXCEPT DISTINCT b"
+    ) {
+        this.outerExcept(
+            setq = PartiqlAst.SetQuantifier.Distinct(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
+
+    @Test
+    fun outerExceptAll() = assertExpressionNoRoundTrip(
+        "a OUTER EXCEPT ALL b"
+    ) {
+        this.outerExcept(
+            setq = PartiqlAst.SetQuantifier.All(),
+            operands = listOf(
+                this.id("a"),
+                this.id("b")
+            )
+        )
+    }
 
     // ****************************************
     // semicolon at end of sqlUnderTest


### PR DESCRIPTION
*Issue #, if available:*

Part 2 of — https://github.com/partiql/partiql-lang-kotlin/issues/184

*Description of changes:*

These changes add the OUTER set operators defined in [RFC-0007 ](https://github.com/partiql/partiql-docs/blob/main/RFCs/0007-rfc-bag-operators.md) to the type universe, lexer, and parser.

*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes? (y/n), If not, please explain why:* No, N/A

*Does your PR include any backward-incompatible changes? (y/n), if yes, please explain the reason. In addition, please
 also mention any other alternatives you've considered and the reason they've been discarded?:* N

```
For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in 
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base.
```

*Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:* N

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
