### PR TITLE
Parallelizes subset of tests by splitting test into many

### DIFF
--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerDateTimeTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerDateTimeTests.kt
@@ -19,7 +19,67 @@ import kotlin.random.Random
 
 class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
 
-    private val randomTestsSize = 50000
+    abstract class RandomTestsProvider() : ArgumentsProviderBase() {
+        private val randomTestsSize = 50000
+        private val randomGenerator = generateRandomSeed()
+
+        private fun generateRandomSeed(): Random {
+            val seed = Random.nextInt()
+            println("Randomly generated seed is $seed. Use this to reproduce failures in dev environment.")
+            return Random(seed)
+        }
+
+        private fun Random.nextTime(withPrecision: Boolean = false, withTimezone: Boolean = false): TimeForValidation {
+            val hour = nextInt(24)
+            val minute = nextInt(60)
+            val second = nextInt(60)
+            val nano = nextInt(999999999)
+            val precision = if (withPrecision) {
+                nextInt(10)
+            } else {
+                val timeStr = Time.of(hour, minute, second, nano, 9).toString()
+                timeStr.split(".")[1].length
+            }
+            val timezoneMinutes = if (withTimezone) {
+                nextInt(-1080, 1081)
+            } else {
+                null
+            }
+            return TimeForValidation(hour, minute, second, nano, precision, timezoneMinutes)
+        }
+        protected val RANDOM_TIMES = List(randomTestsSize) {
+            randomGenerator.nextTime(
+                withPrecision = false,
+                withTimezone = false
+            )
+        }
+        protected val RANDOM_TIMES_WITH_PRECISION = List(randomTestsSize) {
+            randomGenerator.nextTime(
+                withPrecision = true,
+                withTimezone = false
+            )
+        }
+        protected val RANDOM_TIMES_WITH_TIMEZONE = List(randomTestsSize) {
+            randomGenerator.nextTime(
+                withPrecision = false,
+                withTimezone = true
+            )
+        }
+        protected val RANDOM_TIMES_WITH_PRECISION_AND_TIMEZONE = List(randomTestsSize) {
+            randomGenerator.nextTime(
+                withPrecision = true,
+                withTimezone = true
+            )
+        }
+
+        class RandomTimesAndRandomTimesWithTimezone() : RandomTestsProvider() {
+            override fun getParameters(): List<Any> = super.RANDOM_TIMES + super.RANDOM_TIMES_WITH_TIMEZONE
+        }
+
+        class RandomTimesWithPrecisionAndRandomTimesWithPrecisionAndTimezone() : RandomTestsProvider() {
+            override fun getParameters(): List<Any> = super.RANDOM_TIMES_WITH_PRECISION + super.RANDOM_TIMES_WITH_PRECISION_AND_TIMEZONE
+        }
+    }
 
     @Test
     fun testDateLiteral() {
@@ -121,14 +181,6 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
         )
     }
 
-    private val randomGenerator = generateRandomSeed()
-
-    private fun generateRandomSeed(): Random {
-        val seed = Random.nextInt()
-        println("Randomly generated seed is $seed. Use this to reproduce failures in dev environment.")
-        return Random(seed)
-    }
-
     data class TimeForValidation(
         val hour: Int,
         val minute: Int,
@@ -161,105 +213,58 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
         }
     }
 
