### PR TITLE
Fix neg overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ stage in the `PlannerPipeline` and to generate performance metrics for the indiv
 ### Fixed
 - Codecov report uploads in GitHub Actions workflow
 - GitHub Actions capability to run on forks
+- Negation overflow caused by minimum INT8
 
 ### Removed
 - README.md badge for travisci

--- a/lang/src/org/partiql/lang/util/NumberExtensions.kt
+++ b/lang/src/org/partiql/lang/util/NumberExtensions.kt
@@ -111,7 +111,8 @@ fun Number.ionValue(ion: IonSystem): IonValue = when (this) {
 
 operator fun Number.unaryMinus(): Number {
     return when (this) {
-        is Long -> -this
+        // - LONG.MIN_VALUE will result in LONG.MIN_VALUE in JVM because LONG is a signed two's-complement integers
+        is Long -> if (this == Long.MIN_VALUE) BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE) else -this
         is BigInteger -> this.negate()
         is Double -> -this
         is BigDecimal -> if (this.isZero()) {

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerNAryIntOverflowTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerNAryIntOverflowTests.kt
@@ -205,13 +205,13 @@ class EvaluatingCompilerNAryIntOverflowTests : EvaluatorTestBase() {
                     TestCase("${prefix}_1 - ${prefix}_2", "-1"),
                     TestCase("${prefix}_neg1 - ${prefix}_neg2", "1"),
 
-                    // Times 1, -1
+                    // Times 2, -2
                     TestCase("${prefix}_max * ${prefix}_2", "MISSING"),
                     TestCase("${prefix}_min * ${prefix}_neg2", "MISSING"),
                     TestCase("${prefix}_min * ${prefix}_2", "MISSING"),
                     TestCase("${prefix}_max * ${prefix}_neg2", "MISSING"),
 
-                    // Times 2, -2
+                    // Times 1, -1
                     TestCase("${prefix}_max * ${prefix}_1", "${prefix}_max"),
                     TestCase("${prefix}_min * ${prefix}_neg1", "MISSING"),
                     TestCase("${prefix}_min * ${prefix}_1", "${prefix}_min"),
@@ -219,8 +219,7 @@ class EvaluatingCompilerNAryIntOverflowTests : EvaluatorTestBase() {
 
                     // Unary negation
                     TestCase("-${prefix}_max", "${prefix}_minPlus1"),
-                    // https://github.com/partiql/partiql-lang-kotlin/issues/513
-                    // TestCase("-${prefix}_min", "MISSING"),
+                    TestCase("-${prefix}_min", "MISSING"),
                     TestCase("-${prefix}_1", "${prefix}_neg1"),
                     TestCase("-${prefix}_neg1", "${prefix}_1")
                 )


### PR DESCRIPTION
*Issue #, if available:* [#513](https://github.com/partiql/partiql-lang-kotlin/issues/513)

*Description of changes:*
1. fix the bug `neg(LONG.min_value) = LONG.min_value`
2. uncomment the test case
 https://github.com/partiql/partiql-lang-kotlin/blob/cba305370b8cf78772c77808056cecec7a898620/lang/test/org/partiql/lang/eval/EvaluatingCompilerNAryIntOverflowTests.kt#L222
3. fix some typos

*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes? (y/n), If not, please explain why:*

Yes. 

*Does your PR include any backward-incompatible changes? (y/n), if yes, please explain the reason. In addition, please
 also mention any other alternatives you've considered and the reason they've been discarded?:*

```
For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in 
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base.
```

Yes, because now `-(-9223372036854775808)` will throw an error, and before it returns itself.

*Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:*

No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
