### PR TITLE
Renames method to conform to PartiQL's standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ stage in the `PlannerPipeline` and to generate performance metrics for the indiv
 
 ### Deprecated
 - Deprecates `SqlLexer` and `SqlParser` to be replaced with the `PartiQLParserBuilder`.
+- Deprecates helper method, `blacklist`, within `org.partiql.lang.eval` and introduced a functionally equivalent
+  `org.partiql.lang.eval.denyList` method.
 
 ### Fixed
 - Codecov report uploads in GitHub Actions workflow

--- a/lang/src/org/partiql/lang/eval/BindingsExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/BindingsExtensions.kt
@@ -35,19 +35,32 @@ fun <T> Bindings<T>.delegate(fallback: Bindings<T>): Bindings<T> =
  * Wraps a binding with a set of names that should not be resolved to anything.
  *
  * @receiver The [Bindings] to delegate over.
- * @param names, the blacklisted names
+ * @param names, the deny listed names
  */
-fun <T> Bindings<T>.blacklist(vararg names: String) = object : Bindings<T> {
-    val blacklisted = names.toSet()
-    val loweredBlacklisted = names.map { it.toLowerCase() }.toSet()
+@Deprecated(
+    message = "To be replaced with functionally equivalent denyList method.",
+    replaceWith = ReplaceWith("denyList", "org.partiql.lang.eval.denyList"),
+    level = DeprecationLevel.WARNING
+)
+fun <T> Bindings<T>.blacklist(vararg names: String) = this.denyList(*names)
+
+/**
+ * Wraps a binding with a set of names that should not be resolved to anything.
+ *
+ * @receiver The [Bindings] to delegate over.
+ * @param names, the deny listed names
+ */
+fun <T> Bindings<T>.denyList(vararg names: String) = object : Bindings<T> {
+    val denyListed = names.toSet()
+    val loweredDenyListed = names.map { it.toLowerCase() }.toSet()
 
     override fun get(bindingName: BindingName): T? {
-        val isBlacklisted = when (bindingName.bindingCase) {
-            BindingCase.SENSITIVE -> blacklisted.contains(bindingName.name)
-            BindingCase.INSENSITIVE -> loweredBlacklisted.contains(bindingName.loweredName)
+        val isDenyListed = when (bindingName.bindingCase) {
+            BindingCase.SENSITIVE -> denyListed.contains(bindingName.name)
+            BindingCase.INSENSITIVE -> loweredDenyListed.contains(bindingName.loweredName)
         }
         return when {
-            isBlacklisted -> null
+            isDenyListed -> null
             else -> this[bindingName]
         }
     }


### PR DESCRIPTION
## Description

Found a word that is being phased out by PartiQL. Deprecated the function and added a new function to take its place. We actually do not use the code, but as it is a public API, I opted to add the deprecation and a functional equivalent.

### More Information
- No incompatible changes -- marking as deprecated
- Updated the unreleased section
- No external dependencies added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
