### PR TITLE
Adds sort operator to planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ stage in the `PlannerPipeline` and to generate performance metrics for the indiv
   query author, e.g. `true and x.id = 42` -> `x.id = 42`), `true and true` -> `true`, etc.
   - `RemoveUselessFiltersPass`, which removes useless filters introduced by the previous pass or by the query author 
   (e.g. `(filter (lit true) <bexpr>))` -> `<bexpr>`.
+- Adds support for ORDER BY in Planner
 
 ### Changed
 - The default parser for all components of PartiQL is now the PartiQLParser -- see the deprecation of `SqlParser`

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -670,7 +670,11 @@ may then be further optimized by selecting better implementations of each operat
                     join_type::join_type
                     left::bexpr
                     right::bexpr
-                    predicate::(? expr))
+                    predicate::(? expr)
+                )
+
+                // Converts a bindings collection into a sorted bindings collection.
+                (sort source::bexpr sort_specs::(* sort_spec 1))
 
                 // Skips `row_count` rows, then emits all remaining rows.
                 (offset row_count::expr source::bexpr)
@@ -725,12 +729,8 @@ may then be further optimized by selecting better implementations of each operat
             grouping_strategy
             group_key
             group_key_list
-            order_by
-            sort_spec
-            ordering_spec
-
+            order_by             // Replaced with SORT node
             let
-
             dml_op
             dml_op_list
             ddl_op
@@ -858,8 +858,7 @@ may then be further optimized by selecting better implementations of each operat
                 (project i::impl binding::var_decl args::(* arguments::expr 0))
 
                 // Operators below this point are the same as in the logical algebra, but also include an i::impl
-                // element.
-
+                // element. 
                 (scan i::impl expr::expr as_decl::var_decl at_decl::(? var_decl) by_decl::(? var_decl))
                 (filter i::impl predicate::expr source::bexpr)
                 (join
@@ -869,6 +868,7 @@ may then be further optimized by selecting better implementations of each operat
                     right::bexpr
                     predicate::(? expr))
 
+                (sort i::impl source::bexpr sort_specs::(* sort_spec 1))
                 (offset i::impl row_count::expr source::bexpr)
                 (limit i::impl row_count::expr source::bexpr)
                 (let i::impl source::bexpr bindings::(* let_binding 1))

--- a/lang/src/org/partiql/lang/eval/physical/EvaluatorState.kt
+++ b/lang/src/org/partiql/lang/eval/physical/EvaluatorState.kt
@@ -43,4 +43,8 @@ class EvaluatorState(
      * of [SetVariableFunc] that were provided by this library, thus it is marked as `internal`.
      */
     internal val registers: Array<ExprValue>
-)
+) {
+    internal fun load(registers: Array<ExprValue>) = registers.forEachIndexed { index, exprValue ->
+        this.registers[index] = exprValue
+    }
+}

--- a/lang/src/org/partiql/lang/eval/physical/PhysicalBexprToThunkConverter.kt
+++ b/lang/src/org/partiql/lang/eval/physical/PhysicalBexprToThunkConverter.kt
@@ -5,8 +5,10 @@ import com.amazon.ionelement.api.MetaContainer
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.NaturalExprValueComparators
 import org.partiql.lang.eval.Thunk
 import org.partiql.lang.eval.ThunkValue
+import org.partiql.lang.eval.physical.operators.CompiledSortKey
 import org.partiql.lang.eval.physical.operators.FilterRelationalOperatorFactory
 import org.partiql.lang.eval.physical.operators.JoinRelationalOperatorFactory
 import org.partiql.lang.eval.physical.operators.LetRelationalOperatorFactory
@@ -18,6 +20,7 @@ import org.partiql.lang.eval.physical.operators.RelationalOperatorFactory
 import org.partiql.lang.eval.physical.operators.RelationalOperatorFactoryKey
 import org.partiql.lang.eval.physical.operators.RelationalOperatorKind
 import org.partiql.lang.eval.physical.operators.ScanRelationalOperatorFactory
+import org.partiql.lang.eval.physical.operators.SortOperatorFactory
 import org.partiql.lang.eval.physical.operators.VariableBinding
 import org.partiql.lang.eval.physical.operators.valueExpression
 import org.partiql.lang.util.toIntExact
@@ -192,6 +195,17 @@ internal class PhysicalBexprToThunkConverter(
         return bindingsExpr.toRelationThunk(node.metas)
     }
 
