### PR TITLE
Add logical plan support for DO REPLACE EXCLUDED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       [#707](https://github.com/partiql/partiql-lang-kotlin/issues/707), [#683](https://github.com/partiql/partiql-lang-kotlin/issues/683),
       and [#730](https://github.com/partiql/partiql-lang-kotlin/issues/730)
 - Parsing of `INSERT` DML with `ON CONFLICT DO REPLACE EXCLUDED` based on [RFC-0011](https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md)
+- Logical plan representation of `INSERT` DML with `ON CONFLICT DO REPLACE EXCLUDED` based on [RFC-0011](https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md)
 
 #### Experimental Planner Additions
 

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -687,6 +687,7 @@ may then be further optimized by selecting better implementations of each operat
             (sum dml_operation
                 (dml_insert)
                 (dml_delete)
+                (dml_replace)
                 // TODO:
                 // (dml_update)
             )

--- a/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -155,12 +155,31 @@ internal class AstToLogicalVisitorTransform(
                     }
                 }
 
-                PartiqlLogical.build {
-                    dml(
-                        target = dmlOp.target.toDmlTargetId(),
-                        operation = dmlInsert(),
-                        rows = transformExpr(dmlOp.values),
-                        metas = node.metas
+                when (val conflictAction = dmlOp.conflictAction) {
+                    null -> {
+                        PartiqlLogical.build {
+                            dml(
+                                target = dmlOp.target.toDmlTargetId(),
+                                operation = dmlInsert(),
+                                rows = transformExpr(dmlOp.values),
+                                metas = node.metas
+                            )
+                        }
+                    }
+                    is PartiqlAst.ConflictAction.DoReplace -> {
+                        when (conflictAction.value) {
+                            PartiqlAst.OnConflictValue.Excluded() -> PartiqlLogical.build {
+                                dml(
+                                    target = dmlOp.target.toDmlTargetId(),
+                                    operation = dmlReplace(),
+                                    rows = transformExpr(dmlOp.values),
+                                    metas = node.metas
+                                )
+                            } else -> TODO("Only `DO REPLACE EXCLUDED` is supported in logical plan at the moment.")
+                        }
+                    }
+                    is PartiqlAst.ConflictAction.DoNothing -> TODO(
+                        "`ON CONFLICT DO NOTHING` is not supported in logical plan yet."
                     )
                 }
             }

--- a/lang/src/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransform.kt
@@ -112,6 +112,8 @@ internal class LogicalResolvedToDefaultPhysicalVisitorTransform(
         val action = when (node.operation) {
             is PartiqlLogicalResolved.DmlOperation.DmlInsert -> DmlAction.INSERT
             is PartiqlLogicalResolved.DmlOperation.DmlDelete -> DmlAction.DELETE
+            is PartiqlLogicalResolved.DmlOperation.DmlReplace ->
+                TODO("DmlReplace physical transform hasn't been implemented yet")
         }.name.toLowerCase()
 
         return PartiqlPhysical.build {


### PR DESCRIPTION
## Relevant Issues
- [Closes] Issue #743, #739 

## Description
- Adds the logical plan support for `ON CONFLICT DO REPLACE EXCLUDED`; as part of defines a new `dml_operation` called `dml_replace` for replace operations; with `DO REPLACE EXCLUDED` the value associated with the `dml_replace` is the value that is already specified in the replace.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - Yes.
- Any backward-incompatible changes? **[YES/NO]**
  - No.
- Any new external dependencies? **[YES/NO]**
  - No.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.