### PR TITLE
Adds OUTER bag operators [RFC-0007]

### DIFF
--- a/lang/src/org/partiql/lang/eval/BagOp.kt
+++ b/lang/src/org/partiql/lang/eval/BagOp.kt
@@ -1,10 +1,18 @@
 package org.partiql.lang.eval
 
+import com.amazon.ion.IonContainer
+import com.amazon.ion.IonStruct
 import com.amazon.ionelement.api.MetaContainer
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.errors.ErrorCode
 
 fun interface ExprValueBagOp {
+    fun eval(lhs: ExprValue, rhs: ExprValue): Sequence<ExprValue> {
+        val l = lhs.coerceToBag()
+        val r = rhs.coerceToBag()
+        return eval(l, r)
+    }
+
     fun eval(lhs: Sequence<ExprValue>, rhs: Sequence<ExprValue>): Sequence<ExprValue>
 }
 
@@ -22,6 +30,25 @@ fun PartiqlAst.BagOpType.expr(metas: MetaContainer): ExprValueBagOp = when (this
     is PartiqlAst.BagOpType.OuterUnion -> outerUnion
     is PartiqlAst.BagOpType.OuterIntersect -> outerIntersect
     is PartiqlAst.BagOpType.OuterExcept -> outerExcept
+}
+
+/**
+ * Coercion function F for bag operators described in RFC-0007
+ *  - F(absent_value) -> << >>
+ *  - F(scalar_value) -> << scalar_value >> # singleton bag
+ *  - F(tuple_value)  -> << tuple_value >>  # singleton bag, see future extensions
+ *  - F(array_value)  -> bag_value          # discard ordering
+ *  - F(bag_value)    -> bag_value          # identity
+ */
+internal fun ExprValue.coerceToBag(): Sequence<ExprValue> = when {
+    isUnknown() -> emptySequence()
+    this is StructExprValue || this is Scalar -> sequenceOf(this)
+    this is IonExprValue -> when (ionValue) {
+        is IonStruct -> sequenceOf(this)
+        is IonContainer -> this.asSequence()
+        else -> sequenceOf(this)
+    }
+    else -> this.asSequence()
 }
 
 private val outerUnion = ExprValueBagOp { lhs, rhs ->

--- a/lang/src/org/partiql/lang/eval/BagOp.kt
+++ b/lang/src/org/partiql/lang/eval/BagOp.kt
@@ -1,0 +1,67 @@
+package org.partiql.lang.eval
+
+import com.amazon.ionelement.api.MetaContainer
+import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.errors.ErrorCode
+
+fun interface ExprValueBagOp {
+    fun eval(lhs: Sequence<ExprValue>, rhs: Sequence<ExprValue>): Sequence<ExprValue>
+}
+
+fun PartiqlAst.BagOpType.expr(metas: MetaContainer): ExprValueBagOp = when (this) {
+    is PartiqlAst.BagOpType.Union,
+    is PartiqlAst.BagOpType.Intersect,
+    is PartiqlAst.BagOpType.Except -> {
+        throw EvaluationException(
+            message = "${this.javaClass.simpleName} operator is not support yet",
+            errorCode = ErrorCode.EVALUATOR_FEATURE_NOT_SUPPORTED_YET,
+            errorContextFrom(metas),
+            internal = false
+        )
+    }
+    is PartiqlAst.BagOpType.OuterUnion -> outerUnion
+    is PartiqlAst.BagOpType.OuterIntersect -> outerIntersect
+    is PartiqlAst.BagOpType.OuterExcept -> outerExcept
+}
+
+private val outerUnion = ExprValueBagOp { lhs, rhs ->
+    sequence {
+        val multiplicities = lhs.multiplicities()
+        yieldAll(lhs)
+        rhs.forEach {
+            val m = multiplicities.getOrDefault(it, 0)
+            if (m > 0) {
+                multiplicities[it] = m - 1
+            } else {
+                yield(it)
+            }
+        }
+    }
+}
+
+private val outerIntersect = ExprValueBagOp { lhs, rhs ->
+    sequence {
+        val multiplicities = lhs.multiplicities()
+        rhs.forEach {
+            val m = multiplicities.getOrDefault(it, 0)
+            if (m > 0) {
+                yield(it)
+                multiplicities[it] = m - 1
+            }
+        }
+    }
+}
+
+private val outerExcept = ExprValueBagOp { lhs, rhs ->
+    sequence {
+        val multiplicities = rhs.multiplicities()
+        lhs.forEach {
+            val m = multiplicities.getOrDefault(it, 0)
+            if (m > 0) {
+                multiplicities[it] = m - 1
+            } else {
+                yield(it)
+            }
+        }
+    }
+}

--- a/lang/src/org/partiql/lang/eval/BagOp.kt
+++ b/lang/src/org/partiql/lang/eval/BagOp.kt
@@ -8,6 +8,17 @@ import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.pig.runtime.DomainNode
 
+/**
+ * Evaluable representation of PartiQL bag operators.
+ *
+ * ```
+ * - [OUTER] UNION     [ALL|DISTINCT]
+ * - [OUTER] INTERSECT [ALL|DISTINCT]
+ * - [OUTER] EXCEPT    [ALL|DISTINCT]
+ * ```
+ *
+ * @see [RFC-0007](https://github.com/partiql/partiql-docs/blob/main/RFCs/0007-rfc-bag-operators.md).
+ */
 fun interface ExprValueBagOp {
     fun eval(lhs: ExprValue, rhs: ExprValue): Sequence<ExprValue> {
         val l = lhs.coerceToBag()

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -1573,7 +1573,7 @@ internal class EvaluatingCompiler(
     private fun compileBagOp(node: PartiqlAst.Expr.BagOp, metas: MetaContainer): ThunkEnv {
         val lhs = compileAstExpr(node.operands[0])
         val rhs = compileAstExpr(node.operands[1])
-        val op = node.op.expr(metas)
+        val op = ExprValueBagOp.create(node.op, metas)
         return thunkFactory.thunkEnv(metas) { env ->
             val l = lhs(env)
             val r = rhs(env)

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -1575,8 +1575,8 @@ internal class EvaluatingCompiler(
         val rhs = compileAstExpr(node.operands[1])
         val op = node.op.expr(metas)
         return thunkFactory.thunkEnv(metas) { env ->
-            val l = lhs(env).asSequence()
-            val r = rhs(env).asSequence()
+            val l = lhs(env)
+            val r = rhs(env)
             val result = when (node.quantifier) {
                 is PartiqlAst.SetQuantifier.All -> op.eval(l, r)
                 is PartiqlAst.SetQuantifier.Distinct -> op.eval(l, r).distinct()

--- a/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
@@ -58,6 +58,7 @@ import java.time.LocalTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
+import java.util.TreeMap
 import java.util.TreeSet
 import kotlin.math.round
 
@@ -683,4 +684,24 @@ internal fun createUniqueExprValueFilter(): (ExprValue) -> Boolean {
     val seen = TreeSet<ExprValue>(DEFAULT_COMPARATOR)
 
     return { exprValue -> seen.add(exprValue) }
+}
+
+fun Sequence<ExprValue>.distinct(): Sequence<ExprValue> {
+    val seen = TreeSet(DEFAULT_COMPARATOR)
+    return sequence {
+        this@distinct.forEach {
+            if (!seen.contains(it)) {
+                seen.add(it.unnamedValue())
+                yield(it)
+            }
+        }
+    }
+}
+
+fun Sequence<ExprValue>.multiplicities(): TreeMap<ExprValue, Int> {
+    val multiplicities: TreeMap<ExprValue, Int> = TreeMap(DEFAULT_COMPARATOR)
+    this.forEach {
+        multiplicities.compute(it) { _, v -> (v ?: 0) + 1 }
+    }
+    return multiplicities
 }

--- a/lang/src/org/partiql/lang/eval/physical/PhysicalExprToThunkConverterImpl.kt
+++ b/lang/src/org/partiql/lang/eval/physical/PhysicalExprToThunkConverterImpl.kt
@@ -41,6 +41,7 @@ import org.partiql.lang.eval.EvaluationException
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueBagOp
 import org.partiql.lang.eval.ExprValueFactory
 import org.partiql.lang.eval.ExprValueType
 import org.partiql.lang.eval.Expression
@@ -61,6 +62,7 @@ import org.partiql.lang.eval.cast
 import org.partiql.lang.eval.compareTo
 import org.partiql.lang.eval.createErrorSignaler
 import org.partiql.lang.eval.createThunkFactory
+import org.partiql.lang.eval.distinct
 import org.partiql.lang.eval.err
 import org.partiql.lang.eval.errInvalidArgumentType
 import org.partiql.lang.eval.errNoContext
@@ -262,16 +264,7 @@ internal class PhysicalExprToThunkConverterImpl(
             is PartiqlPhysical.Expr.Bag -> compileSeq(ExprValueType.BAG, expr.values, metas)
 
             // bag operators
-            is PartiqlPhysical.Expr.BagOp -> {
-                err(
-                    "${expr.op.javaClass.simpleName} is not yet supported",
-                    ErrorCode.EVALUATOR_FEATURE_NOT_SUPPORTED_YET,
-                    errorContextFrom(metas).also {
-                        it[Property.FEATURE_NAME] = expr.javaClass.canonicalName
-                    },
-                    internal = false
-                )
-            }
+            is PartiqlPhysical.Expr.BagOp -> compileBagOp(expr, metas)
             is PartiqlPhysical.Expr.BindingsToValues -> compileBindingsToValues(expr)
         }
     }
@@ -1839,6 +1832,21 @@ internal class PhysicalExprToThunkConverterImpl(
                 )
             )
         }
+
+    private fun compileBagOp(node: PartiqlPhysical.Expr.BagOp, metas: MetaContainer): PhysicalPlanThunk {
+        val lhs = compileAstExpr(node.operands[0])
+        val rhs = compileAstExpr(node.operands[1])
+        val op = ExprValueBagOp.create(node.op, metas)
+        return thunkFactory.thunkEnv(metas) { env ->
+            val l = lhs(env)
+            val r = rhs(env)
+            val result = when (node.quantifier) {
+                is PartiqlPhysical.SetQuantifier.All -> op.eval(l, r)
+                is PartiqlPhysical.SetQuantifier.Distinct -> op.eval(l, r).distinct()
+            }
+            valueFactory.newBag(result)
+        }
+    }
 
     /** A special wrapper for `UNPIVOT` values as a BAG. */
     private class UnpivotedExprValue(private val values: Iterable<ExprValue>) : BaseExprValue() {

--- a/lang/src/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
@@ -1124,6 +1124,12 @@ internal class StaticTypeInferenceVisitorTransform(
             return transformSeq(seq, seq.values) { BagType(it) }
         }
 
+        override fun transformExprBagOp(node: PartiqlAst.Expr.BagOp): PartiqlAst.Expr {
+            val bagOp = super.transformExprBagOp(node) as PartiqlAst.Expr.BagOp
+            // TODO assert operand compatibility once SQL bag operators are implemented
+            return bagOp.withStaticType(StaticType.BAG)
+        }
+
         override fun transformExprSimpleCase(node: PartiqlAst.Expr.SimpleCase): PartiqlAst.Expr {
             val simpleCase = super.transformExprSimpleCase(node) as PartiqlAst.Expr.SimpleCase
             val caseValue = simpleCase.expr

--- a/lang/test/org/partiql/lang/ast/SerializationRoundTripTests.kt
+++ b/lang/test/org/partiql/lang/ast/SerializationRoundTripTests.kt
@@ -35,7 +35,11 @@ class SerializationRoundTripTests {
                     "outerIntersectDistinct",
                     "outerIntersectAll",
                     "outerExceptDistinct",
-                    "outerExceptAll"
+                    "outerExceptAll",
+                    "outerUnionCoerceScalar",
+                    "outerUnionCoerceStruct",
+                    "outerUnionCoerceNullMissing",
+                    "outerUnionCoerceList"
                 )
             )
                 // we really don't need to test failure cases in this case since the (de)serializers are legacy.

--- a/lang/test/org/partiql/lang/ast/SerializationRoundTripTests.kt
+++ b/lang/test/org/partiql/lang/ast/SerializationRoundTripTests.kt
@@ -27,7 +27,15 @@ class SerializationRoundTripTests {
             EVALUATOR_TEST_SUITE.getAllTests(
                 failingTestNames = hashSetOf(
                     // CAN_CAST is not supported by V0 and will never be.
-                    "canCastAsFloat1"
+                    "canCastAsFloat1",
+
+                    // OUTER bag operators are not in the legacy AST and should be skipped
+                    "outerUnionDistinct",
+                    "outerUnionAll",
+                    "outerIntersectDistinct",
+                    "outerIntersectAll",
+                    "outerExceptDistinct",
+                    "outerExceptAll"
                 )
             )
                 // we really don't need to test failure cases in this case since the (de)serializers are legacy.

--- a/lang/test/org/partiql/lang/eval/EvaluatorTestSuite.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTestSuite.kt
@@ -8,7 +8,20 @@ import org.partiql.lang.util.testdsl.IonResultTestSuite
 import org.partiql.lang.util.testdsl.defineTestSuite
 
 class EvaluatorTestCasesAsExprNodeTestCases : ArgumentsProviderBase() {
-    override fun getParameters() = EVALUATOR_TEST_SUITE.allTestsAsExprNodeTestCases()
+
+    companion object {
+        private val EXPR_NODE_SKIP_LIST = setOf(
+            // OUTER bag operators are not in the legacy AST and should be skipped
+            "outerUnionDistinct",
+            "outerUnionAll",
+            "outerIntersectDistinct",
+            "outerIntersectAll",
+            "outerExceptDistinct",
+            "outerExceptAll"
+        )
+    }
+
+    override fun getParameters() = EVALUATOR_TEST_SUITE.allTestsAsExprNodeTestCases(EXPR_NODE_SKIP_LIST)
 }
 
 /**
@@ -1397,5 +1410,13 @@ internal val EVALUATOR_TEST_SUITE: IonResultTestSuite = defineTestSuite {
             """,
             "$partiql_bag::[[1968, 4, 3, 12, 31, 59]]"
         )
+    }
+    group("bagOperators") {
+        test("outerUnionDistinct", "<< 1, 2, 2, 3, 3, 3 >> OUTER UNION << 1, 2, 3, 3 >>", "$partiql_bag::[1, 2, 3]")
+        test("outerUnionAll", "<< 1, 2, 2, 3, 3, 3 >> OUTER UNION ALL << 1, 2, 3, 3 >>", "$partiql_bag::[1, 2, 2, 3, 3, 3]")
+        test("outerIntersectDistinct", "<< 1, 2, 2, 3, 3, 3 >> OUTER INTERSECT << 1, 2, 3, 3 >>", "$partiql_bag::[1, 2, 3]")
+        test("outerIntersectAll", "<< 1, 2, 2, 3, 3, 3 >> OUTER INTERSECT ALL << 1, 2, 3, 3 >>", "$partiql_bag::[1, 2, 3, 3]")
+        test("outerExceptDistinct", "<< 1, 1, 1, 2 >> OUTER EXCEPT << 1 >>", "$partiql_bag::[1, 2]")
+        test("outerExceptAll", "<< 1, 1, 1, 2 >> OUTER EXCEPT ALL << 1 >>", "$partiql_bag::[1, 1, 2]")
     }
 }

--- a/lang/test/org/partiql/lang/eval/EvaluatorTestSuite.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTestSuite.kt
@@ -17,7 +17,11 @@ class EvaluatorTestCasesAsExprNodeTestCases : ArgumentsProviderBase() {
             "outerIntersectDistinct",
             "outerIntersectAll",
             "outerExceptDistinct",
-            "outerExceptAll"
+            "outerExceptAll",
+            "outerUnionCoerceScalar",
+            "outerUnionCoerceStruct",
+            "outerUnionCoerceNullMissing",
+            "outerUnionCoerceList"
         )
     }
 
@@ -1418,5 +1422,9 @@ internal val EVALUATOR_TEST_SUITE: IonResultTestSuite = defineTestSuite {
         test("outerIntersectAll", "<< 1, 2, 2, 3, 3, 3 >> OUTER INTERSECT ALL << 1, 2, 3, 3 >>", "$partiql_bag::[1, 2, 3, 3]")
         test("outerExceptDistinct", "<< 1, 1, 1, 2 >> OUTER EXCEPT << 1 >>", "$partiql_bag::[1, 2]")
         test("outerExceptAll", "<< 1, 1, 1, 2 >> OUTER EXCEPT ALL << 1 >>", "$partiql_bag::[1, 1, 2]")
+        test("outerUnionCoerceScalar", "1 OUTER UNION 2", "$partiql_bag::[1, 2]")
+        test("outerUnionCoerceStruct", "{'a': 1} OUTER UNION {'b': 2}", "$partiql_bag::[ {'a': 1}, {'b': 2} ]")
+        test("outerUnionCoerceNullMissing", "NULL OUTER UNION MISSING", "$partiql_bag::[]")
+        test("outerUnionCoerceList", "[ 1, 1, 1 ] OUTER UNION ALL [ 1, 2 ]", "$partiql_bag::[1, 1, 1, 2]")
     }
 }

--- a/lang/test/org/partiql/lang/eval/EvaluatorTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTests.kt
@@ -109,7 +109,15 @@ class EvaluatorTests {
             // we are currently not plumbed to be able to return the original letter casing of global variables.
             // (there are other tests in LogicalToLogicalResolvedVisitorTransform which cover this case for the
             // PlannerPipeline)
-            "identifierCaseMismatch"
+            "identifierCaseMismatch",
+
+            // TODO: Support bag operators in planning compiler
+            "outerUnionDistinct",
+            "outerUnionAll",
+            "outerIntersectDistinct",
+            "outerIntersectAll",
+            "outerExceptDistinct",
+            "outerExceptAll"
         )
 
         @JvmStatic

--- a/lang/test/org/partiql/lang/eval/EvaluatorTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTests.kt
@@ -117,7 +117,11 @@ class EvaluatorTests {
             "outerIntersectDistinct",
             "outerIntersectAll",
             "outerExceptDistinct",
-            "outerExceptAll"
+            "outerExceptAll",
+            "outerUnionCoerceScalar",
+            "outerUnionCoerceStruct",
+            "outerUnionCoerceNullMissing",
+            "outerUnionCoerceList"
         )
 
         @JvmStatic

--- a/lang/test/org/partiql/lang/eval/EvaluatorTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTests.kt
@@ -109,19 +109,7 @@ class EvaluatorTests {
             // we are currently not plumbed to be able to return the original letter casing of global variables.
             // (there are other tests in LogicalToLogicalResolvedVisitorTransform which cover this case for the
             // PlannerPipeline)
-            "identifierCaseMismatch",
-
-            // TODO: Support bag operators in planning compiler
-            "outerUnionDistinct",
-            "outerUnionAll",
-            "outerIntersectDistinct",
-            "outerIntersectAll",
-            "outerExceptDistinct",
-            "outerExceptAll",
-            "outerUnionCoerceScalar",
-            "outerUnionCoerceStruct",
-            "outerUnionCoerceNullMissing",
-            "outerUnionCoerceList"
+            "identifierCaseMismatch"
         )
 
         @JvmStatic

--- a/lang/test/org/partiql/lang/util/testdsl/IonResultTestSuite.kt
+++ b/lang/test/org/partiql/lang/util/testdsl/IonResultTestSuite.kt
@@ -1,5 +1,3 @@
-
-
 package org.partiql.lang.util.testdsl
 
 import com.amazon.ion.IonValue
@@ -55,11 +53,12 @@ data class IonResultTestSuite(
         }
     }
 
-    /** Calls [getAllTests] and then maps the result to a [List<ExprNodeTestCase>]. */
-    fun allTestsAsExprNodeTestCases(
-        failingTestNames: Set<String> = emptySet()
-    ) =
-        getAllTests(failingTestNames).map { it.toExprNodeTestCase() }
+    /**
+     * Calls [getAllTests] and then maps the result to a [List<ExprNodeTestCase>].
+     */
+    fun allTestsAsExprNodeTestCases(failingTestNames: Set<String> = emptySet()) = getAllTests(failingTestNames)
+        .filter { !it.expectFailure }
+        .map { it.toExprNodeTestCase() }
 
     /** Invokes [factoryBlock] to create the parameters needed for the tests in the suite. */
     fun createParameters(vf: ExprValueFactory) = factoryBlock(vf)


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/partiql/partiql-lang-kotlin/issues/184

*Description of changes:*

This PR implements OUTER bag operators. These operators are the multi-set operators we know and love from math. The full specification is defined in [RFC-0007 ](https://github.com/partiql/partiql-docs/blob/main/RFCs/0007-rfc-bag-operators.md)

*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes? (y/n), If not, please explain why:* N

I will update CHANGELOG once set operators are added. This is just the OUTER operators.

*Does your PR include any backward-incompatible changes? (y/n), if yes, please explain the reason. In addition, please
 also mention any other alternatives you've considered and the reason they've been discarded?:* N

```
For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in 
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base.
```

*Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:* N

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