+    override fun convertSort(node: PartiqlPhysical.Bexpr.Sort): RelationThunkEnv {
+        // Compile Arguments
+        val source = this.convert(node.source)
+        val sortKeys = compileSortSpecs(node.sortSpecs)
+
+        // Get Implementation
+        val factory = findOperatorFactory<SortOperatorFactory>(RelationalOperatorKind.SORT, node.i.name.text)
+        val bindingsExpr = factory.create(node.i, sortKeys, source)
+        return bindingsExpr.toRelationThunk(node.metas)
+    }
+
     override fun convertLet(node: PartiqlPhysical.Bexpr.Let): RelationThunkEnv {
         // recurse into children
         val sourceBexpr = this.convert(node.source)
@@ -209,6 +223,30 @@ internal class PhysicalBexprToThunkConverter(
 
         // wrap in thunk
         return bindingsExpr.toRelationThunk(node.metas)
+    }
+
+    /**
+     * Returns a list of [CompiledSortKey] with the aim of pre-computing the [NaturalExprValueComparators] prior to
+     * evaluation and leaving the [PartiqlPhysical.SortSpec]'s [PartiqlPhysical.Expr] to be evaluated later.
+     */
+    private fun compileSortSpecs(specs: List<PartiqlPhysical.SortSpec>): List<CompiledSortKey> = specs.map { spec ->
+        val comp = when (spec.orderingSpec) {
+            is PartiqlPhysical.OrderingSpec.Asc ->
+                when (spec.nullsSpec) {
+                    is PartiqlPhysical.NullsSpec.NullsFirst -> NaturalExprValueComparators.NULLS_FIRST_ASC
+                    is PartiqlPhysical.NullsSpec.NullsLast -> NaturalExprValueComparators.NULLS_LAST_ASC
+                    null -> NaturalExprValueComparators.NULLS_LAST_ASC
+                }
+            is PartiqlPhysical.OrderingSpec.Desc ->
+                when (spec.nullsSpec) {
+                    is PartiqlPhysical.NullsSpec.NullsFirst -> NaturalExprValueComparators.NULLS_FIRST_DESC
+                    is PartiqlPhysical.NullsSpec.NullsLast -> NaturalExprValueComparators.NULLS_LAST_DESC
+                    null -> NaturalExprValueComparators.NULLS_LAST_DESC
+                }
+            null -> NaturalExprValueComparators.NULLS_LAST_ASC
+        }
+        val value = exprConverter.convert(spec.expr).toValueExpr(spec.expr.metas.sourceLocationMeta)
+        CompiledSortKey(comp, value)
     }
 }
 

--- a/lang/src/org/partiql/lang/eval/physical/SetVariableFunc.kt
+++ b/lang/src/org/partiql/lang/eval/physical/SetVariableFunc.kt
@@ -1,6 +1,8 @@
 package org.partiql.lang.eval.physical
 
 import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.errors.ErrorCode
+import org.partiql.lang.eval.EvaluationException
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.util.toIntExact
 
@@ -32,4 +34,14 @@ typealias SetVariableFunc = (EvaluatorState, ExprValue) -> Unit
 internal fun PartiqlPhysical.VarDecl.toSetVariableFunc(): SetVariableFunc {
     val index = this.index.value.toIntExact()
     return { state, value -> state.registers[index] = value }
+}
+
+/**
+ * Transfers all [ExprValue]s in [source] to the [target] [EvaluatorState]'s registers
+ */
+internal fun transferState(target: EvaluatorState, source: Array<ExprValue>) {
+    if (target.registers.size != source.size) {
+        throw EvaluationException("No", ErrorCode.EVALUATOR_GENERIC_EXCEPTION, null, null, true)
+    }
+    target.registers.forEachIndexed { index, _ -> target.registers[index] = source[index] }
 }

--- a/lang/src/org/partiql/lang/eval/physical/SetVariableFunc.kt
+++ b/lang/src/org/partiql/lang/eval/physical/SetVariableFunc.kt
@@ -1,8 +1,6 @@
 package org.partiql.lang.eval.physical
 
 import org.partiql.lang.domains.PartiqlPhysical
-import org.partiql.lang.errors.ErrorCode
-import org.partiql.lang.eval.EvaluationException
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.util.toIntExact
 
@@ -34,14 +32,4 @@ typealias SetVariableFunc = (EvaluatorState, ExprValue) -> Unit
 internal fun PartiqlPhysical.VarDecl.toSetVariableFunc(): SetVariableFunc {
     val index = this.index.value.toIntExact()
     return { state, value -> state.registers[index] = value }
-}
-
-/**
- * Transfers all [ExprValue]s in [source] to the [target] [EvaluatorState]'s registers
- */
-internal fun transferState(target: EvaluatorState, source: Array<ExprValue>) {
-    if (target.registers.size != source.size) {
-        throw EvaluationException("No", ErrorCode.EVALUATOR_GENERIC_EXCEPTION, null, null, true)
-    }
-    target.registers.forEachIndexed { index, _ -> target.registers[index] = source[index] }
 }

