### PR TITLE
Narrow domain of DML targets (#677)

### DIFF
--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -697,7 +697,7 @@ may then be further optimized by selecting better implementations of each operat
                 // A DML operation, such as `INSERT`, `UPDATE` or `DELETE`
                 (dml
                     // The target is an expression that is indicates the table whose data is to be manipulated.
-                    // According to the PartiQL's grammar this can be an identifier or a simplified path expression
+                    // With current PartiQL Parser `SqlParser`, this can be an identifier or a simplified path expression
                     // consisting of only literal path steps (and with no wildcard or unpivot operators).
                     // Note: partiql_ast uses the `expr` sum type for this, which is too broad.  We're not
                     // changing that at this time because `partiql_ast` is established public API.

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -697,14 +697,11 @@ may then be further optimized by selecting better implementations of each operat
                 // A DML operation, such as `INSERT`, `UPDATE` or `DELETE`
                 (dml
                     // The target is an expression that is indicates the table whose data is to be manipulated.
-                    // In practice this can be an identifier or a simplified path expression consisting of only
-                    // literal path steps (and with no wildcard or unpivot operators).  This restriction must
-                    // be enforced by the PartiQL implementation.
-                    // TODO: consider ways to reduce the domain of acceptable values here.  Of course, we it would
-                    // be possible to create a `sum` type like `expr` but containing only the valid DML targets,
-                    // but that would might necessitate duplicating some logic related to variable resolution which is
-                    // already implemented for standard expressions.  This is out of scope for current efforts.
-                    target::expr
+                    // According to the PartiQL's grammar this can be an identifier or a simplified path expression
+                    // consisting of only literal path steps (and with no wildcard or unpivot operators).
+                    // Note: partiql_ast uses the `expr` sum type for this, which is too broad.  We're not
+                    // changing that at this time because `partiql_ast` is established public API.
+                    target::identifier
                     operation::dml_operation
                     rows::expr
                 )
@@ -737,7 +734,6 @@ may then be further optimized by selecting better implementations of each operat
             column_component
             returning_mapping
             assignment
-            identifier
         )
     )
 )
@@ -799,6 +795,12 @@ may then be further optimized by selecting better implementations of each operat
                 (global_id uniqueId::symbol)
             )
         )
+
+        // Replace statement.dml.target with statement.dml.uniqueId (the "resolved" corollary).
+        (with statement
+            (exclude dml)
+            (include (dml uniqueId::symbol operation::dml_operation rows::expr))
+        )
     )
 )
 
@@ -822,8 +824,7 @@ may then be further optimized by selecting better implementations of each operat
             (product impl name::symbol static_args::(* ion 0))
         )
 
-        // drop DML stuff added in partiql_logical (we expect these to be rewritten into pure bexprs by the time
-        // we transform a query to this domain).
+        // drop DML stuff added in partiql_logical (these should be rewritten into queries).
         (exclude dml_operation)
         (with statement
             (exclude dml)

--- a/lang/src/org/partiql/lang/planner/PlanningProblemDetails.kt
+++ b/lang/src/org/partiql/lang/planner/PlanningProblemDetails.kt
@@ -28,14 +28,17 @@ sealed class PlanningProblemDetails(
             ProblemSeverity.ERROR,
             {
                 "Undefined variable '$variableName'." +
-                    if (caseSensitive) {
-                        // Individuals that are new to SQL often try to use double quotes for string literals.
-                        // Let's help them out a bit.
-                        " Hint: did you intend to use single-quotes (') here?  Remember that double-quotes (\") denote " +
-                            "quoted identifiers and single-quotes denote strings."
-                    } else {
-                        ""
-                    }
+                    quotationHint(caseSensitive)
+            }
+        )
+
+    data class UndefinedDmlTarget(val variableName: String, val caseSensitive: Boolean) :
+        PlanningProblemDetails(
+            ProblemSeverity.ERROR,
+            {
+                "Data manipulation target table '$variableName' is undefined. " +
+                    "Hint: this must be a name in the global scope. " +
+                    quotationHint(caseSensitive)
             }
         )
 
@@ -49,6 +52,12 @@ sealed class PlanningProblemDetails(
         PlanningProblemDetails(
             ProblemSeverity.ERROR,
             { "The syntax at this location is valid but utilizes unimplemented PartiQL feature '$featureName'" }
+        )
+
+    object InvalidDmlTarget :
+        PlanningProblemDetails(
+            ProblemSeverity.ERROR,
+            { "Expression is not a valid DML target.  Hint: only table names are allowed here." }
         )
 
     object InsertValueDisallowed :
@@ -68,10 +77,14 @@ sealed class PlanningProblemDetails(
                     "Please use the `INSERT INTO <table> << <expr>, ... >>` form instead."
             }
         )
-
-    object InvalidDmlTarget :
-        PlanningProblemDetails(
-            ProblemSeverity.ERROR,
-            { "Expression is not a valid DML target.  Hint: only table names are allowed here." }
-        )
 }
+
+private fun quotationHint(caseSensitive: Boolean) =
+    if (caseSensitive) {
+        // Individuals that are new to SQL often try to use double quotes for string literals.
+        // Let's help them out a bit.
+        " Hint: did you intend to use single-quotes (') here?  Remember that double-quotes (\") denote " +
+            "quoted identifiers and single-quotes denote strings."
+    } else {
+        ""
+    }

--- a/lang/test/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransformTests.kt
@@ -3,19 +3,15 @@ package org.partiql.lang.planner.transforms
 import com.amazon.ionelement.api.ionBool
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.ionSymbol
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
-import org.partiql.lang.ast.UNKNOWN_SOURCE_LOCATION
 import org.partiql.lang.domains.PartiqlLogicalResolved
 import org.partiql.lang.domains.PartiqlPhysical
