### PR TITLE
Enables CLI highlighting using any Parser (PartiQLParser Included)

### DIFF
--- a/cli/src/org/partiql/shell/Shell.kt
+++ b/cli/src/org/partiql/shell/Shell.kt
@@ -39,7 +39,6 @@ import org.partiql.lang.eval.ExprValueFactory
 import org.partiql.lang.eval.delegate
 import org.partiql.lang.syntax.Lexer
 import org.partiql.lang.syntax.Parser
-import org.partiql.lang.syntax.PartiQLParserBuilder
 import org.partiql.lang.syntax.SqlLexer
 import org.partiql.lang.syntax.SqlParser
 import org.partiql.lang.util.ConfigurableExprValueFormatter

--- a/cli/src/org/partiql/shell/Shell.kt
+++ b/cli/src/org/partiql/shell/Shell.kt
@@ -14,7 +14,6 @@
 
 package org.partiql.shell
 
-import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ion.system.IonTextWriterBuilder
 import com.amazon.ionelement.api.toIonValue
 import com.google.common.base.CharMatcher
@@ -39,8 +38,6 @@ import org.partiql.lang.eval.ExprValueFactory
 import org.partiql.lang.eval.delegate
 import org.partiql.lang.syntax.Lexer
 import org.partiql.lang.syntax.Parser
-import org.partiql.lang.syntax.SqlLexer
-import org.partiql.lang.syntax.SqlParser
 import org.partiql.lang.util.ConfigurableExprValueFormatter
 import org.partiql.lang.util.ExprValueFormatter
 import java.io.Closeable
