### PR TITLE
Corrected type inferencer's behavior on aggregate functions

### DIFF
--- a/lang/src/org/partiql/lang/ast/passes/inference/StaticTypeExtensions.kt
+++ b/lang/src/org/partiql/lang/ast/passes/inference/StaticTypeExtensions.kt
@@ -24,6 +24,7 @@ internal fun StaticType.isNumeric(): Boolean = (this is IntType || this is Float
 internal fun StaticType.isText(): Boolean = (this is SymbolType || this is StringType)
 internal fun StaticType.isLob(): Boolean = (this is BlobType || this is ClobType)
 internal fun StaticType.isUnknown(): Boolean = (this.isNullOrMissing() || this == StaticType.NULL_OR_MISSING)
+internal fun StaticType.isKnown(): Boolean = !isUnknown()
 
 /**
  * Returns the maximum number of digits a decimal can hold after reserving digits for scale

--- a/lang/test/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransformTest.kt
+++ b/lang/test/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransformTest.kt
@@ -7428,11 +7428,11 @@ class StaticTypeInferenceVisitorTransformTest : VisitorTransformTestBase() {
             // valid tests
             listOf(
                 // count
-                createAggFunctionValidTests("COUNT", NULL, INT8),
-                createAggFunctionValidTests("COUNT", MISSING, INT8),
-                createAggFunctionValidTests("COUNT", ANY, INT8),
-                createAggFunctionValidTests("COUNT", unionOf(NULL, MISSING, INT), INT8),
-                createAggFunctionValidTests("COUNT", unionOf(NULL, MISSING, INT), INT8),
+                createAggFunctionValidTests("COUNT", NULL, INT),
+                createAggFunctionValidTests("COUNT", MISSING, INT),
+                createAggFunctionValidTests("COUNT", ANY, INT),
+                createAggFunctionValidTests("COUNT", unionOf(NULL, MISSING, INT), INT),
+                createAggFunctionValidTests("COUNT", unionOf(NULL, MISSING, INT), INT),
 
                 // min
                 createAggFunctionValidTests("MIN", MISSING, NULL),
@@ -7449,17 +7449,19 @@ class StaticTypeInferenceVisitorTransformTest : VisitorTransformTestBase() {
                 // avg
                 createAggFunctionValidTests("AVG", MISSING, NULL),
                 createAggFunctionValidTests("AVG", unionOf(MISSING, NULL), NULL),
-                createAggFunctionValidTests("AVG", unionOf(MISSING, NULL, INT), DECIMAL),
+                createAggFunctionValidTests("AVG", unionOf(MISSING, NULL, INT), unionOf(NULL, DECIMAL)),
                 createAggFunctionValidTests("AVG", unionOf(INT, DECIMAL, FLOAT), DECIMAL),
+                createAggFunctionValidTests("AVG", unionOf(INT, DECIMAL, FLOAT, STRING), unionOf(MISSING, DECIMAL)),
 
                 // SUM
                 createAggFunctionValidTests("SUM", MISSING, NULL),
                 createAggFunctionValidTests("SUM", unionOf(MISSING, NULL), NULL),
-                createAggFunctionValidTests("SUM", unionOf(MISSING, NULL, INT2), INT2),
-                createAggFunctionValidTests("SUM", unionOf(INT2, INT4), INT4),
-                createAggFunctionValidTests("SUM", unionOf(INT2, INT4, INT8), INT8),
-                createAggFunctionValidTests("SUM", unionOf(INT2, INT4, INT8, FLOAT), FLOAT),
-                createAggFunctionValidTests("SUM", unionOf(INT2, INT4, INT8, FLOAT, DECIMAL), DECIMAL),
+                createAggFunctionValidTests("SUM", unionOf(MISSING, NULL, INT2), unionOf(NULL, INT2)),
+                createAggFunctionValidTests("SUM", unionOf(INT2, INT4), unionOf(INT2, INT4)),
+                createAggFunctionValidTests("SUM", unionOf(INT2, INT4, INT8), unionOf(INT2, INT4, INT8)),
+                createAggFunctionValidTests("SUM", unionOf(INT2, INT4, INT8, FLOAT), unionOf(INT2, INT4, INT8, FLOAT)),
+                createAggFunctionValidTests("SUM", unionOf(INT2, INT4, INT8, FLOAT, DECIMAL), unionOf(INT2, INT4, INT8, FLOAT, DECIMAL)),
+                createAggFunctionValidTests("SUM", unionOf(INT2, INT4, INT8, FLOAT, DECIMAL, STRING), unionOf(INT2, INT4, INT8, FLOAT, DECIMAL, MISSING))
             ) +
                 // sum input type not compatible
                 TestCase(
@@ -7471,7 +7473,7 @@ class StaticTypeInferenceVisitorTransformTest : VisitorTransformTestBase() {
                             createInvalidArgumentTypeForFunctionError(
                                 sourceLocation = SourceLocationMeta(1L, 1L, 3L),
                                 functionName = "sum",
-                                expectedArgType = unionOf(MISSING, NULL, NUMERIC),
+                                expectedArgType = unionOf(NULL, NUMERIC),
                                 actualType = STRING
                             )
                         )
@@ -7487,7 +7489,7 @@ class StaticTypeInferenceVisitorTransformTest : VisitorTransformTestBase() {
                             createInvalidArgumentTypeForFunctionError(
                                 sourceLocation = SourceLocationMeta(1L, 1L, 3L),
                                 functionName = "avg",
-                                expectedArgType = unionOf(MISSING, NULL, NUMERIC),
+                                expectedArgType = unionOf(NULL, NUMERIC),
                                 actualType = STRING
                             )
                         )


### PR DESCRIPTION
*Motivation:*
The type inferencer's behavior on `sum` & `avg` is not modeled correctly. e.g. the type of expression `sum(a)` with binding `'a' to list(union(int2, int4))` should be inferred as `union(int2, int4)`, instead of only `int4`. This is because with `'a' to list(union(in2, int4))` specified, it does not necessarily mean `a` must have 2 elements, with each one's type to be `int2` & `int4`, separately. It is possible that `a` only has one element with type to be either `int2` or `int4`. In this case, the return type is `union(int2, int4)`. 

The semantics of union of types is that, the type of the actual value can be one of the specified types, instead of must be all the specified types. 
