### PR TITLE
Add an additional example for ExprFunction

### DIFF
--- a/examples/src/kotlin/org/partiql/examples/MergeKeyValues.kt
+++ b/examples/src/kotlin/org/partiql/examples/MergeKeyValues.kt
@@ -1,0 +1,85 @@
+package org.partiql.examples
+
+import org.partiql.lang.eval.BindingCase
+import org.partiql.lang.eval.BindingName
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprFunction
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.ExprValueType
+import org.partiql.lang.eval.StructOrdering
+import org.partiql.lang.eval.namedValue
+import org.partiql.lang.eval.stringValue
+import org.partiql.lang.types.FunctionSignature
+import org.partiql.lang.types.StaticType
+import java.lang.Exception
+import kotlin.collections.HashMap
+
+abstract class MergeKeysBaseExprFunction(
+    val valueFactory: ExprValueFactory,
+) : ExprFunction
+
+/**
+ * For the Given [ExprValue] representing list of structs, merges key/values based on the given inputs in flatten list
+ * for values.
+ *
+ * E.g.
+ * Given:
+ *  [
+ *      {'Name':'certificate','Values':['abc', 'cde']},
+ *      {'Name':'certificate','Values':['ghj', 'klu']},
+ *      {'Name':'test','Values':['ghj', 'klu']}
+ *  ]
+ *  'Name' as mergeKey
+ *  'Values' as valueKey
+ *
+ *  Expected:
+ *  [
+ *      {'test': ['ghj', 'klu']},
+ *      {'certificate': ['abc', 'cde', 'ghj', 'klu']}
+ *  ]
+ */
+class MergeKeyValues(valueFactory: ExprValueFactory) :
+    MergeKeysBaseExprFunction(valueFactory) {
+    override val signature = FunctionSignature(
+        name = "merge_key_values",
+        requiredParameters = listOf(StaticType.BAG, StaticType.STRING, StaticType.STRING),
+        returnType = StaticType.LIST
+    )
+
+    override fun callWithRequired(session: EvaluationSession, value: List<ExprValue>): ExprValue {
+        val mergeKey = value[1].stringValue()
+        val valueKey = value [2].stringValue()
+        val result = HashMap<String, MutableList<ExprValue>>()
+
+        value[0].forEach {
+            if (it.type != ExprValueType.STRUCT) {
+                throw Exception("All elements on input collection must be of type struct. Erroneous value: $it")
+            }
+
+            val binding = it.bindings[BindingName(mergeKey, BindingCase.INSENSITIVE)]
+            val bindingValue = binding!!.stringValue()
+            val valueElem = it.bindings[BindingName(valueKey, BindingCase.INSENSITIVE)]
+
+            if (valueElem != null) {
+                if (result[bindingValue] == null) {
+                    result[bindingValue] = mutableListOf(valueElem)
+                } else {
+                    result[bindingValue]!!.add(valueElem)
+                }
+            }
+        }
+
+        val keys = result.keys.map { valueFactory.newString(it) }
+        val values = result.values.map { valueFactory.newList(it).flatten() }
+
+        val listOfStructs = keys.zip(values)
+            .map {
+                valueFactory.newStruct(
+                    listOf(valueFactory.newList(it.second).namedValue(it.first)).asSequence(),
+                    StructOrdering.UNORDERED
+                )
+            }
+        return valueFactory.newList(listOfStructs)
+    }
+}

