### PR TITLE
Re-modeling Integer Types in `StaticType`

### DIFF
--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -54,6 +54,9 @@ import org.partiql.lang.syntax.SqlParser
 import org.partiql.lang.types.AnyOfType
 import org.partiql.lang.types.AnyType
 import org.partiql.lang.types.FunctionSignature
+import org.partiql.lang.types.Int2Type
+import org.partiql.lang.types.Int4Type
+import org.partiql.lang.types.Int8Type
 import org.partiql.lang.types.IntType
 import org.partiql.lang.types.SingleType
 import org.partiql.lang.types.StaticType
@@ -540,7 +543,7 @@ internal class EvaluatingCompiler(
                         // throw an exception in case we encounter this untested scenario. This might work fine, but I
                         // wouldn't bet on it.
                         val hasConstrainedInteger = staticTypes.any {
-                            it is IntType && it.rangeConstraint != IntType.IntRangeConstraint.UNCONSTRAINED
+                            it is Int2Type || it is Int4Type || it is Int8Type
                         }
                         if (hasConstrainedInteger) {
                             TODO("Legacy mode doesn't support integer size constraints yet.")
@@ -549,13 +552,16 @@ internal class EvaluatingCompiler(
                         }
                     }
                     TypingMode.PERMISSIVE -> {
-                        val biggestIntegerType = staticTypes.filterIsInstance<IntType>().maxBy {
-                            it.rangeConstraint.numBytes
+                        val validRange: LongRange? = when {
+                            staticTypes.any { it is IntType } -> IntType.validRange
+                            staticTypes.any { it is Int8Type } -> Int8Type.validRange
+                            staticTypes.any { it is Int4Type } -> Int4Type.validRange
+                            staticTypes.any { it is Int2Type } -> Int2Type.validRange
+                            else -> null
                         }
-                        when (biggestIntegerType) {
-                            is IntType -> {
-                                val validator = integerValueValidator(biggestIntegerType.rangeConstraint.validRange)
-
+                        when {
+                            validRange != null -> {
+                                val validator = integerValueValidator(validRange)
                                 thunkFactory.thunkEnv(metas) { env ->
                                     val naryResult = computeThunk(env)
                                     errorSignaler.errorIf(
@@ -566,8 +572,6 @@ internal class EvaluatingCompiler(
                                     )
                                 }
                             }
-                            // If there is no IntType StaticType, can't validate the integer size either.
-                            null -> computeThunk
                             else -> computeThunk
                         }
                     }

--- a/lang/src/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
@@ -14,8 +14,8 @@ import org.partiql.lang.ast.passes.SemanticException
 import org.partiql.lang.ast.passes.SemanticProblemDetails
 import org.partiql.lang.ast.passes.inference.cast
 import org.partiql.lang.ast.passes.inference.filterNullMissing
-import org.partiql.lang.ast.passes.inference.intTypesPrecedence
 import org.partiql.lang.ast.passes.inference.getLength
+import org.partiql.lang.ast.passes.inference.intTypesPrecedence
 import org.partiql.lang.ast.passes.inference.isLob
 import org.partiql.lang.ast.passes.inference.isNullOrMissing
 import org.partiql.lang.ast.passes.inference.isNumeric

--- a/lang/src/org/partiql/lang/mappers/StaticTypeMapper.kt
+++ b/lang/src/org/partiql/lang/mappers/StaticTypeMapper.kt
@@ -104,8 +104,8 @@ class StaticTypeMapper(schema: IonSchemaModel.Schema) {
 
         // Create StaticType based on core ISL type
         return when (coreType) {
-            is StringType -> StringType(getStringLengthConstraint(), metas)
-            is IntType -> IntType(getIntRangeConstraint(), metas)
+            is StringType -> getStringType(metas)
+            is IntType -> getIntType(metas)
             is DecimalType -> DecimalType(getPrecisionScaleConstraint(), metas)
             is ListType -> ListType(getElement(currentTopLevelTypeName), metas)
             is SexpType -> SexpType(getElement(currentTopLevelTypeName), metas)

--- a/lang/src/org/partiql/lang/mappers/StaticTypeMapper.kt
+++ b/lang/src/org/partiql/lang/mappers/StaticTypeMapper.kt
@@ -8,10 +8,14 @@ import org.partiql.lang.types.AnyOfType
 import org.partiql.lang.types.AnyType
 import org.partiql.lang.types.BagType
 import org.partiql.lang.types.DecimalType
+import org.partiql.lang.types.Int2Type
+import org.partiql.lang.types.Int4Type
+import org.partiql.lang.types.Int8Type
 import org.partiql.lang.types.IntType
 import org.partiql.lang.types.ListType
 import org.partiql.lang.types.NumberConstraint
 import org.partiql.lang.types.SexpType
+import org.partiql.lang.types.SingleType
 import org.partiql.lang.types.StaticType
 import org.partiql.lang.types.StringType
 import org.partiql.lang.types.StructType
@@ -100,7 +104,7 @@ class StaticTypeMapper(schema: IonSchemaModel.Schema) {
         // Create StaticType based on core ISL type
         return when (coreType) {
             is StringType -> StringType(getStringLengthConstraint(), metas)
-            is IntType -> IntType(getIntRangeConstraint(), metas)
+            is IntType -> getIntType(metas)
             is DecimalType -> DecimalType(getPrecisionScaleConstraint(), metas)
             is ListType -> ListType(getElement(currentTopLevelTypeName), metas)
             is SexpType -> SexpType(getElement(currentTopLevelTypeName), metas)
@@ -198,9 +202,9 @@ class StaticTypeMapper(schema: IonSchemaModel.Schema) {
             else -> constraint.toStringLengthConstraint()
         }
 
-    private fun IonSchemaModel.TypeDefinition.getIntRangeConstraint(): IntType.IntRangeConstraint =
+    private fun IonSchemaModel.TypeDefinition.getIntType(metas: Map<String, List<IonSchemaModel.TypeDefinition>>): SingleType =
         when (val spec = constraints.getConstraint(IonSchemaModel.Constraint.ValidValues::class)?.spec) {
-            null -> IntType.IntRangeConstraint.UNCONSTRAINED
+            null -> IntType(metas)
             is IonSchemaModel.ValidValuesSpec.OneOfValidValues -> error("One of valid values constraint is not supported for integers")
             is IonSchemaModel.ValidValuesSpec.RangeOfValidValues -> when (val range = spec.range) {
                 is IonSchemaModel.ValuesRange.NumRange -> {
@@ -218,9 +222,9 @@ class StaticTypeMapper(schema: IonSchemaModel.Schema) {
                     }
 
                     when {
-                        min == Short.MIN_VALUE.toLong() && max == Short.MAX_VALUE.toLong() -> IntType.IntRangeConstraint.SHORT
-                        min == Int.MIN_VALUE.toLong() && max == Int.MAX_VALUE.toLong() -> IntType.IntRangeConstraint.INT4
-                        min == Long.MIN_VALUE && max == Long.MAX_VALUE -> IntType.IntRangeConstraint.LONG
+                        min == Short.MIN_VALUE.toLong() && max == Short.MAX_VALUE.toLong() -> Int2Type(metas)
+                        min == Int.MIN_VALUE.toLong() && max == Int.MAX_VALUE.toLong() -> Int4Type(metas)
+                        min == Long.MIN_VALUE && max == Long.MAX_VALUE -> Int8Type(metas)
                         else -> error("Invalid range for integers $min-$max")
                     }
                 }

--- a/lang/src/org/partiql/lang/types/PartiqlPhysicalTypeExtensions.kt
+++ b/lang/src/org/partiql/lang/types/PartiqlPhysicalTypeExtensions.kt
@@ -11,10 +11,10 @@ fun PartiqlPhysical.Type.toTypedOpParameter(customTypedOpParameters: Map<String,
     is PartiqlPhysical.Type.NullType -> TypedOpParameter(StaticType.NULL)
     is PartiqlPhysical.Type.ScalarType -> when (id.text) {
         BuiltInScalarTypeId.BOOLEAN -> TypedOpParameter(StaticType.BOOL)
-        BuiltInScalarTypeId.SMALLINT -> TypedOpParameter(IntType(IntType.IntRangeConstraint.SHORT))
-        BuiltInScalarTypeId.INTEGER4 -> TypedOpParameter(IntType(IntType.IntRangeConstraint.INT4))
-        BuiltInScalarTypeId.INTEGER8 -> TypedOpParameter(IntType(IntType.IntRangeConstraint.LONG))
-        BuiltInScalarTypeId.INTEGER -> TypedOpParameter(IntType(IntType.IntRangeConstraint.LONG))
+        BuiltInScalarTypeId.SMALLINT -> TypedOpParameter(StaticType.INT2)
+        BuiltInScalarTypeId.INTEGER4 -> TypedOpParameter(StaticType.INT4)
+        BuiltInScalarTypeId.INTEGER8 -> TypedOpParameter(StaticType.INT8)
+        BuiltInScalarTypeId.INTEGER -> TypedOpParameter(StaticType.INT)
         BuiltInScalarTypeId.FLOAT,
         BuiltInScalarTypeId.REAL,
         BuiltInScalarTypeId.DOUBLE_PRECISION -> TypedOpParameter(StaticType.FLOAT)

--- a/lang/test/org/partiql/lang/CustomTypeTestFixtures.kt
+++ b/lang/test/org/partiql/lang/CustomTypeTestFixtures.kt
@@ -5,7 +5,6 @@ import org.partiql.lang.eval.ExprValueType
 import org.partiql.lang.eval.numberValue
 import org.partiql.lang.types.AnyOfType
 import org.partiql.lang.types.CustomType
-import org.partiql.lang.types.IntType
 import org.partiql.lang.types.NumberConstraint
 import org.partiql.lang.types.StaticType
 import org.partiql.lang.types.StringType
@@ -27,7 +26,7 @@ private val booleanParameter = TypedOpParameter(StaticType.BOOL)
 private val stringParameter = TypedOpParameter(StaticType.STRING)
 
 // ES_INT
-val esIntParameter = TypedOpParameter(IntType(IntType.IntRangeConstraint.LONG))
+val esIntParameter = TypedOpParameter(StaticType.INT8)
 
 // ES_FLOAT
 val esFloatParameter = TypedOpParameter(StaticType.FLOAT) {
@@ -65,10 +64,10 @@ val esAny = TypedOpParameter(
 )
 
 // RS_INTEGER
-private val rsIntegerPrecisionParameter = TypedOpParameter(IntType(IntType.IntRangeConstraint.INT4))
+private val rsIntegerPrecisionParameter = TypedOpParameter(StaticType.INT4)
 
 // RS_BIGINT
-private val rsBigintPrecisionParameter = TypedOpParameter(IntType(IntType.IntRangeConstraint.LONG))
+private val rsBigintPrecisionParameter = TypedOpParameter(StaticType.INT8)
 
 // RS_VARCHAR_MAX
 private val rsStringParameter = TypedOpParameter(
@@ -86,13 +85,13 @@ private val rsDoublePrecisionParameter = TypedOpParameter(StaticType.FLOAT) {
 }
 
 // SPARK_SHORT
-private val sparkShortPrecisionParameter = TypedOpParameter(IntType(IntType.IntRangeConstraint.SHORT))
+private val sparkShortPrecisionParameter = TypedOpParameter(StaticType.INT2)
 
 // SPARK_INTEGER
-private val sparkIntegerPrecisionParameter = TypedOpParameter(IntType(IntType.IntRangeConstraint.INT4))
+private val sparkIntegerPrecisionParameter = TypedOpParameter(StaticType.INT4)
 
 // SPARK_LONG
-private val sparkLongPrecisionParameter = TypedOpParameter(IntType(IntType.IntRangeConstraint.LONG))
+private val sparkLongPrecisionParameter = TypedOpParameter(StaticType.INT8)
 
 // SPARK_FLOAT
 private val sparkFloatPrecisionParameter = TypedOpParameter(StaticType.FLOAT) {

--- a/lang/test/org/partiql/lang/ast/passes/inference/StaticTypeCastTests.kt
+++ b/lang/test/org/partiql/lang/ast/passes/inference/StaticTypeCastTests.kt
@@ -6,7 +6,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.partiql.lang.types.DecimalType
-import org.partiql.lang.types.IntType
 import org.partiql.lang.types.StaticType
 
 @RunWith(JUnitParamsRunner::class)
@@ -429,10 +428,10 @@ class StaticTypeCastTests {
     ).addCastToAnyCases()
 
     fun parametersForNumberCastTests(): List<TestCase> {
-        val smallint = IntType(IntType.IntRangeConstraint.SHORT)
-        val int4 = IntType(IntType.IntRangeConstraint.INT4)
-        val bigint = IntType(IntType.IntRangeConstraint.LONG)
-        val unconstrainedInt = IntType(IntType.IntRangeConstraint.UNCONSTRAINED)
+        val smallint = StaticType.INT2
+        val int4 = StaticType.INT4
+        val bigint = StaticType.INT8
+        val unconstrainedInt = StaticType.INT
 
         val decimal4_2 = DecimalType(DecimalType.PrecisionScaleConstraint.Constrained(4, 2))
         val decimal7_2 = DecimalType(DecimalType.PrecisionScaleConstraint.Constrained(7, 2))

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerNAryIntOverflowTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerNAryIntOverflowTests.kt
@@ -74,25 +74,25 @@ class EvaluatingCompilerNAryIntOverflowTests : EvaluatorTestBase() {
         listOf(
             createVariablesForInt(
                 prefix = "int2",
-                type = IntType(IntType.IntRangeConstraint.SHORT),
+                type = StaticType.INT2,
                 minValue = Short.MIN_VALUE.toLong(),
                 maxValue = Short.MAX_VALUE.toLong()
             ),
             createVariablesForInt(
                 prefix = "int4",
-                type = IntType(IntType.IntRangeConstraint.INT4),
+                type = StaticType.INT4,
                 minValue = Int.MIN_VALUE.toLong(),
                 maxValue = Int.MAX_VALUE.toLong()
             ),
             createVariablesForInt(
                 prefix = "int8",
-                type = IntType(IntType.IntRangeConstraint.LONG),
+                type = StaticType.INT8,
                 minValue = Long.MIN_VALUE,
                 maxValue = Long.MAX_VALUE
             ),
             createVariablesForInt(
                 prefix = "int",
-                type = IntType(IntType.IntRangeConstraint.UNCONSTRAINED),
+                type = StaticType.INT,
                 minValue = Long.MIN_VALUE,
                 maxValue = Long.MAX_VALUE
             ),
@@ -100,8 +100,8 @@ class EvaluatingCompilerNAryIntOverflowTests : EvaluatorTestBase() {
             createVariablesForInt(
                 prefix = "int2_4",
                 type = StaticType.unionOf(
-                    IntType(IntType.IntRangeConstraint.SHORT),
-                    IntType(IntType.IntRangeConstraint.INT4)
+                    StaticType.INT2,
+                    StaticType.INT4
                 ),
                 minValue = Int.MIN_VALUE.toLong(),
                 maxValue = Int.MAX_VALUE.toLong()
@@ -109,8 +109,8 @@ class EvaluatingCompilerNAryIntOverflowTests : EvaluatorTestBase() {
             createVariablesForInt(
                 prefix = "int2_u",
                 type = StaticType.unionOf(
-                    IntType(IntType.IntRangeConstraint.INT4),
-                    IntType(IntType.IntRangeConstraint.UNCONSTRAINED)
+                    StaticType.INT4,
+                    StaticType.INT
                 ),
                 minValue = Long.MIN_VALUE,
                 maxValue = Long.MAX_VALUE

--- a/lang/test/org/partiql/lang/eval/builtins/InvalidArgTypeChecker.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/InvalidArgTypeChecker.kt
@@ -11,6 +11,9 @@ import org.partiql.lang.types.ClobType
 import org.partiql.lang.types.DateType
 import org.partiql.lang.types.DecimalType
 import org.partiql.lang.types.FloatType
+import org.partiql.lang.types.Int2Type
+import org.partiql.lang.types.Int4Type
+import org.partiql.lang.types.Int8Type
 import org.partiql.lang.types.IntType
 import org.partiql.lang.types.ListType
 import org.partiql.lang.types.MissingType
@@ -40,6 +43,9 @@ data class Argument(
 
 private fun SingleType.getExample() = when (this) {
     is BoolType -> "TRUE"
+    is Int2Type,
+    is Int4Type,
+    is Int8Type,
     is IntType -> "0"
     is FloatType -> "`0e0`"
     is DecimalType -> "0."

--- a/lang/test/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransformTest.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransformTest.kt
@@ -24,7 +24,6 @@ import org.partiql.lang.types.BoolType
 import org.partiql.lang.types.CollectionType
 import org.partiql.lang.types.DecimalType
 import org.partiql.lang.types.FunctionSignature
-import org.partiql.lang.types.IntType
 import org.partiql.lang.types.ListType
 import org.partiql.lang.types.NumberConstraint
 import org.partiql.lang.types.SexpType
@@ -4689,8 +4688,8 @@ class StaticTypeInferenceVisitorTransformTest : VisitorTransformTestBase() {
             TestCase(
                 name = "CAST to a type that doesn't expect any parameters",
                 originalSql = "CAST(an_int AS INT)",
-                globals = mapOf("an_int" to IntType(IntType.IntRangeConstraint.LONG)),
-                handler = expectQueryOutputType(IntType(IntType.IntRangeConstraint.LONG))
+                globals = mapOf("an_int" to StaticType.INT8),
+                handler = expectQueryOutputType(StaticType.INT)
             ),
             TestCase(
                 name = "CAST to SMALLINT",
@@ -4699,7 +4698,7 @@ class StaticTypeInferenceVisitorTransformTest : VisitorTransformTestBase() {
                 handler = expectQueryOutputType(
                     unionOf(
                         MISSING,
-                        IntType(IntType.IntRangeConstraint.SHORT)
+                        StaticType.INT2
                     )
                 )
             ),
@@ -4810,13 +4809,13 @@ class StaticTypeInferenceVisitorTransformTest : VisitorTransformTestBase() {
             TestCase(
                 name = "CAST with a custom type without validation thunk",
                 originalSql = "CAST(an_int AS ES_INTEGER)",
-                globals = mapOf("an_int" to IntType(IntType.IntRangeConstraint.LONG)),
+                globals = mapOf("an_int" to StaticType.INT8),
                 handler = expectQueryOutputType(customTypedOpParameters["es_integer"]!!.staticType)
             ),
             TestCase(
                 name = "CAST with a custom type with validation thunk",
                 originalSql = "CAST(an_int AS ES_FLOAT)",
-                globals = mapOf("an_int" to IntType(IntType.IntRangeConstraint.LONG)),
+                globals = mapOf("an_int" to StaticType.INT8),
                 handler = expectQueryOutputType(
                     unionOf(customTypedOpParameters["es_float"]!!.staticType, MISSING)
                 )
@@ -7503,7 +7502,7 @@ class StaticTypeInferenceVisitorTransformTest : VisitorTransformTestBase() {
         )
 
         private val customTypedOpParameters = mapOf(
-            "es_integer" to TypedOpParameter(IntType(IntType.IntRangeConstraint.LONG)),
+            "es_integer" to TypedOpParameter(StaticType.INT8),
             "es_float" to TypedOpParameter(StaticType.FLOAT) {
                 // For the sake of this test, lets say ES_FLOAT only allows values in range (-100, 100)
                 it.numberValue() < 100L && it.numberValue() > -100L

--- a/lang/test/org/partiql/lang/mappers/E2EMapperTests.kt
+++ b/lang/test/org/partiql/lang/mappers/E2EMapperTests.kt
@@ -19,6 +19,8 @@ import org.partiql.lang.types.BoolType
 import org.partiql.lang.types.ClobType
 import org.partiql.lang.types.DecimalType
 import org.partiql.lang.types.FloatType
+import org.partiql.lang.types.Int4Type
+import org.partiql.lang.types.Int8Type
 import org.partiql.lang.types.IntType
 import org.partiql.lang.types.ListType
 import org.partiql.lang.types.NumberConstraint
@@ -804,8 +806,7 @@ internal fun listTests() = listOf(
     MapperE2ETestCase(
         "type::{ name: $typeName, type: list, element: {type: int, valid_values: range::[${Int.MIN_VALUE}, ${Int.MAX_VALUE}]} }",
         ListType(
-            IntType(
-                IntType.IntRangeConstraint.INT4,
+            Int4Type(
                 metas = mapOf(
                     ISL_META_KEY to listOf(
                         buildTypeDef(
@@ -833,8 +834,7 @@ internal fun listTests() = listOf(
         "type::{ name: $typeName, type: list, element: {type: nullable::{type: int, valid_values: range::[${Int.MIN_VALUE}, ${Int.MAX_VALUE}]}}}",
         ListType(
             StaticType.unionOf(
-                IntType(
-                    IntType.IntRangeConstraint.INT4,
+                Int4Type(
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -1260,8 +1260,7 @@ internal fun sexpTests() = listOf(
     MapperE2ETestCase(
         "type::{ name: $typeName, type: sexp, element: {type: int, valid_values: range::[${Int.MIN_VALUE}, ${Int.MAX_VALUE}]} }",
         SexpType(
-            IntType(
-                IntType.IntRangeConstraint.INT4,
+            Int4Type(
                 metas = mapOf(
                     ISL_META_KEY to listOf(
                         buildTypeDef(
@@ -1289,8 +1288,7 @@ internal fun sexpTests() = listOf(
         "type::{ name: $typeName, type: sexp, element: {type: nullable::{type: int, valid_values: range::[${Int.MIN_VALUE}, ${Int.MAX_VALUE}]}}}",
         SexpType(
             StaticType.unionOf(
-                IntType(
-                    IntType.IntRangeConstraint.INT4,
+                Int4Type(
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -1716,8 +1714,7 @@ internal fun bagTests() = listOf(
     MapperE2ETestCase(
         "type::{ name: $typeName, type: bag, element: {type: int, valid_values: range::[${Int.MIN_VALUE}, ${Int.MAX_VALUE}]} }",
         BagType(
-            IntType(
-                IntType.IntRangeConstraint.INT4,
+            Int4Type(
                 metas = mapOf(
                     ISL_META_KEY to listOf(
                         buildTypeDef(
@@ -1745,8 +1742,7 @@ internal fun bagTests() = listOf(
         "type::{ name: $typeName, type: bag, element: {type: nullable::{type: int, valid_values: range::[${Int.MIN_VALUE}, ${Int.MAX_VALUE}]}}}",
         BagType(
             StaticType.unionOf(
-                IntType(
-                    IntType.IntRangeConstraint.INT4,
+                Int4Type(
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -2107,8 +2103,7 @@ internal fun structTests() = listOf(
         StructType(
             mapOf(
                 "a" to StaticType.unionOf(
-                    IntType(
-                        IntType.IntRangeConstraint.INT4,
+                    Int4Type(
                         metas = mapOf(
                             ISL_META_KEY to listOf(
                                 buildTypeDef(
@@ -2158,8 +2153,7 @@ internal fun structTests() = listOf(
         "type::{ name: $typeName, type: struct, fields: { a: {type: int, valid_values: range::[${Int.MIN_VALUE}, ${Int.MAX_VALUE}], occurs: required} } }",
         StructType(
             mapOf(
-                "a" to IntType(
-                    IntType.IntRangeConstraint.INT4,
+                "a" to Int4Type(
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -2278,8 +2272,7 @@ internal fun structTests() = listOf(
         StructType(
             mapOf(
                 "a" to StaticType.unionOf(
-                    IntType(
-                        IntType.IntRangeConstraint.INT4,
+                    Int4Type(
                         metas = mapOf(
                             ISL_META_KEY to listOf(
                                 buildTypeDef(
@@ -3970,8 +3963,7 @@ internal fun intTests() = listOf(
     MapperE2ETestCase(
         "type::{ name: $typeName, type: nullable::{type: int, valid_values: range::[${Long.MIN_VALUE},${Long.MAX_VALUE}]} }",
         StaticType.unionOf(
-            IntType(
-                IntType.IntRangeConstraint.LONG,
+            Int8Type(
                 metas = mapOf(
                     ISL_META_KEY to listOf(
                         buildTypeDef(


### PR DESCRIPTION
*Motivation:*
Currently, `IntType` in `StaticType.kt` has a specific property `rangeConstraint: IntRangeConstraint`. This will cause unnecessary extra work when we try to refactor existing PartiQL scalar types using exposed interface. Because exposed interfaces should be used for defining generic properties or behaviors of a type, and no type should have a specific property when we are pulling all the scalar types out of `org.pariql.lang` package. Thus, in this PR, we removed `rangeConstraint` in `IntType` and refactored the way to model integer types. 

*Description of changes:*
1. Now `INT2`, `INT4`, `INT8` & `INT` are modeled as unique kotlin data classes, instead of one data class with different constraints. 
2. Other changes are just to make compiling & test pass. 

*Note that this PR introduces backward incompatible changes*
