### PR TITLE
Split compilation pipeline reponsibilities

### DIFF
--- a/cli/src/org/partiql/cli/main.kt
+++ b/cli/src/org/partiql/cli/main.kt
@@ -195,8 +195,8 @@ fun main(args: Array<String>) = try {
     // Parser Options
     val parser = when (optionSet.valueOf(parserOpt)) {
         ParserImplementation.LEGACY -> SqlParser(ion)
-        ParserImplementation.STANDARD -> PartiQLParserBuilder().withIonSystem(ion).build()
-        else -> PartiQLParserBuilder().withIonSystem(ion).build()
+        ParserImplementation.STANDARD -> PartiQLParserBuilder().ionSystem(ion).build()
+        else -> PartiQLParserBuilder().ionSystem(ion).build()
     }
 
     // Compile Options

--- a/lang/src/org/partiql/lang/compiler/PartiQLCompiler.kt
+++ b/lang/src/org/partiql/lang/compiler/PartiQLCompiler.kt
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
 package org.partiql.lang.compiler
 
 import org.partiql.lang.domains.PartiqlPhysical

--- a/lang/src/org/partiql/lang/compiler/PartiQLCompiler.kt
+++ b/lang/src/org/partiql/lang/compiler/PartiQLCompiler.kt
@@ -3,7 +3,13 @@ package org.partiql.lang.compiler
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.eval.PartiQLStatement
 
+/**
+ * [PartiQLCompiler] is responsible for transforming a [PartiqlPhysical.Plan] into an executable [PartiQLStatement].
+ */
 interface PartiQLCompiler {
 
+    /**
+     * Compiles the [PartiqlPhysical.Plan] to an executable [PartiQLStatement].
+     */
     fun compile(statement: PartiqlPhysical.Plan): PartiQLStatement
 }

--- a/lang/src/org/partiql/lang/compiler/PartiQLCompiler.kt
+++ b/lang/src/org/partiql/lang/compiler/PartiQLCompiler.kt
@@ -1,0 +1,9 @@
+package org.partiql.lang.compiler
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.PartiQLStatement
+
+interface PartiQLCompiler {
+
+    fun compile(statement: PartiqlPhysical.Plan): PartiQLStatement
+}

--- a/lang/src/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
+++ b/lang/src/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
@@ -1,0 +1,98 @@
+package org.partiql.lang.compiler
+
+import com.amazon.ion.IonSystem
+import org.partiql.lang.eval.ExprFunction
+import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.ThunkReturnTypeAssertions
+import org.partiql.lang.eval.builtins.DynamicLookupExprFunction
+import org.partiql.lang.eval.builtins.createBuiltinFunctions
+import org.partiql.lang.eval.builtins.storedprocedure.StoredProcedure
+import org.partiql.lang.eval.physical.operators.DEFAULT_RELATIONAL_OPERATOR_FACTORIES
+import org.partiql.lang.eval.physical.operators.RelationalOperatorFactory
+import org.partiql.lang.planner.EvaluatorOptions
+import org.partiql.lang.types.CustomType
+import org.partiql.lang.types.TypedOpParameter
+
+class PartiQLCompilerBuilder(val ion: IonSystem) {
+
+    private var valueFactory: ExprValueFactory = ExprValueFactory.standard(ion)
+    private var options: EvaluatorOptions = EvaluatorOptions.standard()
+    private var customTypes: List<CustomType> = mutableListOf()
+    private val customFunctions: MutableList<ExprFunction> = mutableListOf()
+    private val customProcedures: MutableMap<String, StoredProcedure> = mutableMapOf()
+    private val customOperatorFactories: MutableList<RelationalOperatorFactory> = mutableListOf()
+
+    companion object {
+
+        @JvmStatic
+        fun standard(ion: IonSystem) = PartiQLCompilerBuilder(ion)
+    }
+
+    fun build(): PartiQLCompiler {
+        if (options.thunkOptions.thunkReturnTypeAssertions == ThunkReturnTypeAssertions.ENABLED) {
+            TODO("ThunkReturnTypeAssertions.ENABLED requires a static type pass")
+        }
+        return PartiQLCompilerImpl(
+            valueFactory = valueFactory,
+            evaluatorOptions = options,
+            customTypedOpParameters = customTypes.toMap(),
+            functions = allFunctions(),
+            procedures = customProcedures,
+            operatorFactories = allOperatorFactories()
+        )
+    }
+
+    fun options(evaluatorOptions: EvaluatorOptions) = this.apply {
+        options = evaluatorOptions
+    }
+
+    /**
+     * This will be replaced by the open type system.
+     * https://github.com/partiql/partiql-lang-kotlin/milestone/4
+     */
+    internal fun addFunction(function: ExprFunction) = this.apply {
+        customFunctions.add(function)
+    }
+
+    /**
+     * This will be replaced by the open type system.
+     * https://github.com/partiql/partiql-lang-kotlin/milestone/4
+     */
+    internal fun customDataTypes(types: List<CustomType>) = this.apply {
+        customTypes = types
+    }
+
+    /**
+     * This will be replaced by the open type system.
+     * https://github.com/partiql/partiql-lang-kotlin/milestone/4
+     */
+    internal fun addProcedure(procedure: StoredProcedure) = this.apply {
+        customProcedures[procedure.signature.name] = procedure
+    }
+
+    internal fun addOperatorFactory(operator: RelationalOperatorFactory) = this.apply {
+        customOperatorFactories.add(operator)
+    }
+
+    // --- Internal ----------------------------------
+
+    // To be replaced by OTS — https://media.giphy.com/media/3o6Zt3l22wlJ0HLpUk/giphy.gif
+    private fun allFunctions(): Map<String, ExprFunction> {
+        val builtins = createBuiltinFunctions(valueFactory)
+        val allFunctions = builtins + customFunctions + DynamicLookupExprFunction()
+        return allFunctions.associateBy { it.signature.name }
+    }
+
+    private fun List<CustomType>.toMap(): Map<String, TypedOpParameter> = this.associateBy(
+        keySelector = { it.name },
+        valueTransform = { it.typedOpParameter }
+    )
+
+    private fun allOperatorFactories() = (DEFAULT_RELATIONAL_OPERATOR_FACTORIES + customOperatorFactories).apply {
+        groupBy { it.key }.entries.firstOrNull { it.value.size > 1 }?.let {
+            error(
+                "More than one BindingsOperatorFactory for ${it.key.operator} named '${it.value}' was specified."
+            )
+        }
+    }.associateBy { it.key }
+}

--- a/lang/src/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
+++ b/lang/src/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
 package org.partiql.lang.compiler
 
 import com.amazon.ion.IonSystem
@@ -24,8 +38,8 @@ import org.partiql.lang.types.CustomType
  *
  * // Fluent builder
  * val compiler = PartiQLCompilerBuilder.standard()
- *                                      .withIonSystem(myIonSystem)
- *                                      .withCustomFunctions(myCustomFunctionList)
+ *                                      .ionSystem(myIonSystem)
+ *                                      .customFunctions(myCustomFunctionList)
  *                                      .build()
  * ```
  */
@@ -66,11 +80,11 @@ class PartiQLCompilerBuilder private constructor() {
         )
     }
 
-    fun withIonSystem(ion: IonSystem): PartiQLCompilerBuilder = this.apply {
+    fun ionSystem(ion: IonSystem): PartiQLCompilerBuilder = this.apply {
         this.valueFactory = ExprValueFactory.standard(ion)
     }
 
-    fun withOptions(options: EvaluatorOptions) = this.apply {
+    fun options(options: EvaluatorOptions) = this.apply {
         this.options = options
     }
 
@@ -78,7 +92,7 @@ class PartiQLCompilerBuilder private constructor() {
      * TODO This will be replaced by the open type system.
      *  - https://github.com/partiql/partiql-lang-kotlin/milestone/4
      */
-    internal fun withCustomFunctions(customFunctions: List<ExprFunction>) = this.apply {
+    internal fun customFunctions(customFunctions: List<ExprFunction>) = this.apply {
         this.customFunctions = customFunctions
     }
 
@@ -86,7 +100,7 @@ class PartiQLCompilerBuilder private constructor() {
      * TODO This will be replaced by the open type system.
      *  - https://github.com/partiql/partiql-lang-kotlin/milestone/4
      */
-    internal fun withCustomTypes(customTypes: List<CustomType>) = this.apply {
+    internal fun customTypes(customTypes: List<CustomType>) = this.apply {
         this.customTypes = customTypes
     }
 
@@ -94,11 +108,11 @@ class PartiQLCompilerBuilder private constructor() {
      * TODO This will be replaced by the open type system.
      *  - https://github.com/partiql/partiql-lang-kotlin/milestone/4
      */
-    internal fun withCustomProcedures(customProcedures: List<StoredProcedure>) = this.apply {
+    internal fun customProcedures(customProcedures: List<StoredProcedure>) = this.apply {
         this.customProcedures = customProcedures
     }
 
-    internal fun withCustomOperatorFactories(customOperatorFactories: List<RelationalOperatorFactory>) = this.apply {
+    internal fun customOperatorFactories(customOperatorFactories: List<RelationalOperatorFactory>) = this.apply {
         this.customOperatorFactories = customOperatorFactories
     }
 

--- a/lang/src/org/partiql/lang/compiler/PartiQLCompilerDefault.kt
+++ b/lang/src/org/partiql/lang/compiler/PartiQLCompilerDefault.kt
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
 package org.partiql.lang.compiler
 
 import org.partiql.lang.domains.PartiqlPhysical

--- a/lang/src/org/partiql/lang/compiler/PartiQLCompilerDefault.kt
+++ b/lang/src/org/partiql/lang/compiler/PartiQLCompilerDefault.kt
@@ -24,7 +24,7 @@ import org.partiql.lang.planner.DmlAction
 import org.partiql.lang.planner.EvaluatorOptions
 import org.partiql.lang.types.TypedOpParameter
 
-internal class PartiQLCompilerImpl(
+internal class PartiQLCompilerDefault(
     private val valueFactory: ExprValueFactory,
     private val evaluatorOptions: EvaluatorOptions,
     private val customTypedOpParameters: Map<String, TypedOpParameter>,

--- a/lang/src/org/partiql/lang/compiler/PartiQLCompilerImpl.kt
+++ b/lang/src/org/partiql/lang/compiler/PartiQLCompilerImpl.kt
@@ -1,0 +1,106 @@
+package org.partiql.lang.compiler
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.BindingCase
+import org.partiql.lang.eval.BindingName
+import org.partiql.lang.eval.Bindings
+import org.partiql.lang.eval.ExprFunction
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.Expression
+import org.partiql.lang.eval.PartiQLResult
+import org.partiql.lang.eval.PartiQLStatement
+import org.partiql.lang.eval.builtins.storedprocedure.StoredProcedure
+import org.partiql.lang.eval.physical.PhysicalBexprToThunkConverter
+import org.partiql.lang.eval.physical.PhysicalExprToThunkConverter
+import org.partiql.lang.eval.physical.PhysicalExprToThunkConverterImpl
+import org.partiql.lang.eval.physical.PhysicalPlanThunk
+import org.partiql.lang.eval.physical.operators.RelationalOperatorFactory
+import org.partiql.lang.eval.physical.operators.RelationalOperatorFactoryKey
+import org.partiql.lang.planner.DML_COMMAND_FIELD_ACTION
+import org.partiql.lang.planner.DML_COMMAND_FIELD_ROWS
+import org.partiql.lang.planner.DML_COMMAND_FIELD_TARGET_UNIQUE_ID
+import org.partiql.lang.planner.DmlAction
+import org.partiql.lang.planner.EvaluatorOptions
+import org.partiql.lang.types.TypedOpParameter
+
+internal class PartiQLCompilerImpl(
+    private val valueFactory: ExprValueFactory,
+    private val evaluatorOptions: EvaluatorOptions,
+    private val customTypedOpParameters: Map<String, TypedOpParameter>,
+    private val functions: Map<String, ExprFunction>,
+    private val procedures: Map<String, StoredProcedure>,
+    private val operatorFactories: Map<RelationalOperatorFactoryKey, RelationalOperatorFactory>
+) : PartiQLCompiler {
+
+    private lateinit var exprConverter: PhysicalExprToThunkConverterImpl
+    private val bexprConverter = PhysicalBexprToThunkConverter(
+        valueFactory = this.valueFactory,
+        exprConverter = object : PhysicalExprToThunkConverter {
+            override fun convert(expr: PartiqlPhysical.Expr): PhysicalPlanThunk = exprConverter.convert(expr)
+        },
+        relationalOperatorFactory = operatorFactories
+    )
+
+    init {
+        exprConverter = PhysicalExprToThunkConverterImpl(
+            valueFactory = valueFactory,
+            functions = functions,
+            customTypedOpParameters = customTypedOpParameters,
+            procedures = procedures,
+            evaluatorOptions = evaluatorOptions,
+            bexperConverter = bexprConverter
+        )
+    }
+
+    override fun compile(statement: PartiqlPhysical.Plan): PartiQLStatement {
+        val expression = exprConverter.compile(statement)
+        return when (statement.stmt) {
+            is PartiqlPhysical.Statement.DmlQuery -> PartiQLStatement { expression.eval(it).toDML() }
+            is PartiqlPhysical.Statement.Exec,
+            is PartiqlPhysical.Statement.Query -> PartiQLStatement { expression.eval(it).toValue() }
+        }
+    }
+
+    // --- INTERNAL -------------------
+
+    /**
+     * The physical expr converter is EvaluatingCompiler with s/Ast/Physical and `bindingsToValues -> Thunk`
+     *   so it returns the [Expression] rather than a [PartiQLStatement]. This method parses a DML Command from the result.
+     *
+     * {
+     *     'action': <action>,
+     *     'target_unique_id': <unique_id>
+     *     'rows': <rows>
+     * }
+     *
+     * Later refactors will rework the Compiler to use [PartiQLStatement], but this is an acceptable workaround for now.
+     */
+    private fun ExprValue.toDML(): PartiQLResult {
+        val action = bindings string DML_COMMAND_FIELD_ACTION
+        val target = bindings string DML_COMMAND_FIELD_TARGET_UNIQUE_ID
+        val rows = bindings seq DML_COMMAND_FIELD_ROWS
+        return when (DmlAction.safeValueOf(action)) {
+            DmlAction.INSERT -> PartiQLResult.Insert(target, rows)
+            DmlAction.DELETE -> PartiQLResult.Delete(target, rows)
+            null -> error("Unknown DML Action `$action`")
+        }
+    }
+
+    private fun ExprValue.toValue(): PartiQLResult = PartiQLResult.Value(this)
+
+    private infix fun Bindings<ExprValue>.string(field: String): String {
+        return this[BindingName(field, BindingCase.SENSITIVE)]?.scalar?.stringValue() ?: missing(field)
+    }
+
+    private infix fun Bindings<ExprValue>.seq(field: String): Iterable<ExprValue> {
+        val v = this[BindingName(field, BindingCase.SENSITIVE)] ?: missing(field)
+        if (!v.type.isSequence) {
+            error("DML command struct '$DML_COMMAND_FIELD_ROWS' field must be a bag or list")
+        }
+        return v.asIterable()
+    }
+
+    private fun missing(field: String): Nothing =
+        error("Field `$field` missing from DML command struct or has incorrect Ion type")
+}

--- a/lang/src/org/partiql/lang/compiler/PartiQLCompilerPipeline.kt
+++ b/lang/src/org/partiql/lang/compiler/PartiQLCompilerPipeline.kt
@@ -1,0 +1,59 @@
+package org.partiql.lang.compiler
+
+import com.amazon.ion.IonSystem
+import com.amazon.ion.system.IonSystemBuilder
+import org.partiql.lang.CompilerPipeline
+import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.errors.PartiQLException
+import org.partiql.lang.eval.PartiQLStatement
+import org.partiql.lang.planner.PartiQLPlanner
+import org.partiql.lang.planner.PartiQLPlannerBuilder
+import org.partiql.lang.syntax.Parser
+import org.partiql.lang.syntax.SqlParser
+
+class PartiQLCompilerPipeline(
+    private val parser: Parser,
+    private val planner: PartiQLPlanner,
+    private val compiler: PartiQLCompiler
+) {
+
+    companion object {
+
+        private val ION_STANDARD = IonSystemBuilder.standard().build()
+
+        @Deprecated(
+            message = "To be removed in 1.0 release",
+            replaceWith = ReplaceWith("standard"),
+            level = DeprecationLevel.WARNING
+        )
+        @JvmStatic
+        fun legacy(ion: IonSystem = ION_STANDARD): CompilerPipeline.Builder = CompilerPipeline.builder(ion)
+
+        @JvmStatic
+        fun standard(ion: IonSystem = ION_STANDARD) = PartiQLCompilerPipeline(
+            parser = SqlParser(ion),
+            planner = PartiQLPlannerBuilder.standard(ion).build(),
+            compiler = PartiQLCompilerBuilder.standard(ion).build()
+        )
+    }
+
+    fun compile(statement: String): PartiQLStatement {
+        val ast = parser.parseAstStatement(statement)
+        return compile(ast)
+    }
+
+    fun compile(statement: PartiqlAst.Statement): PartiQLStatement {
+        val result = planner.plan(statement)
+        // error handling is likely to be refactored after design review with the PartiQL team
+        if (result is PartiQLPlanner.Result.Error) {
+            throw PartiQLException(result.problems.toString())
+        }
+        val plan = (result as PartiQLPlanner.Result.Success).plan
+        return compile(plan)
+    }
+
+    fun compile(statement: PartiqlPhysical.Plan): PartiQLStatement {
+        return compiler.compile(statement)
+    }
+}

--- a/lang/src/org/partiql/lang/compiler/PartiQLCompilerPipeline.kt
+++ b/lang/src/org/partiql/lang/compiler/PartiQLCompilerPipeline.kt
@@ -1,8 +1,6 @@
 package org.partiql.lang.compiler
 
-import com.amazon.ion.IonSystem
 import com.amazon.ion.system.IonSystemBuilder
-import org.partiql.lang.CompilerPipeline
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.errors.PartiQLException
@@ -12,7 +10,24 @@ import org.partiql.lang.planner.PartiQLPlannerBuilder
 import org.partiql.lang.syntax.Parser
 import org.partiql.lang.syntax.SqlParser
 
-class PartiQLCompilerPipeline(
+/**
+ * [PartiQLCompilerPipeline] is the top-level class for embedded usage of PartiQL.
+ *
+ * Example usage:
+ * ```
+ * val pipeline = PartiQLCompilerPipeline.standard()
+ * val session = // session bindings
+ * val statement = pipeline.compile("-- some PartiQL query!")
+ * val result = statement.eval(session)
+ * when (result) {
+ *   is PartiQLResult.Value -> handle(result)  // Query Result
+ *   is PartiQLResult.Insert -> handle(result) // DML `Insert`
+ *   is PartiQLResult.Delete -> handle(result) // DML `Delete`
+ *   ...
+ * }
+ * ```
+ */
+class PartiQLCompilerPipeline private constructor(
     private val parser: Parser,
     private val planner: PartiQLPlanner,
     private val compiler: PartiQLCompiler
@@ -20,32 +35,51 @@ class PartiQLCompilerPipeline(
 
     companion object {
 
-        private val ION_STANDARD = IonSystemBuilder.standard().build()
+        private val DEFAULT_ION = IonSystemBuilder.standard().build()
 
-        @Deprecated(
-            message = "To be removed in 1.0 release",
-            replaceWith = ReplaceWith("standard"),
-            level = DeprecationLevel.WARNING
-        )
+        /**
+         *
+         */
         @JvmStatic
-        fun legacy(ion: IonSystem = ION_STANDARD): CompilerPipeline.Builder = CompilerPipeline.builder(ion)
+        fun standard() = PartiQLCompilerPipeline(
+            parser = SqlParser(DEFAULT_ION),
+            planner = PartiQLPlannerBuilder.standard().build(),
+            compiler = PartiQLCompilerBuilder.standard().build()
+        )
 
-        @JvmStatic
-        fun standard(ion: IonSystem = ION_STANDARD) = PartiQLCompilerPipeline(
-            parser = SqlParser(ion),
-            planner = PartiQLPlannerBuilder.standard(ion).build(),
-            compiler = PartiQLCompilerBuilder.standard(ion).build()
-        )
+        /**
+         * Builder utility for easy pipeline creation.
+         *
+         * Example usage:
+         * ```
+         *
+         * ```
+         */
+        fun build(block: Builder.() -> Unit): PartiQLCompilerPipeline {
+            val builder = Builder()
+            block.invoke(builder)
+            return PartiQLCompilerPipeline(
+                parser = builder.parser,
+                planner = builder.planner.build(),
+                compiler = builder.compiler.build(),
+            )
+        }
     }
 
+    /**
+     * Compiles a PartiQL query into an executable [PartiQLStatement].
+     */
     fun compile(statement: String): PartiQLStatement {
         val ast = parser.parseAstStatement(statement)
         return compile(ast)
     }
 
+    /**
+     * Compiles a [PartiqlAst.Statement] representation of a query into an executable [PartiQLStatement].
+     */
     fun compile(statement: PartiqlAst.Statement): PartiQLStatement {
         val result = planner.plan(statement)
-        // error handling is likely to be refactored after design review with the PartiQL team
+        // TODO review error handling pattern with the PartiQL team
         if (result is PartiQLPlanner.Result.Error) {
             throw PartiQLException(result.problems.toString())
         }
@@ -53,7 +87,17 @@ class PartiQLCompilerPipeline(
         return compile(plan)
     }
 
+    /**
+     * Compiles a [PartiqlPhysical.Plan] representation of a query into an executable [PartiQLStatement].
+     */
     fun compile(statement: PartiqlPhysical.Plan): PartiQLStatement {
         return compiler.compile(statement)
+    }
+
+    class Builder internal constructor() {
+        // TODO replace with PartiQLParserBuilder after https://github.com/partiql/partiql-lang-kotlin/pull/711
+        var parser = SqlParser(DEFAULT_ION)
+        val planner = PartiQLPlannerBuilder.standard()
+        val compiler = PartiQLCompilerBuilder.standard()
     }
 }

--- a/lang/src/org/partiql/lang/errors/PartiQLException.kt
+++ b/lang/src/org/partiql/lang/errors/PartiQLException.kt
@@ -1,0 +1,3 @@
+package org.partiql.lang.errors
+
+class PartiQLException(override val message: String) : RuntimeException()

--- a/lang/src/org/partiql/lang/errors/PartiQLException.kt
+++ b/lang/src/org/partiql/lang/errors/PartiQLException.kt
@@ -1,3 +1,6 @@
 package org.partiql.lang.errors
 
+/**
+ * Base class for PartiQL Exceptions
+ */
 class PartiQLException(override val message: String) : RuntimeException()

--- a/lang/src/org/partiql/lang/errors/PartiQLException.kt
+++ b/lang/src/org/partiql/lang/errors/PartiQLException.kt
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
 package org.partiql.lang.errors
 
 /**

--- a/lang/src/org/partiql/lang/eval/PartiQLResult.kt
+++ b/lang/src/org/partiql/lang/eval/PartiQLResult.kt
@@ -1,0 +1,19 @@
+package org.partiql.lang.eval
+
+/**
+ * Result of an evaluated PartiQLStatement
+ */
+sealed class PartiQLResult {
+
+    class Value(val value: ExprValue) : PartiQLResult()
+
+    class Insert(
+        val target: String,
+        val rows: Iterable<ExprValue>
+    ) : PartiQLResult()
+
+    class Delete(
+        val target: String,
+        val rows: Iterable<ExprValue>
+    ) : PartiQLResult()
+}

--- a/lang/src/org/partiql/lang/eval/PartiQLResult.kt
+++ b/lang/src/org/partiql/lang/eval/PartiQLResult.kt
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
 package org.partiql.lang.eval
 
 /**

--- a/lang/src/org/partiql/lang/eval/PartiQLStatement.kt
+++ b/lang/src/org/partiql/lang/eval/PartiQLStatement.kt
@@ -1,0 +1,9 @@
+package org.partiql.lang.eval
+
+/**
+ * A compiled PartiQL statement
+ */
+fun interface PartiQLStatement {
+
+    fun eval(session: EvaluationSession): PartiQLResult
+}

--- a/lang/src/org/partiql/lang/eval/PartiQLStatement.kt
+++ b/lang/src/org/partiql/lang/eval/PartiQLStatement.kt
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
 package org.partiql.lang.eval
 
 /**

--- a/lang/src/org/partiql/lang/planner/GlobalVariableResolver.kt
+++ b/lang/src/org/partiql/lang/planner/GlobalVariableResolver.kt
@@ -55,9 +55,9 @@ fun interface GlobalVariableResolver {
      * be used outside this project.
      */
     fun resolveGlobal(bindingName: BindingName): GlobalResolutionResult
+
+    companion object {
+
+        val EMPTY = GlobalVariableResolver { GlobalResolutionResult.Undefined }
+    }
 }
-
-private val EMPTY: GlobalVariableResolver = GlobalVariableResolver { GlobalResolutionResult.Undefined }
-
-/** Convenience function for obtaining an instance of [GlobalVariableResolver] with no defined global variables. */
-fun emptyGlobalsResolver(): GlobalVariableResolver = EMPTY

--- a/lang/src/org/partiql/lang/planner/PartiQLPlanner.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlanner.kt
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
 package org.partiql.lang.planner
 
 import org.partiql.lang.domains.PartiqlAst
@@ -14,8 +28,8 @@ interface PartiQLPlanner {
      * Transforms the given statement to an equivalent expression tree with each SELECT-FROM-WHERE block
      * expanded into its relational algebra form.
      *
-     * If planning succeeds, this returns a PartiQLPlanner.Result.Success,
-     * Else this returns a PartiQLPlanner.Result.Error.
+     * If planning succeeds, this returns a [PartiQLPlanner.Result.Success],
+     * Else this returns a [PartiQLPlanner.Result.Error].
      *
      * TODO this error handling pattern is subject to review and change
      */
@@ -26,7 +40,7 @@ interface PartiQLPlanner {
     }
 
     /**
-     * TODO review error handling pattern with the team
+     * TODO move Result.Success/Result.Error variant to the PartiQLCompiler
      */
     sealed class Result {
 
@@ -40,5 +54,8 @@ interface PartiQLPlanner {
         }
     }
 
+    /**
+     * Options which control [PartiQLPlanner] behavior.
+     */
     class Options(val allowedUndefinedVariables: Boolean = false)
 }

--- a/lang/src/org/partiql/lang/planner/PartiQLPlanner.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlanner.kt
@@ -1,0 +1,31 @@
+package org.partiql.lang.planner
+
+import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.errors.Problem
+
+interface PartiQLPlanner {
+
+    fun plan(statement: PartiqlAst.Statement): Result
+
+    companion object {
+        const val PLAN_VERSION = "0.0"
+    }
+
+    /**
+     * This method of error handling will be reviewed by the team and is subject to change.
+     */
+    sealed class Result {
+
+        data class Success(
+            val plan: PartiqlPhysical.Plan,
+            val warnings: List<Problem>
+        ) : Result()
+
+        data class Error(val problems: List<Problem>) : Result() {
+            override fun toString(): String = problems.joinToString()
+        }
+    }
+
+    class Options(val allowedUndefinedVariables: Boolean = false)
+}

--- a/lang/src/org/partiql/lang/planner/PartiQLPlanner.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlanner.kt
@@ -4,8 +4,21 @@ import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.errors.Problem
 
+/**
+ * [PartiQLPlanner] is responsible for transforming a [PartiqlAst.Statement] representation of a query into an
+ * equivalent [PartiqlPhysical.Plan] representation of the query.
+ */
 interface PartiQLPlanner {
 
+    /**
+     * Transforms the given statement to an equivalent expression tree with each SELECT-FROM-WHERE block
+     * expanded into its relational algebra form.
+     *
+     * If planning succeeds, this returns a PartiQLPlanner.Result.Success,
+     * Else this returns a PartiQLPlanner.Result.Error.
+     *
+     * TODO this error handling pattern is subject to review and change
+     */
     fun plan(statement: PartiqlAst.Statement): Result
 
     companion object {
@@ -13,7 +26,7 @@ interface PartiQLPlanner {
     }
 
     /**
-     * This method of error handling will be reviewed by the team and is subject to change.
+     * TODO review error handling pattern with the team
      */
     sealed class Result {
 

--- a/lang/src/org/partiql/lang/planner/PartiQLPlannerBuilder.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlannerBuilder.kt
@@ -1,5 +1,22 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
 package org.partiql.lang.planner
 
+/**
+ * Builder class to instantiate a [PartiQLPlanner].
+ */
 class PartiQLPlannerBuilder private constructor() {
 
     private var globalVariableResolver = GlobalVariableResolver.EMPTY
@@ -13,19 +30,19 @@ class PartiQLPlannerBuilder private constructor() {
         fun standard() = PartiQLPlannerBuilder()
     }
 
-    fun withGlobalVariableResolver(globalVariableResolver: GlobalVariableResolver) = this.apply {
+    fun globalVariableResolver(globalVariableResolver: GlobalVariableResolver) = this.apply {
         this.globalVariableResolver = globalVariableResolver
     }
 
-    fun withPhysicalPlannerPasses(physicalPlanPasses: List<PartiQLPlannerPass.Physical>) = this.apply {
+    fun physicalPlannerPasses(physicalPlanPasses: List<PartiQLPlannerPass.Physical>) = this.apply {
         this.physicalPlanPasses = physicalPlanPasses
     }
 
-    fun withOptions(options: PartiQLPlanner.Options) = this.apply {
+    fun options(options: PartiQLPlanner.Options) = this.apply {
         this.options = options
     }
 
-    fun withCallback(callback: PlannerEventCallback) = this.apply {
+    fun callback(callback: PlannerEventCallback) = this.apply {
         this.callback = callback
     }
 

--- a/lang/src/org/partiql/lang/planner/PartiQLPlannerBuilder.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlannerBuilder.kt
@@ -1,40 +1,35 @@
 package org.partiql.lang.planner
 
-import com.amazon.ion.IonSystem
-
-class PartiQLPlannerBuilder private constructor(private val ion: IonSystem) {
+class PartiQLPlannerBuilder private constructor() {
 
     private var globalVariableResolver = GlobalVariableResolver.EMPTY
-    private val physicalPlanPasses = mutableListOf<PartiQLPlannerPass.Physical>()
+    private var physicalPlanPasses: List<PartiQLPlannerPass.Physical> = emptyList()
     private var callback: PlannerEventCallback? = null
     private var options = PartiQLPlanner.Options()
 
     companion object {
 
         @JvmStatic
-        fun standard(ion: IonSystem) = PartiQLPlannerBuilder(ion)
+        fun standard() = PartiQLPlannerBuilder()
     }
 
-    fun globalVariableResolver(g: GlobalVariableResolver) = this.apply {
-        globalVariableResolver = g
+    fun withGlobalVariableResolver(globalVariableResolver: GlobalVariableResolver) = this.apply {
+        this.globalVariableResolver = globalVariableResolver
     }
 
-    fun addPass(pass: PartiQLPlannerPass<*>) = this.apply {
-        when (pass) {
-            is PartiQLPlannerPass.Physical -> physicalPlanPasses.add(pass)
-            else -> error("PartiQLPlanner currently supports only `PartiQLPlannerPass.Physical` planner passes")
-        }
+    fun withPhysicalPlannerPasses(physicalPlanPasses: List<PartiQLPlannerPass.Physical>) = this.apply {
+        this.physicalPlanPasses = physicalPlanPasses
     }
 
-    fun options(o: PartiQLPlanner.Options) = this.apply {
-        options = o
+    fun withOptions(options: PartiQLPlanner.Options) = this.apply {
+        this.options = options
     }
 
-    fun callback(cb: PlannerEventCallback) = this.apply {
-        callback = cb
+    fun withCallback(callback: PlannerEventCallback) = this.apply {
+        this.callback = callback
     }
 
-    fun build(): PartiQLPlanner = PartiQLPlannerImpl(
+    fun build(): PartiQLPlanner = PartiQLPlannerDefault(
         globalVariableResolver = globalVariableResolver,
         physicalPlanPasses = physicalPlanPasses,
         callback = callback,

--- a/lang/src/org/partiql/lang/planner/PartiQLPlannerBuilder.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlannerBuilder.kt
@@ -1,0 +1,43 @@
+package org.partiql.lang.planner
+
+import com.amazon.ion.IonSystem
+
+class PartiQLPlannerBuilder private constructor(private val ion: IonSystem) {
+
+    private var globalVariableResolver = GlobalVariableResolver.EMPTY
+    private val physicalPlanPasses = mutableListOf<PartiQLPlannerPass.Physical>()
+    private var callback: PlannerEventCallback? = null
+    private var options = PartiQLPlanner.Options()
+
+    companion object {
+
+        @JvmStatic
+        fun standard(ion: IonSystem) = PartiQLPlannerBuilder(ion)
+    }
+
+    fun globalVariableResolver(g: GlobalVariableResolver) = this.apply {
+        globalVariableResolver = g
+    }
+
+    fun addPass(pass: PartiQLPlannerPass<*>) = this.apply {
+        when (pass) {
+            is PartiQLPlannerPass.Physical -> physicalPlanPasses.add(pass)
+            else -> error("PartiQLPlanner currently supports only `PartiQLPlannerPass.Physical` planner passes")
+        }
+    }
+
+    fun options(o: PartiQLPlanner.Options) = this.apply {
+        options = o
+    }
+
+    fun callback(cb: PlannerEventCallback) = this.apply {
+        callback = cb
+    }
+
+    fun build(): PartiQLPlanner = PartiQLPlannerImpl(
+        globalVariableResolver = globalVariableResolver,
+        physicalPlanPasses = physicalPlanPasses,
+        callback = callback,
+        options = options
+    )
+}

--- a/lang/src/org/partiql/lang/planner/PartiQLPlannerDefault.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlannerDefault.kt
@@ -15,7 +15,7 @@ import org.partiql.lang.planner.transforms.LogicalToLogicalResolvedVisitorTransf
 import org.partiql.lang.planner.transforms.allocateVariableIds
 import org.partiql.pig.runtime.asPrimitive
 
-internal class PartiQLPlannerImpl(
+internal class PartiQLPlannerDefault(
     private val globalVariableResolver: GlobalVariableResolver,
     private val physicalPlanPasses: List<PartiQLPlannerPass.Physical>,
     private val callback: PlannerEventCallback?,

--- a/lang/src/org/partiql/lang/planner/PartiQLPlannerDefault.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlannerDefault.kt
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
 package org.partiql.lang.planner
 
 import org.partiql.lang.domains.PartiqlAst

--- a/lang/src/org/partiql/lang/planner/PartiQLPlannerImpl.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlannerImpl.kt
@@ -1,0 +1,128 @@
+package org.partiql.lang.planner
+
+import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.PartiqlLogical
+import org.partiql.lang.domains.PartiqlLogicalResolved
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.errors.ProblemCollector
+import org.partiql.lang.eval.visitors.FromSourceAliasVisitorTransform
+import org.partiql.lang.eval.visitors.PipelinedVisitorTransform
+import org.partiql.lang.eval.visitors.SelectListItemAliasVisitorTransform
+import org.partiql.lang.eval.visitors.SelectStarVisitorTransform
+import org.partiql.lang.planner.transforms.AstToLogicalVisitorTransform
+import org.partiql.lang.planner.transforms.LogicalResolvedToDefaultPhysicalVisitorTransform
+import org.partiql.lang.planner.transforms.LogicalToLogicalResolvedVisitorTransform
+import org.partiql.lang.planner.transforms.allocateVariableIds
+import org.partiql.pig.runtime.asPrimitive
+
+internal class PartiQLPlannerImpl(
+    private val globalVariableResolver: GlobalVariableResolver,
+    private val physicalPlanPasses: List<PartiQLPlannerPass.Physical>,
+    private val callback: PlannerEventCallback?,
+    private val options: PartiQLPlanner.Options
+) : PartiQLPlanner {
+
+    private val problemHandler = ProblemCollector()
+
+    override fun plan(statement: PartiqlAst.Statement): PartiQLPlanner.Result {
+
+        // Step 1. Normalize the AST
+        val normalized = callback.doEvent("normalize_ast", statement) {
+            statement.normalize()
+        }
+        if (problemHandler.hasErrors) {
+            return PartiQLPlanner.Result.Error(problemHandler.problems)
+        }
+
+        // Step 2. AST -> LogicalPlan
+        val logicalPlan = callback.doEvent("ast_to_logical", normalized) {
+            normalized.toLogicalPlan()
+        }
+        if (problemHandler.hasErrors) {
+            return PartiQLPlanner.Result.Error(problemHandler.problems)
+        }
+
+        // Step 3. Replace variable references
+        val resolvedLogicalPlan = callback.doEvent("logical_to_logical_resolved", logicalPlan) {
+            logicalPlan.toResolvedPlan()
+        }
+        if (problemHandler.hasErrors) {
+            return PartiQLPlanner.Result.Error(problemHandler.problems)
+        }
+
+        // Step 4. LogicalPlan -> PhysicalPlan
+        val physicalPlan = callback.doEvent("logical_resolved_to_physical", resolvedLogicalPlan) {
+            resolvedLogicalPlan.toPhysicalPlan()
+        }
+        if (problemHandler.hasErrors) {
+            return PartiQLPlanner.Result.Error(problemHandler.problems)
+        }
+
+        // Step 5. Apply additional physical transformations
+        val plan = physicalPlanPasses.fold(physicalPlan) { plan, pass ->
+            val result = callback.doEvent("pass_${pass::class.java.simpleName}", plan) {
+                pass.apply(plan, problemHandler)
+            }
+            if (problemHandler.hasErrors) {
+                return PartiQLPlanner.Result.Error(problemHandler.problems)
+            }
+            result
+        }
+
+        return PartiQLPlanner.Result.Success(
+            plan = plan,
+            warnings = problemHandler.problems
+        )
+    }
+
+    // --- Internal --------------------------
+
+    /**
+     * AST Normalization Passes
+     *  1. Synthesizes unspecified `SELECT <expr> AS ...` aliases
+     *  2. Synthesizes unspecified `FROM <expr> AS ...` aliases
+     *  3. Changes `SELECT * FROM a, b` to SELECT a.*, b.* FROM a, b`
+     */
+    private fun PartiqlAst.Statement.normalize(): PartiqlAst.Statement {
+        val transform = PipelinedVisitorTransform(
+            SelectListItemAliasVisitorTransform(),
+            FromSourceAliasVisitorTransform(),
+            SelectStarVisitorTransform()
+        )
+        return transform.transformStatement(this)
+    }
+
+    /**
+     * See [AstToLogicalVisitorTransform]
+     */
+    private fun PartiqlAst.Statement.toLogicalPlan(): PartiqlLogical.Plan {
+        val transform = AstToLogicalVisitorTransform(
+            problemHandler = problemHandler
+        )
+        return PartiqlLogical.Plan(
+            stmt = transform.transformStatement(this),
+            version = PartiQLPlanner.PLAN_VERSION.asPrimitive()
+        )
+    }
+
+    /**
+     * See [LogicalToLogicalResolvedVisitorTransform]
+     */
+    private fun PartiqlLogical.Plan.toResolvedPlan(): PartiqlLogicalResolved.Plan {
+        val (planWithAllocatedVariables, allLocals) = this.allocateVariableIds()
+        val transform = LogicalToLogicalResolvedVisitorTransform(
+            allowUndefinedVariables = options.allowedUndefinedVariables,
+            problemHandler = problemHandler,
+            globals = globalVariableResolver,
+        )
+        return transform.transformPlan(planWithAllocatedVariables).copy(locals = allLocals)
+    }
+
+    /**
+     * See [LogicalResolvedToDefaultPhysicalVisitorTransform]
+     */
+    private fun PartiqlLogicalResolved.Plan.toPhysicalPlan(): PartiqlPhysical.Plan {
+        val transform = LogicalResolvedToDefaultPhysicalVisitorTransform(problemHandler)
+        return transform.transformPlan(this)
+    }
+}