--- a/examples/src/kotlin/org/partiql/examples/MergeKeyValues.kt
+++ b/examples/src/kotlin/org/partiql/examples/MergeKeyValues.kt
@@ -20,7 +20,7 @@ abstract class MergeKeysBaseExprFunction(
 ) : ExprFunction
 
 /**
- * For the Given [ExprValue] representing list of structs, merges key/values based on the given inputs in flatten list
+ * For the given [ExprValue] representing list of structs, merges key/values based on the given inputs in flatten list
  * for values.
  *
  * E.g.

--- a/examples/src/kotlin/org/partiql/examples/MergeKeyValues.kt
+++ b/examples/src/kotlin/org/partiql/examples/MergeKeyValues.kt
@@ -20,7 +20,7 @@ abstract class MergeKeysBaseExprFunction(
 ) : ExprFunction
 
 /**
- * For the given [ExprValue] representing list of structs, merges key/values based on the given inputs in flatten list
+ * For the Given [ExprValue] representing collection of structs, merges key/values based on the given inputs in flatten list
  * for values.
  *
  * E.g.
@@ -43,16 +43,20 @@ class MergeKeyValues(valueFactory: ExprValueFactory) :
     MergeKeysBaseExprFunction(valueFactory) {
     override val signature = FunctionSignature(
         name = "merge_key_values",
-        requiredParameters = listOf(StaticType.BAG, StaticType.STRING, StaticType.STRING),
+        requiredParameters = listOf(
+            StaticType.unionOf(StaticType.BAG, StaticType.LIST, StaticType.SEXP),
+            StaticType.STRING,
+            StaticType.STRING
+        ),
         returnType = StaticType.LIST
     )
 
-    override fun callWithRequired(session: EvaluationSession, value: List<ExprValue>): ExprValue {
-        val mergeKey = value[1].stringValue()
-        val valueKey = value [2].stringValue()
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
+        val mergeKey = required[1].stringValue()
+        val valueKey = required[2].stringValue()
         val result = HashMap<String, MutableList<ExprValue>>()
 
-        value[0].forEach {
+        required[0].forEach {
             if (it.type != ExprValueType.STRUCT) {
                 throw Exception("All elements on input collection must be of type struct. Erroneous value: $it")
             }

--- a/examples/test/org/partiql/examples/MergeKeyValuesTests.kt
+++ b/examples/test/org/partiql/examples/MergeKeyValuesTests.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.partiql.examples
+
+import com.amazon.ion.system.IonSystemBuilder
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotNull
+import org.junit.Test
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.StructOrdering
+import org.partiql.lang.eval.namedValue
+
+class MergeKeyValuesTests {
+    private val ion = IonSystemBuilder.standard().build()
+    private val factory = ExprValueFactory.standard(ion)
+    private val session = EvaluationSession.standard()
+
+    @Test
+    fun testFunction() {
+        val fn = MergeKeyValues(factory)
+
+        val ionValue1 = ion.newList(ion.newString("abc"), ion.newString("cde"))
+        val ionValue2 = ion.newList(ion.newString("ghj"), ion.newString("klu"))
+        val ionValue3 = ion.newList(ion.newString("ghj"), ion.newString("klu"))
+
+        val list1 = listOf(
+            factory.newString("certificate").namedValue(factory.newSymbol("Name")),
+            factory.newFromIonValue(ionValue1).namedValue(factory.newSymbol("Values")),
+        )
+        val list2 = listOf(
+            factory.newString("certificate").namedValue(factory.newSymbol("Name")),
+            factory.newFromIonValue(ionValue2).namedValue(factory.newSymbol("Values")),
+        )
+        val list3 = listOf(
+            factory.newString("test").namedValue(factory.newSymbol("Name")),
+            factory.newFromIonValue(ionValue3).namedValue(factory.newSymbol("Values")),
+        )
+        val res = fn.callWithRequired(
+            session,
+            listOf(
+                factory.newBag(
+                    listOf(
+                        factory.newStruct(list1.asSequence(), StructOrdering.UNORDERED),
+                        factory.newStruct(list2.asSequence(), StructOrdering.UNORDERED),
+                        factory.newStruct(list3.asSequence(), StructOrdering.UNORDERED)
+                    )
+                ),
+                factory.newString("Name"),
+                factory.newString("Values")
+            )
+        )
+
+        assertNotNull(res)
+        assertEquals(
+            "[{'test': ['ghj', 'klu']}, {'certificate': ['abc', 'cde', 'ghj', 'klu']}]",
+            res.toString()
+        )
+    }
+}


### PR DESCRIPTION
Adds an example for using a custom function for working with elements of lists and struct members.

## Relevant Issues
- [Closes] Issue #785 

## Description
- Adds an example for using a custom function for working with elements
of lists and struct members. In this case it's a function for merging the values of common given keys in the input.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No, adding just an example, not a feature.
- Any backward-incompatible changes? **[YES/NO]**
  - No
- Any new external dependencies? **[YES/NO]**
  - No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.