### PR TITLE
change trim spec to be case insensitive 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ stage in the `PlannerPipeline` and to generate performance metrics for the indiv
 - GitHub Actions capability to run on forks
 - Negation overflow caused by minimum INT8
 - Type mismatch error caused by evaluator's integer overflow check
+- Changed Trim Function Specification handling(fixed error message, and now can take case-insensitive trim spec)
 
 ### Removed
 - README.md badge for travisci

--- a/lang/src/org/partiql/lang/errors/ErrorCode.kt
+++ b/lang/src/org/partiql/lang/errors/ErrorCode.kt
@@ -531,6 +531,12 @@ enum class ErrorCode(
         "Other expressions may not be present in the select list when '*' is used without dot notation."
     ),
 
+    PARSE_INVALID_ARGUMENTS_FOR_TRIM(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "Invalid arguments for trim"
+    ),
+
     // Evaluator errors
     // TODO:  replace uses of this with UNIMPLEMENTED_FEATURE
     EVALUATOR_FEATURE_NOT_SUPPORTED_YET(

--- a/lang/src/org/partiql/lang/errors/ErrorCode.kt
+++ b/lang/src/org/partiql/lang/errors/ErrorCode.kt
@@ -531,7 +531,7 @@ enum class ErrorCode(
         "Other expressions may not be present in the select list when '*' is used without dot notation."
     ),
 
-    PARSE_INVALID_ARGUMENTS_FOR_TRIM(
+    PARSE_INVALID_TRIM_SPEC(
         ErrorCategory.PARSER,
         LOC_TOKEN,
         "Invalid arguments for trim"

--- a/lang/src/org/partiql/lang/eval/builtins/TrimExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/TrimExprFunction.kt
@@ -136,9 +136,11 @@ internal class TrimExprFunction(private val valueFactory: ExprValueFactory) : Ex
     private fun trim3Arg(specification: ExprValue, toRemove: ExprValue, sourceString: ExprValue): ExprValue {
         val trimSpec = TrimSpecification.from(specification)
         if (trimSpec == NONE) {
+            // todo with ANTLR, the invalid_argument should be caught in visitTrimFunction in PartiQLVisitor
+            // we should decide where this error shall be caught and whether it is a parsing error or an evaluator error.
             errNoContext(
                 "'${specification.stringValue()}' is an unknown trim specification, " +
-                    "valid vales: ${TrimSpecification.validValues}",
+                    "valid values: ${TrimSpecification.validValues}",
                 errorCode = ErrorCode.EVALUATOR_INVALID_ARGUMENTS_FOR_TRIM,
                 internal = false
             )
@@ -162,7 +164,7 @@ private enum class TrimSpecification {
     BOTH, LEADING, TRAILING, NONE;
 
     companion object {
-        fun from(arg: ExprValue) = when (arg.stringValue()) {
+        fun from(arg: ExprValue) = when (arg.stringValue().toLowerCase()) {
             "both" -> BOTH
             "leading" -> LEADING
             "trailing" -> TRAILING
@@ -170,7 +172,7 @@ private enum class TrimSpecification {
         }
 
         val validValues = TrimSpecification.values()
-            .filter { it == NONE }
+            .filterNot { it == NONE }
             .joinToString()
     }
 

--- a/lang/src/org/partiql/lang/visitors/PartiQLVisitor.kt
+++ b/lang/src/org/partiql/lang/visitors/PartiQLVisitor.kt
@@ -48,7 +48,6 @@ import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.errors.PropertyValueMap
 import org.partiql.lang.eval.EvaluationException
-import org.partiql.lang.eval.stringValue
 import org.partiql.lang.eval.time.MAX_PRECISION_FOR_TIME
 import org.partiql.lang.syntax.DATE_TIME_PART_KEYWORDS
 import org.partiql.lang.syntax.ParserException
@@ -1022,7 +1021,7 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
                     errorContext[Property.TOKEN_STRING] = ctx.mod.text
                     throw ctx.mod.err(
                         "'${ctx.mod.text}' is an unknown trim specification, valid values: $TRIM_SPECIFICATION_KEYWORDS",
-                        ErrorCode.PARSE_INVALID_ARGUMENTS_FOR_TRIM,
+                        ErrorCode.PARSE_INVALID_TRIM_SPEC,
                         errorContext
                     )
                 }

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -21,6 +21,7 @@ import org.partiql.lang.util.sourceLocationProperties
 
 class ParserErrorsTest : SqlParserTestBase() {
 
+    // TODO: now we are testing on both parsers(SQL_PARSER AND PARTIQL_PARSER). We need to remove test cases targeting SQL_PARSER once we removed it.
     @Test
     fun emptyQuery() {
         checkInputThrowingParserException(
@@ -1305,7 +1306,7 @@ class ParserErrorsTest : SqlParserTestBase() {
         // throw out a parser error
         checkInputThrowingParserException(
             "trim(something ' ' from ' string ')",
-            ErrorCode.PARSE_INVALID_ARGUMENTS_FOR_TRIM,
+            ErrorCode.PARSE_INVALID_TRIM_SPEC,
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 6L,

--- a/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/test/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -1287,6 +1287,36 @@ class ParserErrorsTest : SqlParserTestBase() {
     }
 
     @Test
+    fun callTrimSpecificationMismatch() {
+        // for SQL parser, the logic seems to be if the first token is not one of { NONE | BOTH | LEADING | TRAILING}
+        // treating the token as identifier and expect the trim expression to end
+        checkInputThrowingParserException(
+            "trim(something ' ' from ' string ')",
+            ErrorCode.PARSE_EXPECTED_RIGHT_PAREN_BUILTIN_FUNCTION_CALL,
+            mapOf(
+                Property.LINE_NUMBER to 1L,
+                Property.COLUMN_NUMBER to 16L,
+                Property.TOKEN_TYPE to TokenType.LITERAL,
+                Property.TOKEN_VALUE to ion.newString(" ")
+            ),
+            targetParsers = setOf(ParserTypes.SQL_PARSER)
+        )
+        // for sql parser, the logic is, if the first token is not one of { NONE | BOTH | LEADING | TRAILING}
+        // throw out a parser error
+        checkInputThrowingParserException(
+            "trim(something ' ' from ' string ')",
+            ErrorCode.PARSE_INVALID_ARGUMENTS_FOR_TRIM,
+            mapOf(
+                Property.LINE_NUMBER to 1L,
+                Property.COLUMN_NUMBER to 6L,
+                Property.TOKEN_TYPE to TokenType.IDENTIFIER,
+                Property.TOKEN_VALUE to ion.newSymbol("something")
+            ),
+            targetParsers = setOf(ParserTypes.PARTIQL_PARSER)
+        )
+    }
+
+    @Test
     fun nullIsNotNullIonLiteral() {
         checkInputThrowingParserException(
             "NULL is not `null`",


### PR DESCRIPTION
*Issue #, if available:*
Closes Issue #744 

*Description of changes:*
1. Added support for trim to accept case insensitive [ BOTH | LEADING | TRAILING]
2. Fixed error message in case of Trim Spec mismatch
3. Added an Parser Error to specifically for trim spec mismatch
4. Added test case for upper case trim spec
5. Added test cases for Trim Spec Mismatch

Future to do: 
Decide whether or not Trim Spec mismatch shall be a parser error or an evaluator error, and clean up the code accordingly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