--- a/lang/src/org/partiql/lang/eval/physical/operators/DefaultOperatorFactories.kt
+++ b/lang/src/org/partiql/lang/eval/physical/operators/DefaultOperatorFactories.kt
@@ -24,6 +24,7 @@ import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
  * @see [org.partiql.lang.planner.PlannerPipeline.Builder.addRelationalOperatorFactory]
  */
 internal val DEFAULT_RELATIONAL_OPERATOR_FACTORIES = listOf(
+    InMemorySortFactory(DEFAULT_IMPL_NAME),
     object : ScanRelationalOperatorFactory(DEFAULT_IMPL_NAME) {
         override fun create(
             impl: PartiqlPhysical.Impl,
@@ -125,8 +126,8 @@ internal val DEFAULT_RELATIONAL_OPERATOR_FACTORIES = listOf(
         ): RelationExpression =
             RelationExpression { state ->
                 val skipCount: Long = evalOffsetRowCount(rowCountExpr, state)
-                relation(RelationType.BAG) {
-                    val sourceRel = sourceBexpr.evaluate(state)
+                val sourceRel = sourceBexpr.evaluate(state)
+                relation(sourceRel.relType) {
                     var rowCount = 0L
                     while (rowCount++ < skipCount) {
                         // stop iterating if we run out of rows before we hit the offset.
@@ -147,7 +148,7 @@ internal val DEFAULT_RELATIONAL_OPERATOR_FACTORIES = listOf(
             RelationExpression { state ->
                 val limitCount = evalLimitRowCount(rowCountExpr, state)
                 val rowIter = sourceBexpr.evaluate(state)
-                relation(RelationType.BAG) {
+                relation(rowIter.relType) {
                     var rowCount = 0L
                     while (rowCount++ < limitCount && rowIter.nextRow()) {
                         yield()

--- a/lang/src/org/partiql/lang/eval/physical/operators/RelationalOperatorKind.kt
+++ b/lang/src/org/partiql/lang/eval/physical/operators/RelationalOperatorKind.kt
@@ -15,5 +15,6 @@ enum class RelationalOperatorKind {
     JOIN,
     OFFSET,
     LIMIT,
-    LET
+    LET,
+    SORT
 }

--- a/lang/src/org/partiql/lang/eval/physical/operators/SortOperatorFactory.kt
+++ b/lang/src/org/partiql/lang/eval/physical/operators/SortOperatorFactory.kt
@@ -1,0 +1,75 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.errors.ErrorCode
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.NaturalExprValueComparators
+import org.partiql.lang.eval.err
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.physical.transferState
+import org.partiql.lang.eval.relation.RelationType
+import org.partiql.lang.eval.relation.relation
+import org.partiql.lang.util.interruptibleFold
+
+/** Provides an implementation of the [PartiqlPhysical.Bexpr.Order] operator.*/
+internal abstract class SortOperatorFactory(name: String) : RelationalOperatorFactory {
+    final override val key: RelationalOperatorFactoryKey = RelationalOperatorFactoryKey(RelationalOperatorKind.SORT, name)
+    internal abstract fun create(
+        impl: PartiqlPhysical.Impl,
+        sortKeys: List<CompiledSortKey>,
+        sourceRelation: RelationExpression
+    ): RelationExpression
+}
+
+internal class CompiledSortKey(val comparator: NaturalExprValueComparators, val value: ValueExpression)
+
+/**
+ * A simple [SortOperatorFactory] that sorts relations completely in memory.
+ */
+internal class InMemorySortFactory(name: String) : SortOperatorFactory(name) {
+    override fun create(
+        impl: PartiqlPhysical.Impl,
+        sortKeys: List<CompiledSortKey>,
+        sourceRelation: RelationExpression
+    ): RelationExpression = RelationExpression { state ->
+        val source = sourceRelation.evaluate(state)
+        relation(RelationType.LIST) {
+            val registers = mutableListOf<Array<ExprValue>>()
+            while (source.nextRow()) { registers.add(state.registers.clone()) }
+
+            val comparator = getSortingComparator(sortKeys, state)
+            val sortedRegisters = registers.sortedWith(comparator)
+
+            val iterator = sortedRegisters.iterator()
+            while (iterator.hasNext()) {
+                transferState(state, iterator.next())
+                yield()
+            }
+        }
+    }
+}
+
+/**
+ * Returns a [Comparator] that compares arrays of registers by using un-evaluated sort keys. It does this by modifying
+ * the [state] to allow evaluation of the [sortKeys]
+ */
+private fun getSortingComparator(sortKeys: List<CompiledSortKey>, state: EvaluatorState): Comparator<Array<ExprValue>> {
+    val initial: Comparator<Array<ExprValue>>? = null
+    return sortKeys.interruptibleFold(initial) { intermediate, sortKey ->
+        if (intermediate == null) {
+            return@interruptibleFold compareBy<Array<ExprValue>, ExprValue>(sortKey.comparator) { row ->
+                transferState(state, row)
+                sortKey.value(state)
+            }
+        }
+        return@interruptibleFold intermediate.thenBy(sortKey.comparator) { row ->
+            transferState(state, row)
+            sortKey.value(state)
+        }
+    } ?: err(
+        "Order BY comparator cannot be null",
+        ErrorCode.EVALUATOR_ORDER_BY_NULL_COMPARATOR,
+        null,
+        internal = true
+    )
+}

--- a/lang/src/org/partiql/lang/planner/PartiQLPlannerDefault.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlannerDefault.kt
@@ -20,6 +20,7 @@ import org.partiql.lang.domains.PartiqlLogicalResolved
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.errors.ProblemCollector
 import org.partiql.lang.eval.visitors.FromSourceAliasVisitorTransform
+import org.partiql.lang.eval.visitors.OrderBySortSpecVisitorTransform
 import org.partiql.lang.eval.visitors.PipelinedVisitorTransform
 import org.partiql.lang.eval.visitors.SelectListItemAliasVisitorTransform
 import org.partiql.lang.eval.visitors.SelectStarVisitorTransform
@@ -101,6 +102,7 @@ internal class PartiQLPlannerDefault(
         val transform = PipelinedVisitorTransform(
             SelectListItemAliasVisitorTransform(),
             FromSourceAliasVisitorTransform(),
+            OrderBySortSpecVisitorTransform(),
             SelectStarVisitorTransform()
         )
         return transform.transformStatement(this)

--- a/lang/src/org/partiql/lang/planner/transforms/AstNormalize.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/AstNormalize.kt
@@ -2,6 +2,7 @@ package org.partiql.lang.planner.transforms
 
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.eval.visitors.FromSourceAliasVisitorTransform
+import org.partiql.lang.eval.visitors.OrderBySortSpecVisitorTransform
 import org.partiql.lang.eval.visitors.PipelinedVisitorTransform
 import org.partiql.lang.eval.visitors.SelectListItemAliasVisitorTransform
 import org.partiql.lang.eval.visitors.SelectStarVisitorTransform
@@ -18,6 +19,7 @@ fun PartiqlAst.Statement.normalize(): PartiqlAst.Statement {
         SelectListItemAliasVisitorTransform(),
         // Synthesizes unspecified `FROM <expr> AS ...` aliases
         FromSourceAliasVisitorTransform(),
+        OrderBySortSpecVisitorTransform(),
         // Changes `SELECT * FROM a, b` to SELECT a.*, b.* FROM a, b`
         SelectStarVisitorTransform()
     )

--- a/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -46,6 +46,11 @@ internal class AstToLogicalVisitorTransform(
             PartiqlLogical.build { filter(transformExpr(it), algebra, it.metas) }
         } ?: algebra
 
+        algebra = node.order?.let { orderBy ->
+            val sortSpecs = orderBy.sortSpecs.map { sortSpec -> transformSortSpec(sortSpec) }
+            PartiqlLogical.build { sort(algebra, sortSpecs, orderBy.metas) }
+        } ?: algebra
+
         algebra = node.offset?.let {
             PartiqlLogical.build { offset(transformExpr(it), algebra, node.offset.metas) }
         } ?: algebra
@@ -111,7 +116,6 @@ internal class AstToLogicalVisitorTransform(
     private fun checkForUnsupportedSelectClauses(node: PartiqlAst.Expr.Select) {
         when {
             node.group != null -> problemHandler.handleUnimplementedFeature(node.group, "GROUP BY")
-            node.order != null -> problemHandler.handleUnimplementedFeature(node.order, "ORDER BY")
             node.having != null -> problemHandler.handleUnimplementedFeature(node.having, "HAVING")
         }
     }

--- a/lang/src/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransform.kt
@@ -84,6 +84,18 @@ internal class LogicalResolvedToDefaultPhysicalVisitorTransform(
         }
     }
 
+    override fun transformBexprSort(node: PartiqlLogicalResolved.Bexpr.Sort): PartiqlPhysical.Bexpr {
+        val thiz = this
+        return PartiqlPhysical.build {
+            sort(
+                i = DEFAULT_IMPL,
+                sortSpecs = node.sortSpecs.map { thiz.transformSortSpec(it) },
+                source = thiz.transformBexpr(node.source),
+                metas = node.metas
+            )
+        }
+    }
+
     override fun transformBexprLimit(node: PartiqlLogicalResolved.Bexpr.Limit): PartiqlPhysical.Bexpr {
         val thiz = this
         return PartiqlPhysical.build {

--- a/lang/src/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
@@ -374,10 +374,6 @@ internal data class LogicalToLogicalResolvedVisitorTransform(
         }
     }
 
-    override fun transformSortSpec(node: PartiqlLogical.SortSpec): PartiqlLogicalResolved.SortSpec {
-        return super.transformSortSpec(node)
-    }
-
     override fun transformBexprSort_sortSpecs(node: PartiqlLogical.Bexpr.Sort): List<PartiqlLogicalResolved.SortSpec> {
         val bindings = getOutputScope(node.source).concatenate(this.inputScope)
         return withInputScope(bindings) {

--- a/lang/src/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
@@ -374,6 +374,19 @@ internal data class LogicalToLogicalResolvedVisitorTransform(
         }
     }
 
+    override fun transformSortSpec(node: PartiqlLogical.SortSpec): PartiqlLogicalResolved.SortSpec {
+        return super.transformSortSpec(node)
+    }
+
+    override fun transformBexprSort_sortSpecs(node: PartiqlLogical.Bexpr.Sort): List<PartiqlLogicalResolved.SortSpec> {
+        val bindings = getOutputScope(node.source).concatenate(this.inputScope)
+        return withInputScope(bindings) {
+            node.sortSpecs.map {
+                this.transformSortSpec(it)
+            }
+        }
+    }
+
     override fun transformBexprFilter_predicate(node: PartiqlLogical.Bexpr.Filter): PartiqlLogicalResolved.Expr {
         val bindings = getOutputScope(node.source)
         return withInputScope(bindings) {
@@ -423,6 +436,7 @@ internal data class LogicalToLogicalResolvedVisitorTransform(
             is PartiqlLogical.Bexpr.Filter -> getOutputScope(bexpr.source)
             is PartiqlLogical.Bexpr.Limit -> getOutputScope(bexpr.source)
             is PartiqlLogical.Bexpr.Offset -> getOutputScope(bexpr.source)
+            is PartiqlLogical.Bexpr.Sort -> getOutputScope(bexpr.source)
             is PartiqlLogical.Bexpr.Scan -> {
                 LocalScope(
                     listOfNotNull(bexpr.asDecl.markForDynamicResolution(), bexpr.atDecl, bexpr.byDecl).also {

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerOrderByTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerOrderByTests.kt
@@ -109,39 +109,47 @@ class EvaluatingCompilerOrderByTests : EvaluatorTestBase() {
                 "[{'productId': 4, 'supplierId_nulls': NULL}, {'productId': 5, 'supplierId_nulls': NULL}, {'productId': 8, 'supplierId_nulls': NULL}, {'productId': 9, 'supplierId_nulls': NULL}, {'productId': 10, 'supplierId_nulls': NULL}, {'productId': 6, 'supplierId_nulls': 11}, {'productId': 7, 'supplierId_nulls': 11}, {'productId': 1, 'supplierId_nulls': 10}, {'productId': 2, 'supplierId_nulls': 10}, {'productId': 3, 'supplierId_nulls': 10}]"
             ),
             // should group and order by asc sellerId
+            // @TODO: Planner does NOT support GROUP BY yet. Need to add support for the following 7 tests
             EvaluatorTestCase(
                 "SELECT sellerId FROM orders GROUP BY sellerId ORDER BY sellerId ASC",
-                "[{'sellerId': 1}, {'sellerId': 2}]"
+                "[{'sellerId': 1}, {'sellerId': 2}]",
+                target = EvaluatorTestTarget.COMPILER_PIPELINE
             ),
             // should group and order by desc sellerId
             EvaluatorTestCase(
                 "SELECT sellerId FROM orders GROUP BY sellerId ORDER BY sellerId DESC",
-                "[{'sellerId': 2}, {'sellerId': 1}]"
+                "[{'sellerId': 2}, {'sellerId': 1}]",
+                target = EvaluatorTestTarget.COMPILER_PIPELINE
             ),
             // should group and order by DESC (NULLS FIRST as default)
             EvaluatorTestCase(
                 "SELECT supplierId_nulls FROM products_sparse GROUP BY supplierId_nulls ORDER BY supplierId_nulls DESC",
-                " [{'supplierId_nulls': NULL}, {'supplierId_nulls': 11}, {'supplierId_nulls': 10}]"
+                " [{'supplierId_nulls': NULL}, {'supplierId_nulls': 11}, {'supplierId_nulls': 10}]",
+                target = EvaluatorTestTarget.COMPILER_PIPELINE
             ),
             // should group and order by ASC (NULLS LAST as default)
             EvaluatorTestCase(
                 "SELECT supplierId_nulls FROM products_sparse GROUP BY supplierId_nulls ORDER BY supplierId_nulls ASC",
-                "[{'supplierId_nulls': 10}, {'supplierId_nulls': 11}, {'supplierId_nulls': NULL}]"
+                "[{'supplierId_nulls': 10}, {'supplierId_nulls': 11}, {'supplierId_nulls': NULL}]",
+                target = EvaluatorTestTarget.COMPILER_PIPELINE
             ),
             // should group and place nulls first (asc as default)
             EvaluatorTestCase(
                 "SELECT supplierId_nulls FROM products_sparse GROUP BY supplierId_nulls ORDER BY supplierId_nulls NULLS FIRST",
-                "[{'supplierId_nulls': NULL}, {'supplierId_nulls': 10}, {'supplierId_nulls': 11}]"
+                "[{'supplierId_nulls': NULL}, {'supplierId_nulls': 10}, {'supplierId_nulls': 11}]",
+                target = EvaluatorTestTarget.COMPILER_PIPELINE
             ),
             // should group and place nulls last (asc as default)
             EvaluatorTestCase(
                 "SELECT supplierId_nulls FROM products_sparse GROUP BY supplierId_nulls ORDER BY supplierId_nulls NULLS LAST",
-                "[{'supplierId_nulls': 10}, {'supplierId_nulls': 11}, {'supplierId_nulls': NULL}]"
+                "[{'supplierId_nulls': 10}, {'supplierId_nulls': 11}, {'supplierId_nulls': NULL}]",
+                target = EvaluatorTestTarget.COMPILER_PIPELINE
             ),
             // should group and order by asc and place nulls first
             EvaluatorTestCase(
                 "SELECT supplierId_nulls FROM products_sparse GROUP BY supplierId_nulls ORDER BY supplierId_nulls ASC NULLS FIRST",
-                "[{'supplierId_nulls': NULL}, {'supplierId_nulls': 10}, {'supplierId_nulls': 11}]"
+                "[{'supplierId_nulls': NULL}, {'supplierId_nulls': 10}, {'supplierId_nulls': 11}]",
+                target = EvaluatorTestTarget.COMPILER_PIPELINE
             ),
 
             // DIFFERENT DATA TYPES
@@ -289,8 +297,7 @@ class EvaluatingCompilerOrderByTests : EvaluatorTestBase() {
     @ArgumentsSource(ArgsProviderValid::class)
     fun validTests(tc: EvaluatorTestCase) = runEvaluatorTestCase(
         tc = tc.copy(
-            excludeLegacySerializerAssertions = true,
-            targetPipeline = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for ORDER BY (yet)
+            excludeLegacySerializerAssertions = true
         ),
         session = session
     )

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestCase.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestCase.kt
@@ -117,9 +117,7 @@ data class EvaluatorTestCase(
         b.appendLine("Query           : $query")
         b.appendLine("Target pipeline : $targetPipeline")
         b.appendLine("Expected result : $expectedResult")
-        if (actualResult != null) {
-            b.appendLine("Actual result   : $actualResult")
-        }
+        b.appendLine("Actual result   : $actualResult")
         b.appendLine("Result format   : $expectedResultFormat")
 
         return b.toString()

--- a/lang/test/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
@@ -117,6 +117,20 @@ class AstToLogicalVisitorTransformTests {
                     )
                 }
             ),
+            TestCase(
+                "SELECT b.* FROM bar AS b ORDER BY y",
+                PartiqlLogical.build {
+                    query(
+                        bindingsToValues(
+                            struct(structFields(id("b"))),
+                            sort(
+                                scan(id("bar"), varDecl("b")),
+                                sortSpec(id("y"), asc(), nullsLast())
+                            )
+                        )
+                    )
+                }
+            ),
         )
     }
 
@@ -240,7 +254,6 @@ class AstToLogicalVisitorTransformTests {
             ProblemTestCase("SELECT b.* FROM UNPIVOT x as y", unimplementedProblem("UNPIVOT", 1, 17)),
             ProblemTestCase("SELECT b.* FROM bar AS b GROUP BY a", unimplementedProblem("GROUP BY", 1, 26)),
             ProblemTestCase("SELECT b.* FROM bar AS b HAVING x", unimplementedProblem("HAVING", 1, 33)),
-            ProblemTestCase("SELECT b.* FROM bar AS b ORDER BY y", unimplementedProblem("ORDER BY", 1, 26)),
             ProblemTestCase("PIVOT v AT n FROM data AS d", unimplementedProblem("PIVOT", 1, 1)),
 
             // DDL is  not implemented

--- a/lang/test/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransformTests.kt
@@ -72,6 +72,44 @@ class LogicalResolvedToDefaultPhysicalVisitorTransformTests {
                         )
                     )
                 }
+            ),
+            BexprTestCase(
+                PartiqlLogicalResolved.build {
+                    sort(
+                        source = scan(
+                            expr = globalId("foo"),
+                            asDecl = varDecl(0),
+                            atDecl = varDecl(1),
+                            byDecl = varDecl(2)
+                        ),
+                        sortSpecs = listOf(
+                            sortSpec(
+                                globalId("foo"),
+                                asc(),
+                                nullsLast()
+                            )
+                        )
+                    )
+                },
+                PartiqlPhysical.build {
+                    sort(
+                        i = DEFAULT_IMPL,
+                        source = scan(
+                            i = DEFAULT_IMPL,
+                            expr = globalId("foo"),
+                            asDecl = varDecl(0),
+                            atDecl = varDecl(1),
+                            byDecl = varDecl(2)
+                        ),
+                        sortSpecs = listOf(
+                            sortSpec(
+                                globalId("foo"),
+                                asc(),
+                                nullsLast()
+                            )
+                        )
+                    )
+                }
             )
         )
     }

--- a/lang/test/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransformTests.kt
@@ -412,6 +412,30 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 ).withLocals(localVariable("foo", 0))
             ),
             TestCase(
+                // all uppercase
+                "SELECT FOO.* FROM 1 AS foo ORDER BY FOO",
+                Expectation.Success(
+                    ResolvedId(1, 8) { localId(0) },
+                    ResolvedId(1, 37) { localId(0) }
+                ).withLocals(localVariable("foo", 0))
+            ),
+            TestCase(
+                // all lowercase
+                "SELECT foo.* FROM 1 AS foo ORDER BY foo",
+                Expectation.Success(
+                    ResolvedId(1, 8) { localId(0) },
+                    ResolvedId(1, 37) { localId(0) }
+                ).withLocals(localVariable("foo", 0))
+            ),
+            TestCase(
+                // mixed case
+                "SELECT FoO.* FROM 1 AS foo ORDER BY fOo",
+                Expectation.Success(
+                    ResolvedId(1, 8) { localId(0) },
+                    ResolvedId(1, 37) { localId(0) }
+                ).withLocals(localVariable("foo", 0))
+            ),
+            TestCase(
                 // foobar is undefined (select list)
                 "SELECT foobar.* FROM [] AS foo",
                 Expectation.Problems(
@@ -459,6 +483,30 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 )
             ),
             TestCase(
+                // all uppercase
+                "SELECT \"FOO\".* FROM 1 AS foo ORDER BY \"FOO\"",
+                Expectation.Problems(
+                    problem(1, 8, PlanningProblemDetails.UndefinedVariable("FOO", caseSensitive = true)),
+                    problem(1, 39, PlanningProblemDetails.UndefinedVariable("FOO", caseSensitive = true))
+                )
+            ),
+            TestCase(
+                // all lowercase
+                "SELECT \"foo\".* FROM 1 AS foo ORDER BY \"foo\"",
+                Expectation.Success(
+                    ResolvedId(1, 8) { localId(0) },
+                    ResolvedId(1, 39) { localId(0) },
+                ).withLocals(localVariable("foo", 0))
+            ),
+            TestCase(
+                // mixed case
+                "SELECT \"FoO\".* FROM 1 AS foo ORDER BY \"fOo\"",
+                Expectation.Problems(
+                    problem(1, 8, PlanningProblemDetails.UndefinedVariable("FoO", caseSensitive = true)),
+                    problem(1, 39, PlanningProblemDetails.UndefinedVariable("fOo", caseSensitive = true))
+                )
+            ),
+            TestCase(
                 // "foobar" is undefined (select list)
                 "SELECT \"foobar\".* FROM [] AS foo ",
                 Expectation.Problems(
@@ -470,6 +518,13 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 "SELECT \"foo\".* FROM [] AS foo WHERE \"barbat\"",
                 Expectation.Problems(
                     problem(1, 37, PlanningProblemDetails.UndefinedVariable("barbat", caseSensitive = true))
+                )
+            ),
+            TestCase(
+                // "barbat" is undefined (ORDER BY clause)
+                "SELECT \"foo\".* FROM [] AS foo ORDER BY \"barbat\"",
+                Expectation.Problems(
+                    problem(1, 40, PlanningProblemDetails.UndefinedVariable("barbat", caseSensitive = true))
                 )
             )
         )
@@ -555,6 +610,16 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 ).withLocals(localVariable("b", 0))
             ),
 
+            // Covers local variables in select list, global variables in FROM source, local variables in ORDER BY clause
+            TestCase(
+                "SELECT b.* FROM bar AS b ORDER BY b.primaryKey = 42",
+                Expectation.Success(
+                    ResolvedId(1, 8) { localId(0) },
+                    ResolvedId(1, 17) { globalId("fake_uid_for_bar") },
+                    ResolvedId(1, 35) { localId(0) },
+                ).withLocals(localVariable("b", 0))
+            ),
+
             // Demonstrate that globals-first variable lookup only happens in the FROM clause.
             TestCase(
                 "SELECT shadow.* FROM shadow AS shadow", // `shadow` defined here shadows the global `shadow`
@@ -623,6 +688,37 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 ).withLocals(localVariable("f", 0), localVariable("b", 1), localVariable("t", 2)),
                 allowUndefinedVariables = true
             ),
+
+            // In select list and ORDER BY clause
+            TestCase(
+                "SELECT undefined1 AS u FROM 1 AS f ORDER BY undefined2", // 1 from source
+                Expectation.Success(
+                    ResolvedId(1, 8) { dynamicLookup("undefined1", BindingCase.INSENSITIVE, globalsFirst = false, localId(0)) },
+                    ResolvedId(1, 45) { dynamicLookup("undefined2", BindingCase.INSENSITIVE, globalsFirst = false, localId(0)) }
+                ).withLocals(localVariable("f", 0)),
+                allowUndefinedVariables = true
+            ),
+            TestCase(
+                sql = "SELECT undefined1 AS u FROM 1 AS a, 2 AS b ORDER BY undefined2", // 2 from sources
+                Expectation.Success(
+                    ResolvedId(1, 8) { dynamicLookup("undefined1", BindingCase.INSENSITIVE, globalsFirst = false, localId(1), localId(0)) },
+                    ResolvedId(1, 53) { dynamicLookup("undefined2", BindingCase.INSENSITIVE, globalsFirst = false, localId(1), localId(0)) }
+                ).withLocals(localVariable("a", 0), localVariable("b", 1)),
+                allowUndefinedVariables = true
+            ),
+            TestCase(
+                sql = "SELECT undefined1 AS u FROM 1 AS f, 1 AS b, 1 AS t ORDER BY undefined2", // 3 from sources
+                Expectation.Success(
+                    ResolvedId(1, 8) {
+                        dynamicLookup("undefined1", BindingCase.INSENSITIVE, globalsFirst = false, localId(2), localId(1), localId(0))
+                    },
+                    ResolvedId(1, 61) {
+                        dynamicLookup("undefined2", BindingCase.INSENSITIVE, globalsFirst = false, localId(2), localId(1), localId(0))
+                    }
+                ).withLocals(localVariable("f", 0), localVariable("b", 1), localVariable("t", 2)),
+                allowUndefinedVariables = true
+            ),
+
             // In from clause
             TestCase(
                 // Wihtout scope override


### PR DESCRIPTION
## Relevant Issues
- Closes #781 

## Description
- Adds a `SORT` node to `logical`, `resolved`, and `physical` plans (domains)
- Adds appropriate transforms
- Adds an abstract class `SortOperatorFactory` implementing a `RelationalOperatorFactory`
- Adds a simple `InMemorySortFactory` that takes in a `RelationExpression` and outputs a sorted `RelationExpression`. It is the default `SORT` implementation.
  - It works by evaluating the source relation expression, copying the state's registers (for the purpose of sorting), evaluating the ORDER BY sort specs using the passed state's registers, and then modifying the state's registers to output the correct state order.
- Removes the check for the existence of `ORDER BY` -- it used to throw intentional "unimplemented" exceptions
- Adds tests to the three types of transforms, and enables the evaluator tests for ORDER BY to test using the new planner

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
  - No. Only adding PartiQL domain nodes.
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.