### PR TITLE
Adds issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: An issue to track an existing bug in PartiQL
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Description
+- A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. XXX
+2. XXX
+
+## Expected Behavior
+- < A clear and concise description of what you expected to happen. >
+
+## Additional Context
+- Java version: XXX
+- PartiQL version: XXX
+- Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## Relevant Issue/Bug
+- Reference Issue #XXX -- how is it related?
+
+## Requested Solution/Feature
+- A clear and concise description of what you want to happen.
+
+## Describe Alternatives
+- A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional Context
+Add any other context about the feature request here.


### PR DESCRIPTION
## Description
- Adds issue templates
- No external dependencies, no CHANGELOG modification.
- See the [official GH documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) on issue templates.