### PR TITLE
Add `partiql-lang-kotlin` major version migration guides

### DIFF
--- a/docs/dev/version-migration/cli-versions.md
+++ b/docs/dev/version-migration/cli-versions.md
@@ -2,12 +2,12 @@
 
 ## v0.2.* (latest v0.2.7)
 
-* New features
-    * Version number and commit hash in REPL
-    * `PARTIQL_PRETTY` output-format added for non-interactive CLI users
-* Misc/bug fixes
-    * [fix] close CLI stream correctly
-    * [fix] preserve negative zero when writing values to the CLI/REPL
+### New features
+* Version number and commit hash in REPL
+* `PARTIQL_PRETTY` output-format added for non-interactive CLI users
+### Misc/bug fixes
+* [fix] close CLI stream correctly
+* [fix] preserve negative zero when writing values to the CLI/REPL
 
 ## v0.3.* (latest v0.3.4)
 
@@ -19,32 +19,31 @@
 
 ## v0.5.* (latest v0.5.0)
 
-* New features
-    * Replaces CSV file reader with Apache’s CSVParser 
-    * Adds ability to read custom CSV configurations
-* Misc/bug fixes
-    * [fix] CLI command bug when input data is empty
-    * [fix] CLI bug when outputting IONTEXT to file
+### New features
+* Replaces CSV file reader with Apache’s CSVParser 
+* Adds ability to read custom CSV configurations
+### Misc/bug fixes
+* [fix] CLI command bug when input data is empty
+* [fix] CLI bug when outputting IONTEXT to file
 
 ## v0.6.* (latest v0.6.0)
 
-* New features
-    * Adds permissive evaluation mode option to CLI/REPL
+### New features
+* Adds permissive evaluation mode option to CLI/REPL
 
 ## v0.7.* (latest v0.7.0)
 
