### PR TITLE
Suppress Build warning

### DIFF
--- a/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
+++ b/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
@@ -321,6 +321,7 @@ class QueryPrettyPrinter {
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.Missing, sb: StringBuilder) {
         sb.append("MISSING")
     }
@@ -370,6 +371,7 @@ class QueryPrettyPrinter {
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.Bag, sb: StringBuilder, level: Int) {
         sb.append("<< ")
         node.values.forEach {
@@ -383,6 +385,7 @@ class QueryPrettyPrinter {
         sb.append(" >>")
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.Sexp, sb: StringBuilder, level: Int) {
         sb.append("sexp(")
         node.values.forEach {
@@ -396,6 +399,7 @@ class QueryPrettyPrinter {
         sb.append(")")
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.List, sb: StringBuilder, level: Int) {
         sb.append("[ ")
         node.values.forEach {
@@ -409,6 +413,7 @@ class QueryPrettyPrinter {
         sb.append(" ]")
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.Struct, sb: StringBuilder, level: Int) {
         sb.append("{ ")
         node.fields.forEach {
@@ -424,6 +429,7 @@ class QueryPrettyPrinter {
         sb.append(" }")
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.Parameter, sb: StringBuilder) {
         sb.append("?")
     }
@@ -435,6 +441,7 @@ class QueryPrettyPrinter {
         }
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.Call, sb: StringBuilder, level: Int) {
         sb.append("${node.funcName.text}(")
         node.args.forEach { arg ->
@@ -448,6 +455,7 @@ class QueryPrettyPrinter {
         sb.append(')')
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.CallAgg, sb: StringBuilder, level: Int) {
         sb.append("${node.funcName.text}(")
         if (node.setq is PartiqlAst.SetQuantifier.Distinct) {
@@ -848,6 +856,7 @@ class QueryPrettyPrinter {
         sb.append(')')
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.Coalesce, sb: StringBuilder, level: Int) {
         sb.append("COALESCE(")
         node.args.forEach { arg ->
@@ -861,6 +870,7 @@ class QueryPrettyPrinter {
         sb.append(')')
     }
 
+    @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.NullIf, sb: StringBuilder, level: Int) {
         // Write anything as one line as COALESCE arguments
         sb.append("NULLIF(")


### PR DESCRIPTION
*Description of changes:*
When we build the the project, it gives us such warnings: 
```
./gradlew build                                                                                                                                                                                            SIGINT(2) ↵  3781  12:40:25  

> Task :lang:compileKotlin
w: /home/ANT.AMAZON.COM/dlurton/projects/dlurton/partiql-lang-kotlin/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt: (324, 30): Parameter 'node' is never used
w: /home/ANT.AMAZON.COM/dlurton/projects/dlurton/partiql-lang-kotlin/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt: (373, 76): Parameter 'level' is never used
w: /home/ANT.AMAZON.COM/dlurton/projects/dlurton/partiql-lang-kotlin/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt: (386, 77): Parameter 'level' is never used
w: /home/ANT.AMAZON.COM/dlurton/projects/dlurton/partiql-lang-kotlin/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt: (399, 77): Parameter 'level' is never used
w: /home/ANT.AMAZON.COM/dlurton/projects/dlurton/partiql-lang-kotlin/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt: (412, 79): Parameter 'level' is never used
w: /home/ANT.AMAZON.COM/dlurton/projects/dlurton/partiql-lang-kotlin/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt: (427, 30): Parameter 'node' is never used
w: /home/ANT.AMAZON.COM/dlurton/projects/dlurton/partiql-lang-kotlin/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt: (438, 77): Parameter 'level' is never used
w: /home/ANT.AMAZON.COM/dlurton/projects/dlurton/partiql-lang-kotlin/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt: (451, 80): Parameter 'level' is never used
w: /home/ANT.AMAZON.COM/dlurton/projects/dlurton/partiql-lang-kotlin/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt: (851, 81): Parameter 'level' is never used
w: /home/ANT.AMAZON.COM/dlurton/projects/dlurton/partiql-lang-kotlin/lang/src/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt: (864, 79): Parameter 'level' is never used

> Task :lang:detekt


197 kotlin files were analyzed.

BUILD SUCCESSFUL in 6m 13s
```

This PR aims to suppress these warnings. 

*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes? (y/n), If not, please explain why:*
No. No need to mention in the new release note. 

*Does your PR include any backward-incompatible changes? (y/n), if yes, please explain the reason. In addition, please
 also mention any other alternatives you've considered and the reason they've been discarded?:*
No

*Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:*
No
