### PR TITLE
Refactored StaticType.STRING

### DIFF
--- a/lang/src/org/partiql/lang/ast/passes/inference/StaticTypeExtensions.kt
+++ b/lang/src/org/partiql/lang/ast/passes/inference/StaticTypeExtensions.kt
@@ -5,6 +5,7 @@ import org.partiql.lang.types.AnyOfType
 import org.partiql.lang.types.AnyType
 import org.partiql.lang.types.BlobType
 import org.partiql.lang.types.BoolType
+import org.partiql.lang.types.CharType
 import org.partiql.lang.types.ClobType
 import org.partiql.lang.types.CollectionType
 import org.partiql.lang.types.DecimalType
@@ -18,12 +19,19 @@ import org.partiql.lang.types.StringType
 import org.partiql.lang.types.StructType
 import org.partiql.lang.types.SymbolType
 import org.partiql.lang.types.TimestampType
+import org.partiql.lang.types.VarcharType
 
 internal fun StaticType.isNullOrMissing(): Boolean = (this is NullType || this is MissingType)
 internal fun StaticType.isNumeric(): Boolean = (this is IntType || this is FloatType || this is DecimalType)
-internal fun StaticType.isText(): Boolean = (this is SymbolType || this is StringType)
+internal fun StaticType.isText(): Boolean = (this is SymbolType || this is StringType || this is VarcharType || this is CharType)
 internal fun StaticType.isLob(): Boolean = (this is BlobType || this is ClobType)
 internal fun StaticType.isUnknown(): Boolean = (this.isNullOrMissing() || this == StaticType.NULL_OR_MISSING)
