### PR TITLE
wiki format change

### DIFF
--- a/docs/documentation/Functions.md
+++ b/docs/documentation/Functions.md
@@ -44,7 +44,7 @@ Where `DataType` is one of
 * `struct`
 * `bag`
 
-Note for handling `CAST` Operation on `+inf`, `-inf`, and `nan`, see [Special Float Value Handling](#Special Float Value Handling)
+Note for handling `CAST` Operation on `+inf`, `-inf`, and `nan`, see Special Float Value Handling below.
 
 Header
 : `CAST(exp AS dt)` 


### PR DESCRIPTION
*Issue #, if available:*
N/A 

*Description of changes:*
Github wiki does not support anchor tags parsing. This is simply for a format change. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
