### PR TITLE
Marked TypedOpBehavior.LEGACY as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ stage in the `PlannerPipeline` and to generate performance metrics for the indiv
 - Deprecates `SqlLexer` and `SqlParser` to be replaced with the `PartiQLParserBuilder`.
 - Deprecates helper method, `blacklist`, within `org.partiql.lang.eval` and introduced a functionally equivalent
   `org.partiql.lang.eval.denyList` method.
+- Deprecates `TypedOpParameter.LEGACY` to be replaces with `TypedOpParameter.HONOR_PARAMETERS`
 
 ### Fixed
 - Codecov report uploads in GitHub Actions workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ stage in the `PlannerPipeline` and to generate performance metrics for the indiv
 - Deprecates `SqlLexer` and `SqlParser` to be replaced with the `PartiQLParserBuilder`.
 - Deprecates helper method, `blacklist`, within `org.partiql.lang.eval` and introduced a functionally equivalent
   `org.partiql.lang.eval.denyList` method.
-- Deprecates `TypedOpParameter.LEGACY` to be replaces with `TypedOpParameter.HONOR_PARAMETERS`
+- Deprecates `TypedOpParameter.LEGACY` to be replaced with `TypedOpParameter.HONOR_PARAMETERS`
 
 ### Fixed
 - Codecov report uploads in GitHub Actions workflow

--- a/lang/src/org/partiql/lang/eval/CompileOptions.kt
+++ b/lang/src/org/partiql/lang/eval/CompileOptions.kt
@@ -79,7 +79,7 @@ enum class TypingMode {
  * Indicates how CAST should behave.
  */
 enum class TypedOpBehavior {
-    @Deprecated("Please use HONOR_PARAMETERS")
+    @Deprecated(message = "TypedOpBehavior.LEGACY is an old compile option that will be removed in an upcoming release", replaceWith = ReplaceWith("TypedOpBehavior.HONOR_PARAMETERS"))
     /** The old behavior that ignores type arguments in CAST and IS. */
     LEGACY,
 

--- a/lang/src/org/partiql/lang/eval/CompileOptions.kt
+++ b/lang/src/org/partiql/lang/eval/CompileOptions.kt
@@ -79,6 +79,7 @@ enum class TypingMode {
  * Indicates how CAST should behave.
  */
 enum class TypedOpBehavior {
+    @Deprecated("Please use HONOR_PARAMETERS")
     /** The old behavior that ignores type arguments in CAST and IS. */
     LEGACY,
 


### PR DESCRIPTION
Deprecates `TypedOpParameter.LEGACY` to be replaced with `TypedOpParameter.HONOR_PARAMETERS`