-    private fun Random.nextTime(withPrecision: Boolean = false, withTimezone: Boolean = false): TimeForValidation {
-        val hour = nextInt(24)
-        val minute = nextInt(60)
-        val second = nextInt(60)
-        val nano = nextInt(999999999)
-        val precision = if (withPrecision) {
-            nextInt(10)
-        } else {
-            val timeStr = Time.of(hour, minute, second, nano, 9).toString()
-            timeStr.split(".")[1].length
-        }
-        val timezoneMinutes = if (withTimezone) {
-            nextInt(-1080, 1081)
-        } else {
-            null
-        }
-        return TimeForValidation(hour, minute, second, nano, precision, timezoneMinutes)
-    }
-
-    private val RANDOM_TIMES = List(randomTestsSize) {
-        randomGenerator.nextTime(
-            withPrecision = false,
-            withTimezone = false
-        )
-    }
-    private val RANDOM_TIMES_WITH_PRECISION = List(randomTestsSize) {
-        randomGenerator.nextTime(
-            withPrecision = true,
-            withTimezone = false
-        )
-    }
-    private val RANDOM_TIMES_WITH_TIMEZONE = List(randomTestsSize) {
-        randomGenerator.nextTime(
-            withPrecision = false,
-            withTimezone = true
-        )
-    }
-    private val RANDOM_TIMES_WITH_PRECISION_AND_TIMEZONE = List(randomTestsSize) {
-        randomGenerator.nextTime(
-            withPrecision = true,
-            withTimezone = true
+    @ParameterizedTest
+    @ArgumentsSource(RandomTestsProvider.RandomTimesAndRandomTimesWithTimezone::class)
+    fun testRandomTimes(time: TimeForValidation) {
+        val query = "TIME '$time'"
+        val expected = "TIME '${time.expectedTimeString(withTimeZone = false)}'"
+        runEvaluatorTestCase(
+            query = query,
+            expectedResult = expected,
+            excludeLegacySerializerAssertions = true,
+            expectedResultFormat = ExpectedResultFormat.STRING
         )
     }
 
-    @Test
-    fun testRandomTimes() {
-        (RANDOM_TIMES + RANDOM_TIMES_WITH_TIMEZONE).map {
-            val query = "TIME '$it'"
-            val expected = "TIME '${it.expectedTimeString(withTimeZone = false)}'"
-            runEvaluatorTestCase(
-                query = query,
-                expectedResult = expected,
-                excludeLegacySerializerAssertions = true,
-                expectedResultFormat = ExpectedResultFormat.STRING
-            )
-        }
+    @ParameterizedTest
+    @ArgumentsSource(RandomTestsProvider.RandomTimesWithPrecisionAndRandomTimesWithPrecisionAndTimezone::class)
+    fun testRandomTimesWithPrecision(time: TimeForValidation) {
+        val query = "TIME (${time.precision}) '$time'"
+        val expected = "TIME '${time.expectedTimeString(withTimeZone = false)}'"
+        runEvaluatorTestCase(
+            query = query,
+            expectedResult = expected,
+            excludeLegacySerializerAssertions = true,
+            expectedResultFormat = ExpectedResultFormat.STRING
+        )
     }
 
-    @Test
-    fun testRandomTimesWithPrecision() {
-        (RANDOM_TIMES_WITH_PRECISION + RANDOM_TIMES_WITH_PRECISION_AND_TIMEZONE).map {
-            val query = "TIME (${it.precision}) '$it'"
-            val expected = "TIME '${it.expectedTimeString(withTimeZone = false)}'"
-            runEvaluatorTestCase(
-                query = query,
-                expectedResult = expected,
-                excludeLegacySerializerAssertions = true,
-                expectedResultFormat = ExpectedResultFormat.STRING
-            )
-        }
+    @ParameterizedTest
+    @ArgumentsSource(RandomTestsProvider.RandomTimesAndRandomTimesWithTimezone::class)
+    fun testRandomTimesWithTimezone(time: TimeForValidation) {
+        val query = "TIME WITH TIME ZONE '$time'"
+        val expected = "TIME WITH TIME ZONE '${time.expectedTimeString(withTimeZone = true)}'"
+        runEvaluatorTestCase(
+            query = query,
+            expectedResult = expected,
+            excludeLegacySerializerAssertions = true,
+            expectedResultFormat = ExpectedResultFormat.STRING
+        )
     }
 
-    @Test
-    fun testRandomTimesWithTimezone() {
-        (RANDOM_TIMES + RANDOM_TIMES_WITH_TIMEZONE).map {
-            val query = "TIME WITH TIME ZONE '$it'"
-            val expected = "TIME WITH TIME ZONE '${it.expectedTimeString(withTimeZone = true)}'"
-            runEvaluatorTestCase(
-                query = query,
-                expectedResult = expected,
-                excludeLegacySerializerAssertions = true,
-                expectedResultFormat = ExpectedResultFormat.STRING
-            )
-        }
+    @ParameterizedTest
+    @ArgumentsSource(RandomTestsProvider.RandomTimesWithPrecisionAndRandomTimesWithPrecisionAndTimezone::class)
+    fun testRandomTimesWithPrecisionAndTimezone(time: TimeForValidation) {
+        val query = "TIME (${time.precision}) WITH TIME ZONE '$time'"
+        val expected = "TIME WITH TIME ZONE '${time.expectedTimeString(withTimeZone = true)}'"
+        runEvaluatorTestCase(
+            query = query,
+            expectedResult = expected,
+            excludeLegacySerializerAssertions = true,
+            expectedResultFormat = ExpectedResultFormat.STRING
+        )
     }
 
-    @Test
-    fun testRandomTimesWithPrecisionAndTimezone() {
-        (RANDOM_TIMES_WITH_PRECISION + RANDOM_TIMES_WITH_PRECISION_AND_TIMEZONE).map {
-            val query = "TIME (${it.precision}) WITH TIME ZONE '$it'"
-            val expected = "TIME WITH TIME ZONE '${it.expectedTimeString(withTimeZone = true)}'"
-            runEvaluatorTestCase(
-                query = query,
-                expectedResult = expected,
-                excludeLegacySerializerAssertions = true,
-                expectedResultFormat = ExpectedResultFormat.STRING
-            )
-        }
-    }
     @ParameterizedTest
     @ArgumentsSource(ArgumentsForComparison::class)
     fun testComparison(tc: ComparisonTestCase) {


### PR DESCRIPTION
## Relevant Issues
- Closes #778 

## Description
- There was 4-5 tests performing 100,000 iterations each of an operation
- This caused an annoying test experience -- as the build would stop at around 77,000 tests, and it wouldn't give you an update for several minutes
- I took the input data and wrapped it to pass it to a ParameterizedTest so that JUnit could parallelize the test runs
- This way, the tests never freeze (YAY !), we can always see our progress, and I saw preliminary results of significantly faster tests.

## Testing Results
Ran tests over two days (seems like Day 1 my computer was more friendly). Removed the build cache before each run and ran `./gradlew clean build` -- below are the test times.
- Branch `main`
  - 8m 46s (Day 1)
  - 8m 59s (Day 1)
  - 10m 6s (Day 2)
  - 9m 19s (Day 2)
  - **AVERAGE: 9m 17.5s**
- Branch `fix-stopped-tests`
  - 4m 58s (Day 1)
  - 4m 50s (Day 1)
  - 7m 21s (Day 2)
  - 6m 55s (Day 2)
  - **AVERAGE: 06m 01s**

From the tests, there is approximately a speedup of 54.4% for local builds.

## Other Information
- Another thing is that, before, we used to have between 80-90K tests. Now, since I've split up these massive tests, we now have around 490K tests
- Also, according to the [Gradle documentation](https://docs.gradle.org/current/userguide/performance.html#parallel_test_execution), we should probably add the following to our Gradle tests config at some point:
```
tasks.withType(Test).configureEach {
    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
}
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
  - No -- it's a testing change
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.