### PR TITLE
Make PlannerPipeline.Builder.plannerEventCallback public

### DIFF
--- a/lang/src/org/partiql/lang/planner/PlannerPipeline.kt
+++ b/lang/src/org/partiql/lang/planner/PlannerPipeline.kt
@@ -372,7 +372,7 @@ interface PlannerPipeline {
          * queries but no facility is provided by PartiQL to redact ASTs or plans yet.  Such redaction must currently
          * be provided by the embedding PartiQL application.
          */
-        internal fun plannerEventCallback(cb: PlannerEventCallback): Builder = this.apply {
+        fun plannerEventCallback(cb: PlannerEventCallback): Builder = this.apply {
             plannerEventCallback = cb
         }
 


### PR DESCRIPTION
This is a miss in previous commits.

*Description of changes:*

Just like the title says.  I just missed this from #681.

*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes? (y/n), If not, please explain why:*

No, because what's already discussed for planner event callbacks is adequate.

*Does your PR include any backward-incompatible changes? (y/n), if yes, please explain the reason. In addition, please
 also mention any other alternatives you've considered and the reason they've been discarded?:*

No.

*Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:*

No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