@@ -81,6 +78,7 @@ class Shell(
     private val valueFactory: ExprValueFactory,
     private val output: OutputStream,
     private val parser: Parser,
+    private val lexer: Lexer,
     private val compiler: CompilerPipeline,
     private val initialGlobal: Bindings<ExprValue>,
     private val config: ShellConfiguration = ShellConfiguration()
@@ -129,8 +127,7 @@ class Shell(
     private fun run(exiting: AtomicBoolean) = TerminalBuilder.builder().build().use { terminal ->
         val highlighter = when {
             this.config.isMonochrome -> null
-            this.parser is SqlParser -> ShellHighlighter(SqlLexer(IonSystemBuilder.standard().build()), this.parser)
-            else -> ShellHighlighter(this.parser as Lexer, this.parser)
+            else -> ShellHighlighter(this.lexer, this.parser)
         }
         val reader = LineReaderBuilder.builder()
             .terminal(terminal)

--- a/cli/src/org/partiql/shell/Shell.kt
+++ b/cli/src/org/partiql/shell/Shell.kt
@@ -14,6 +14,7 @@
 
 package org.partiql.shell
 
+import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ion.system.IonTextWriterBuilder
 import com.amazon.ionelement.api.toIonValue
 import com.google.common.base.CharMatcher
@@ -36,7 +37,11 @@ import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueFactory
 import org.partiql.lang.eval.delegate
+import org.partiql.lang.syntax.Lexer
 import org.partiql.lang.syntax.Parser
+import org.partiql.lang.syntax.PartiQLParserBuilder
+import org.partiql.lang.syntax.SqlLexer
+import org.partiql.lang.syntax.SqlParser
 import org.partiql.lang.util.ConfigurableExprValueFormatter
 import org.partiql.lang.util.ExprValueFormatter
 import java.io.Closeable
@@ -125,7 +130,8 @@ class Shell(
     private fun run(exiting: AtomicBoolean) = TerminalBuilder.builder().build().use { terminal ->
         val highlighter = when {
             this.config.isMonochrome -> null
-            else -> ShellHighlighter()
+            this.parser is SqlParser -> ShellHighlighter(SqlLexer(IonSystemBuilder.standard().build()), this.parser)
+            else -> ShellHighlighter(this.parser as Lexer, this.parser)
         }
         val reader = LineReaderBuilder.builder()
             .terminal(terminal)

--- a/lang/src/org/partiql/lang/syntax/PartiQLLexer.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLLexer.kt
@@ -30,5 +30,4 @@ internal class PartiQLLexer(private val ion: IonSystem) : Lexer {
         }
         return tokens
     }
-
 }

--- a/lang/src/org/partiql/lang/syntax/PartiQLLexer.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLLexer.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.syntax
+
+import com.amazon.ion.IonSystem
+import org.antlr.v4.runtime.CommonTokenStream
+import org.partiql.lang.util.getLexer
+import org.partiql.lang.util.toPartiQLToken
+
+internal class PartiQLLexer(private val ion: IonSystem) : Lexer {
+
+    override fun tokenize(source: String): List<Token> {
+        val lexer = getLexer(source, ion)
+        val antlrTokens = CommonTokenStream(lexer)
+        val tokens = mutableListOf<Token>()
+        for (i in 0 until antlrTokens.numberOfOnChannelTokens) {
+            tokens.add(antlrTokens[i].toPartiQLToken(ion = ion))
+        }
+        return tokens
+    }
+
+}

--- a/lang/src/org/partiql/lang/syntax/PartiQLLexerBuilder.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLLexerBuilder.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.syntax
+
+import com.amazon.ion.IonSystem
+import com.amazon.ion.system.IonSystemBuilder
+
+/**
+ * A builder class to instantiate a [Lexer].
+ *
+ * Example usages:
+ *
+ * ```
+ * val lexer = PartiQLLexerBuilder.standard().build()
+ * val lexer = PartiQLLexerBuilder().ionSystem(ion).build()
+ * ```
+ */
+public class PartiQLLexerBuilder {
+
+    companion object {
+        private val DEFAULT_ION = IonSystemBuilder.standard().build()
+
+        @JvmStatic
+        public fun standard(): PartiQLLexerBuilder {
+            return PartiQLLexerBuilder().ionSystem(DEFAULT_ION)
+        }
+    }
+
+    private var ion: IonSystem = DEFAULT_ION
+
+    public fun ionSystem(ion: IonSystem): PartiQLLexerBuilder = this.apply { this.ion = ion }
+
+    public fun build(): Lexer = PartiQLLexer(this.ion)
+}

--- a/lang/src/org/partiql/lang/util/AntlrUtilities.kt
+++ b/lang/src/org/partiql/lang/util/AntlrUtilities.kt
@@ -28,6 +28,7 @@ import org.partiql.lang.syntax.ALL_SINGLE_LEXEME_OPERATORS
 import org.partiql.lang.syntax.KEYWORDS
 import org.partiql.lang.syntax.MULTI_LEXEME_TOKEN_MAP
 import org.partiql.lang.syntax.ParserException
+import org.partiql.lang.syntax.SourceSpan
 import org.partiql.lang.syntax.TYPE_ALIASES
 import org.partiql.lang.syntax.TokenType
 import java.math.BigInteger
@@ -58,6 +59,24 @@ internal fun Token?.error(
         errorContext[Property.TOKEN_VALUE] = getIonValue(ion, this)
         ParserException(message, errorCode, errorContext, cause)
     }
+}
+
+internal fun Token.toPartiQLToken(ion: IonSystem): org.partiql.lang.syntax.Token {
+    val text = when (this.type) {
+        PartiQLParser.EOF -> ""
+        else -> this.text
+    }
+    val span = SourceSpan(
+        line = this.line.toLong(),
+        column = this.charPositionInLine.toLong() + 1L,
+        length = text.length.toLong()
+    )
+    return org.partiql.lang.syntax.Token(
+        type = getPartiQLTokenType(this),
+        value = getIonValue(ion, this),
+        sourceText = text,
+        span = span
+    )
 }
 
 /**


### PR DESCRIPTION
## Relevant Issues
- Closes #748

## Note
- Leaving as draft until I determine whether we should create a public `PartiQLLexerBuilder`, or if we should deprecate `Lexer` and add `tokenize` to Parser public methods since `Lexer` isn't really used. Will consult with team.

## Description
- Modifies internal impl of Parser to also implement Lexer (tokenize method)
- Modifies shell highlighter to take in Lexer and Parser as params
- Modifies shell to use a Shell Highlighter specific to which parser is being used

## Other Information
- No backward incompatible changes
- No need to update changelog. Small changes.
- No external dependency changes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