-* New features
-    * Replacement of REPL with [JLine](https://jline.github.io/) shell
-    * Syntax highlighting for CLI
-    * Three additional CLI flags related to evaluation options:
-        * `-r --projection-iter-behavior:` Controls the behavior of ExprValue.iterator in the projection result: (default: FILTER_MISSING) [FILTER_MISSING, UNFILTERED]
-        * `-t --typed-op-behavior`: indicates how CAST should behave: (default: HONOR_PARAMETERS) [LEGACY, HONOR_PARAMETERS]
-        * `-v --undefined-variable-behavior`: Defines the behavior when a non-existent variable is referenced: (default: ERROR) [ERROR, MISSING]
-    * `--input-format` flag to the CLI
-    * An optional flag, `--wrap-ion`, to give users the old functionality of reading multiple Ion values to support the previous behavior
-* Misc/bug fixes
-    * `query_ddb` function added to allow for querying AWS DDB from the CLI
-    * [fix] `write_file` CLI function; the old function required the input to be a `string`, but it must be a generic type
-    * [adjust] handling of Ion input (requires a single value)
-    * [adjust] handling of Ion output (outputting the actual evaluation result value)
-
+### New features
+* Replacement of REPL with [JLine](https://jline.github.io/) shell
+* Syntax highlighting for CLI
+* Three additional CLI flags related to evaluation options:
+    * `-r --projection-iter-behavior:` Controls the behavior of ExprValue.iterator in the projection result: (default: FILTER_MISSING) [FILTER_MISSING, UNFILTERED]
+    * `-t --typed-op-behavior`: indicates how CAST should behave: (default: HONOR_PARAMETERS) [LEGACY, HONOR_PARAMETERS]
+    * `-v --undefined-variable-behavior`: Defines the behavior when a non-existent variable is referenced: (default: ERROR) [ERROR, MISSING]
+* `--input-format` flag to the CLI
+* An optional flag, `--wrap-ion`, to give users the old functionality of reading multiple Ion values to support the previous behavior
+### Misc/bug fixes
+* `query_ddb` function added to allow for querying AWS DDB from the CLI
+* [fix] `write_file` CLI function; the old function required the input to be a `string`, but it must be a generic type
+* [adjust] handling of Ion input (requires a single value)
+* [adjust] handling of Ion output (outputting the actual evaluation result value)

--- a/docs/dev/version-migration/cli-versions.md
+++ b/docs/dev/version-migration/cli-versions.md
@@ -1,0 +1,50 @@
+# CLI/REPL Changes between Major Versions
+
+## v0.2.* (latest v0.2.7)
+
+* New features
+    * Version number and commit hash in REPL
+    * `PARTIQL_PRETTY` output-format added for non-interactive CLI users
+* Misc/bug fixes
+    * [fix] close CLI stream correctly
+    * [fix] preserve negative zero when writing values to the CLI/REPL
+
+## v0.3.* (latest v0.3.4)
+
+* No changes
+
+## v0.4.* (latest v0.4.0)
+
+* No changes
+
+## v0.5.* (latest v0.5.0)
+
+* New features
+    * Replaces CSV file reader with Apache’s CSVParser 
+    * Adds ability to read custom CSV configurations
+* Misc/bug fixes
+    * [fix] CLI command bug when input data is empty
+    * [fix] CLI bug when outputting IONTEXT to file
+
+## v0.6.* (latest v0.6.0)
+
+* New features
+    * Adds permissive evaluation mode option to CLI/REPL
+
+## v0.7.* (latest v0.7.0)
+
+* New features
+    * Replacement of REPL with [JLine](https://jline.github.io/) shell
+    * Syntax highlighting for CLI
+    * Three additional CLI flags related to evaluation options:
+        * `-r --projection-iter-behavior:` Controls the behavior of ExprValue.iterator in the projection result: (default: FILTER_MISSING) [FILTER_MISSING, UNFILTERED]
+        * `-t --typed-op-behavior`: indicates how CAST should behave: (default: HONOR_PARAMETERS) [LEGACY, HONOR_PARAMETERS]
+        * `-v --undefined-variable-behavior`: Defines the behavior when a non-existent variable is referenced: (default: ERROR) [ERROR, MISSING]
+    * `--input-format` flag to the CLI
+    * An optional flag, `--wrap-ion`, to give users the old functionality of reading multiple Ion values to support the previous behavior
+* Misc/bug fixes
+    * `query_ddb` function added to allow for querying AWS DDB from the CLI
+    * [fix] `write_file` CLI function; the old function required the input to be a `string`, but it must be a generic type
+    * [adjust] handling of Ion input (requires a single value)
+    * [adjust] handling of Ion output (outputting the actual evaluation result value)
+

--- a/docs/dev/version-migration/migration-guide.md
+++ b/docs/dev/version-migration/migration-guide.md
@@ -14,9 +14,8 @@ build-related changes)
 * moved CLI/REPL changes to a separate section
 * found other breaking changes from the compatibility reports between versions using the [japi-compliance-checker](https://github.com/lvc/japi-compliance-checker)
 
+The [CHANGLOG](https://github.com/partiql/partiql-lang-kotlin/blob/main/CHANGELOG.md) can also be viewed to see changes
+between releases and also includes a section on features yet to be released (see [Unreleased](https://github.com/partiql/partiql-lang-kotlin/blob/main/CHANGELOG.md#unreleased)).
+
 The repo, [test-partiql-version-migration](https://github.com/alancai98/test-partiql-version-migration), hosts all the 
 example migration code between major versions.
-
-
-
-

--- a/docs/dev/version-migration/migration-guide.md
+++ b/docs/dev/version-migration/migration-guide.md
@@ -1,0 +1,22 @@
+# `partiql-lang-kotlin` Version Migration Guide
+
+(Note: this folder's documents will likely be converted to a set of wikis on https://github.com/partiql/partiql-lang-kotlin/wiki
+with each major version bump on a separate wiki page.
+TBD if this document will remain as a markdown file on GitHub)
+
+The `partiql-lang-kotlin` [release notes](https://github.com/partiql/partiql-lang-kotlin/releases) list changes 
+between minor versions as well as the last minor version to the subsequent major version (e.g. v0.2.7 -> v0.3.0). This 
+document lists the aggregated release notes between major `partiql-lang-kotlin` versions (e.g. v0.2.7 -> v0.3.4). To 
+make it easier to understand differences between `partiql-lang-kotlin` major versions, we've also
+* unified the change format (new features, breaking changes - behavioral and API, deprecated items, misc/bug fixes)
+* cleaned up some release note items (summarized sequences of related commits, omitted commits related to tests and 
+build-related changes)
+* separated CLI/REPL changes to a separate section
+* found other breaking changes from the compatibility reports between versions using the [japi-compliance-checker](https://github.com/lvc/japi-compliance-checker)
+
+The repo, [test-partiql-version-migration](https://github.com/alancai98/test-partiql-version-migration), hosts all the 
+example migration code between major versions.
+
+
+
+

--- a/docs/dev/version-migration/migration-guide.md
+++ b/docs/dev/version-migration/migration-guide.md
@@ -11,7 +11,7 @@ make it easier to understand differences between `partiql-lang-kotlin` major ver
 * unified the change format (new features, breaking changes - behavioral and API, deprecated items, misc/bug fixes)
 * cleaned up some release note items (summarized sequences of related commits, omitted commits related to tests and 
 build-related changes)
-* separated CLI/REPL changes to a separate section
+* moved CLI/REPL changes to a separate section
 * found other breaking changes from the compatibility reports between versions using the [japi-compliance-checker](https://github.com/lvc/japi-compliance-checker)
 
 The repo, [test-partiql-version-migration](https://github.com/alancai98/test-partiql-version-migration), hosts all the 

--- a/docs/dev/version-migration/migration-guide.md
+++ b/docs/dev/version-migration/migration-guide.md
@@ -19,3 +19,5 @@ between releases and also includes a section on features yet to be released (see
 
 The repo, [test-partiql-version-migration](https://github.com/alancai98/test-partiql-version-migration), hosts all the 
 example migration code between major versions.
+TODO: as part of [partiql-lang-kotlin#692](https://github.com/partiql/partiql-lang-kotlin/issues/692), move the repo
+under the `partiql` GitHub organization (either as submodule or as a separate repo).

--- a/docs/dev/version-migration/migration-guide.md
+++ b/docs/dev/version-migration/migration-guide.md
@@ -14,7 +14,7 @@ build-related changes)
 * moved CLI/REPL changes to a separate section
 * found other breaking changes from the compatibility reports between versions using the [japi-compliance-checker](https://github.com/lvc/japi-compliance-checker)
 
-The [CHANGLOG](https://github.com/partiql/partiql-lang-kotlin/blob/main/CHANGELOG.md) can also be viewed to see changes
+The [CHANGELOG](https://github.com/partiql/partiql-lang-kotlin/blob/main/CHANGELOG.md) can also be viewed to see changes
 between releases and also includes a section on features yet to be released (see [Unreleased](https://github.com/partiql/partiql-lang-kotlin/blob/main/CHANGELOG.md#unreleased)).
 
 The repo, [test-partiql-version-migration](https://github.com/alancai98/test-partiql-version-migration), hosts all the 

--- a/docs/dev/version-migration/migration-guide.md
+++ b/docs/dev/version-migration/migration-guide.md
@@ -2,7 +2,7 @@
 
 (Note: this folder's documents will likely be converted to a set of wikis on https://github.com/partiql/partiql-lang-kotlin/wiki
 with each major version bump on a separate wiki page.
-TBD if this document will remain as a markdown file on GitHub)
+TBD if these documents will remain as a markdown file on GitHub)
 
 The `partiql-lang-kotlin` [release notes](https://github.com/partiql/partiql-lang-kotlin/releases) list changes 
 between minor versions as well as the last minor version to the subsequent major version (e.g. v0.2.7 -> v0.3.0). This 

--- a/docs/dev/version-migration/v0.1-to-v0.2-migration.md
+++ b/docs/dev/version-migration/v0.1-to-v0.2-migration.md
@@ -1,30 +1,32 @@
 # v0.2.* (latest v0.2.7)
 
-* New features
-    * Adds support for `DISTINCT`, `LET` (from `FROM` clause), system stored procedure calls (`EXEC`)
-    * Adds parser support for DML statements (`INSERT`, `UPDATE`, `DELETE`), `Parameter`, `BY` variable
-    * Improvements to `LIKE` pattern compilation performance
-    * Adds function to convert from UNIX epoch to TIMESTAMP and TIMESTAMP to UNIX epoch
-* Deprecated items
-    * `AstRewriter`, `AstRewriterBase`, `MetaStrippingRewriter`, `RewriterTestBase`
-        * Existing AST rewriters migrated to use PIG’s `VisitorTransform`s
-        * Migration guide provided [here](https://github.com/partiql/partiql-lang-kotlin/blob/feb84730c64a2ad0f12c57bef3b1c45e21279538/docs/dev/RewriterToVisitorTransformGuide.md)
-    * `V0AstSerializer`, `AstSerializer`, `AstDeserializer`, and classes & functions relating to the V0Ast
-        * Users are encouraged to use `PartiqlAst` (not `ExprNode` which was deprecated in v0.6.*)
-* Misc/bug fixes
-    * New error codes for division by `0` and modulo `0`
-    * [fix] float negative zero equality
-    * Removes invalid syntax check on case expressions w/ type parameters e.g., `CAST(a AS DECIMAL(1, 2))` now does not throw
-    * [fix] `LIMIT` with value over 2^31 returning no values
-    * [fix] `LIMIT` clause execution order
-    * [fix] stop treating date parts as if they are string literals
-    * [fix] parsing of `TRIM` specification keywords (`BOTH`, `LEADING`, and `TRAILING`)
-    * Adds some AST rewriters — `SelectStarRewriter` and `StaticTypeRewriter`
+## New features
+* Adds support for `DISTINCT`, `LET` (from `FROM` clause), system stored procedure calls (`EXEC`)
+* Adds parser support for DML statements (`INSERT`, `UPDATE`, `DELETE`), `Parameter`, `BY` variable
+* Improvements to `LIKE` pattern compilation performance
+* Adds function to convert from UNIX epoch to TIMESTAMP and TIMESTAMP to UNIX epoch
+## Deprecated items
+* `AstRewriter`, `AstRewriterBase`, `MetaStrippingRewriter`, `RewriterTestBase`
+    * Existing AST rewriters migrated to use PIG’s `VisitorTransform`s
+    * `AstRewriterBase` to `VisitorTransform` guide provided 
+  [here](https://github.com/partiql/partiql-lang-kotlin/blob/feb84730c64a2ad0f12c57bef3b1c45e21279538/docs/dev/RewriterToVisitorTransformGuide.md)
+* `V0AstSerializer`, `AstSerializer`, `AstDeserializer`, and classes & functions relating to the V0Ast
+    * Users are encouraged to use `PartiqlAst`. Do **not** use `ExprNode` which was deprecated in v0.6.* and will be removed in an
+  upcoming major version (see [partiql-lang-kotlin#682](https://github.com/partiql/partiql-lang-kotlin/issues/682) for tracking).
+## Misc/bug fixes
+* New error codes for division by `0` and modulo `0`
+* [fix] float negative zero equality
+* Removes invalid syntax check on case expressions w/ type parameters e.g., `CAST(a AS DECIMAL(1, 2))` now does not throw
+* [fix] `LIMIT` with value over 2^31 returning no values
+* [fix] `LIMIT` clause execution order
+* [fix] stop treating date parts as if they are string literals
+* [fix] parsing of `TRIM` specification keywords (`BOTH`, `LEADING`, and `TRAILING`)
+* Adds some AST rewriters — `SelectStarRewriter` and `StaticTypeRewriter`
 ## Breaking changes
 ### Breaking behavioral changes
 1. `JOIN` requires an `ON` clause. In v0.1.*, the `ON` clause was optional, which caused ambiguous parsing of multiple `JOIN`
 ```kotlin
-// v0.1.*
+// ----- v0.1.* -----
 // Initialization of components related to evaluating a query end-to-end
 val ion = IonSystemBuilder.standard().build()
 val parser = SqlParser(ion)
@@ -42,11 +44,7 @@ assertEquals("<<{'a': 1, 'a': 2}>>", result.toString())
 ```
 
 ```kotlin
-// v0.2.*
-// Initialization of components related to parsing a query end-to-end
-val ion = IonSystemBuilder.standard().build()
-val parser = SqlParser(ion)
-
+// ----- v0.2.* -----
 // Query with a JOIN without an ON clause. Starting in v0.2.0, the ON condition is REQUIRED except for cross
 // joins. When not provided, a parser error is thrown.
 val query = "SELECT * FROM <<{'a': 1}>> INNER JOIN <<{'a': 2}>>"
@@ -54,12 +52,17 @@ assertFailsWith<ParserException> {
     parser.parseExprNode(query)
 }
 ```
+
+- [v0.1.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.1-to-v0.2-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L25-L41)
+- [v0.2.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.1-to-v0.2-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L27-L39)
 ### Breaking API changes
-1. Refactoring of `ExprNode` AST (see [16fefe0](https://github.com/partiql/partiql-lang-kotlin/commit/16fefe0f096175a6a7b284313634dfad23858a38)) `FromSourceExpr` variables (changed to use `LetVariables`)
+#### **NOTE**: `ExprNode` is deprecated and replaced with `PartiqlAst`. Users can look at [ExprNodeToStatement.kt](https://github.com/partiql/partiql-lang-kotlin/blob/0b4540f474caff7dba1d6c327e0e85012402829b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt) and [RewriterToVisitorTransformGuide.md](https://github.com/partiql/partiql-lang-kotlin/blob/0b4540f474caff7dba1d6c327e0e85012402829b/docs/dev/RewriterToVisitorTransformGuide.md) to see how to migrate from `ExprNode` to `PartiqlAst`.
+
+1. Refactoring of `ExprNode` AST (see [16fefe0](https://github.com/partiql/partiql-lang-kotlin/commit/16fefe0f096175a6a7b284313634dfad23858a38)) `FromSourceExpr` variables (changed to use `LetVariables`). 
 ```kotlin
-// v0.1.*
+// ----- v0.1.* -----
 // FROM source and FROM source UNPIVOT are modeled differently between v0.1.* and v0.2.*
-// The following is an AstNode/ExprNode representation of '... FROM foo AS f AT g'
+// The following is an AstNode/ExprNode representation of '... FROM foo AS f AT g' in v0.1.*
 val fromExpr = VariableReference(id = "foo", case = CaseSensitivity.INSENSITIVE, metas = metaContainerOf())
 FromSourceExpr(
     expr = fromExpr,
@@ -76,9 +79,8 @@ FromSourceUnpivot(
 )
 ```
 ```kotlin
-// v0.2.*
-// FROM source and FROM source UNPIVOT are modeled differently between v0.1.* and v0.2.*
-// The following is an AstNode/ExprNode representation of '... FROM foo AS f AT g'
+// ----- v0.2.* -----
+// The following is an AstNode/ExprNode representation of '... FROM foo AS f AT g' in v0.2.*
 val fromExpr = VariableReference(id = "foo", case = CaseSensitivity.INSENSITIVE, metas = metaContainerOf())
 FromSourceExpr(
     expr = fromExpr,
@@ -99,9 +101,12 @@ FromSourceUnpivot(
     metas = metaContainerOf()
 )
 ```
+- [v0.1.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.1-to-v0.2-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L43-L61)
+- [v0.2.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.1-to-v0.2-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L41-L64)
+
 2. Refactoring of `ExprNode` AST (see [16fefe0](https://github.com/partiql/partiql-lang-kotlin/commit/16fefe0f096175a6a7b284313634dfad23858a38)) `List` and `Bag` `ExprNode`s defined under a `Seq` class
 ```kotlin
-// v0.1.*
+// ----- v0.1.* -----
 val ion = IonSystemBuilder.standard().build()
 val elem1 = Literal(ionValue = ion.singleValue("1"), metas = metaContainerOf())
 val elem2 = Literal(ionValue = ion.singleValue("2"), metas = metaContainerOf())
@@ -129,12 +134,7 @@ Bag(
 )
 ```
 ```kotlin
-// v0.2.*
-val ion = IonSystemBuilder.standard().build()
-val elem1 = Literal(ionValue = ion.singleValue("1"), metas = metaContainerOf())
-val elem2 = Literal(ionValue = ion.singleValue("2"), metas = metaContainerOf())
-val elem3 = Literal(ionValue = ion.singleValue("3"), metas = metaContainerOf())
-// LIST and BAG are modeled differently between v0.1.* and v0.2.*
+// ----- v0.2.* -----
 // The following is an AstNode/ExprNode representation of [1, 2, 3]
 Seq(
     type = SeqType.LIST,
@@ -168,12 +168,15 @@ Seq(
     metas = metaContainerOf()
 )
 ```
+- [v0.1.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.1-to-v0.2-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L63-L90)
+- [v0.2.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.1-to-v0.2-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L66-L106)
 
 3. Starting in v0.2.*, the classes and functions related to `V0AstSerializer`, `AstSerializer`, `AstDeserializer` have
-been deprecated and will be removed in a future PartiQL release. Below is an example demonstrating how to migrate some
-V0Ast IonSexp manipulation code to use `PartiqlAst`.
+been deprecated and will be removed in a future PartiQL release. Below is an example demonstrating how to migrate
+V0Ast `IonSexp` rewriting code to use `PartiqlAst`.
 ```kotlin
-// v0.1.* parsed the PartiQL statement to an ExprNode that could be serialized to the V0Ast. ExprNode and V0Ast
+// ----- v0.1.* -----
+// v0.1.* parsed the PartiQL statement to an `ExprNode` that could be serialized to the V0Ast. `ExprNode` and `V0Ast`
 // have been deprecated in favor of PartiqlAst.
 val node: ExprNode = SqlParser(ion).parseExprNode("SELECT * FROM <<{'a': 1, 'b': {'c': 23}}>>")
 val ionSexp: IonSexp = V0AstSerializer.serialize(node, ion)
@@ -198,11 +201,11 @@ assertEquals(expectedIonSexp.filterMetaNodes(), rewrittenIonSexp.filterMetaNodes
 ```
 
 ```kotlin
-// v0.2.* onwards recommend using the PartiqlAst over any other AST versions
+// v0.2.* onwards recommend using the `PartiqlAst` over any other AST versions
 val partiqlAst = SqlParser(ion).parseAstStatement("SELECT * FROM <<{'a': 1, 'b': {'c': 23}}>>")
 
-// below shows a way to create the same recursive rewriting function on PartiqlAst statements using the
-// VisitorTransform class
+// below shows a way to create the same recursive rewriting function on `PartiqlAst` statements using the
+// `VisitorTransform` class
 class RewriteIntsTo42: PartiqlAst.VisitorTransform() {
     override fun transformExprLit(node: PartiqlAst.Expr.Lit): PartiqlAst.Expr {
         val newValue = when (node.value) {
@@ -219,3 +222,5 @@ val rewrittenStatement = RewriteIntsTo42().transformStatement(partiqlAst)
 val expectedPartiqlAst = SqlParser(ion).parseAstStatement("SELECT * FROM <<{'a': 42, 'b': {'c': 42}}>>")
 assertEquals(expectedPartiqlAst, rewrittenStatement)
 ```
+- [v0.1.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.1-to-v0.2-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L92-L117)
+- [v0.2.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.1-to-v0.2-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L108-L131)

--- a/docs/dev/version-migration/v0.1-to-v0.2-migration.md
+++ b/docs/dev/version-migration/v0.1-to-v0.2-migration.md
@@ -1,0 +1,168 @@
+# v0.2.* (latest v0.2.7)
+
+* New features
+    * Adds support for `DISTINCT`, `LET` (from `FROM` clause), system stored procedure calls (`EXEC`)
+    * Adds parser support for DML statements (`INSERT`, `UPDATE`, `DELETE`), `Parameter`, `BY` variable
+    * Improvements to `LIKE` pattern compilation performance
+    * Adds function to convert from UNIX epoch to TIMESTAMP and TIMESTAMP to UNIX epoch
+* Deprecated items
+    * `AstRewriter`, `AstRewriterBase`, `MetaStrippingRewriter`, `RewriterTestBase`
+        * Existing AST rewriters migrated to use PIG’s `VisitorTransform`s
+        * Migration guide provided [here](https://github.com/partiql/partiql-lang-kotlin/blob/feb84730c64a2ad0f12c57bef3b1c45e21279538/docs/dev/RewriterToVisitorTransformGuide.md)
+* Misc/bug fixes
+    * New error codes for division by `0` and modulo `0`
+    * [fix] float negative zero equality
+    * Removes invalid syntax check on case expressions w/ type parameters e.g., `CAST(a AS DECIMAL(1, 2))` now does not throw
+    * [fix] `LIMIT` with value over 2^31 returning no values
+    * [fix] `LIMIT` clause execution order
+    * [fix] stop treating date parts as if they are string literals
+    * [fix] parsing of `TRIM` specification keywords (`BOTH`, `LEADING`, and `TRAILING`)
+    * Adds some AST rewriters — `SelectStarRewriter` and `StaticTypeRewriter`
+## Breaking changes
+### Breaking behavioral changes
+1. `JOIN` requires an `ON` clause. In v0.1.*, the `ON` clause was optional, which caused ambiguous parsing of multiple `JOIN`
+```kotlin
+// v0.1.*
+// Initialization of components related to evaluating a query end-to-end
+val ion = IonSystemBuilder.standard().build()
+val parser = SqlParser(ion)
+val pipeline = CompilerPipeline.standard(ion)
+val evaluationSession = EvaluationSession.standard()
+
+// Query with a JOIN without an ON clause. In v0.1.*, the ON condition is optional.
+val query = "SELECT * FROM <<{'a': 1}>> INNER JOIN <<{'a': 2}>>"
+val parsedQuery = parser.parseExprNode(query)
+val compiledQuery = pipeline.compile(parsedQuery)
+val result = compiledQuery.eval(evaluationSession)
+
+// Query successfully evaluates. Here we compare the result to its string representation.
+assertEquals("<<{'a': 1, 'a': 2}>>", result.toString())
+```
+
+```kotlin
+// v0.2.*
+// Initialization of components related to parsing a query end-to-end
+val ion = IonSystemBuilder.standard().build()
+val parser = SqlParser(ion)
+
+// Query with a JOIN without an ON clause. Starting in v0.2.0, the ON condition is REQUIRED except for cross
+// joins. When not provided, a parser error is thrown.
+val query = "SELECT * FROM <<{'a': 1}>> INNER JOIN <<{'a': 2}>>"
+assertFailsWith<ParserException> {
+    parser.parseExprNode(query)
+}
+```
+### Breaking API changes
+1. Refactoring of `ExprNode` AST (see [16fefe0](https://github.com/partiql/partiql-lang-kotlin/commit/16fefe0f096175a6a7b284313634dfad23858a38)) `FromSourceExpr` variables (changed to use `LetVariables`)
+```kotlin
+// v0.1.*
+// FROM source and FROM source UNPIVOT are modeled differently between v0.1.* and v0.2.*
+// The following is an AstNode/ExprNode representation of '... FROM foo AS f AT g'
+val fromExpr = VariableReference(id = "foo", case = CaseSensitivity.INSENSITIVE, metas = metaContainerOf())
+FromSourceExpr(
+    expr = fromExpr,
+    asName = SymbolicName(name = "f", metas = metaContainerOf()),
+    atName = SymbolicName(name = "g", metas = metaContainerOf())
+)
+
+// The following models '... FROM UNPIVOT foo AS f AT g'
+FromSourceUnpivot(
+    expr = fromExpr,
+    asName = SymbolicName(name = "f", metas = metaContainerOf()),
+    atName = SymbolicName(name = "g", metas = metaContainerOf()),
+    metas = metaContainerOf()
+)
+```
+```kotlin
+// v0.2.*
+// FROM source and FROM source UNPIVOT are modeled differently between v0.1.* and v0.2.*
+// The following is an AstNode/ExprNode representation of '... FROM foo AS f AT g'
+val fromExpr = VariableReference(id = "foo", case = CaseSensitivity.INSENSITIVE, metas = metaContainerOf())
+FromSourceExpr(
+    expr = fromExpr,
+    variables = LetVariables(
+        asName = SymbolicName(name = "f", metas = metaContainerOf()),
+        atName = SymbolicName(name = "g", metas = metaContainerOf())
+        // v0.2.0 onwards also allows specifying a `BY` variable in FROM sources
+    )
+)
+
+// The following models '... FROM UNPIVOT foo AS f AT g'
+FromSourceUnpivot(
+    expr = fromExpr,
+    variables = LetVariables(
+        asName = SymbolicName(name = "f", metas = metaContainerOf()),
+        atName = SymbolicName(name = "g", metas = metaContainerOf())
+    ),
+    metas = metaContainerOf()
+)
+```
+2. Refactoring of `ExprNode` AST (see [16fefe0](https://github.com/partiql/partiql-lang-kotlin/commit/16fefe0f096175a6a7b284313634dfad23858a38)) `List` and `Bag` `ExprNode`s defined under a `Seq` class
+```kotlin
+// v0.1.*
+val ion = IonSystemBuilder.standard().build()
+val elem1 = Literal(ionValue = ion.singleValue("1"), metas = metaContainerOf())
+val elem2 = Literal(ionValue = ion.singleValue("2"), metas = metaContainerOf())
+val elem3 = Literal(ionValue = ion.singleValue("3"), metas = metaContainerOf())
+
+// LIST and BAG are modeled differently between v0.1.* and v0.2.*
+// The following is an AstNode/ExprNode representation of [1, 2, 3]
+ListExprNode(
+    values = listOf(
+        elem1,
+        elem2,
+        elem3
+    ),
+    metas = metaContainerOf()
+)
+
+// The following is an AstNode/ExprNode representation of <<1, 2, 3>>
+Bag(
+    bag = listOf(
+        elem1,
+        elem2,
+        elem3
+    ),
+    metas = metaContainerOf()
+)
+```
+```kotlin
+// v0.2.*
+val ion = IonSystemBuilder.standard().build()
+val elem1 = Literal(ionValue = ion.singleValue("1"), metas = metaContainerOf())
+val elem2 = Literal(ionValue = ion.singleValue("2"), metas = metaContainerOf())
+val elem3 = Literal(ionValue = ion.singleValue("3"), metas = metaContainerOf())
+// LIST and BAG are modeled differently between v0.1.* and v0.2.*
+// The following is an AstNode/ExprNode representation of [1, 2, 3]
+Seq(
+    type = SeqType.LIST,
+    values = listOf(
+        elem1,
+        elem2,
+        elem3
+    ),
+    metas = metaContainerOf()
+)
+
+// The following is an AstNode/ExprNode representation of <<1, 2, 3>>
+Seq(
+    type = SeqType.BAG,
+    values = listOf(
+        elem1,
+        elem2,
+        elem3
+    ),
+    metas = metaContainerOf()
+)
+
+// v0.2.0 onwards also allows for specifying s-expressions. E.g. (1 2 3)
+Seq(
+    type = SeqType.SEXP,
+    values = listOf(
+        elem1,
+        elem2,
+        elem3
+    ),
+    metas = metaContainerOf()
+)
+```

--- a/docs/dev/version-migration/v0.1-to-v0.2-migration.md
+++ b/docs/dev/version-migration/v0.1-to-v0.2-migration.md
@@ -41,6 +41,10 @@ val result = compiledQuery.eval(evaluationSession)
 
 // Query successfully evaluates. Here we compare the result to its string representation.
 assertEquals("<<{'a': 1, 'a': 2}>>", result.toString())
+
+// Query with an ON clause successfully parses and can be evaluated
+val resultWithOn = pipeline.compile("SELECT * FROM <<{'a': 1}>> INNER JOIN <<{'a': 2}>> ON true").eval(evaluationSession)
+assertEquals(result.toString(), resultWithOn.toString())
 ```
 
 ```kotlin
@@ -51,10 +55,14 @@ val query = "SELECT * FROM <<{'a': 1}>> INNER JOIN <<{'a': 2}>>"
 assertFailsWith<ParserException> {
     parser.parseExprNode(query)
 }
+
+// Query with an ON clause still successfully parses and can be evaluated in v0.2.* onwards
+val resultWithOn = pipeline.compile("SELECT * FROM <<{'a': 1}>> INNER JOIN <<{'a': 2}>> ON true").eval(evaluationSession)
+assertEquals("<<{'a': 1, 'a': 2}>>", resultWithOn.toString())
 ```
 
-- [v0.1.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.1-to-v0.2-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L25-L41)
-- [v0.2.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.1-to-v0.2-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L27-L39)
+- [v0.1.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/37eff39c88d15ddb1647ddedd134c9e663f81a95/v0.1-to-v0.2-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L25-L45)
+- [v0.2.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/37eff39c88d15ddb1647ddedd134c9e663f81a95/v0.1-to-v0.2-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L29-L47)
 ### Breaking API changes
 #### **NOTE**: `ExprNode` is deprecated and replaced with `PartiqlAst`. Users can look at [ExprNodeToStatement.kt](https://github.com/partiql/partiql-lang-kotlin/blob/0b4540f474caff7dba1d6c327e0e85012402829b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt) and [RewriterToVisitorTransformGuide.md](https://github.com/partiql/partiql-lang-kotlin/blob/0b4540f474caff7dba1d6c327e0e85012402829b/docs/dev/RewriterToVisitorTransformGuide.md) to see how to migrate from `ExprNode` to `PartiqlAst`.
 

--- a/docs/dev/version-migration/v0.1-to-v0.2-migration.md
+++ b/docs/dev/version-migration/v0.1-to-v0.2-migration.md
@@ -9,6 +9,8 @@
     * `AstRewriter`, `AstRewriterBase`, `MetaStrippingRewriter`, `RewriterTestBase`
         * Existing AST rewriters migrated to use PIG’s `VisitorTransform`s
         * Migration guide provided [here](https://github.com/partiql/partiql-lang-kotlin/blob/feb84730c64a2ad0f12c57bef3b1c45e21279538/docs/dev/RewriterToVisitorTransformGuide.md)
+    * `V0AstSerializer`, `AstSerializer`, `AstDeserializer`, and classes & functions relating to the V0Ast
+        * Users are encouraged to use `PartiqlAst` (not `ExprNode` which was deprecated in v0.6.*)
 * Misc/bug fixes
     * New error codes for division by `0` and modulo `0`
     * [fix] float negative zero equality
@@ -165,4 +167,55 @@ Seq(
     ),
     metas = metaContainerOf()
 )
+```
+
+3. Starting in v0.2.*, the classes and functions related to `V0AstSerializer`, `AstSerializer`, `AstDeserializer` have
+been deprecated and will be removed in a future PartiQL release. Below is an example demonstrating how to migrate some
+V0Ast IonSexp manipulation code to use `PartiqlAst`.
+```kotlin
+// v0.1.* parsed the PartiQL statement to an ExprNode that could be serialized to the V0Ast. ExprNode and V0Ast
+// have been deprecated in favor of PartiqlAst.
+val node: ExprNode = SqlParser(ion).parseExprNode("SELECT * FROM <<{'a': 1, 'b': {'c': 23}}>>")
+val ionSexp: IonSexp = V0AstSerializer.serialize(node, ion)
+
+// below is a way to recursively rewrite a V0Ast/IonSexp statement. This particular example function rewrites
+// any encountered int literal to 42.
+fun rewriteIntsTo42(sexp: IonSexp): IonSexp {
+    val rewritten = sexp.map { child ->
+        when (child) {
+            is IonSexp -> rewriteIntsTo42(child)
+            is IonInt -> ion.newInt(42)
+            else -> child.clone()
+        }
+    }
+    return ion.newSexp(*rewritten.toTypedArray())
+}
+
+val rewrittenIonSexp = rewriteIntsTo42(ionSexp)
+// the rewritten statement will be equivalent to the following statement (excluding source location metas)
+val expectedIonSexp = SqlParser(ion).parse("SELECT * FROM <<{'a': 42, 'b': {'c': 42}}>>")
+assertEquals(expectedIonSexp.filterMetaNodes(), rewrittenIonSexp.filterMetaNodes())
+```
+
+```kotlin
+// v0.2.* onwards recommend using the PartiqlAst over any other AST versions
+val partiqlAst = SqlParser(ion).parseAstStatement("SELECT * FROM <<{'a': 1, 'b': {'c': 23}}>>")
+
+// below shows a way to create the same recursive rewriting function on PartiqlAst statements using the
+// VisitorTransform class
+class RewriteIntsTo42: PartiqlAst.VisitorTransform() {
+    override fun transformExprLit(node: PartiqlAst.Expr.Lit): PartiqlAst.Expr {
+        val newValue = when (node.value) {
+            is IntElement -> ionInt(42)
+            else -> node.value
+        }
+        val newNode = PartiqlAst.build {
+            lit(newValue)
+        }
+        return super.transformExprLit(newNode)
+    }
+}
+val rewrittenStatement = RewriteIntsTo42().transformStatement(partiqlAst)
+val expectedPartiqlAst = SqlParser(ion).parseAstStatement("SELECT * FROM <<{'a': 42, 'b': {'c': 42}}>>")
+assertEquals(expectedPartiqlAst, rewrittenStatement)
 ```

--- a/docs/dev/version-migration/v0.2-to-v0.3-migration.md
+++ b/docs/dev/version-migration/v0.2-to-v0.3-migration.md
@@ -1,26 +1,27 @@
 # v0.3.* (latest v0.3.4)
 
-* New features
-    * DATE and TIME data types
-    * Parser support for
-        * Multiple `SET`, `REMOVE` operations per DML statement
-        * `ON CONFLICT` and `RETURNING` DML clause
-        * `ORDER BY` clause (not yet implemented in evaluator)
-    * Redact function that removes potentially sensitive information from SQL queries, allowing them to be logged for later analysis
-    * Optimizes `AstNode`’s `Iterator`
-* Deprecated items
-* Misc/bug fixes
-    * [fix] parser handling of top-level tokens
-    * [fix] `SIZE` `ExprFunction` to work with s-expressions
-    * [fix] Change usage of `LazyThreadSafetyMode` from `NONE` to `PUBLICATION`
+## New features
+* DATE and TIME data types
+* Parser support for
+    * Multiple `SET`, `REMOVE` operations per DML statement
+    * `ON CONFLICT` and `RETURNING` DML clause
+    * `ORDER BY` clause (not yet implemented in evaluator)
+* Redact function that removes potentially sensitive information from SQL queries, allowing them to be logged for later analysis
+* Optimizes `AstNode`’s `Iterator`
+## Deprecated items
+## Misc/bug fixes
+* [fix] parser handling of top-level tokens
+* [fix] `SIZE` `ExprFunction` to work with s-expressions
+* [fix] Change usage of `LazyThreadSafetyMode` from `NONE` to `PUBLICATION`
 ## Breaking changes
-### Breaking behavioral changes
 ### Breaking API changes
+#### **NOTE**: `ExprNode` is deprecated and replaced with `PartiqlAst`. Users can look at [ExprNodeToStatement.kt](https://github.com/partiql/partiql-lang-kotlin/blob/0b4540f474caff7dba1d6c327e0e85012402829b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt) and [RewriterToVisitorTransformGuide.md](https://github.com/partiql/partiql-lang-kotlin/blob/0b4540f474caff7dba1d6c327e0e85012402829b/docs/dev/RewriterToVisitorTransformGuide.md) to see how to migrate from `ExprNode` to `PartiqlAst`.
+
 1. Replace `SourcePosition` in `Token` with `SourceSpan`
 ```kotlin
-// v0.2.*
+// ----- v0.2.* -----
 val ion = IonSystemBuilder.standard().build()
-// SqlLexer provides us with `Token`s
+// `SqlLexer` provides us with `Token`s
 val tokens = SqlLexer(ion).tokenize("42")
 val firstToken = tokens.first()
 
@@ -37,12 +38,7 @@ assertEquals(tokenFromConstructor, firstToken)
 ```
 
 ```kotlin
-// v0.3.*
-val ion = IonSystemBuilder.standard().build()
-// SqlLexer provides us with `Token`s
-val tokens = SqlLexer(ion).tokenize("42")
-val firstToken = tokens.first()
-
+// ----- v0.3.* -----
 // `Token`s defined in v0.3.* onwards used `SourceSpan` specifying the `line`, `column`, and length of a `Token`
 val tokenFromConstructor = Token(
     type = TokenType.LITERAL,
@@ -55,9 +51,12 @@ val tokenFromConstructor = Token(
 )
 assertEquals(tokenFromConstructor, firstToken)
 ```
+- [v0.2.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.2-to-v0.3-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L22-L40)
+- [v0.3.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.2-to-v0.3-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L23-L42)
+
 2. Removed `PARSE_EXEC_AT_UNEXPECTED_LOCATION` error code from `ErrorCode`
 ```kotlin
-// v0.2.*
+// ----- v0.2.* -----
 val ion = IonSystemBuilder.standard().build()
 val parser = SqlParser(ion)
 
@@ -74,13 +73,7 @@ try {
 ```
 
 ```kotlin
-// v0.3.*
-val ion = IonSystemBuilder.standard().build()
-val parser = SqlParser(ion)
-
-// bad query containing a stored procedure call, `EXEC`, at an unexpected location
-val badQuery = "SELECT * FROM (EXEC undrop 'foo')"
-
+// ----- v0.3.* -----
 try {
     parser.parseExprNode(badQuery)
 } catch (pe: ParserException) {
@@ -88,11 +81,14 @@ try {
     assertEquals(ErrorCode.PARSE_UNEXPECTED_TERM, pe.errorCode)
 }
 ```
+- [v0.2.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.2-to-v0.3-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L42-L58)
+- [v0.3.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.2-to-v0.3-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L44-L58)
+
 3. Refactoring of `ExprNode` AST
 * `AssignmentOp` node stores one `Assignment` rather than a list
 * `DataManipulation` node stores a `DmlOpList` rather than a single `DataManipulationOperation`
 ```kotlin
-// v0.2.*
+// ----- v0.2.* -----
 val ion = IonSystemBuilder.standard().build()
 // In v0.2.* and before,
 // - `DataManipulation` node can only specify a single `dmlOperation`
@@ -130,8 +126,7 @@ DataManipulation(
 ```
 
 ```kotlin
-// v0.3.*
-val ion = IonSystemBuilder.standard().build()
+// ----- v0.3.* -----
 // In v0.3.* onwards,
 // - `DataManipulation` node specifies a list of `dmlOperation`s
 // - `AssignmentOp`, a type of `DataManipulationOperation` contains a single assignment
@@ -170,3 +165,5 @@ DataManipulation(
     metas = emptyMetaContainer
 )
 ```
+- [v0.2.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.2-to-v0.3-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L60-L96)
+- [v0.3.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.2-to-v0.3-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L60-L100)

--- a/docs/dev/version-migration/v0.2-to-v0.3-migration.md
+++ b/docs/dev/version-migration/v0.2-to-v0.3-migration.md
@@ -1,0 +1,172 @@
+# v0.3.* (latest v0.3.4)
+
+* New features
+    * DATE and TIME data types
+    * Parser support for
+        * Multiple `SET`, `REMOVE` operations per DML statement
+        * `ON CONFLICT` and `RETURNING` DML clause
+        * `ORDER BY` clause (not yet implemented in evaluator)
+    * Redact function that removes potentially sensitive information from SQL queries, allowing them to be logged for later analysis
+    * Optimizes `AstNode`’s `Iterator`
+* Deprecated items
+* Misc/bug fixes
+    * [fix] parser handling of top-level tokens
+    * [fix] `SIZE` `ExprFunction` to work with s-expressions
+    * [fix] Change usage of `LazyThreadSafetyMode` from `NONE` to `PUBLICATION`
+## Breaking changes
+### Breaking behavioral changes
+### Breaking API changes
+1. Replace `SourcePosition` in `Token` with `SourceSpan`
+```kotlin
+// v0.2.*
+val ion = IonSystemBuilder.standard().build()
+// SqlLexer provides us with `Token`s
+val tokens = SqlLexer(ion).tokenize("42")
+val firstToken = tokens.first()
+
+// `Token`s defined in v0.2.* and before used `SourcePosition` specifying the `line` and `column` of a `Token`
+val tokenFromConstructor = Token(
+    type = TokenType.LITERAL,
+    value = ion.singleValue("42"),
+    position = SourcePosition(
+        line = 1,
+        column = 1
+    )
+)
+assertEquals(tokenFromConstructor, firstToken)
+```
+
+```kotlin
+// v0.3.*
+val ion = IonSystemBuilder.standard().build()
+// SqlLexer provides us with `Token`s
+val tokens = SqlLexer(ion).tokenize("42")
+val firstToken = tokens.first()
+
+// `Token`s defined in v0.3.* onwards used `SourceSpan` specifying the `line`, `column`, and length of a `Token`
+val tokenFromConstructor = Token(
+    type = TokenType.LITERAL,
+    value = ion.singleValue("42"),
+    span = SourceSpan(
+        line = 1,
+        column = 1,
+        length = 2
+    )
+)
+assertEquals(tokenFromConstructor, firstToken)
+```
+2. Removed `PARSE_EXEC_AT_UNEXPECTED_LOCATION` error code from `ErrorCode`
+```kotlin
+// v0.2.*
+val ion = IonSystemBuilder.standard().build()
+val parser = SqlParser(ion)
+
+// bad query containing a stored procedure call, `EXEC`, at an unexpected location
+val badQuery = "SELECT * FROM (EXEC undrop 'foo')"
+
+try {
+    parser.parseExprNode(badQuery)
+} catch (pe: ParserException) {
+    // the parser gives a `ParserException` with error code `PARSE_EXEC_AT_UNEXPECTED_LOCATION`, which is
+    // removed starting in v0.3.* onwards
+    assertEquals(ErrorCode.PARSE_EXEC_AT_UNEXPECTED_LOCATION, pe.errorCode)
+}
+```
+
+```kotlin
+// v0.3.*
+val ion = IonSystemBuilder.standard().build()
+val parser = SqlParser(ion)
+
+// bad query containing a stored procedure call, `EXEC`, at an unexpected location
+val badQuery = "SELECT * FROM (EXEC undrop 'foo')"
+
+try {
+    parser.parseExprNode(badQuery)
+} catch (pe: ParserException) {
+    // the parser gives a `ParserException` with error code `PARSE_UNEXPECTED_TERM` in v0.3.* onwards
+    assertEquals(ErrorCode.PARSE_UNEXPECTED_TERM, pe.errorCode)
+}
+```
+3. Refactoring of `ExprNode` AST
+* `AssignmentOp` node stores one `Assignment` rather than a list
+* `DataManipulation` node stores a `DmlOpList` rather than a single `DataManipulationOperation`
+```kotlin
+// v0.2.*
+val ion = IonSystemBuilder.standard().build()
+// In v0.2.* and before,
+// - `DataManipulation` node can only specify a single `dmlOperation`
+// - `AssignmentOp`, a type of `DataManipulationOperation` contains a list of `Assignments`
+// The following AST represents the DML query (without source location metas): SET k = 5, l = 6
+DataManipulation(
+    dmlOperation = AssignmentOp(
+        assignments = listOf(
+            Assignment(
+                lvalue = VariableReference(
+                    id = "k",
+                    case = CaseSensitivity.INSENSITIVE,
+                    metas = emptyMetaContainer
+                ),
+                rvalue = Literal(
+                    ionValue = ion.singleValue("5"),
+                    metas = emptyMetaContainer
+                )
+            ),
+            Assignment(
+                lvalue = VariableReference(
+                    id = "l",
+                    case = CaseSensitivity.INSENSITIVE,
+                    metas = emptyMetaContainer
+                ),
+                rvalue = Literal(
+                    ionValue = ion.singleValue("6"),
+                    metas = emptyMetaContainer
+                )
+            )
+        )
+    ),
+    metas = emptyMetaContainer
+)
+```
+
+```kotlin
+// v0.3.*
+val ion = IonSystemBuilder.standard().build()
+// In v0.3.* onwards,
+// - `DataManipulation` node specifies a list of `dmlOperation`s
+// - `AssignmentOp`, a type of `DataManipulationOperation` contains a single assignment
+// The following AST represents the DML query (without source location metas): SET k = 5, l = 6
+DataManipulation(
+    dmlOperations = DmlOpList(
+        ops = listOf(
+            AssignmentOp(
+                assignment = Assignment(
+                    lvalue = VariableReference(
+                        id = "k",
+                        case = CaseSensitivity.INSENSITIVE,
+                        metas = emptyMetaContainer
+                    ),
+                    rvalue = Literal(
+                        ionValue = ion.singleValue("5"),
+                        metas = emptyMetaContainer
+                    )
+                )
+            ),
+            AssignmentOp(
+                assignment = Assignment(
+                    lvalue = VariableReference(
+                        id = "l",
+                        case = CaseSensitivity.INSENSITIVE,
+                        metas = emptyMetaContainer
+                    ),
+                    rvalue = Literal(
+                        ionValue = ion.singleValue("6"),
+                        metas = emptyMetaContainer
+                    )
+                )
+            )
+        )
+    ),
+    metas = emptyMetaContainer
+)
+```

--- a/docs/dev/version-migration/v0.3-to-v0.4-migration.md
+++ b/docs/dev/version-migration/v0.3-to-v0.4-migration.md
@@ -1,24 +1,24 @@
 # v0.4.* (latest v0.4.0)
 
-* New features
-* Deprecated items
-* Misc/bug fixes
-    * [fix] structs to handle non-text struct fields
-    * Allows configuration of default timezone
+## New features
+## Deprecated items
+## Misc/bug fixes
+* [fix] structs to handle non-text struct fields
+* Allows configuration of default timezone
 ## Breaking changes
 ### Breaking behavioral changes
 ### Breaking API changes
 1. Upgrades PIG major version to v0.4.0 which may introduce some breaking changes related to imported builders
 * Note: `partiql-lang-kotlin` v0.3.3 and `partiql-lang-kotlin` v0.3.4 use the PIG v0.4.0 behavior; `partiql-lang-kotlin` v0.3.1 and v0.3.0 and before allows use of the old builders
 ```kotlin
-// v0.3.* (v0.3.1 and v0.3.0)
-// (in imports) import org.partiql.lang.domains.PartiqlAst.Builder.lit
+// ----- v0.3.* ----- (v0.3.1 and v0.3.0)
+import org.partiql.lang.domains.PartiqlAst.Builder.lit
 
 // PartiQL v0.3.1 and older used partiql-ir-generator (PIG) v0.3.0 and older, which allowed for specifying PIG-
 // generated objects using the <TypeDomain>.Builder object and importing the builder functions. These were
 // unintended exposed APIs and bypassed the recommended way to create domain objects.
 //
-// The following uses the imported builder function to create the literal, 1
+// The following uses the imported builder function to create the int literal, 1
 lit(value = ionInt(1), emptyMetaContainer())
 
 // Newer versions made this builder an interface with a private implementation. The recommended way to create
@@ -29,7 +29,7 @@ PartiqlAst.build {
 ```
 
 ```kotlin
-// v0.4.*
+// ----- v0.4.* -----
 // Newer versions made this builder an interface with a private implementation, so users can no longer import
 // the TypeDomain's builders. The recommended way to create the objects is to use `<TypeDomain>.build { ... }`
 // pattern:
@@ -37,3 +37,5 @@ PartiqlAst.build {
     lit(value = ionInt(1), emptyMetaContainer())
 }
 ```
+- [v0.3.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.3-to-v0.4-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L10-L24)
+- [v0.4.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.3-to-v0.4-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L9-L17)

--- a/docs/dev/version-migration/v0.3-to-v0.4-migration.md
+++ b/docs/dev/version-migration/v0.3-to-v0.4-migration.md
@@ -1,0 +1,39 @@
+# v0.4.* (latest v0.4.0)
+
+* New features
+* Deprecated items
+* Misc/bug fixes
+    * [fix] structs to handle non-text struct fields
+    * Allows configuration of default timezone
+## Breaking changes
+### Breaking behavioral changes
+### Breaking API changes
+1. Upgrades PIG major version to v0.4.0 which may introduce some breaking changes related to imported builders
+* Note: `partiql-lang-kotlin` v0.3.3 and `partiql-lang-kotlin` v0.3.4 use the PIG v0.4.0 behavior; `partiql-lang-kotlin` v0.3.1 and v0.3.0 and before allows use of the old builders
+```kotlin
+// v0.3.* (v0.3.1 and v0.3.0)
+// (in imports) import org.partiql.lang.domains.PartiqlAst.Builder.lit
+
+// PartiQL v0.3.1 and older used partiql-ir-generator (PIG) v0.3.0 and older, which allowed for specifying PIG-
+// generated objects using the <TypeDomain>.Builder object and importing the builder functions. These were
+// unintended exposed APIs and bypassed the recommended way to create domain objects.
+//
+// The following uses the imported builder function to create the literal, 1
+lit(value = ionInt(1), emptyMetaContainer())
+
+// Newer versions made this builder an interface with a private implementation. The recommended way to create
+// the objects is to use `<TypeDomain>.build { ... }`:
+PartiqlAst.build {
+    lit(value = ionInt(1), emptyMetaContainer())
+}
+```
+
+```kotlin
+// v0.4.*
+// Newer versions made this builder an interface with a private implementation, so users can no longer import
+// the TypeDomain's builders. The recommended way to create the objects is to use `<TypeDomain>.build { ... }`
+// pattern:
+PartiqlAst.build {
+    lit(value = ionInt(1), emptyMetaContainer())
+}
+```

--- a/docs/dev/version-migration/v0.4-to-v0.5-migration.md
+++ b/docs/dev/version-migration/v0.4-to-v0.5-migration.md
@@ -1,0 +1,177 @@
+# v0.5.* (latest v0.5.0)
+
+* New features
+    * Adds support for `OFFSET`
+    * Adds a static type inferencer for static query checks and query type inference
+    * Adds multiple exception logging and severity level API
+    * Adds the dataguide API which can be used to infer Ion schema from Ion data
+        * Also adds mappers to and from PartiQL’s static type and ISL
+    * Adds evaluator option for `PERMISSIVE` mode
+    * Adds support for `CAN_CAST` and `CAN_LOSSLESS_CAST` `ExprFunction`s
+    * Adds evaluation-time function call (i.e. `ExprFunction`) argument type checks
+    * Adds `integer8`, `int8`, `bigint`, `int2`, and `integer2` as type names
+    * Adds additional types to `StaticType` and additional methods on those types
+* Deprecated items
+    * `ExprNode` in parser
+* Misc/bug fixes
+    * [fix] evaluator behavior to error for structs with non-text keys
+    * [fix] the parser error for unexpected reserved keywords in a select list
+    * [fix] static initializing cycle with `lazy` initialization of `SqlDataType`
+    * [fix] unknown propagation for `IN` operator
+    * [fix] bug in precision check for `NUMERIC`
+    * Makes unknown simple `CASE WHEN` predicate the same as false
+    * Make unknown branch predicates the same as false for searched `CASE WHEN`
+    * Disallows duplicate projected fields in select list query
+    * [fix] `EXTRACT` `ExprFunction` to return a decimal instead of float
+    * [fix] `EXISTS` and `DATE_DIFF` function signatures
+    * [fix] `GROUP BY` for more than 2 nested path expressions ([#461](https://github.com/partiql/partiql-lang-kotlin/pull/461))
+## Breaking changes
+### Breaking behavioral changes
+### Breaking API changes
+1. Removes outer sealed class of `DateTimeType`
+```kotlin
+// v0.4.*
+// In v0.4.0 and before, date value constructor required the outer `DateTimeType` sealed class
+val date = DateTimeType.Date(year = 2022, month = 1, day = 1, metas = emptyMetaContainer)
+
+// Similarly for the time value constructor
+val time = DateTimeType.Time(
+    hour = 12,
+    minute = 34,
+    second = 56,
+    nano = 78,
+    precision = 2,
+    with_time_zone = false,
+    metas = emptyMetaContainer
+)
+```
+
+```kotlin
+// v0.5.*
+// In v0.5.0 and before, date value constructor uses `DateLiteral` without an outer sealed class
+val date = DateLiteral(year = 2022, month = 1, day = 1, metas = emptyMetaContainer)
+
+// Similarly, for the time value constructor uses `TimeLiteral` without an outer sealed class
+val time = TimeLiteral(
+    hour = 12,
+    minute = 34,
+    second = 56,
+    nano = 78,
+    precision = 2,
+    with_time_zone = false,
+    metas = emptyMetaContainer
+)
+```
+2. Refactor of `ExprFunction` interface
+```kotlin
+// v0.4.*
+val exprValueFactory = ExprValueFactory.standard(IonSystemBuilder.standard().build())
+
+// `ExprFunction`s defined in v0.4.0 and before implemented the `NullPropagatingExprFunction`
+// abstract class, which implements the `ArityCheckingTrait` and `ExprFunction` interfaces
+// Below is an example `ExprFunction` definition that requires one argument and makes another
+// argument optional. The implementation will need to override `eval` to specify the behavior.
+class SomeExprFunction():  NullPropagatingExprFunction(
+    name = "some_expr_function",
+    arity = 1..2,
+    exprValueFactory
+) {
+    override fun eval(env: Environment, args: List<ExprValue>): ExprValue {
+        TODO("Implementation details with and without the optional argument")
+    }
+}
+```
+
+```kotlin
+// v0.5.*
+// Starting in v0.5.0, the `ExprFunction` interface has been refactored and `ExprFunction` implementations will
+// need to define the `FunctionSignature` of the function which specifies the name, return type, and any
+// required, optional, and variadic arguments. The implementation will need to override `callWith*` depending
+// on the permitted arguments (in this example, overriding `callWithRequired` and `callWithOptional`).
+// Note: in v0.6.0, the first argument to the `callWith*` function was changed from `Environment` to
+// `EvaluationSession`
+class SomeExprFunction(): ExprFunction {
+    override val signature = FunctionSignature(
+        name = "some_expr_function",
+        requiredParameters = listOf(StaticType.ANY),
+        optionalParameter = StaticType.ANY,
+        returnType = StaticType.ANY
+    )
+
+    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+        TODO("Implementation details without optional argument")
+    }
+
+    override fun callWithOptional(env: Environment, required: List<ExprValue>, opt: ExprValue): ExprValue {
+        TODO("Implementation details with optional argument")
+    }
+}
+```
+3. Upgrades to Kotlin 1.4 -- see https://kotlinlang.org/docs/compatibility-guide-14.html#language-and-stdlib for 
+interop between Kotlin 1.3 and Kotlin 1.4
+4. Models `NULLIF` and `COALESCE` as `PartiqlAst` nodes rather than `ExprFunction`s
+```kotlin
+// v0.4.*
+val ion = IonSystemBuilder.standard().build()
+val parser = SqlParser(ion)
+
+// In v0.4.0 and before, NULLIF was modeled as an `ExprFunction` call
+val nullIfQuery = "NULLIF(1, 2)"
+val nullIfParsedAst = parser.parseAstStatement(nullIfQuery)
+val nullIfExpectedAst = PartiqlAst.build {
+    query(
+        call(
+            funcName = "nullif",
+            args = listOf(lit(ionInt(1)), lit(ionInt(2))),
+        )
+    )
+}
+assertEquals(nullIfExpectedAst, nullIfParsedAst)
+
+// In v0.4.0 and before, COALESCE was modeled as an `ExprFunction` call
+val coalesceQuery = "COALESCE(1, 2)"
+val coalesceParsedAst = parser.parseAstStatement(coalesceQuery)
+val coalesceExpectedAst = PartiqlAst.build {
+    query(
+        call(
+            funcName = "coalesce",
+            args = listOf(lit(ionInt(1)), lit(ionInt(2))),
+        )
+    )
+}
+assertEquals(coalesceExpectedAst, coalesceParsedAst)
+```
+
+```kotlin
+// v0.5.*
+val ion = IonSystemBuilder.standard().build()
+val parser = SqlParser(ion)
+
+// In v0.5.0 onwards, NULLIF is modeled as a separate AST node
+val nullIfQuery = "NULLIF(1, 2)"
+val nullIfParsedAst = parser.parseAstStatement(nullIfQuery)
+val nullIfExpectedAst = PartiqlAst.build {
+    query(
+        nullIf(
+            lit(ionInt(1)),
+            lit(ionInt(2))
+        )
+    )
+}
+assertEquals(nullIfExpectedAst, nullIfParsedAst)
+
+// In v0.5.0 onwards, COALESCE is modeled as a separate AST node
+val coalesceQuery = "COALESCE(1, 2)"
+val coalesceParsedAst = parser.parseAstStatement(coalesceQuery)
+val coalesceExpectedAst = PartiqlAst.build {
+    query(
+        coalesce(
+            args = listOf(lit(ionInt(1)), lit(ionInt(2))),
+        )
+    )
+}
+assertEquals(coalesceExpectedAst, coalesceParsedAst)
+```
+5. `SqlDataType` class made abstract
+6. `Meta deserialize (IonSexp)` removed from `MetaDeserializer` interface -- was previously deprecated
+7. `PARSE_EXPECTED_DATE_PART` `ErrorCode` changed

--- a/docs/dev/version-migration/v0.4-to-v0.5-migration.md
+++ b/docs/dev/version-migration/v0.4-to-v0.5-migration.md
@@ -1,40 +1,41 @@
 # v0.5.* (latest v0.5.0)
 
-* New features
-    * Adds support for `OFFSET`
-    * Adds a static type inferencer for static query checks and query type inference
-    * Adds multiple exception logging and severity level API
-    * Adds the dataguide API which can be used to infer Ion schema from Ion data
-        * Also adds mappers to and from PartiQL’s static type and ISL
-    * Adds evaluator option for `PERMISSIVE` mode
-    * Adds support for `CAN_CAST` and `CAN_LOSSLESS_CAST` `ExprFunction`s
-    * Adds evaluation-time function call (i.e. `ExprFunction`) argument type checks
-    * Adds `integer8`, `int8`, `bigint`, `int2`, and `integer2` as type names
-    * Adds additional types to `StaticType` and additional methods on those types
-* Deprecated items
-    * `ExprNode` in parser
-* Misc/bug fixes
-    * [fix] evaluator behavior to error for structs with non-text keys
-    * [fix] the parser error for unexpected reserved keywords in a select list
-    * [fix] static initializing cycle with `lazy` initialization of `SqlDataType`
-    * [fix] unknown propagation for `IN` operator
-    * [fix] bug in precision check for `NUMERIC`
-    * Makes unknown simple `CASE WHEN` predicate the same as false
-    * Make unknown branch predicates the same as false for searched `CASE WHEN`
-    * Disallows duplicate projected fields in select list query
-    * [fix] `EXTRACT` `ExprFunction` to return a decimal instead of float
-    * [fix] `EXISTS` and `DATE_DIFF` function signatures
-    * [fix] `GROUP BY` for more than 2 nested path expressions ([#461](https://github.com/partiql/partiql-lang-kotlin/pull/461))
+## New features
+* Adds support for `OFFSET`
+* Adds a static type inferencer for static query checks and query type inference
+* Adds multiple exception logging and severity level API
+* Adds the dataguide API which can be used to infer Ion schema from Ion data
+    * Also adds mappers to and from PartiQL’s static type and ISL
+* Adds evaluator option for `PERMISSIVE` mode
+* Adds support for `CAN_CAST` and `CAN_LOSSLESS_CAST` `ExprFunction`s
+* Adds evaluation-time function call (i.e. `ExprFunction`) argument type checks
+* Adds `integer8`, `int8`, `bigint`, `int2`, and `integer2` as type names
+* Adds additional types to `StaticType` and additional methods on those types
+## Deprecated items
+* `ExprNode` in parser
+## Misc/bug fixes
+* [fix] evaluator behavior to error for structs with non-text keys
+* [fix] the parser error for unexpected reserved keywords in a select list
+* [fix] static initializing cycle with `lazy` initialization of `SqlDataType`
+* [fix] unknown propagation for `IN` operator
+* [fix] bug in precision check for `NUMERIC`
+* Makes unknown simple `CASE WHEN` predicate the same as false
+* Make unknown branch predicates the same as false for searched `CASE WHEN`
+* Disallows duplicate projected fields in select list query
+* [fix] `EXTRACT` `ExprFunction` to return a decimal instead of float
+* [fix] `EXISTS` and `DATE_DIFF` function signatures
+* [fix] `GROUP BY` for more than 2 nested path expressions ([#461](https://github.com/partiql/partiql-lang-kotlin/pull/461))
 ## Breaking changes
-### Breaking behavioral changes
 ### Breaking API changes
-1. Removes outer sealed class of `DateTimeType`
+#### **NOTE**: `ExprNode` is deprecated and replaced with `PartiqlAst`. Users can look at [ExprNodeToStatement.kt](https://github.com/partiql/partiql-lang-kotlin/blob/0b4540f474caff7dba1d6c327e0e85012402829b/lang/src/org/partiql/lang/ast/ExprNodeToStatement.kt) and [RewriterToVisitorTransformGuide.md](https://github.com/partiql/partiql-lang-kotlin/blob/0b4540f474caff7dba1d6c327e0e85012402829b/docs/dev/RewriterToVisitorTransformGuide.md) to see how to migrate from `ExprNode` to `PartiqlAst`.
+
+1. Removes outer sealed class of `DateTimeType` for `ExprNode`
 ```kotlin
-// v0.4.*
+// ----- v0.4.* -----
 // In v0.4.0 and before, date value constructor required the outer `DateTimeType` sealed class
 val date = DateTimeType.Date(year = 2022, month = 1, day = 1, metas = emptyMetaContainer)
 
-// Similarly for the time value constructor
+// Similarly, for the time value constructor
 val time = DateTimeType.Time(
     hour = 12,
     minute = 34,
@@ -47,7 +48,7 @@ val time = DateTimeType.Time(
 ```
 
 ```kotlin
-// v0.5.*
+// ----- v0.5.* -----
 // In v0.5.0 and before, date value constructor uses `DateLiteral` without an outer sealed class
 val date = DateLiteral(year = 2022, month = 1, day = 1, metas = emptyMetaContainer)
 
@@ -62,9 +63,11 @@ val time = TimeLiteral(
     metas = emptyMetaContainer
 )
 ```
+- [v0.4.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.4-to-v0.5-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L17-L32)
+- [v0.5.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.4-to-v0.5-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L19-L34)
 2. Refactor of `ExprFunction` interface
 ```kotlin
-// v0.4.*
+// ----- v0.4.* -----
 val exprValueFactory = ExprValueFactory.standard(IonSystemBuilder.standard().build())
 
 // `ExprFunction`s defined in v0.4.0 and before implemented the `NullPropagatingExprFunction`
@@ -83,7 +86,7 @@ class SomeExprFunction():  NullPropagatingExprFunction(
 ```
 
 ```kotlin
-// v0.5.*
+// ----- v0.5.* -----
 // Starting in v0.5.0, the `ExprFunction` interface has been refactored and `ExprFunction` implementations will
 // need to define the `FunctionSignature` of the function which specifies the name, return type, and any
 // required, optional, and variadic arguments. The implementation will need to override `callWith*` depending
@@ -107,11 +110,11 @@ class SomeExprFunction(): ExprFunction {
     }
 }
 ```
-3. Upgrades to Kotlin 1.4 -- see https://kotlinlang.org/docs/compatibility-guide-14.html#language-and-stdlib for 
-interop between Kotlin 1.3 and Kotlin 1.4
-4. Models `NULLIF` and `COALESCE` as `PartiqlAst` nodes rather than `ExprFunction`s
+- [v0.4.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.4-to-v0.5-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L34-L51)
+- [v0.5.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.4-to-v0.5-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L36-L60)
+3. Models `NULLIF` and `COALESCE` as `PartiqlAst` nodes rather than `ExprFunction`s
 ```kotlin
-// v0.4.*
+// ----- v0.4.* -----
 val ion = IonSystemBuilder.standard().build()
 val parser = SqlParser(ion)
 
@@ -143,10 +146,7 @@ assertEquals(coalesceExpectedAst, coalesceParsedAst)
 ```
 
 ```kotlin
-// v0.5.*
-val ion = IonSystemBuilder.standard().build()
-val parser = SqlParser(ion)
-
+// ----- v0.5.* -----
 // In v0.5.0 onwards, NULLIF is modeled as a separate AST node
 val nullIfQuery = "NULLIF(1, 2)"
 val nullIfParsedAst = parser.parseAstStatement(nullIfQuery)
@@ -172,6 +172,11 @@ val coalesceExpectedAst = PartiqlAst.build {
 }
 assertEquals(coalesceExpectedAst, coalesceParsedAst)
 ```
-5. `SqlDataType` class made abstract
-6. `Meta deserialize (IonSexp)` removed from `MetaDeserializer` interface -- was previously deprecated
-7. `PARSE_EXPECTED_DATE_PART` `ErrorCode` changed
+- [v0.4.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.4-to-v0.5-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L53-L83)
+- [v0.5.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.4-to-v0.5-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L62-L91)
+4. Upgrades to Kotlin 1.4 -- see https://kotlinlang.org/docs/compatibility-guide-14.html#language-and-stdlib for 
+interop between Kotlin 1.3 and Kotlin 1.4
+5. `SqlDataType` class changed from an `enum class` to a `sealed class`. Note: this class relates to `ExprNode` which 
+is deprecated in v0.6.0. Recommend migration path is to use the `PartiqlAst`.
+6. `Meta deserialize (IonSexp)` removed from `MetaDeserializer` interface (was deprecated in a prior major version)
+7. `PARSE_EXPECTED_DATE_PART` `ErrorCode` changed to `PARSE_EXPECTED_DATE_TIME_PART`

--- a/docs/dev/version-migration/v0.4-to-v0.5-migration.md
+++ b/docs/dev/version-migration/v0.4-to-v0.5-migration.md
@@ -112,7 +112,37 @@ class SomeExprFunction(): ExprFunction {
 ```
 - [v0.4.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.4-to-v0.5-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L34-L51)
 - [v0.5.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.4-to-v0.5-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L36-L60)
-3. Models `NULLIF` and `COALESCE` as `PartiqlAst` nodes rather than `ExprFunction`s
+3. `UntypedFunctionSignature` data class removed
+```kotlin
+// ----- v0.4.* -----
+// v0.4.0 and before had a convenience data class to create an untyped `FunctionSignature` that used a variadic
+// number of [StaticType.ANY] parameters and returned [StaticType.ANY]
+val funName = "untyped_fun"
+// initialization of the untyped `FunctionSignature`
+val signature = UntypedFunctionSignature(name = funName)
+assertEquals(funName, signature.name)
+assertEquals(listOf(VarargFormalParameter(StaticType.ANY)), signature.formalParameters)
+assertEquals(StaticType.ANY, signature.returnType)
+```
+
+```kotlin
+// ----- v0.5.* -----
+// In v0.5.0, due to the refactor of `FunctionSignature`, `UntypedFunctionSignature` was removed. The equivalent
+// can be created using the `FunctionSignature` constructor that includes the `variadicParameter` argument.
+// Initialization of an untyped `FunctionSignature` with the refactored APIs
+val signature = FunctionSignature(
+    name = funName,
+    requiredParameters = emptyList(),
+    variadicParameter = VarargFormalParameter(StaticType.ANY, minCount = 0),
+    returnType = StaticType.ANY
+)
+assertEquals(funName, signature.name)
+assertEquals(VarargFormalParameter(StaticType.ANY, minCount = 0), signature.variadicParameter)
+assertEquals(StaticType.ANY, signature.returnType)
+```
+- [v0.4.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/74cb11437df3ce995c10802eb63b9b884e28bc0b/v0.4-to-v0.5-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L56-L66)
+- [v0.5.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/74cb11437df3ce995c10802eb63b9b884e28bc0b/v0.4-to-v0.5-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L63-L78)
+4. Models `NULLIF` and `COALESCE` as `PartiqlAst` nodes rather than `ExprFunction`s
 ```kotlin
 // ----- v0.4.* -----
 val ion = IonSystemBuilder.standard().build()
@@ -174,9 +204,9 @@ assertEquals(coalesceExpectedAst, coalesceParsedAst)
 ```
 - [v0.4.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.4-to-v0.5-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L53-L83)
 - [v0.5.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.4-to-v0.5-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L62-L91)
-4. Upgrades to Kotlin 1.4 -- see https://kotlinlang.org/docs/compatibility-guide-14.html#language-and-stdlib for 
+5. Upgrades to Kotlin 1.4 -- see https://kotlinlang.org/docs/compatibility-guide-14.html#language-and-stdlib for 
 interop between Kotlin 1.3 and Kotlin 1.4
-5. `SqlDataType` class changed from an `enum class` to a `sealed class`. Note: this class relates to `ExprNode` which 
+6. `SqlDataType` class changed from an `enum class` to a `sealed class`. Note: this class relates to `ExprNode` which 
 is deprecated in v0.6.0. Recommend migration path is to use the `PartiqlAst`.
-6. `Meta deserialize (IonSexp)` removed from `MetaDeserializer` interface (was deprecated in a prior major version)
-7. `PARSE_EXPECTED_DATE_PART` `ErrorCode` changed to `PARSE_EXPECTED_DATE_TIME_PART`
+7. `Meta deserialize (IonSexp)` removed from `MetaDeserializer` interface (was deprecated in a prior major version)
+8. `PARSE_EXPECTED_DATE_PART` `ErrorCode` changed to `PARSE_EXPECTED_DATE_TIME_PART`

--- a/docs/dev/version-migration/v0.5-to-v0.6-migration.md
+++ b/docs/dev/version-migration/v0.5-to-v0.6-migration.md
@@ -1,0 +1,69 @@
+# v0.6.* (latest v0.6.0)
+
+* New features
+    * `ORDER BY` implementation in the evaluator
+* Deprecated items
+    * `ExprNode` deprecated in rest of code base including evaluator
+* Misc/bug fixes
+    * Upgrade Kotlin version to 1.4.322
+    * [fix] changed path ast node to sue its root node source location
+## Breaking changes
+### Breaking behavioral changes
+### Breaking API changes
+1. Replace `Environment` with `EvaluationSession` for `ExprFunction`s
+```kotlin
+// v0.5.*
+class SomeExprFunction(): ExprFunction {
+    override val signature = FunctionSignature(
+        name = "some_expr_function",
+        requiredParameters = listOf(StaticType.ANY),
+        optionalParameter = StaticType.ANY,
+        returnType = StaticType.ANY
+    )
+
+    // In v0.5.0, the `callWith*` functions' first argument was `Environment`
+    override fun callWithRequired(env: Environment, required: List<ExprValue>): ExprValue {
+        TODO("Implementation details without optional argument")
+    }
+
+    override fun callWithOptional(env: Environment, required: List<ExprValue>, opt: ExprValue): ExprValue {
+        TODO("Implementation details with optional argument")
+    }
+}
+```
+
+```kotlin
+// v0.6.*
+class SomeExprFunction(): ExprFunction {
+    override val signature = FunctionSignature(
+        name = "some_expr_function",
+        requiredParameters = listOf(StaticType.ANY),
+        optionalParameter = StaticType.ANY,
+        returnType = StaticType.ANY
+    )
+
+    // Starting in v0.6.0, the `callWith*` functions' first argument is changed to `EvaluationSession`.
+    // `Environment` has also been made private
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
+        TODO("Implementation details without optional argument")
+    }
+
+    override fun callWithOptional(session: EvaluationSession, required: List<ExprValue>, opt: ExprValue): ExprValue {
+        TODO("Implementation details with optional argument")
+    }
+}
+```
+3. `NaturalExprValueComparators` fields have been renamed
+* `NULLS_FIRST` → `NULLS_FIRST_ASC`
+* `NULLS_LAST` → `NULLS_FIRST_DESC`
+3. Migrate to PIG v0.5.0
+* TODO: Code example probably not relevant. Need to at least call out the file structure change
+4. Make a few APIs internal:
+* `Environment`
+* `ExprAggregator`
+* `ExprAggregatorFactory`
+* lang/eval’s `Group` class
+* `RegisterBank`
+* `ThunkEnv`
+* `ThunkExceptionHandlerForLegacyMode` and `ThunkExceptionHandlerForPermissiveMode`
+* `DEFAULT_EXCEPTION_HANDLER_FOR_LEGACY_MODE` and `DEFAULT_EXCEPTION_HANDLER_FOR_PERMISSIVE_MODE`

--- a/docs/dev/version-migration/v0.5-to-v0.6-migration.md
+++ b/docs/dev/version-migration/v0.5-to-v0.6-migration.md
@@ -1,18 +1,18 @@
 # v0.6.* (latest v0.6.0)
 
-* New features
-    * `ORDER BY` implementation in the evaluator
-* Deprecated items
-    * `ExprNode` deprecated in rest of code base including evaluator
-* Misc/bug fixes
-    * Upgrade Kotlin version to 1.4.322
-    * [fix] changed path ast node to sue its root node source location
+## New features
+* `ORDER BY` implementation in the evaluator
+## Deprecated items
+* `ExprNode` deprecated in rest of code base including evaluator
+## Misc/bug fixes
+* Upgrade Kotlin version to 1.4.322
+* [fix] changed path ast node to sue its root node source location
 ## Breaking changes
 ### Breaking behavioral changes
 ### Breaking API changes
 1. Replace `Environment` with `EvaluationSession` for `ExprFunction`s
 ```kotlin
-// v0.5.*
+// ----- v0.5.* -----
 class SomeExprFunction(): ExprFunction {
     override val signature = FunctionSignature(
         name = "some_expr_function",
@@ -33,7 +33,7 @@ class SomeExprFunction(): ExprFunction {
 ```
 
 ```kotlin
-// v0.6.*
+// ----- v0.6.* -----
 class SomeExprFunction(): ExprFunction {
     override val signature = FunctionSignature(
         name = "some_expr_function",
@@ -53,11 +53,14 @@ class SomeExprFunction(): ExprFunction {
     }
 }
 ```
-3. `NaturalExprValueComparators` fields have been renamed
+- [v0.5.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.5-to-v0.6-migration/examples/src/test/kotlin/examples/BreakingChanges.kt#L11-L30)
+- [v0.6.* example code](https://github.com/alancai98/test-partiql-version-migration/blob/4045a414dda65f29422934e599cce10d85bcf579/v0.5-to-v0.6-migration/migrated-examples/src/test/kotlin/examples/BreakingChanges.kt#L11-L31)
+
+2. `NaturalExprValueComparators` fields have been renamed
 * `NULLS_FIRST` → `NULLS_FIRST_ASC`
 * `NULLS_LAST` → `NULLS_FIRST_DESC`
-3. Migrate to PIG v0.5.0
-* TODO: Code example probably not relevant. Need to at least call out the file structure change
+3. Migrate to PIG v0.5.0. This doesn't have any direct breaking changes. With PIG v0.5.0, the generated sources will 
+now be in `lang/domains/PartiqlAst.generated.kt` rather than `lang/domains/partiql-domains.kt`.
 4. Make a few APIs internal:
 * `Environment`
 * `ExprAggregator`

--- a/docs/dev/version-migration/v0.6-to-v0.7-migration.md
+++ b/docs/dev/version-migration/v0.6-to-v0.7-migration.md
@@ -1,0 +1,25 @@
+# v0.7.* (latest v0.7.0)
+
+* New features
+    * 2.3x more performance `LIKE` operator
+    * An experimental query planner API along with logical and physical plans structures with the support of non-default physical operator implementations.
+    * Enable `MIN` and `MAX` to work with all the data-types.
+    * Introduction of `extensions` and addition of the `query_ddb` function to allow querying AWS DynamodB from the CLI.
+    * `CEIL` and `FLOOR` functions
+    * `DATE/TIME` formatting and the support for `DATE/TIME` in Ion data format
+* Deprecated items
+* Misc/bug fixes
+    * Convenience `StaticType` for `TEXT` and `NUMERIC`
+    * Adds missing metas to `ORDER BY` `ExprNode` and `PartiqlAst` (e.g. source location)
+## Breaking changes
+### Breaking behavioral changes
+### Breaking API changes
+1. Removal of field `EVALUATOR_SQL_EXCEPTION` from `ErrorCode` class - only used in [NaturalExprValueComparatorsTest.kt](https://github.com/partiql/partiql-lang-kotlin/blob/v0.6.0-alpha/lang/test/org/partiql/lang/eval/NaturalExprValueComparatorsTest.kt#L301)
+2. Renaming of field `SEMANTIC_INFERENCER_ERROR` from `ErrorCode` to `SEMANTIC_PROBLEM`
+3. Removal of `NodeMetadata` from `org.partiql.lang.eval` only used in testing
+4. Removal of the following classes from `org.partiql.lang.eval.like` - APIs were unintentionally public. They have been removed and replaced with regex pattern matching.
+* `CodepointCheckpointIterator`
+* `PatternPart`
+* `PatternPart.AnyOneChar`
+* `PatternPart.ExactChars`
+* `PatternPartKt`

--- a/docs/dev/version-migration/v0.6-to-v0.7-migration.md
+++ b/docs/dev/version-migration/v0.6-to-v0.7-migration.md
@@ -1,12 +1,12 @@
 # v0.7.* (latest v0.7.0)
 
 ## New features
-* 2.3x more performance `LIKE` operator
+* 2.3x more performant `LIKE` operator
 * An experimental query planner API along with logical and physical plans structures with the support of non-default physical operator implementations.
-* Enable `MIN` and `MAX` to work with all the data-types.
+* `MIN` and `MAX` now work with all data types.
 * Introduction of `extensions` and addition of the `query_ddb` function to allow querying AWS DynamodB from the CLI.
 * `CEIL` and `FLOOR` functions
-* `DATE/TIME` formatting and the support for `DATE/TIME` in Ion data format
+* `DATE/TIME` formatting and support for `DATE/TIME` in Ion data format
 ## Deprecated items
 ## Misc/bug fixes
 * Convenience `StaticType` for `TEXT` and `NUMERIC`

--- a/docs/dev/version-migration/v0.6-to-v0.7-migration.md
+++ b/docs/dev/version-migration/v0.6-to-v0.7-migration.md
@@ -1,22 +1,22 @@
 # v0.7.* (latest v0.7.0)
 
-* New features
-    * 2.3x more performance `LIKE` operator
-    * An experimental query planner API along with logical and physical plans structures with the support of non-default physical operator implementations.
-    * Enable `MIN` and `MAX` to work with all the data-types.
-    * Introduction of `extensions` and addition of the `query_ddb` function to allow querying AWS DynamodB from the CLI.
-    * `CEIL` and `FLOOR` functions
-    * `DATE/TIME` formatting and the support for `DATE/TIME` in Ion data format
-* Deprecated items
-* Misc/bug fixes
-    * Convenience `StaticType` for `TEXT` and `NUMERIC`
-    * Adds missing metas to `ORDER BY` `ExprNode` and `PartiqlAst` (e.g. source location)
+## New features
+* 2.3x more performance `LIKE` operator
+* An experimental query planner API along with logical and physical plans structures with the support of non-default physical operator implementations.
+* Enable `MIN` and `MAX` to work with all the data-types.
+* Introduction of `extensions` and addition of the `query_ddb` function to allow querying AWS DynamodB from the CLI.
+* `CEIL` and `FLOOR` functions
+* `DATE/TIME` formatting and the support for `DATE/TIME` in Ion data format
+## Deprecated items
+## Misc/bug fixes
+* Convenience `StaticType` for `TEXT` and `NUMERIC`
+* Adds missing metas to `ORDER BY` `ExprNode` and `PartiqlAst` (e.g. source location)
 ## Breaking changes
 ### Breaking behavioral changes
 ### Breaking API changes
 1. Removal of field `EVALUATOR_SQL_EXCEPTION` from `ErrorCode` class - only used in [NaturalExprValueComparatorsTest.kt](https://github.com/partiql/partiql-lang-kotlin/blob/v0.6.0-alpha/lang/test/org/partiql/lang/eval/NaturalExprValueComparatorsTest.kt#L301)
 2. Renaming of field `SEMANTIC_INFERENCER_ERROR` from `ErrorCode` to `SEMANTIC_PROBLEM`
-3. Removal of `NodeMetadata` from `org.partiql.lang.eval` only used in testing
+3. Removal of `NodeMetadata` from `org.partiql.lang.eval` - only used in testing
 4. Removal of the following classes from `org.partiql.lang.eval.like` - APIs were unintentionally public. They have been removed and replaced with regex pattern matching.
 * `CodepointCheckpointIterator`
 * `PatternPart`


### PR DESCRIPTION
#668.

*Description of changes:* Adds migration guides relevant for PartiQL library users who would like to migrate to a newer major version. This PR adds a folder to `docs/dev` with the guides. TBD if this folder will remain or if the contents are more appropriate as a set of wiki pages: https://github.com/partiql/partiql-lang-kotlin/wiki.

Rendered markdown files can be viewed by going to "Files changed" -> clicking the three horizontal dots on the given file -> click "View file". Also viewable here:
- [cli-versions.md](https://github.com/partiql/partiql-lang-kotlin/blob/aabbc98dc3097d601b2e4d9bcb083d66cf9a576a/docs/dev/version-migration/cli-versions.md)
- [migration-guide.md](https://github.com/partiql/partiql-lang-kotlin/blob/aabbc98dc3097d601b2e4d9bcb083d66cf9a576a/docs/dev/version-migration/migration-guide.md)
- [v0.1-to-v0.2-migration.md](https://github.com/partiql/partiql-lang-kotlin/blob/aabbc98dc3097d601b2e4d9bcb083d66cf9a576a/docs/dev/version-migration/v0.1-to-v0.2-migration.md)
- [v0.2-to-v0.3-migration.md](https://github.com/partiql/partiql-lang-kotlin/blob/aabbc98dc3097d601b2e4d9bcb083d66cf9a576a/docs/dev/version-migration/v0.2-to-v0.3-migration.md)
- [v0.3-to-v0.4-migration.md](https://github.com/partiql/partiql-lang-kotlin/blob/aabbc98dc3097d601b2e4d9bcb083d66cf9a576a/docs/dev/version-migration/v0.3-to-v0.4-migration.md)
- [v0.4-to-v0.5-migration.md](https://github.com/partiql/partiql-lang-kotlin/blob/aabbc98dc3097d601b2e4d9bcb083d66cf9a576a/docs/dev/version-migration/v0.4-to-v0.5-migration.md)
- [v0.5-to-v0.6-migration.md](https://github.com/partiql/partiql-lang-kotlin/blob/aabbc98dc3097d601b2e4d9bcb083d66cf9a576a/docs/dev/version-migration/v0.5-to-v0.6-migration.md)
- [v0.6-to-v0.7-migration.md](https://github.com/partiql/partiql-lang-kotlin/blob/aabbc98dc3097d601b2e4d9bcb083d66cf9a576a/docs/dev/version-migration/v0.6-to-v0.7-migration.md)


*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes? (y/n), If not, please explain why:*

No, this PR is intended to collect feedback on the migration guides content, format, and other details.

*Does your PR include any backward-incompatible changes? (y/n), if yes, please explain the reason. In addition, please
 also mention any other alternatives you've considered and the reason they've been discarded?:*

No.

```
For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in 
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base.
```

*Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:*

No.

---

Draft till the following TODOs are addressed:
- [x] more notes on deprecated items between versions (e.g. `ExprNode`)
- [x] more descriptions for breaking changes found in the compatibility reports
- [x] links to code examples from https://github.com/alancai98/test-partiql-version-migration
- [x] consolidate boilerplate used by both versions in code examples
- [x] some missing deprecated items (e.g. from v0.1.* -> v0.2.*, the ASTs and APIs (`V0AstSerializer`, `AstSerializer`, `AstDeserializer`) predating `ExprNode` were deprecated)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