--- a/lang/src/org/partiql/lang/planner/PartiQLPlannerPass.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlannerPass.kt
@@ -1,0 +1,14 @@
+package org.partiql.lang.planner
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.errors.ProblemHandler
+import org.partiql.pig.runtime.DomainNode
+
+/**
+ * As of now, we cannot place lower bounds because PIG permuted domains are in Kotlin are unrelated.
+ */
+fun interface PartiQLPlannerPass<T : DomainNode> {
+    fun apply(plan: T, problemHandler: ProblemHandler): T
+
+    fun interface Physical : PartiQLPlannerPass<PartiqlPhysical.Plan>
+}

--- a/lang/src/org/partiql/lang/planner/PartiQLPlannerPass.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlannerPass.kt
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
 package org.partiql.lang.planner
 
 import org.partiql.lang.domains.PartiqlPhysical
@@ -5,9 +19,9 @@ import org.partiql.lang.errors.ProblemHandler
 import org.partiql.pig.runtime.DomainNode
 
 /**
- * As of now, we cannot place lower bounds because PIG permuted domains in Kotlin are unrelated.
+ * [PartiQLPlannerPass] is a transformation of the plan representation of the a PartiQL query.
  *
- * TODO lower the upper bound to `Plan` after https://github.com/partiql/partiql-ir-generator/issues/65
+ * TODO lower the upper bound of T to `Plan` after https://github.com/partiql/partiql-ir-generator/issues/65
  */
 fun interface PartiQLPlannerPass<T : DomainNode> {
     fun apply(plan: T, problemHandler: ProblemHandler): T

--- a/lang/src/org/partiql/lang/planner/PartiQLPlannerPass.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlannerPass.kt
@@ -5,7 +5,9 @@ import org.partiql.lang.errors.ProblemHandler
 import org.partiql.pig.runtime.DomainNode
 
 /**
- * As of now, we cannot place lower bounds because PIG permuted domains are in Kotlin are unrelated.
+ * As of now, we cannot place lower bounds because PIG permuted domains in Kotlin are unrelated.
+ *
+ * TODO lower the upper bound to `Plan` after https://github.com/partiql/partiql-ir-generator/issues/65
  */
 fun interface PartiQLPlannerPass<T : DomainNode> {
     fun apply(plan: T, problemHandler: ProblemHandler): T

--- a/lang/src/org/partiql/lang/planner/PlannerPipeline.kt
+++ b/lang/src/org/partiql/lang/planner/PlannerPipeline.kt
@@ -207,7 +207,7 @@ interface PlannerPipeline {
         private val customProcedures: MutableMap<String, StoredProcedure> = HashMap()
         private val physicalPlanPasses = ArrayList<PartiqlPhysicalPass>()
         private val physicalOperatorFactories = ArrayList<RelationalOperatorFactory>()
-        private var globalVariableResolver: GlobalVariableResolver = emptyGlobalsResolver()
+        private var globalVariableResolver: GlobalVariableResolver = GlobalVariableResolver.EMPTY
         private var allowUndefinedVariables: Boolean = false
         private var enableLegacyExceptionHandling: Boolean = false
         private var plannerEventCallback: PlannerEventCallback? = null

--- a/lang/src/org/partiql/lang/planner/QueryPlan.kt
+++ b/lang/src/org/partiql/lang/planner/QueryPlan.kt
@@ -50,7 +50,8 @@ sealed class QueryResult {
 }
 
 /**
- * Identifies the action to take. This should be represented by PIG.
+ * Identifies the action to take.
+ * TODO This should be represented in the IR grammar.
  */
 enum class DmlAction {
     INSERT,

--- a/lang/src/org/partiql/lang/planner/QueryPlan.kt
+++ b/lang/src/org/partiql/lang/planner/QueryPlan.kt
@@ -49,8 +49,21 @@ sealed class QueryResult {
     ) : QueryResult()
 }
 
-/** Identifies the action to take. */
-enum class DmlAction { INSERT, DELETE }
+/**
+ * Identifies the action to take. This should be represented by PIG.
+ */
+enum class DmlAction {
+    INSERT,
+    DELETE;
+
+    companion object {
+        fun safeValueOf(v: String): DmlAction? = try {
+            valueOf(v.toUpperCase())
+        } catch (ex: IllegalArgumentException) {
+            null
+        }
+    }
+}
 
 internal const val DML_COMMAND_FIELD_ACTION = "action"
 internal const val DML_COMMAND_FIELD_TARGET_UNIQUE_ID = "target_unique_id"
@@ -90,7 +103,7 @@ internal fun ExprValue.toDmlCommand(): QueryResult.DmlCommand {
     val actionString = this.bindings[DML_COMMAND_FIELD_ACTION]?.scalar?.stringValue()?.toUpperCase()
         ?: errMissing(DML_COMMAND_FIELD_ACTION)
 
-    val dmlAction = DmlAction.values().firstOrNull { it.name == actionString }
+    val dmlAction = DmlAction.safeValueOf(actionString)
         ?: error("Unknown DmlAction in DML command struct: '$actionString'")
 
     val targetUniqueId = this.bindings[DML_COMMAND_FIELD_TARGET_UNIQUE_ID]?.scalar?.stringValue()

--- a/lang/src/org/partiql/lang/planner/QueryPlan.kt
+++ b/lang/src/org/partiql/lang/planner/QueryPlan.kt
@@ -51,7 +51,7 @@ sealed class QueryResult {
 
 /**
  * Identifies the action to take.
- * TODO This should be represented in the IR grammar.
+ * TODO This should be represented in the IR grammar - https://github.com/partiql/partiql-lang-kotlin/issues/756
  */
 enum class DmlAction {
     INSERT,
@@ -90,7 +90,7 @@ private fun errMissing(fieldName: String): Nothing =
  * ```
  *
  * Where:
- *  - `<action>` is either `insert` or `delete` TODO: update
+ *  - `<action>` is either `insert` or `delete`
  *  - `<target_unique_id>` is a string or symbol containing the unique identifier of the table to be effected
  *  by the DML statement.
  *  - `<rows>` is a bag or list containing the rows (structs) effected by the DML statement.

--- a/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -10,6 +10,14 @@ import org.partiql.lang.eval.physical.sourceLocationMetaOrUnknown
 import org.partiql.lang.planner.PlanningProblemDetails
 import org.partiql.lang.planner.handleUnimplementedFeature
 
+internal fun PartiqlAst.Statement.toLogicalPlan(problemHandler: ProblemHandler): PartiqlLogical.Plan =
+    PartiqlLogical.build {
+        plan(
+            AstToLogicalVisitorTransform(problemHandler).transformStatement(this@toLogicalPlan),
+            version = PLAN_VERSION_NUMBER
+        )
+    }
+
 /**
  * Transforms an instance of [PartiqlAst.Statement] to [PartiqlLogical.Statement].  This representation of the query
  * expresses the intent of the query author in terms of PartiQL's relational algebra instead of its AST.
@@ -19,15 +27,7 @@ import org.partiql.lang.planner.handleUnimplementedFeature
  * This conversion (and the logical algebra) are early in their lifecycle and so only a limited subset of SFW queries
  * are transformable.  See `AstToLogicalVisitorTransformTests` to see which queries are transformable.
  */
-internal fun PartiqlAst.Statement.toLogicalPlan(problemHandler: ProblemHandler): PartiqlLogical.Plan =
-    PartiqlLogical.build {
-        plan(
-            AstToLogicalVisitorTransform(problemHandler).transformStatement(this@toLogicalPlan),
-            version = PLAN_VERSION_NUMBER
-        )
-    }
-
-private class AstToLogicalVisitorTransform(
+internal class AstToLogicalVisitorTransform(
     val problemHandler: ProblemHandler
 ) : PartiqlAstToPartiqlLogicalVisitorTransform() {
 

--- a/lang/src/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
@@ -1,7 +1,6 @@
 package org.partiql.lang.planner.transforms
 
 import com.amazon.ionelement.api.ionSymbol
-import org.partiql.lang.ast.DeleteOp.name
 import org.partiql.lang.ast.sourceLocation
 import org.partiql.lang.domains.PartiqlLogical
 import org.partiql.lang.domains.PartiqlLogicalResolved
@@ -130,7 +129,7 @@ private fun GlobalResolutionResult.toResolvedVariable() =
  */
 private data class LocalScope(val varDecls: List<PartiqlLogical.VarDecl>)
 
-private data class LogicalToLogicalResolvedVisitorTransform(
+internal data class LogicalToLogicalResolvedVisitorTransform(
     /** If set to `true`, do not log errors about undefined variables. Rewrite such variables to a `dynamic_id` node. */
     val allowUndefinedVariables: Boolean,
     /** Where to send error reports. */

--- a/lang/src/org/partiql/lang/syntax/PartiQLParserBuilder.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLParserBuilder.kt
@@ -25,8 +25,8 @@ import org.partiql.lang.types.CustomType
  *
  * ```
  * val parser = PartiQLParserBuilder.standard().build()
- * val parser = PartiQLParserBuilder.standard().withCustomTypes(types).build()
- * val parser = PartiQLParserBuilder().withIonSystem(ion).withCustomTypes().build()
+ * val parser = PartiQLParserBuilder.standard().customTypes(types).build()
+ * val parser = PartiQLParserBuilder().ionSystem(ion).customTypes().build()
  * ```
  */
 class PartiQLParserBuilder {
@@ -36,18 +36,18 @@ class PartiQLParserBuilder {
 
         @JvmStatic
         fun standard(): PartiQLParserBuilder {
-            return PartiQLParserBuilder().withIonSystem(DEFAULT_ION)
+            return PartiQLParserBuilder().ionSystem(DEFAULT_ION)
         }
     }
 
     private var ion: IonSystem = DEFAULT_ION
     private var customTypes: List<CustomType> = emptyList()
 
-    fun withIonSystem(ion: IonSystem): PartiQLParserBuilder = this.apply {
+    fun ionSystem(ion: IonSystem): PartiQLParserBuilder = this.apply {
         this.ion = ion
     }
 
-    fun withCustomTypes(types: List<CustomType>): PartiQLParserBuilder = this.apply {
+    fun customTypes(types: List<CustomType>): PartiQLParserBuilder = this.apply {
         this.customTypes = types
     }
 

--- a/lang/test/org/partiql/lang/eval/EvaluatorTestBase.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTestBase.kt
@@ -35,6 +35,7 @@ import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestTarget
 import org.partiql.lang.eval.evaluatortestframework.ExpectedResultFormat
 import org.partiql.lang.eval.evaluatortestframework.LegacySerializerTestAdapter
 import org.partiql.lang.eval.evaluatortestframework.MultipleTestAdapter
+import org.partiql.lang.eval.evaluatortestframework.PartiQLCompilerPipelineFactory
 import org.partiql.lang.eval.evaluatortestframework.PartiqlAstExprNodeRoundTripAdapter
 import org.partiql.lang.eval.evaluatortestframework.PipelineEvaluatorTestAdapter
 import org.partiql.lang.eval.evaluatortestframework.PlannerPipelineFactory
@@ -49,6 +50,7 @@ abstract class EvaluatorTestBase : TestBase() {
         listOf(
             PipelineEvaluatorTestAdapter(CompilerPipelineFactory()),
             PipelineEvaluatorTestAdapter(PlannerPipelineFactory()),
+            PipelineEvaluatorTestAdapter(PartiQLCompilerPipelineFactory()),
             PartiqlAstExprNodeRoundTripAdapter(),
             LegacySerializerTestAdapter(),
             AstRewriterBaseTestAdapter()

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactory.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactory.kt
@@ -1,0 +1,104 @@
+package org.partiql.lang.eval.evaluatortestframework
+
+import org.partiql.lang.ION
+import org.partiql.lang.compiler.PartiQLCompilerBuilder
+import org.partiql.lang.compiler.PartiQLCompilerPipeline
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.PartiQLResult
+import org.partiql.lang.eval.TypingMode
+import org.partiql.lang.eval.UndefinedVariableBehavior
+import org.partiql.lang.planner.EvaluatorOptions
+import org.partiql.lang.planner.GlobalResolutionResult
+import org.partiql.lang.planner.GlobalVariableResolver
+import org.partiql.lang.planner.PartiQLPlanner
+import org.partiql.lang.planner.PartiQLPlannerBuilder
+import org.partiql.lang.syntax.SqlParser
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+/**
+ * Proof-of-refactor. Delete this once `partiql-tests` is ready
+ */
+internal class PartiQLCompilerPipelineFactory : PipelineFactory {
+
+    override val pipelineName: String = "PartiQLCompilerPipeline"
+
+    override val target: EvaluatorTestTarget = EvaluatorTestTarget.PLANNER_PIPELINE
+
+    override fun createPipeline(
+        evaluatorTestDefinition: EvaluatorTestDefinition,
+        session: EvaluationSession,
+        forcePermissiveMode: Boolean
+    ): AbstractPipeline {
+
+        // Construct a legacy CompilerPipeline
+        val legacyPipeline = evaluatorTestDefinition.createCompilerPipeline(forcePermissiveMode)
+        val co = legacyPipeline.compileOptions
+
+        assertNotEquals(
+            co.undefinedVariable, UndefinedVariableBehavior.MISSING,
+            "The planner and physical plan evaluator do not support UndefinedVariableBehavior.MISSING. " +
+                "Please set target = EvaluatorTestTarget.COMPILER_PIPELINE for this test.\n" +
+                "Test groupName: ${evaluatorTestDefinition.groupName}"
+        )
+
+        assertNull(
+            legacyPipeline.globalTypeBindings,
+            "The planner and physical plan evaluator do not support globalTypeBindings (yet)" +
+                "Please set target = EvaluatorTestTarget.COMPILER_PIPELINE for this test."
+        )
+
+        val evaluatorOptions = EvaluatorOptions.build {
+            typingMode(co.typingMode)
+            thunkOptions(co.thunkOptions)
+            defaultTimezoneOffset(co.defaultTimezoneOffset)
+            typedOpBehavior(co.typedOpBehavior)
+            projectionIteration(co.projectionIteration)
+        }
+
+        val globalVariableResolver = GlobalVariableResolver { bindingName ->
+            val boundValue = session.globals[bindingName]
+            if (boundValue != null) {
+                GlobalResolutionResult.GlobalVariable(bindingName.name)
+            } else {
+                GlobalResolutionResult.Undefined
+            }
+        }
+
+        val planner = PartiQLPlannerBuilder.standard(ION)
+            .options(
+                PartiQLPlanner.Options(
+                    allowedUndefinedVariables = true
+                )
+            )
+            .globalVariableResolver(globalVariableResolver)
+
+        val compiler = PartiQLCompilerBuilder.standard(ION)
+            .customDataTypes(legacyPipeline.customDataTypes)
+            .options(evaluatorOptions)
+
+        legacyPipeline.functions.values.forEach { compiler.addFunction(it) }
+        legacyPipeline.procedures.values.forEach { compiler.addProcedure(it) }
+
+        val pipeline = PartiQLCompilerPipeline(
+            parser = SqlParser(ION, customTypes = legacyPipeline.customDataTypes),
+            planner = planner.build(),
+            compiler = compiler.build()
+        )
+
+        return object : AbstractPipeline {
+
+            override val typingMode: TypingMode = evaluatorOptions.typingMode
+
+            override fun evaluate(query: String): ExprValue {
+                val statement = pipeline.compile(query)
+                return when (val result = statement.eval(session)) {
+                    is PartiQLResult.Delete,
+                    is PartiQLResult.Insert -> error("DML is not supported by test suite")
+                    is PartiQLResult.Value -> result.value
+                }
+            }
+        }
+    }
+}

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactory.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactory.kt
@@ -1,6 +1,7 @@
 package org.partiql.lang.eval.evaluatortestframework
 
 import org.partiql.lang.ION
+import org.partiql.lang.compiler.PartiQLCompilerBuilder
 import org.partiql.lang.compiler.PartiQLCompilerPipeline
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
@@ -11,6 +12,7 @@ import org.partiql.lang.planner.EvaluatorOptions
 import org.partiql.lang.planner.GlobalResolutionResult
 import org.partiql.lang.planner.GlobalVariableResolver
 import org.partiql.lang.planner.PartiQLPlanner
+import org.partiql.lang.planner.PartiQLPlannerBuilder
 import org.partiql.lang.syntax.SqlParser
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
@@ -68,18 +70,20 @@ internal class PartiQLCompilerPipelineFactory : PipelineFactory {
             allowedUndefinedVariables = true
         )
 
-        val pipeline = PartiQLCompilerPipeline.build {
-            parser = SqlParser(ION, customTypes = legacyPipeline.customDataTypes)
-            planner
-                .withOptions(plannerOptions)
-                .withGlobalVariableResolver(globalVariableResolver)
-            compiler
-                .withIonSystem(ION)
-                .withOptions(evaluatorOptions)
-                .withCustomTypes(legacyPipeline.customDataTypes)
-                .withCustomFunctions(legacyPipeline.functions.values.toList())
-                .withCustomProcedures(legacyPipeline.procedures.values.toList())
-        }
+        val pipeline = PartiQLCompilerPipeline(
+            parser = SqlParser(ION, legacyPipeline.customDataTypes),
+            planner = PartiQLPlannerBuilder.standard()
+                .options(plannerOptions)
+                .globalVariableResolver(globalVariableResolver)
+                .build(),
+            compiler = PartiQLCompilerBuilder.standard()
+                .ionSystem(ION)
+                .options(evaluatorOptions)
+                .customTypes(legacyPipeline.customDataTypes)
+                .customFunctions(legacyPipeline.functions.values.toList())
+                .customProcedures(legacyPipeline.procedures.values.toList())
+                .build(),
+        )
 
         return object : AbstractPipeline {
 

--- a/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTestBase.kt
@@ -43,7 +43,7 @@ import org.partiql.pig.runtime.toIonElement
 
 abstract class SqlParserTestBase : TestBase() {
     // Default Parser
-    val parser = PartiQLParserBuilder().withIonSystem(ion).withCustomTypes(CUSTOM_TEST_TYPES).build()
+    val parser = PartiQLParserBuilder().ionSystem(ion).customTypes(CUSTOM_TEST_TYPES).build()
 
     protected fun parse(source: String): PartiqlAst.Statement = parser.parseAstStatement(source)
 


### PR DESCRIPTION
## Overview

This introduces **PartiQLCompilerPipeline** to replace the legacy **CompilerPipeline**. There are two major differences which are important to our team's goals.
1. Parsing, planning, and compiling responsibilities are split to enable plug-ability for library consumers. This is also a prerequisite for future refactor goals.
2. The legacy compiler methods return **ExprValue** which is representative of an Ion value. The **PartiQLCompilerPipeline** returns a new class called **Statement** which represents either a Query, DML command, or stored procedure. This verbiage is consistent with the PartiQL type domains.

As it stands, this is a replacement for the experimental PlannerPipeline, but this commit does not modify or remove PlannerPipeline. This commit shares most of the same code as PlannerPipeline. Once this factoring is merged, the PlannerPipeline will be removed. We intend to have parity with the CompilerPipeline as soon as possible, at which point the CompilerPipeline will be deprecated.

#### Structure
The Github PR UI does a nice job of showing the newly introduced files in the relevant tree. The relevant classes are
- org.partiql.lang.compiler.PartiQLCompiler
- org.partiql.lang.compiler.PartiQLCompilerPipeline
- org.partiql.lang.planner.PartiQLPlanner
- org.partiql.lang.eval.PartiQLStatement
- org.partiql.lang.eval.PartiQLResult

## Conventions

These conventions are similar to the Amazon Ion patterns, and this style is comfortable for Java interop. I do like the receiver block in the builder.

```kotlin
interface Foo {
   fun method(): Bar
}

// See Discussion Q3
class FooBuilder {

    companion object {

        // See Discussion Q4
        @JvmStatic
        fun standard(): FooBuilder(...) // builder with default parameters
    }

   fun build(): Foo {
       // logic to build FooImpl
   }
}

// Discussion Q5
internal FooImpl : Foo { ... }
```

## Future Usage

```kotlin
// Defaults
val partiql = PartiQLCompilerPipeline.standard(); // Default Ion system
val statement = partiql.compile('-- some PartiQL query');
val result = statement.eval(session);
when (result) {
  is PartiQL.Value -> handle(result)    // Query Result
  is PartiQL.Insert -> handle(result)   // DML `Insert`
  is PartiQL.Delete -> handle(result)   // DML `Delete`
}
```


## Discussion Questions
- Q0: Compiler/Parser/Planner are generic terms and we don't have explicit namespaces.
  - On one hand, prefixing disambiguates major interfaces and introduces structure within a jvm package tree
  - On the other hand, consider JT's advice. ![https://i.imgflip.com/6r5z8v.jpg](https://i.imgflip.com/6r5z8v.jpg)
- Q1: Yes, there are no comments yet. Public API worthy comments will be added upon structure finalization
- Q2: Which conventions do you (any reviewer) prefer? These were chosen to be a similar to Ion, hide implementations, and be consistent with Java conventions for interop. The more opinions the better.
- Q3: Builders have been moved to their own files to de-clutter the interfaces. Is anyone particularly attached to nested class `Builder`? It makes sense for a concrete class because of private-member access, but these builders are for interfaces so there is no private-member access. This style was chosen to de-clutter interfaces.
- Q4. I find the receiver block convenient for Kotlin, but not as much for Java interop. The major downside to the builder block however is that it gives callers access to the private members of a builder class which in turn undermines the purpose of controlling the object creation process. Perhaps we can achieve a similar end by a different mean.
- Q5. How are we feeling about "Impl"? These are `internal` but it would be great to find a package-private equivalent. We can also change Impl to something like Standard / Default / etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