+
+internal fun SingleType.getLength() = when (this) {
+    is CharType -> length
+    is VarcharType -> length
+    else -> error("Internal error: Only CHAR & VARCHAR type has length")
+}
 
 /**
  * Returns the maximum number of digits a decimal can hold after reserving digits for scale
@@ -193,7 +201,7 @@ internal fun StaticType.cast(targetType: StaticType): StaticType {
                     this is TimestampType -> return targetType
                     this.isText() -> return StaticType.unionOf(targetType, StaticType.MISSING)
                 }
-                is StringType, is SymbolType -> when {
+                is VarcharType, is CharType, is StringType, is SymbolType -> when {
                     this.isNumeric() || this.isText() -> return targetType
                     this is BoolType || this is TimestampType -> return targetType
                 }

--- a/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
@@ -18,6 +18,7 @@ import com.amazon.ion.IntegerSize
 import com.amazon.ion.IonInt
 import com.amazon.ion.Timestamp
 import org.partiql.lang.ast.SourceLocationMeta
+import org.partiql.lang.ast.passes.inference.getLength
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.errors.PropertyValueMap
@@ -28,6 +29,7 @@ import org.partiql.lang.syntax.DateTimePart
 import org.partiql.lang.types.BagType
 import org.partiql.lang.types.BlobType
 import org.partiql.lang.types.BoolType
+import org.partiql.lang.types.CharType
 import org.partiql.lang.types.ClobType
 import org.partiql.lang.types.DateType
 import org.partiql.lang.types.DecimalType
@@ -36,13 +38,13 @@ import org.partiql.lang.types.IntType
 import org.partiql.lang.types.ListType
 import org.partiql.lang.types.MissingType
 import org.partiql.lang.types.NullType
-import org.partiql.lang.types.NumberConstraint
 import org.partiql.lang.types.SexpType
 import org.partiql.lang.types.SingleType
 import org.partiql.lang.types.StringType
 import org.partiql.lang.types.SymbolType
 import org.partiql.lang.types.TimeType
 import org.partiql.lang.types.TimestampType
+import org.partiql.lang.types.VarcharType
 import org.partiql.lang.util.ConfigurableExprValueFormatter
 import org.partiql.lang.util.bigDecimalOf
 import org.partiql.lang.util.coerce
@@ -380,13 +382,16 @@ fun ExprValue.cast(
     }
 
     fun String.exprValue(type: SingleType) = when (type) {
+        is CharType,
+        is VarcharType,
         is StringType -> when (typedOpBehavior) {
             TypedOpBehavior.LEGACY -> valueFactory.newString(this)
-            TypedOpBehavior.HONOR_PARAMETERS -> when (type.lengthConstraint) {
-                StringType.StringLengthConstraint.Unconstrained -> valueFactory.newString(this)
-                is StringType.StringLengthConstraint.Constrained -> {
+            TypedOpBehavior.HONOR_PARAMETERS -> when (type) {
+                is StringType -> valueFactory.newString(this)
+                is CharType,
+                is VarcharType -> {
                     val actualCodepointCount = this.codePointCount(0, this.length)
-                    val lengthConstraint = type.lengthConstraint.length.value
+                    val lengthConstraint = type.getLength()
                     val truncatedString = if (actualCodepointCount <= lengthConstraint) {
                         this // no truncation needed
                     } else {
@@ -394,12 +399,14 @@ fun ExprValue.cast(
                     }
 
                     valueFactory.newString(
-                        when (type.lengthConstraint.length) {
-                            is NumberConstraint.Equals -> truncatedString.trimEnd { c -> c == '\u0020' }
-                            is NumberConstraint.UpTo -> truncatedString
+                        when (type) {
+                            is CharType -> truncatedString.trimEnd { c -> c == '\u0020' }
+                            is VarcharType -> truncatedString
+                            else -> error("Unreachable code")
                         }
                     )
                 }
+                else -> error("Unreachable code")
             }
         }
         is SymbolType -> valueFactory.newSymbol(this)
@@ -416,7 +423,7 @@ fun ExprValue.cast(
         type == targetType.runtimeType && type != ExprValueType.TIME -> {
             return when (targetType) {
                 is IntType, is FloatType, is DecimalType -> numberValue().exprValue(targetType)
-                is StringType -> stringValue().exprValue(targetType)
+                is CharType, is VarcharType, is StringType -> stringValue().exprValue(targetType)
                 else -> this
             }
         }
@@ -578,7 +585,7 @@ fun ExprValue.cast(
                         }
                     }
                 }
-                is StringType, is SymbolType -> when {
+                is CharType, is VarcharType, is StringType, is SymbolType -> when {
                     type.isNumber -> return numberValue().toString().exprValue(targetType)
                     type.isText -> return stringValue().exprValue(targetType)
                     type == ExprValueType.DATE -> return dateValue().toString().exprValue(targetType)

--- a/lang/src/org/partiql/lang/mappers/IonSchemaMapper.kt
+++ b/lang/src/org/partiql/lang/mappers/IonSchemaMapper.kt
@@ -8,6 +8,7 @@ import org.partiql.lang.types.AnyType
 import org.partiql.lang.types.BagType
 import org.partiql.lang.types.BlobType
 import org.partiql.lang.types.BoolType
+import org.partiql.lang.types.CharType
 import org.partiql.lang.types.ClobType
 import org.partiql.lang.types.DateType
 import org.partiql.lang.types.DecimalType
@@ -16,7 +17,6 @@ import org.partiql.lang.types.IntType
 import org.partiql.lang.types.ListType
 import org.partiql.lang.types.MissingType
 import org.partiql.lang.types.NullType
-import org.partiql.lang.types.NumberConstraint
 import org.partiql.lang.types.SexpType
 import org.partiql.lang.types.StaticType
 import org.partiql.lang.types.StringType
@@ -24,6 +24,7 @@ import org.partiql.lang.types.StructType
 import org.partiql.lang.types.SymbolType
 import org.partiql.lang.types.TimeType
 import org.partiql.lang.types.TimestampType
+import org.partiql.lang.types.VarcharType
 
 internal const val ISL_META_KEY = "ISL"
 
@@ -250,27 +251,32 @@ class IonSchemaMapper(private val staticType: StaticType) {
         } ?: listOf()
 
         return when (this) {
+            is CharType,
+            is VarcharType,
             is StringType -> listOfNotNull(
-                when (val lengthConstraint = this.lengthConstraint) {
-                    StringType.StringLengthConstraint.Unconstrained -> null
-                    is StringType.StringLengthConstraint.Constrained -> {
+                when (this) {
+                    is StringType -> null
+                    is CharType,
+                    is VarcharType -> {
                         constraintsFromISL = constraintsFromISL.filterNot { it is IonSchemaModel.Constraint.CodepointLength }
-                        when (lengthConstraint.length) {
-                            is NumberConstraint.Equals -> IonSchemaModel.build {
-                                codepointLength(equalsNumber(ionInt(lengthConstraint.length.value.toLong())))
+                        when (this) {
+                            is CharType -> IonSchemaModel.build {
+                                codepointLength(equalsNumber(ionInt(length.toLong())))
                             }
-                            is NumberConstraint.UpTo -> IonSchemaModel.build {
+                            is VarcharType -> IonSchemaModel.build {
                                 codepointLength(
                                     equalsRange(
                                         numberRange(
                                             inclusive(ionInt(0)),
-                                            inclusive(ionInt(lengthConstraint.length.value.toLong()))
+                                            inclusive(ionInt(length.toLong()))
                                         )
                                     )
                                 )
                             }
+                            else -> error("Unreachable code")
                         }
                     }
+                    else -> error("Unreachable code")
                 }
             )
             is IntType -> {
@@ -533,6 +539,8 @@ fun StaticType.getBaseTypeName(): String = when (this) {
     is BoolType -> "bool"
     is TimestampType -> "timestamp"
     is SymbolType -> "symbol"
+    is CharType,
+    is VarcharType,
     is StringType -> "string"
     is BlobType -> "blob"
     is ClobType -> "clob"

--- a/lang/src/org/partiql/lang/types/PartiqlPhysicalTypeExtensions.kt
+++ b/lang/src/org/partiql/lang/types/PartiqlPhysicalTypeExtensions.kt
@@ -38,26 +38,13 @@ fun PartiqlPhysical.Type.toTypedOpParameter(customTypedOpParameters: Map<String,
         }
         BuiltInScalarTypeId.TIMESTAMP -> TypedOpParameter(StaticType.TIMESTAMP)
         BuiltInScalarTypeId.CHARACTER -> when (parameters.size) {
-            0 -> TypedOpParameter(
-                StringType(
-                    // TODO: See if we need to use unconstrained string instead
-                    StringType.StringLengthConstraint.Constrained(
-                        NumberConstraint.Equals(1)
-                    )
-                )
-            )
-            1 -> TypedOpParameter(
-                StringType(
-                    StringType.StringLengthConstraint.Constrained(
-                        NumberConstraint.Equals(parameters[0].value.toInt())
-                    )
-                )
-            )
+            0 -> TypedOpParameter(CharType(1)) // TODO: See if we need to use unconstrained string instead
+            1 -> TypedOpParameter(CharType(parameters[0].value.toInt()))
             else -> error("Internal Error: CHARACTER type must have 1 parameters during compiling")
         }
         BuiltInScalarTypeId.CHARACTER_VARYING -> when (parameters.size) {
-            0 -> TypedOpParameter(StringType(StringType.StringLengthConstraint.Unconstrained))
-            1 -> TypedOpParameter(StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(parameters[0].value.toInt()))))
+            0 -> TypedOpParameter(StaticType.STRING)
+            1 -> TypedOpParameter(VarcharType(parameters[0].value.toInt()))
             else -> error("Internal Error: CHARACTER_VARYING type must have 1 parameters during compiling")
         }
         BuiltInScalarTypeId.STRING -> TypedOpParameter(StaticType.STRING)

--- a/lang/test/org/partiql/lang/CustomTypeTestFixtures.kt
+++ b/lang/test/org/partiql/lang/CustomTypeTestFixtures.kt
@@ -4,11 +4,10 @@ import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueType
 import org.partiql.lang.eval.numberValue
 import org.partiql.lang.types.AnyOfType
+import org.partiql.lang.types.CharType
 import org.partiql.lang.types.CustomType
 import org.partiql.lang.types.IntType
-import org.partiql.lang.types.NumberConstraint
 import org.partiql.lang.types.StaticType
-import org.partiql.lang.types.StringType
 import org.partiql.lang.types.TypedOpParameter
 import org.partiql.lang.util.compareTo
 
@@ -71,9 +70,7 @@ private val rsIntegerPrecisionParameter = TypedOpParameter(IntType(IntType.IntRa
 private val rsBigintPrecisionParameter = TypedOpParameter(IntType(IntType.IntRangeConstraint.LONG))
 
 // RS_VARCHAR_MAX
-private val rsStringParameter = TypedOpParameter(
-    StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(10)))
-)
+private val rsStringParameter = TypedOpParameter(CharType(10))
 
 // RS_REAL
 private val rsRealParameter = TypedOpParameter(StaticType.FLOAT) {

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerCustomAnyOfTypeOperationTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerCustomAnyOfTypeOperationTests.kt
@@ -8,12 +8,11 @@ import org.partiql.lang.esAny
 import org.partiql.lang.types.BagType
 import org.partiql.lang.types.CustomType
 import org.partiql.lang.types.ListType
-import org.partiql.lang.types.NumberConstraint
 import org.partiql.lang.types.SexpType
 import org.partiql.lang.types.StaticType
-import org.partiql.lang.types.StringType
 import org.partiql.lang.types.StructType
 import org.partiql.lang.types.TypedOpParameter
+import org.partiql.lang.types.VarcharType
 import org.partiql.lang.util.ArgumentsProviderBase
 import org.partiql.lang.util.honorTypedOpParameters
 import org.partiql.lang.util.legacyTypingMode
@@ -263,7 +262,7 @@ class EvaluatingCompilerCustomAnyOfTypeOperationTests : CastTestBase() {
                     // duplicate types
                     anyOfType(
                         StaticType.STRING,
-                        StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(500)))
+                        VarcharType(500)
                     ),
                     anyOfType(
                         StaticType.INT,

--- a/lang/test/org/partiql/lang/eval/ThunkFactoryTests.kt
+++ b/lang/test/org/partiql/lang/eval/ThunkFactoryTests.kt
@@ -7,9 +7,8 @@ import org.partiql.lang.ION
 import org.partiql.lang.ast.StaticTypeMeta
 import org.partiql.lang.domains.metaContainerOf
 import org.partiql.lang.errors.ErrorCode
-import org.partiql.lang.types.NumberConstraint
 import org.partiql.lang.types.StaticType
-import org.partiql.lang.types.StringType
+import org.partiql.lang.types.VarcharType
 import kotlin.test.assertEquals
 
 /**
@@ -65,7 +64,7 @@ class ThunkFactoryTests {
 
             createTestCases(StaticType.STRING, INT_42000, true),
             createTestCases(
-                StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(20))),
+                VarcharType(20),
                 STRING_LONG,
                 true
             )

--- a/lang/test/org/partiql/lang/eval/builtins/InvalidArgTypeChecker.kt
+++ b/lang/test/org/partiql/lang/eval/builtins/InvalidArgTypeChecker.kt
@@ -7,6 +7,7 @@ import org.partiql.lang.eval.expectedArgTypeErrorMsg
 import org.partiql.lang.types.BagType
 import org.partiql.lang.types.BlobType
 import org.partiql.lang.types.BoolType
+import org.partiql.lang.types.CharType
 import org.partiql.lang.types.ClobType
 import org.partiql.lang.types.DateType
 import org.partiql.lang.types.DecimalType
@@ -23,6 +24,7 @@ import org.partiql.lang.types.StructType
 import org.partiql.lang.types.SymbolType
 import org.partiql.lang.types.TimeType
 import org.partiql.lang.types.TimestampType
+import org.partiql.lang.types.VarcharType
 import org.partiql.lang.util.propertyValueMapOf
 import java.lang.StringBuilder
 
@@ -47,6 +49,8 @@ private fun SingleType.getExample() = when (this) {
     is TimestampType -> "`2017T`"
     is TimeType -> "TIME '23:12:59.128'"
     is SymbolType -> "`a`"
+    is CharType,
+    is VarcharType,
     is StringType -> "'a'"
     is ClobType -> "`{{ \"HelloWorld\" }}`"
     is BlobType -> "`{{ aGVsbG8= }}`"

--- a/lang/test/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransformTest.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransformTest.kt
@@ -21,12 +21,12 @@ import org.partiql.lang.eval.numberValue
 import org.partiql.lang.types.AnyOfType
 import org.partiql.lang.types.BagType
 import org.partiql.lang.types.BoolType
+import org.partiql.lang.types.CharType
 import org.partiql.lang.types.CollectionType
 import org.partiql.lang.types.DecimalType
 import org.partiql.lang.types.FunctionSignature
 import org.partiql.lang.types.IntType
 import org.partiql.lang.types.ListType
-import org.partiql.lang.types.NumberConstraint
 import org.partiql.lang.types.SexpType
 import org.partiql.lang.types.StaticType
 import org.partiql.lang.types.StaticType.Companion.ALL_TYPES
@@ -50,10 +50,10 @@ import org.partiql.lang.types.StaticType.Companion.STRUCT
 import org.partiql.lang.types.StaticType.Companion.SYMBOL
 import org.partiql.lang.types.StaticType.Companion.TIMESTAMP
 import org.partiql.lang.types.StaticType.Companion.unionOf
-import org.partiql.lang.types.StringType
 import org.partiql.lang.types.StructType
 import org.partiql.lang.types.TypedOpParameter
 import org.partiql.lang.types.VarargFormalParameter
+import org.partiql.lang.types.VarcharType
 import org.partiql.lang.util.cartesianProduct
 import org.partiql.lang.util.compareTo
 import org.partiql.lang.util.countMatchingSubstrings
@@ -1826,39 +1826,39 @@ class StaticTypeInferenceVisitorTransformTest : VisitorTransformTestBase() {
             ),
             createNAryConcatTest(
                 name = "constrained string equals, unconstrained string",
-                leftType = StringType(NumberConstraint.Equals(4)),
+                leftType = CharType(4),
                 rightType = STRING,
                 expectedType = STRING
             ),
             createNAryConcatTest(
                 name = "constrained string up to, unconstrained string",
-                leftType = StringType(NumberConstraint.UpTo(4)),
+                leftType = CharType(4),
                 rightType = STRING,
                 expectedType = STRING
             ),
             createNAryConcatTest(
                 name = "constrained string equals 4, constrained string equals 6",
-                leftType = StringType(NumberConstraint.Equals(4)),
-                rightType = StringType(NumberConstraint.Equals(6)),
-                expectedType = StringType(NumberConstraint.Equals(10))
+                leftType = CharType(4),
+                rightType = CharType(6),
+                expectedType = CharType(10)
             ),
             createNAryConcatTest(
                 name = "constrained string equals 4, constrained string up to 6",
-                leftType = StringType(NumberConstraint.Equals(4)),
-                rightType = StringType(NumberConstraint.UpTo(6)),
-                expectedType = StringType(NumberConstraint.UpTo(10))
+                leftType = CharType(4),
+                rightType = VarcharType(6),
+                expectedType = VarcharType(10)
             ),
             createNAryConcatTest(
                 name = "constrained string up to 4, constrained string equals 6",
-                leftType = StringType(NumberConstraint.UpTo(4)),
-                rightType = StringType(NumberConstraint.Equals(6)),
-                expectedType = StringType(NumberConstraint.UpTo(10))
+                leftType = VarcharType(4),
+                rightType = CharType(6),
+                expectedType = VarcharType(10)
             ),
             createNAryConcatTest(
                 name = "constrained string up to 4, constrained string up to 6",
-                leftType = StringType(NumberConstraint.UpTo(4)),
-                rightType = StringType(NumberConstraint.UpTo(6)),
-                expectedType = StringType(NumberConstraint.UpTo(10))
+                leftType = VarcharType(4),
+                rightType = VarcharType(6),
+                expectedType = VarcharType(10)
             ),
             createNAryConcatTest(
                 name = "ANY, ANY",
@@ -1926,13 +1926,13 @@ class StaticTypeInferenceVisitorTransformTest : VisitorTransformTestBase() {
             } + listOf(
             createNAryConcatDataTypeMismatchTest(
                 name = "null or missing error - constrained string, null",
-                leftType = StringType(NumberConstraint.Equals(2)),
+                leftType = CharType(2),
                 rightType = NULL,
                 expectedProblems = listOf(createReturnsNullOrMissingError(col = 3, nAryOp = "||"))
             ),
             createNAryConcatDataTypeMismatchTest(
                 name = "null or missing error - constrained string, missing",
-                leftType = StringType(NumberConstraint.Equals(2)),
+                leftType = CharType(2),
                 rightType = MISSING,
                 expectedProblems = listOf(createReturnsNullOrMissingError(col = 3, nAryOp = "||"))
             ),
@@ -1946,7 +1946,7 @@ class StaticTypeInferenceVisitorTransformTest : VisitorTransformTestBase() {
             singleNAryOpMismatchWithSwappedCases(
                 name = "data type mismatch - constrained string, int",
                 op = "||",
-                leftType = StringType(NumberConstraint.Equals(2)),
+                leftType = CharType(2),
                 rightType = INT
             ) +
             singleNAryOpMismatchWithSwappedCases(
@@ -4707,61 +4707,31 @@ class StaticTypeInferenceVisitorTransformTest : VisitorTransformTestBase() {
                 name = "CAST to VARCHAR",
                 originalSql = "CAST(a_string AS VARCHAR)",
                 globals = mapOf("a_string" to STRING),
-                handler = expectQueryOutputType(StringType(StringType.StringLengthConstraint.Unconstrained))
+                handler = expectQueryOutputType(STRING)
             ),
             TestCase(
                 name = "CAST to VARCHAR(x)",
                 originalSql = "CAST(a_string AS VARCHAR(10))",
                 globals = mapOf(
-                    "a_string" to StringType(
-                        StringType.StringLengthConstraint.Constrained(
-                            NumberConstraint.UpTo(10)
-                        )
-                    )
+                    "a_string" to VarcharType(10)
                 ),
-                handler = expectQueryOutputType(
-                    StringType(
-                        StringType.StringLengthConstraint.Constrained(
-                            NumberConstraint.UpTo(10)
-                        )
-                    )
-                )
+                handler = expectQueryOutputType(VarcharType(10))
             ),
             TestCase(
                 name = "CAST to CHAR",
                 originalSql = "CAST(a_string AS CHAR)",
                 globals = mapOf(
-                    "a_string" to StringType(
-                        StringType.StringLengthConstraint.Constrained(
-                            NumberConstraint.Equals(1)
-                        )
-                    )
+                    "a_string" to CharType(1)
                 ),
-                handler = expectQueryOutputType(
-                    StringType(
-                        StringType.StringLengthConstraint.Constrained(
-                            NumberConstraint.Equals(1)
-                        )
-                    )
-                )
+                handler = expectQueryOutputType(CharType(1))
             ),
             TestCase(
                 name = "CAST to CHAR(x)",
                 originalSql = "CAST(a_string AS CHAR(10))",
                 globals = mapOf(
-                    "a_string" to StringType(
-                        StringType.StringLengthConstraint.Constrained(
-                            NumberConstraint.Equals(10)
-                        )
-                    )
+                    "a_string" to CharType(10)
                 ),
-                handler = expectQueryOutputType(
-                    StringType(
-                        StringType.StringLengthConstraint.Constrained(
-                            NumberConstraint.Equals(10)
-                        )
-                    )
-                )
+                handler = expectQueryOutputType(CharType(10))
             ),
             TestCase(
                 name = "CAST to DECIMAL",

--- a/lang/test/org/partiql/lang/mappers/E2EMapperTests.kt
+++ b/lang/test/org/partiql/lang/mappers/E2EMapperTests.kt
@@ -16,18 +16,19 @@ import org.partiql.lang.types.AnyType
 import org.partiql.lang.types.BagType
 import org.partiql.lang.types.BlobType
 import org.partiql.lang.types.BoolType
+import org.partiql.lang.types.CharType
 import org.partiql.lang.types.ClobType
 import org.partiql.lang.types.DecimalType
 import org.partiql.lang.types.FloatType
 import org.partiql.lang.types.IntType
 import org.partiql.lang.types.ListType
-import org.partiql.lang.types.NumberConstraint
 import org.partiql.lang.types.SexpType
 import org.partiql.lang.types.StaticType
 import org.partiql.lang.types.StringType
 import org.partiql.lang.types.StructType
 import org.partiql.lang.types.SymbolType
 import org.partiql.lang.types.TimestampType
+import org.partiql.lang.types.VarcharType
 import org.partiql.pig.runtime.toIonElement
 
 internal fun buildTypeDef(name: String? = null, vararg constraints: IonSchemaModel.Constraint) =
@@ -707,8 +708,8 @@ internal fun listTests() = listOf(
     MapperE2ETestCase(
         "type::{ name: $typeName, type: list, element: {type: string, codepoint_length: 5} }",
         ListType(
-            StringType(
-                StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)),
+            CharType(
+                5,
                 metas = mapOf(
                     ISL_META_KEY to listOf(
                         buildTypeDef(
@@ -726,8 +727,8 @@ internal fun listTests() = listOf(
         "type::{ name: $typeName, type: list, element: {type: nullable::{type: string, codepoint_length:5}}}",
         ListType(
             StaticType.unionOf(
-                StringType(
-                    StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)),
+                CharType(
+                    5,
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -769,7 +770,6 @@ internal fun listTests() = listOf(
         "type::{ name: $typeName, type: list, element: {type: string, codepoint_length: range::[1, 2048]} }",
         ListType(
             StringType(
-                StringType.StringLengthConstraint.Unconstrained,
                 metas = mapOf(
                     ISL_META_KEY to listOf(
                         buildTypeDef(
@@ -963,8 +963,8 @@ internal fun listTests() = listOf(
         ListType(
             StaticType.unionOf(
                 StaticType.NULL,
-                StringType(
-                    StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)),
+                CharType(
+                    5,
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -1163,8 +1163,8 @@ internal fun sexpTests() = listOf(
     MapperE2ETestCase(
         "type::{ name: $typeName, type: sexp, element: {type: string, codepoint_length: 5} }",
         SexpType(
-            StringType(
-                StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)),
+            CharType(
+                5,
                 metas = mapOf(
                     ISL_META_KEY to listOf(
                         buildTypeDef(
@@ -1182,8 +1182,8 @@ internal fun sexpTests() = listOf(
         "type::{ name: $typeName, type: sexp, element: {type: nullable::{type: string, codepoint_length:5}}}",
         SexpType(
             StaticType.unionOf(
-                StringType(
-                    StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)),
+                CharType(
+                    5,
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -1225,7 +1225,6 @@ internal fun sexpTests() = listOf(
         "type::{ name: $typeName, type: sexp, element: {type: string, codepoint_length: range::[1, 2048]} }",
         SexpType(
             StringType(
-                StringType.StringLengthConstraint.Unconstrained,
                 metas = mapOf(
                     ISL_META_KEY to listOf(
                         buildTypeDef(
@@ -1419,8 +1418,8 @@ internal fun sexpTests() = listOf(
         SexpType(
             StaticType.unionOf(
                 StaticType.NULL,
-                StringType(
-                    StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)),
+                CharType(
+                    5,
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -1619,8 +1618,8 @@ internal fun bagTests() = listOf(
     MapperE2ETestCase(
         "type::{ name: $typeName, type: bag, element: {type: string, codepoint_length: 5} }",
         BagType(
-            StringType(
-                StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)),
+            CharType(
+                5,
                 metas = mapOf(
                     ISL_META_KEY to listOf(
                         buildTypeDef(
@@ -1638,8 +1637,8 @@ internal fun bagTests() = listOf(
         "type::{ name: $typeName, type: bag, element: {type: nullable::{type: string, codepoint_length:5}}}",
         BagType(
             StaticType.unionOf(
-                StringType(
-                    StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)),
+                CharType(
+                    5,
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -1681,7 +1680,6 @@ internal fun bagTests() = listOf(
         "type::{ name: $typeName, type: bag, element: {type: string, codepoint_length: range::[1, 2048]} }",
         BagType(
             StringType(
-                StringType.StringLengthConstraint.Unconstrained,
                 metas = mapOf(
                     ISL_META_KEY to listOf(
                         buildTypeDef(
@@ -2076,8 +2074,8 @@ internal fun structTests() = listOf(
         StructType(
             mapOf(
                 "a" to StaticType.unionOf(
-                    StringType(
-                        StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(5)),
+                    VarcharType(
+                        5,
                         metas = mapOf(
                             ISL_META_KEY to listOf(
                                 buildTypeDef(
@@ -2138,8 +2136,8 @@ internal fun structTests() = listOf(
         "type::{ name: $typeName, type: struct, fields: { a: {type: string, codepoint_length: range::[0, 5], occurs: required} } }",
         StructType(
             mapOf(
-                "a" to StringType(
-                    StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(5)),
+                "a" to VarcharType(
+                    5,
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -2180,8 +2178,8 @@ internal fun structTests() = listOf(
         StructType(
             mapOf(
                 "a" to StaticType.unionOf(
-                    StringType(
-                        StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(5)),
+                    VarcharType(
+                        5,
                         metas = mapOf(
                             ISL_META_KEY to listOf(
                                 buildTypeDef(
@@ -2213,7 +2211,6 @@ internal fun structTests() = listOf(
             mapOf(
                 "a" to StaticType.unionOf(
                     StringType(
-                        StringType.StringLengthConstraint.Unconstrained,
                         metas = mapOf(
                             ISL_META_KEY to listOf(
                                 buildTypeDef(
@@ -2998,8 +2995,8 @@ internal fun bagWithCustomElementTests() = listOf(
         BagType(
             StaticType.unionOf(
                 StaticType.NULL,
-                StringType(
-                    StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)),
+                CharType(
+                    5,
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -3616,8 +3613,8 @@ internal fun structWithCustomFieldTests() = listOf(
         StructType(
             mapOf(
                 "a" to StaticType.unionOf(
-                    StringType(
-                        StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)),
+                    CharType(
+                        5,
                         metas = mapOf(
                             ISL_META_KEY to listOf(
                                 buildTypeDef(
@@ -3651,7 +3648,8 @@ internal fun structWithCustomFieldTests() = listOf(
         """,
         StructType(
             mapOf(
-                "a" to StringType(
+                "a" to CharType(
+                    5,
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -3664,7 +3662,11 @@ internal fun structWithCustomFieldTests() = listOf(
                     )
                 )
             )
-        )
+        ),
+        """
+            type::{ name: bar, type: string, codepoint_length: 5, utf8_byte_length: 5 }
+            type::{ name: $typeName, type: struct, fields: { a: { type: bar, codepoint_length: 5, occurs: required } } }
+        """
     ),
     // nullable, required field, custom type with constraints
     MapperE2ETestCase(
@@ -3675,8 +3677,8 @@ internal fun structWithCustomFieldTests() = listOf(
         StructType(
             mapOf(
                 "a" to StaticType.unionOf(
-                    StringType(
-                        StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)),
+                    CharType(
+                        5,
                         metas = mapOf(
                             ISL_META_KEY to listOf(
                                 buildTypeDef(
@@ -3863,17 +3865,17 @@ internal fun structWithCustomFieldTests() = listOf(
 internal fun stringTests() = listOf(
     MapperE2ETestCase(
         "type::{ name: $typeName, type: string }",
-        StringType(StringType.StringLengthConstraint.Unconstrained)
+        StaticType.STRING
     ),
     MapperE2ETestCase(
         "type::{ name: $typeName, type: string, codepoint_length: 5 }",
-        StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)))
+        CharType(5)
     ),
     MapperE2ETestCase(
         "type::{ name: $typeName, type: nullable::{type: string, codepoint_length: 5} }",
         StaticType.unionOf(
-            StringType(
-                StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(5)),
+            CharType(
+                5,
                 metas = mapOf(
                     ISL_META_KEY to listOf(
                         buildTypeDef(
@@ -3889,7 +3891,7 @@ internal fun stringTests() = listOf(
     ),
     MapperE2ETestCase(
         "type::{ name: $typeName, type: string, codepoint_length: range::[0, 5] }",
-        StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(5)))
+        VarcharType(5)
     ),
     // nullable string with constraints
     MapperE2ETestCase(
@@ -3897,8 +3899,8 @@ internal fun stringTests() = listOf(
         AnyOfType(
             setOf(
                 StaticType.NULL,
-                StringType(
-                    StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(5)),
+                VarcharType(
+                    5,
                     metas = mapOf(
                         ISL_META_KEY to listOf(
                             buildTypeDef(
@@ -3914,28 +3916,27 @@ internal fun stringTests() = listOf(
     ),
     MapperE2ETestCase(
         "type::{ name: $typeName, type: string, codepoint_length: range::[exclusive::-1, 5] }",
-        StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(5))),
+        VarcharType(5),
         "type::{ name: $typeName, type: string, codepoint_length: range::[0, 5] }"
     ),
     MapperE2ETestCase(
         "type::{ name: $typeName, type: string, codepoint_length: range::[0, exclusive::5] }",
-        StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(4))),
+        VarcharType(4),
         "type::{ name: $typeName, type: string, codepoint_length: range::[0, 4] }"
     ),
     MapperE2ETestCase(
         "type::{ name: $typeName, type: string, codepoint_length: range::[min, 5] }",
-        StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(5))),
+        VarcharType(5),
         "type::{ name: $typeName, type: string, codepoint_length: range::[0, 5] }"
     ),
     MapperE2ETestCase(
         "type::{ name: $typeName, type: string, codepoint_length: range::[min, max] }",
-        StringType(StringType.StringLengthConstraint.Unconstrained),
+        StaticType.STRING,
         "type::{ name: $typeName, type: string }"
     ),
     MapperE2ETestCase(
         "type::{ name: $typeName, type: string, codepoint_length: range::[1, 2048] }",
         StringType(
-            StringType.StringLengthConstraint.Unconstrained,
             metas = mapOf(
                 ISL_META_KEY to listOf(
                     buildTypeDef(


### PR DESCRIPTION
*Description of changes:*
Similar to https://github.com/partiql/partiql-lang-kotlin/pull/693, `Varchar`, `Char` & `String` types currently in partiql are modeled using the same kotlin data class with with different constraints of `StringLengthConstraint`. We need to refactor them so they are modeled using different kotlin data classes with similar properties, just as how other common types are modeled, before we start the work of rewriting all the static scalar types by exposed interfaces. 