### PR TITLE
Add planner event callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ a subset has been implemented--see examples below) and
     - `INSERT INTO foo SELECT c.id, c.name FROM customer AS c` (insert the results of a query into another table)
     - `DELETE FROM foo` (delete all records in a table)
     - `DELETE FROM foo AS f WHERE f.zipCode = '90210'` (delete all records matching a predicate)
+- Introduced planner event callbacks as a means to provide a facility that allows the query to be visualized at every 
+stage in the `PlannerPipeline` and to generate performance metrics for the individual phases of query planning.  See
+`PlannerPipe.Builder.plannerEventCallback` for details.
+
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 session state such as current user and transaction details available to custom [ExprFunction] implementations 
 and custom physical operator implementations.
 - Renamed PassResult to PlannerPassResult for clarity. (This is part of the experimental query planner API.)
-- Renamed PassResult to PlannerPassResult for clarity. (This is part of the experimental query planner API.)
 - The `PlannerPipeline` API now has experimental and partial support for `INSERT` and `DELETE` DML statements— 
 tracking PartiQL specification issues are [partiql-docs/#4](https://github.com/partiql/partiql-docs/issues/4) (only
 a subset has been implemented--see examples below) and 
@@ -43,7 +42,6 @@ a subset has been implemented--see examples below) and
 - Introduced planner event callbacks as a means to provide a facility that allows the query to be visualized at every 
 stage in the `PlannerPipeline` and to generate performance metrics for the individual phases of query planning.  See
 `PlannerPipe.Builder.plannerEventCallback` for details.
-
 
 
 ### Changed

--- a/lang/src/org/partiql/lang/planner/PlannerEventCallback.kt
+++ b/lang/src/org/partiql/lang/planner/PlannerEventCallback.kt
@@ -1,0 +1,47 @@
+package org.partiql.lang.planner
+
+import java.time.Duration
+import java.time.Instant
+
+/** Called by [PlannerPipeline] after a phase of query planning has completed. */
+typealias PlannerEventCallback = (PlannerEvent) -> Unit
+
+/** Information about a planner event. */
+data class PlannerEvent (
+    /** The name of the event. */
+    val eventName: String,
+    /** The input to the pass, e.g. the SQL query text or instance of the AST or query plan.*/
+    val input: Any,
+    /** The output of the pass, e.g., the AST or rewritten query plan. */
+    val output: Any?,
+    /** The duration of the pass. */
+    val duration: Duration
+) {
+    override fun toString(): String =
+        StringBuilder().let { sb ->
+            println("event:    $eventName")
+            // NOTE: please do not be surprised by the durations shown here if they are from the first
+            // run in an instance of the JVM.  Those durations are 50-100x longer than subsequent runs
+            // and should improve vastly once the JIT warms up.
+            sb.appendLine("duration: $duration")
+            sb.appendLine("input:\n$input")
+            sb.append("output:\n$output")
+            sb.toString()
+        }
+
+}
+
+/** Convenience function for optionally invoking [PlannerEventCallback] functions. */
+internal inline fun <T> PlannerEventCallback?.doEvent(eventName: String, input: Any, crossinline block: () -> T): T {
+    if(this == null) return block()
+    val startTime = Instant.now()
+    return block().also { output ->
+        val endTime = Instant.now()
+        this(PlannerEvent(eventName, input, output, Duration.between(startTime, endTime)))
+    }
+}
+
+
+
+
+

--- a/lang/src/org/partiql/lang/planner/PlannerEventCallback.kt
+++ b/lang/src/org/partiql/lang/planner/PlannerEventCallback.kt
@@ -7,7 +7,7 @@ import java.time.Instant
 typealias PlannerEventCallback = (PlannerEvent) -> Unit
 
 /** Information about a planner event. */
