### PR TITLE
cast function inf/nan behavior change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ stage in the `PlannerPipeline` and to generate performance metrics for the indiv
 - GitHub Actions capability to run on forks
 - Negation overflow caused by minimum INT8
 - Type mismatch error caused by evaluator's integer overflow check
+- Cast function's behavior on positive_infinity, negative_infinity, NaN explicitly defined and handled. 
 
 ### Removed
 - README.md badge for travisci

--- a/docs/documentation/Functions.md
+++ b/docs/documentation/Functions.md
@@ -44,6 +44,7 @@ Where `DataType` is one of
 * `struct`
 * `bag`
 
+Note for handling `CAST` Operation on `+inf`, `-inf`, and `nan`, see [Special Float Value Handling](#Special Float Value Handling)
 
 Header
 : `CAST(exp AS dt)` 
@@ -113,6 +114,24 @@ The runtime support for casts is
 * Casting to `bag` from
     * Bag is a no-op
     * List: return a list with the same elements. The order of the elements in the resulting bag is unspecified. 
+
+#### Special Float Value Handling
+The following table list explicitly on behavior of CAST Function when expression supplied is one of `+inf`, `-inf`, or `nan`.
+
+| target type | can cast | cast quality |     expected result/Error      | 
+|:-----------:|:--------:|:------------:|:------------------------------:|
+|   missing   |  false   |     N/A      |     EVALUATOR_INVALID_CAST     | 
+|    null     |  false   |     N/A      |     EVALUATOR_INVALID_CAST     |
+|   integer   |  false   |     N/A      |     EVALUATOR_CAST_FAILED      | 
+|   boolean   |   true   |    LOSSY     |              true              |
+|    float    |   true   |   LOSSLESS   |        +inf, -inf, nan         |
+|   decimal   |  false   |     N/A      |     EVALUATOR_CAST_FAILED      | 
+|  timestamp  |  false   |     N/A      |     EVALUATOR_INVALID_CAST     |
+|   symbol    |   true   |   LOSSLESS   | 'Infinity', '-Infinity', 'NaN' | 
+|   string    |   true   |   LOSSLESS   | "Infinity", "-Infinity", "NaN" |
+ |    list     |  false   |     N/A      |     EVALUATOR_INVALID_CAST     | 
+|   struct    |  false   |     N/A      |     EVALUATOR_INVALID_CAST     | 
+|     bag     |  false   |     N/A      |     EVALUATOR_INVALID_CAST     |
 
 
 Examples

--- a/docs/documentation/Functions.md
+++ b/docs/documentation/Functions.md
@@ -118,7 +118,7 @@ The runtime support for casts is
 #### Special Float Value Handling
 The following table list explicitly on behavior of CAST Function when expression supplied is one of `+inf`, `-inf`, or `nan`.
 
-| target type | can cast | cast quality |     expected result/Error      | 
+| target type | can cast | cast quality |     expected result/error      | 
 |:-----------:|:--------:|:------------:|:------------------------------:|
 |   missing   |  false   |     N/A      |     EVALUATOR_INVALID_CAST     | 
 |    null     |  false   |     N/A      |     EVALUATOR_INVALID_CAST     |
@@ -129,7 +129,7 @@ The following table list explicitly on behavior of CAST Function when expression
 |  timestamp  |  false   |     N/A      |     EVALUATOR_INVALID_CAST     |
 |   symbol    |   true   |   LOSSLESS   | 'Infinity', '-Infinity', 'NaN' | 
 |   string    |   true   |   LOSSLESS   | "Infinity", "-Infinity", "NaN" |
- |    list     |  false   |     N/A      |     EVALUATOR_INVALID_CAST     | 
+|    list     |  false   |     N/A      |     EVALUATOR_INVALID_CAST     | 
 |   struct    |  false   |     N/A      |     EVALUATOR_INVALID_CAST     | 
 |     bag     |  false   |     N/A      |     EVALUATOR_INVALID_CAST     |
 

--- a/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
@@ -364,7 +364,7 @@ fun ExprValue.cast(
         is FloatType -> valueFactory.newFloat(this.toDouble())
         is DecimalType -> {
             if (this.isNaN || this.isNegInf || this.isPosInf) {
-                castFailedErr("Can't convert Infinity or NaN to INT.", internal = false)
+                castFailedErr("Can't convert Infinity or NaN to DECIMAL.", internal = false)
             }
 
             when (typedOpBehavior) {

--- a/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
@@ -306,6 +306,11 @@ fun ExprValue.cast(
 
     fun Number.exprValue(type: SingleType) = when (type) {
         is IntType -> {
+            // If the source is Positive/Negative Infinity or Nan, We throw an error
+            if (this.isNaN || this.isNegInf || this.isPosInf) {
+                castFailedErr("Can't convert Infinity or NaN to INT.", internal = false)
+            }
+
             val rangeForType = when (typedOpBehavior) {
                 // Legacy behavior doesn't honor SMALLINT, INT4 constraints
                 TypedOpBehavior.LEGACY -> LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
@@ -317,11 +322,6 @@ fun ExprValue.cast(
                         IntType.IntRangeConstraint.LONG, IntType.IntRangeConstraint.UNCONSTRAINED ->
                             LongRange(Long.MIN_VALUE, Long.MAX_VALUE)
                     }
-            }
-
-            // If the source is Positive/Negative Infinity or Nan, We do not allow cast operator to continue
-            if (this.isNaN || this.isNegInf || this.isPosInf) {
-                castFailedErr("Can't convert Infinity or NaN to INT.", internal = false)
             }
 
             // Here, we check if there is a possibility of being able to fit this number into


### PR DESCRIPTION
*Issue #, if available:*
#749 

*Description of changes:*
cast(`+inf` AS INT) now produces error ` Can't convert Infinity or NaN to INT.` Before it produces `Internal error, Infinite or NaN`
Also added test cases to demonstrate how `cast([`+inf` | `-inf` | `nan`] as <type>)` behaves under different types. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
