### PR TITLE
Deprecates SqlLexer and SqlParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ stage in the `PlannerPipeline` and to generate performance metrics for the indiv
 ### Changed
 
 ### Deprecated
+- Deprecates `SqlLexer` and `SqlParser` to be replaced with the `PartiQLParserBuilder`.
 
 ### Fixed
 - Codecov report uploads in GitHub Actions workflow

--- a/lang/src/org/partiql/lang/syntax/SqlLexer.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlLexer.kt
@@ -27,6 +27,10 @@ import java.math.BigInteger
 /**
  * Simple tokenizer for PartiQL.
  */
+@Deprecated(
+    message = "Bug fixes, enhancements, and features will no longer be implemented. SqlLexer will be removed after v0.8.",
+    level = DeprecationLevel.WARNING
+)
 class SqlLexer(private val ion: IonSystem) : Lexer {
     /** Transition types. */
     internal enum class StateType(

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -76,6 +76,11 @@ import java.time.temporal.Temporal
  * Parses a list of tokens as infix query expression into a prefix s-expression
  * as the abstract syntax tree.
  */
+@Deprecated(
+    message = "Bug fixes, enhancements, and features will no longer be implemented. SqlParser will be deleted after v0.8.",
+    replaceWith = ReplaceWith("PartiQLParserBuilder.standard().build()", "org.partiql.lang.syntax.PartiQLParserBuilder"),
+    level = DeprecationLevel.WARNING
+)
 class SqlParser(
     private val ion: IonSystem,
     customTypes: List<CustomType> = listOf()


### PR DESCRIPTION
## Relevant Issues
- Closes #742

## Description
- Marks SqlLexer and SqlParser as DEPRECATED
- Updated CHANGELOG
- No backward incompatible changes. Marking as deprecated -- not removing.
- No new external dependencies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