-data class PlannerEvent (
+data class PlannerEvent(
     /** The name of the event. */
     val eventName: String,
     /** The input to the pass, e.g. the SQL query text or instance of the AST or query plan.*/
@@ -28,20 +28,14 @@ data class PlannerEvent (
             sb.append("output:\n$output")
             sb.toString()
         }
-
 }
 
 /** Convenience function for optionally invoking [PlannerEventCallback] functions. */
 internal inline fun <T> PlannerEventCallback?.doEvent(eventName: String, input: Any, crossinline block: () -> T): T {
-    if(this == null) return block()
+    if (this == null) return block()
     val startTime = Instant.now()
     return block().also { output ->
         val endTime = Instant.now()
         this(PlannerEvent(eventName, input, output, Duration.between(startTime, endTime)))
     }
 }
-
-
-
-
-

--- a/lang/src/org/partiql/lang/planner/PlannerEventNames.kt
+++ b/lang/src/org/partiql/lang/planner/PlannerEventNames.kt
@@ -1,2 +1,0 @@
-package org.partiql.lang.planner
-

--- a/lang/src/org/partiql/lang/planner/PlannerEventNames.kt
+++ b/lang/src/org/partiql/lang/planner/PlannerEventNames.kt
@@ -1,0 +1,2 @@
+package org.partiql.lang.planner
+

--- a/lang/src/org/partiql/lang/planner/PlannerPipeline.kt
+++ b/lang/src/org/partiql/lang/planner/PlannerPipeline.kt
@@ -310,28 +310,26 @@ interface PlannerPipeline {
             name: String,
             passBody: (PartiqlPhysical.Plan, ProblemHandler) -> PartiqlPhysical.Plan
         ) = this.apply {
-                physicalPlanPasses.add(
-                    object : PartiqlPhysicalPass {
-                        override val passName = name
+            physicalPlanPasses.add(
+                object : PartiqlPhysicalPass {
+                    override val passName = name
 
-                        override fun rewrite(
-                            inputPlan: PartiqlPhysical.Plan,
-                            problemHandler: ProblemHandler
-                        ): PartiqlPhysical.Plan =
-                            passBody(inputPlan, problemHandler)
+                    override fun rewrite(
+                        inputPlan: PartiqlPhysical.Plan,
+                        problemHandler: ProblemHandler
+                    ): PartiqlPhysical.Plan =
+                        passBody(inputPlan, problemHandler)
+                }
+            )
+        }
 
-                    }
-                )
-            }
-
-
-            /**
-             * Makes an instance of [RelationalOperatorFactory] available during plan compilation.
-             *
-             * To actually be used, operator implementations must be selected during a pass over the physical plan.
-             * See [addPhysicalPlanPass].
-             */
-            fun addRelationalOperatorFactory(factory: RelationalOperatorFactory) = this.apply {
+        /**
+         * Makes an instance of [RelationalOperatorFactory] available during plan compilation.
+         *
+         * To actually be used, operator implementations must be selected during a pass over the physical plan.
+         * See [addPhysicalPlanPass].
+         */
+        fun addRelationalOperatorFactory(factory: RelationalOperatorFactory) = this.apply {
             physicalOperatorFactories.add(factory)
         }
 

--- a/lang/test/org/partiql/lang/planner/PlannerPipelineSmokeTests.kt
+++ b/lang/test/org/partiql/lang/planner/PlannerPipelineSmokeTests.kt
@@ -42,12 +42,11 @@ class PlannerPipelineSmokeTests {
         var pecCallbacks = 0
         val plannerEventCallback: PlannerEventCallback = { _ ->
             pecCallbacks++
-            //println("*******************************************************************************")
-            //println(event)
+            // println("*******************************************************************************")
+            // println(event)
         }
 
         val pipeline = createPlannerPipelineForTest(allowUndefinedVariables = true, plannerEventCallback = plannerEventCallback)
-
 
         val planResult = pipeline.plan("SELECT c.* FROM Customer AS c WHERE c.primaryKey = 42")
             as PlannerPassResult.Success<PartiqlPhysical.Plan>
@@ -65,7 +64,7 @@ class PlannerPipelineSmokeTests {
         // - compile
         assertEquals(6, pecCallbacks)
 
-        //println(SexpAstPrettyPrinter.format(result.output.toIonElement().asAnyElement().toIonValue(ION)))
+        // println(SexpAstPrettyPrinter.format(result.output.toIonElement().asAnyElement().toIonValue(ION)))
 
         assertEquals(
             planResult,

--- a/lang/test/org/partiql/lang/planner/PlannerPipelineSmokeTests.kt
+++ b/lang/test/org/partiql/lang/planner/PlannerPipelineSmokeTests.kt
@@ -2,7 +2,6 @@ package org.partiql.lang.planner
 
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.ionString
-import com.amazon.ionelement.api.toIonValue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -19,7 +18,6 @@ import org.partiql.lang.eval.physical.operators.ValueExpression
 import org.partiql.lang.eval.physical.sourceLocationMetaOrUnknown
 import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
 import org.partiql.lang.planner.transforms.PLAN_VERSION_NUMBER
-import org.partiql.lang.util.SexpAstPrettyPrinter
 
 /**
  * Query planning primarily consists of AST traversals and rewrites.  Each of those are thoroughly tested separately,
@@ -30,23 +28,47 @@ class PlannerPipelineSmokeTests {
     @Suppress("DEPRECATION")
     private fun createPlannerPipelineForTest(
         allowUndefinedVariables: Boolean,
+        plannerEventCallback: PlannerEventCallback?,
         block: PlannerPipeline.Builder.() -> Unit = { }
     ) = PlannerPipeline.build(ION) {
         allowUndefinedVariables(allowUndefinedVariables)
         globalVariableResolver(createFakeGlobalsResolver("Customer" to "fake_uid_for_Customer"))
+        plannerEventCallback?.let { plannerEventCallback(it) }
         block()
     }
 
     @Test
     fun `happy path`() {
-        val pipeline = createPlannerPipelineForTest(allowUndefinedVariables = true)
-        val result = pipeline.plan("SELECT c.* FROM Customer AS c WHERE c.primaryKey = 42")
+        var pecCallbacks = 0
+        val plannerEventCallback: PlannerEventCallback = { _ ->
+            pecCallbacks++
+            //println("*******************************************************************************")
+            //println(event)
+        }
 
-        result as PlannerPassResult.Success
-        println(SexpAstPrettyPrinter.format(result.output.toIonElement().asAnyElement().toIonValue(ION)))
+        val pipeline = createPlannerPipelineForTest(allowUndefinedVariables = true, plannerEventCallback = plannerEventCallback)
+
+
+        val planResult = pipeline.plan("SELECT c.* FROM Customer AS c WHERE c.primaryKey = 42")
+            as PlannerPassResult.Success<PartiqlPhysical.Plan>
+
+        // we call compile even tho we do nothing with the result just to ensure the PlannerEventCallback is invoked
+        // for the compile pass.
+        pipeline.compile(planResult.output)
+
+        // pec should be called once for each pass in the planner:
+        // - parse
+        // - normalize ast
+        // - ast -> logical
+        // - logical -> logical resolved
+        // - logical resolved -> default physical
+        // - compile
+        assertEquals(6, pecCallbacks)
+
+        //println(SexpAstPrettyPrinter.format(result.output.toIonElement().asAnyElement().toIonValue(ION)))
 
         assertEquals(
-            result,
+            planResult,
             PlannerPassResult.Success(
                 output = PartiqlPhysical.build {
                     plan(
@@ -81,7 +103,7 @@ class PlannerPipelineSmokeTests {
 
     @Test
     fun `undefined variable`() {
-        val qp = createPlannerPipelineForTest(allowUndefinedVariables = false)
+        val qp = createPlannerPipelineForTest(allowUndefinedVariables = false, plannerEventCallback = null)
         val result = qp.plan("SELECT undefined.* FROM Customer AS c")
         assertEquals(
             PlannerPassResult.Error<PartiqlPhysical.Statement>(
@@ -93,8 +115,8 @@ class PlannerPipelineSmokeTests {
 
     @Test
     fun `physical plan pass - happy path`() {
-        val qp = createPlannerPipelineForTest(allowUndefinedVariables = false) {
-            addPhysicalPlanPass { inputPlan, _ ->
+        val qp = createPlannerPipelineForTest(allowUndefinedVariables = false, plannerEventCallback = null) {
+            addPhysicalPlanPass("fake pass 1") { inputPlan, _ ->
                 // ensure we're getting the correct plan as input
                 assertEquals(createFakePlan(1), inputPlan)
 
@@ -102,12 +124,12 @@ class PlannerPipelineSmokeTests {
                 // plan entirely.
                 createFakePlan(2)
             }
-            addPhysicalPlanPass { inputPlan, _ ->
+            addPhysicalPlanPass("fake pass 2") { inputPlan, _ ->
                 // second pass should get the output of the first pass as input
                 assertEquals(createFakePlan(2), inputPlan)
                 createFakePlan(3)
             }
-            addPhysicalPlanPass { inputPlan, _ ->
+            addPhysicalPlanPass("fake pass 3") { inputPlan, _ ->
                 // third pass should get the output of the second pass as input
                 assertEquals(createFakePlan(3), inputPlan)
                 createFakePlan(4)
@@ -129,14 +151,15 @@ class PlannerPipelineSmokeTests {
 
     @Test
     fun `physical plan pass - first user pass sends semantic error`() {
-        val qp = createPlannerPipelineForTest(allowUndefinedVariables = false) {
-            addPhysicalPlanPass { inputPlan, problemHandler ->
+        val qp = createPlannerPipelineForTest(allowUndefinedVariables = false, plannerEventCallback = null) {
+            addPhysicalPlanPass("test_pass") { inputPlan, problemHandler ->
                 problemHandler.handleProblem(
                     createFakeErrorProblem(inputPlan.stmt.metas.sourceLocationMetaOrUnknown)
                 )
                 inputPlan
             }
-            addPhysicalPlanPass { _, _ ->
+
+            addPhysicalPlanPass("test_pass_2") { _, _ ->
                 error(
                     "This pass should not be reached due to an error being sent to to the problem handler " +
                         "in the previous pass"

--- a/lang/test/org/partiql/lang/planner/PlannerPipelineSmokeTests.kt
+++ b/lang/test/org/partiql/lang/planner/PlannerPipelineSmokeTests.kt
@@ -40,11 +40,7 @@ class PlannerPipelineSmokeTests {
     @Test
     fun `happy path`() {
         var pecCallbacks = 0
-        val plannerEventCallback: PlannerEventCallback = { _ ->
-            pecCallbacks++
-            // println("*******************************************************************************")
-            // println(event)
-        }
+        val plannerEventCallback: PlannerEventCallback = { _ -> pecCallbacks++ }
 
         val pipeline = createPlannerPipelineForTest(allowUndefinedVariables = true, plannerEventCallback = plannerEventCallback)
 
@@ -63,8 +59,6 @@ class PlannerPipelineSmokeTests {
         // - logical resolved -> default physical
         // - compile
         assertEquals(6, pecCallbacks)
-
-        // println(SexpAstPrettyPrinter.format(result.output.toIonElement().asAnyElement().toIonValue(ION)))
 
         assertEquals(
             planResult,


### PR DESCRIPTION
*Description of changes:*

Planner event callbacks provide a facility that allows the query to be visualized at every stage in the PlannerPipeline and to generate performance metrics for the individual parts of the planner.

*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes? (y/n), If not, please explain why:*
Yes

*Does your PR include any backward-incompatible changes? (y/n), if yes, please explain the reason. In addition, please
 also mention any other alternatives you've considered and the reason they've been discarded?:*

No.

*Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:*

No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
