### PR TITLE
Fixes Build on JDK17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 9, 10, 11]
+        java: [8, 11, 17]
     steps:
       - uses: actions/checkout@v2
       - name: Use Java ${{ matrix.java }}
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Use Java 11
+      - name: Use Java 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Generate test coverage report
         run: ./gradlew build jacocoTestReport
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@
  */
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.4.32' apply false
+    id 'org.jetbrains.kotlin.jvm' version '1.5.31' apply false
     // https://arturbosch.github.io/detekt/groovydsl.html
     id "io.gitlab.arturbosch.detekt" version "1.20.0-RC1" apply false
     id 'org.jlleitschuh.gradle.ktlint' version '10.2.1'
@@ -24,7 +24,7 @@ allprojects {
     apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
     jacoco {
-        toolVersion = '0.8.5'
+        toolVersion = '0.8.8'
         reportsDirectory = file("$buildDir/reports/jacoco/")
     }
 
@@ -88,12 +88,16 @@ subprojects {
     }
 
     plugins.withId('java', { _ ->
-
         sourceSets {
             main.java.srcDirs = ["src"]
             main.resources.srcDirs = ["resources"]
             test.java.srcDirs = ["test"]
             test.resources.srcDirs = ["test-resources"]
+        }
+
+        java {
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
         }
     })
     plugins.withId('org.jetbrains.kotlin.jvm', { _ ->

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -31,6 +31,8 @@ plugins {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         jvmTarget = "1.8"
+        apiVersion = "1.4"
+        languageVersion = "1.4"
     }
 }
 

--- a/pts/build.gradle
+++ b/pts/build.gradle
@@ -19,6 +19,8 @@ group = 'org.partiql.lang'
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         jvmTarget = "1.8"
+        apiVersion = "1.4"
+        languageVersion = "1.4"
     }
 }
 

--- a/testscript/build.gradle
+++ b/testscript/build.gradle
@@ -16,8 +16,16 @@ dependencies {
 }
 
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions {
+        jvmTarget = "1.8"
+        apiVersion = "1.4"
+        languageVersion = "1.4"
+    }
 }
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions {
+        jvmTarget = "1.8"
+        apiVersion = "1.4"
+        languageVersion = "1.4"
+    }
 }


### PR DESCRIPTION
Fixes #375

*Description of changes:*

* Upgrades Kotlin Gradle plugin to 1.5.31.
* Upgrades JaCoCo to 0.8.8.
* Adds language/lib target to Kotlin 1.4 to ensure compatibility.
* Adds Java 8 compatibility globally to align with Kotlin.
* Adds CI support for JDK 17 and removes non-LTS releases that are past EOL.

The CI change showing build failure with JDK 17 before this change can be seen here[^1].

*Have you updated the `Unreleased` section of `CHANGELOG.md` with your changes? (y/n), If not, please explain why:* No, this change is purely build/CI.

*Does your PR include any backward-incompatible changes? (y/n), if yes, please explain the reason. In addition, please
 also mention any other alternatives you've considered and the reason they've been discarded?:* No.

*Does your PR introduce a new external dependency? (y/n), if yes, please explain the reason. In addition, please
also mention any other alternatives you've considered and the reason they've been discarded?:* No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[^1]: https://github.com/almann/partiql-lang-kotlin/runs/8145823436?check_suite_focus=true
