### PR TITLE
Optimize GH Actions Build by removing documentation builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,15 @@
 name: "Build and Report Generation"
-on: [push, pull_request]
+on: 
+  push:
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!*.md'
+  pull_request:
+    paths:
+      - '**'
+      - '!docs/**'
+      - '!*.md'
 
 jobs:
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,12 @@ on:
     paths:
       - '**'
       - '!docs/**'
-      - '!*.md'
+      - '!**/*.md'
   pull_request:
     paths:
       - '**'
       - '!docs/**'
-      - '!*.md'
+      - '!**.*.md'
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This will build the reference interpreter and test framework, then run all unit 
 ## Directory Structure
 
 - `docs` source code for the GitHub Wiki
+- `partiql-grammar` contains the ANTLR files to generate the PartiQL Parser.
 - `lang` contains the source code of the library containing the interpreter.
 - `lang/jmh` contains the JMH benchmarks for PartiQL.
 - `cli` contains the source code of the command-line interface and interactive prompt. (CLI/REPL)

--- a/README.md
+++ b/README.md
@@ -70,10 +70,6 @@ To build this project, clone this repository and from its root directory execute
 
 This will build the reference interpreter and test framework, then run all unit and integration tests.
 
-### Building the Documentation
-
-[Instructions on how to build PartiQL's documentation](docs/Docker/README.md)
-
 ## Directory Structure
 
 - `docs` source code for the GitHub Wiki

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,5 +1,9 @@
  # PartiQL CLI
 
-Command line interface for executing PartiQL queries.
+## Description
 
-See [CLI.md](../docs/user/CLI.md) for documentation.
+Command Line Interface for executing PartiQL queries.
+
+## More Information
+
+For more information, please see the CLI tutorials in our [project's Wiki](https://github.com/partiql/partiql-lang-kotlin/wiki)!

--- a/docs/general/Home.md
+++ b/docs/general/Home.md
@@ -4,7 +4,7 @@ This project is an implementation of the [PartiQL Specification](https://partiql
 PartiQL is based on SQL-92 and has added support for working with schemaless hierarchical data. PartiQL’s extensions to
 SQL are easy to understand, treat nested data as first class citizens and compose seamlessly with each other and SQL.
 
-You can find more information on [our website](https://partiql.org).
+You can find more information on [our website](https://partiql.org)!
 
 # Contributing
 

--- a/partiql-grammar/README.md
+++ b/partiql-grammar/README.md
@@ -1,0 +1,17 @@
+# PartiQL Grammar
+
+## Description
+
+This Gradle sub-project is dedicated to providing a generated parser by leveraging [ANTLR](https://docs.gradle.org/current/userguide/antlr_plugin.html).
+
+## Requirements
+
+To build this sub-project, Java 11+ is required.
+
+## Parser Generation
+
+To build the generated sources, run:
+
+```shell
+./gradlew :partiql-grammar:build
+```

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,4 +21,5 @@ include('lang',
         'testscript',
         'pts',
         'extensions',
-        'partiql-grammar')
+        'partiql-grammar'
+)


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Modifies build GH actions to not build when updating documentation.
- See the commit history to see the types of changes and the build types.

## Other Information
- Updated Unreleased Section in CHANGELOG: NO
  - Small change.
- Any backward-incompatible changes? NO
- Any new external dependencies? NO

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.