-import org.partiql.lang.errors.Problem
 import org.partiql.lang.errors.ProblemCollector
 import org.partiql.lang.planner.DML_COMMAND_FIELD_ACTION
 import org.partiql.lang.planner.DML_COMMAND_FIELD_ROWS
 import org.partiql.lang.planner.DML_COMMAND_FIELD_TARGET_UNIQUE_ID
-import org.partiql.lang.planner.PlanningProblemDetails
 import org.partiql.lang.util.ArgumentsProviderBase
 import kotlin.test.fail
 
@@ -100,7 +96,7 @@ class LogicalResolvedToDefaultPhysicalVisitorTransformTests {
                 // INSERT INTO foo VALUE 1
                 PartiqlLogicalResolved.build {
                     dml(
-                        target = globalId("foo"),
+                        uniqueId = "foo",
                         operation = dmlInsert(),
                         rows = bag(lit(ionInt(1)))
                     )
@@ -119,7 +115,7 @@ class LogicalResolvedToDefaultPhysicalVisitorTransformTests {
                 // INSERT INTO foo SELECT x.* FROM 1 AS x
                 PartiqlLogicalResolved.build {
                     dml(
-                        target = globalId("foo"),
+                        uniqueId = "foo",
                         operation = dmlInsert(),
                         rows = bindingsToValues(
                             struct(structFields(localId(0))),
@@ -151,7 +147,7 @@ class LogicalResolvedToDefaultPhysicalVisitorTransformTests {
                 // DELETE FROM y AS y
                 PartiqlLogicalResolved.build {
                     dml(
-                        target = globalId("foo"),
+                        uniqueId = "foo",
                         operation = dmlDelete(),
                         rows = bindingsToValues(
                             localId(0),
@@ -183,7 +179,7 @@ class LogicalResolvedToDefaultPhysicalVisitorTransformTests {
                 // DELETE FROM y AS y WHERE 1=1
                 PartiqlLogicalResolved.build {
                     dml(
-                        target = globalId("y"),
+                        uniqueId = "y",
                         operation = dmlDelete(),
                         rows = bindingsToValues(
                             localId(0),
@@ -220,62 +216,6 @@ class LogicalResolvedToDefaultPhysicalVisitorTransformTests {
                     )
                 }
             ),
-        )
-    }
-
-    data class UnimplementedFeatureTestCase(val input: PartiqlLogicalResolved.Statement, val expectedProblem: Problem)
-    @ParameterizedTest
-    @ArgumentsSource(ArgumentsForUnimplementedFeatureTests::class)
-    fun `unimplemented features are blocked`(tc: UnimplementedFeatureTestCase) {
-        val problemHandler = ProblemCollector()
-        LogicalResolvedToDefaultPhysicalVisitorTransform(problemHandler).transformStatement(tc.input)
-        Assertions.assertFalse(problemHandler.hasWarnings, "didn't expect any warnings")
-        Assertions.assertTrue(problemHandler.hasErrors, "at least one error was expected")
-
-        assertEquals(tc.expectedProblem, problemHandler.problems.first())
-    }
-
-    class ArgumentsForUnimplementedFeatureTests : ArgumentsProviderBase() {
-        private fun createSimpleDmlStatement(
-            target: PartiqlLogicalResolved.Expr
-        ) = PartiqlLogicalResolved.build {
-            dml(
-                target = target,
-                operation = dmlDelete(),
-                rows = bindingsToValues(localId(0), scan(lit(ionSymbol("doesntmattereither")), varDecl(0)))
-            )
-        }
-
-        override fun getParameters() = listOf(
-            UnimplementedFeatureTestCase(
-                createSimpleDmlStatement(
-                    target = PartiqlLogicalResolved.build {
-                        // path expressions such as this are not currently supported, but it is likely that
-                        // we will one day need to support dot notation in our from source table names.  this is
-                        // supported by the parser but not within the scope of current efforts.
-                        path(globalId("doesntmatter"), pathExpr(lit(ionSymbol("foo")), caseInsensitive()))
-                    }
-                ),
-                Problem(
-                    UNKNOWN_SOURCE_LOCATION,
-                    PlanningProblemDetails.InvalidDmlTarget
-                )
-            ),
-            UnimplementedFeatureTestCase(
-                createSimpleDmlStatement(
-                    target = PartiqlLogicalResolved.build {
-                        // the parser doesn't actually allow expressions other than identifiers (which are
-                        // later resolved to (global_id ...) nodes to serve as pass targets, but we include this test
-                        // case in case something really funky is going on, like a user specified planner pass that
-                        // specifies an invalid dml target.
-                        lit(ionInt(42))
-                    }
-                ),
-                Problem(
-                    UNKNOWN_SOURCE_LOCATION,
-                    PlanningProblemDetails.InvalidDmlTarget
-                )
-            )
         )
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

#677 

*Description of changes:*

The domain of values allowed in the `partiql_logical.dml.target` element was too broad because it allowed for any expression.

This commit changes this to `partiql_logical.dml.target` to be simply `identifier`, which is the only currently supported form of DML targets in the planner.

*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes? (y/n), If not, please explain why:*

No, this PR only slightly changes stuff already in the change log.

*Does your PR include any backward-incompatible changes? (y/n), if yes, please explain the reason. In addition, please
 also mention any other alternatives you've considered and the reason they've been discarded?:*

"Technically", the only change is to  `partiql_logical.dml.target`--an API that is previously unreleased.

*Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:*

No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
