### PR TITLE
Tests for SELECT * with graph query.

### DIFF
--- a/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
@@ -101,7 +101,8 @@ class SqlParserMatchTest : SqlParserTestBase() {
                             parts = listOf(
                                 node(
                                     prefilter = null,
-                                    variable = "x"
+                                    variable = "x",
+                                    label = listOf()
                                 )
                             )
                         )
@@ -125,7 +126,8 @@ class SqlParserMatchTest : SqlParserTestBase() {
                             parts = listOf(
                                 node(
                                     prefilter = null,
-                                    variable = "x"
+                                    variable = "x",
+                                    label = listOf()
                                 )
                             )
                         )

--- a/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
@@ -37,6 +37,31 @@ class SqlParserMatchTest : SqlParserTestBase() {
     }
 
     @Test
+    fun starAllNodesNoLabel() = assertExpressionNoRoundTrip(
+        "SELECT * FROM my_graph MATCH ()"
+    ) {
+        select(
+            project = projectStar(),
+            from = graphMatch(
+                expr = id("my_graph"),
+                graphExpr = graphMatchExpr(
+                    patterns = listOf(
+                        graphMatchPattern(
+                            parts = listOf(
+                                node(
+                                    prefilter = null,
+                                    variable = null,
+                                    label = listOf()
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
     fun allNodesNoLabelFilter() = assertExpressionNoRoundTrip(
         "SELECT 1 FROM my_graph MATCH () WHERE contains_value('1')",
     ) {
@@ -59,6 +84,54 @@ class SqlParserMatchTest : SqlParserTestBase() {
                 )
             ),
             where = call(funcName = "contains_value", args = listOf(lit(ionString("1"))))
+        )
+    }
+
+    @Test
+    fun bindAllNodesProjectBound() = assertExpressionNoRoundTrip(
+        "SELECT x FROM my_graph MATCH (x)"
+    ) {
+        select(
+            project = projectList(projectExpr(expr = id("x"))),
+            from = graphMatch(
+                expr = id("my_graph"),
+                graphExpr = graphMatchExpr(
+                    patterns = listOf(
+                        graphMatchPattern(
+                            parts = listOf(
+                                node(
+                                    prefilter = null,
+                                    variable = "x"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun bindAllNodesProjectStar() = assertExpressionNoRoundTrip(
+        "SELECT * FROM my_graph MATCH (x)"
+    ) {
+        select(
+            project = projectStar(),
+            from = graphMatch(
+                expr = id("my_graph"),
+                graphExpr = graphMatchExpr(
+                    patterns = listOf(
+                        graphMatchPattern(
+                            parts = listOf(
+                                node(
+                                    prefilter = null,
+                                    variable = "x"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
         )
     }
 


### PR DESCRIPTION
*Description of changes:*
Added a few tests to make sure that SELECT * parses with graph queries. 


*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes?*
No - this is a minor catch-up for the graph query work already described for the next release.

*Does your PR include any backward-incompatible changes?*
No


*Does your PR introduce a new external dependency?*
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
