### PR TITLE
Switched from MATCH-as-FROM-source to MATCH-as-expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on the changes that include these and the alternatives that have been considered.
 - README.md badges for GitHub Actions status, codecov, and license
 - An experimental (pending [#15](https://github.com/partiql/partiql-docs/issues/15)) embedding of a subset of
-  the [GPML (Graph Pattern Matching Language)](https://arxiv.org/abs/2112.06217) graph query into the `FROM` clause,
-  supporting. The use within the grammar is based on the assumption of a new graph data type being added to the
+  the [GPML (Graph Pattern Matching Language)](https://arxiv.org/abs/2112.06217) graph query, as a new expression
+  form `<expr> MATCH <gpml_pattern>`, which can be used as a bag-of-structs data source in the `FROM` clause.   
+  The use within the grammar is based on the assumption of a new graph data type being added to the
   specification of data types within PartiQL, and should be considered experimental until the semantics of the graph
   data type are specified.
   - basic and abbreviated node and edge patterns (section 4.1 of the GPML paper)

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -208,11 +208,11 @@ may then be further optimized by selecting better implementations of each operat
             // UNPIVOT <expr> [AS <id>] [AT <id>] [BY <id>]
             (unpivot expr::expr as_alias::(? symbol) at_alias::(? symbol) by_alias::(? symbol))
 
-             // <from_source> JOIN [INNER | LEFT | RIGHT | FULL] <from_source> ON <expr>
-             (join type::join_type left::from_source right::from_source predicate::(? expr))
+            // <from_source> JOIN [INNER | LEFT | RIGHT | FULL] <from_source> ON <expr>
+            (join type::join_type left::from_source right::from_source predicate::(? expr))
 
-             // <expr> MATCH <graph_pattern>
-             (graph_match expr::expr graph_expr::graph_match_expr))
+            // <expr> MATCH <gpml_pattern>
+            (graph_match expr::expr gpml_pattern::gpml_pattern))
 
         // Indicates the logical type of join.
         (sum join_type (inner) (left) (right) (full))
@@ -302,9 +302,9 @@ may then be further optimized by selecting better implementations of each operat
              (selector_shortest_k k::int)
              (selector_shortest_k_group k::int))
 
-        // A graph match clause as defined in GPML
+        // A graph pattern as defined in GPML
         // See https://arxiv.org/abs/2112.06217
-        (product graph_match_expr
+        (product gpml_pattern
                  selector::(? graph_match_selector)
                  patterns::(* graph_match_pattern 1))
 

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -129,6 +129,9 @@ may then be further optimized by selecting better implementations of each operat
             // Bag operators
             (bag_op op::bag_op_type quantifier::set_quantifier operands::(* expr 2))
 
+            // GPML graph pattern match:  <expr> MATCH <gpml_pattern>
+            (graph_match expr::expr gpml_pattern::gpml_pattern)
+
             // Other expression types
             (path root::expr steps::(* path_step 1))
             (call func_name::symbol args::(* expr 1))
@@ -210,9 +213,7 @@ may then be further optimized by selecting better implementations of each operat
 
             // <from_source> JOIN [INNER | LEFT | RIGHT | FULL] <from_source> ON <expr>
             (join type::join_type left::from_source right::from_source predicate::(? expr))
-
-            // <expr> MATCH <gpml_pattern>
-            (graph_match expr::expr gpml_pattern::gpml_pattern))
+        )
 
         // Indicates the logical type of join.
         (sum join_type (inner) (left) (right) (full))

--- a/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
+++ b/lang/src/org/partiql/lang/ast/StatementToExprNode.kt
@@ -194,6 +194,7 @@ private class StatementTransformer(val ion: IonSystem) {
                 )
             is PartiqlAst.Expr.NullIf -> NullIf(expr1.toExprNode(), expr2.toExprNode(), metas)
             is PartiqlAst.Expr.Coalesce -> Coalesce(args.map { it.toExprNode() }, metas)
+            is PartiqlAst.Expr.GraphMatch -> error("$this node has no representation in prior ASTs.")
         }
     }
 
@@ -252,7 +253,6 @@ private class StatementTransformer(val ion: IonSystem) {
                     condition = predicate?.toExprNode() ?: Literal(ion.newBool(true), metaContainerOf(StaticTypeMeta(StaticType.BOOL))),
                     metas = metas
                 )
-            is PartiqlAst.FromSource.GraphMatch -> error("$this node has no representation in prior ASTs.")
         }
     }
 

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -440,6 +440,8 @@ internal class EvaluatingCompiler(
 
             // bag operators
             is PartiqlAst.Expr.BagOp -> compileBagOp(expr, metas)
+
+            is PartiqlAst.Expr.GraphMatch -> TODO("Compilation of GraphMatch expression")
         }
     }
 

--- a/lang/src/org/partiql/lang/eval/physical/PhysicalExprToThunkConverterImpl.kt
+++ b/lang/src/org/partiql/lang/eval/physical/PhysicalExprToThunkConverterImpl.kt
@@ -266,6 +266,8 @@ internal class PhysicalExprToThunkConverterImpl(
             // bag operators
             is PartiqlPhysical.Expr.BagOp -> compileBagOp(expr, metas)
             is PartiqlPhysical.Expr.BindingsToValues -> compileBindingsToValues(expr)
+
+            is PartiqlPhysical.Expr.GraphMatch -> TODO("Physical compilation of GraphMatch expression")
         }
     }
 

--- a/lang/src/org/partiql/lang/eval/visitors/GroupByPathExpressionVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/GroupByPathExpressionVisitorTransform.kt
@@ -77,8 +77,6 @@ class GroupByPathExpressionVisitorTransform(
                 is PartiqlAst.FromSource.Unpivot ->
                     listOfNotNull(fromSource.asAlias?.text, fromSource.atAlias?.text)
 
-                is PartiqlAst.FromSource.GraphMatch ->
-                    TODO("Handle MATCH for GROUP BY")
             }
     }
 

--- a/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -346,8 +346,6 @@ private class FromSourceToBexpr(
             )
         }
 
-    override fun convertGraphMatch(node: PartiqlAst.FromSource.GraphMatch): PartiqlLogical.Bexpr =
-        INVALID_BEXPR.also { problemHandler.handleUnimplementedFeature(node, "MATCH") }
 }
 
 private val INVALID_STATEMENT = PartiqlLogical.build {

--- a/lang/src/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
+++ b/lang/src/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
@@ -557,6 +557,8 @@ class ASTPrettyPrinter {
                     if (node.offset == null) it else (it.plusElement(toRecursionTree(node.offset, "offset")))
                 }
             )
+            // PR-COMMENT This is on par with the TODO that was in toRecursionTree(PartiqlAst.FromSource) overload.
+            is PartiqlAst.Expr.GraphMatch -> TODO("Unsupported GraphMatch AST node")
         }
 
     private fun toRecursionTreeList(nodes: List<PartiqlAst.Expr>, attrOfParent: String? = null): List<RecursionTree> =
@@ -668,7 +670,6 @@ class ASTPrettyPrinter {
                     if (node.byAlias == null) it else { it.plusElement(toRecursionTree(node.byAlias, attrOfParent = "by")) }
                 }
             )
-            else -> TODO("Unsupported FROM AST node")
         }
 
     private fun toRecursionTree(node: PartiqlAst.Let, attrOfParent: String? = null): RecursionTree =

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -985,7 +985,7 @@ class SqlParser(
                 it.toGraphMatchPattern()
             }
 
-            val matchExpr = PartiqlAst.GraphMatchExpr(selector = selector, patterns = patterns, metas = metas)
+            val matchExpr = PartiqlAst.GpmlPattern(selector = selector, patterns = patterns, metas = metas)
             PartiqlAst.FromSource.GraphMatch(expr, matchExpr, metas)
         }
     }

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -942,13 +942,15 @@ class SqlParser(
                         if (isCrossJoin) metas + metaContainerOf(IsImplictJoinMeta.instance) else metas
                     )
                 }
-                ParseType.MATCH -> toGraphMatch()
                 else -> unwrapAliasesAndUnpivot()
             }
         }
     }
 
-    private fun ParseNode.toGraphMatch(): PartiqlAst.FromSource {
+    // PR-COMMENT As changed, this compiles,
+    // transforming into the changed PartiqlAst,
+    // but this is not called from anywhere currently.
+    private fun ParseNode.toGraphMatch(): PartiqlAst.Expr {
         val metas = getMetas()
         var selector: PartiqlAst.GraphMatchSelector? = null
 
@@ -986,7 +988,7 @@ class SqlParser(
             }
 
             val matchExpr = PartiqlAst.GpmlPattern(selector = selector, patterns = patterns, metas = metas)
-            PartiqlAst.FromSource.GraphMatch(expr, matchExpr, metas)
+            PartiqlAst.Expr.GraphMatch(expr, matchExpr, metas)
         }
     }
 

--- a/lang/src/org/partiql/lang/visitors/PartiQLVisitor.kt
+++ b/lang/src/org/partiql/lang/visitors/PartiQLVisitor.kt
@@ -742,17 +742,11 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
     }
 
     override fun visitMatchSingle(ctx: PartiQLParser.MatchSingleContext) = PartiqlAst.build {
-        val source = visitExpr(ctx.lhs)
-        val metas = ctx.MATCH().getSourceMetaContainer()
-        val gpmlPattern = visitGpmlPattern(ctx.gpmlPattern())
-        graphMatch(source, gpmlPattern, metas)
+        visitGpmlPattern(ctx.gpmlPattern())
     }
 
     override fun visitMatchMultiple(ctx: PartiQLParser.MatchMultipleContext) = PartiqlAst.build {
-        val source = visitExpr(ctx.lhs)
-        val metas = ctx.MATCH().getSourceMetaContainer()
-        val gpmlPattern = visitGpmlPatternList(ctx.gpmlPatternList())
-        graphMatch(source, gpmlPattern, metas)
+        visitGpmlPatternList(ctx.gpmlPatternList())
     }
 
     override fun visitFromClauseSimpleExplicit(ctx: PartiQLParser.FromClauseSimpleExplicitContext) = PartiqlAst.build {
@@ -920,6 +914,12 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
         val base = visit(ctx.exprPrimary()) as PartiqlAst.Expr
         val steps = ctx.pathStep().map { step -> visit(step) as PartiqlAst.PathStep }
         path(base, steps, base.metas)
+    }
+
+    override fun visitExprPrimaryMatch(ctx: PartiQLParser.ExprPrimaryMatchContext) = PartiqlAst.build {
+        val graph = visit(ctx.exprPrimary()) as PartiqlAst.Expr
+        val gpmlPattern = visit(ctx.matchPostfix()) as PartiqlAst.GpmlPattern
+        graphMatch(graph, gpmlPattern, graph.metas)
     }
 
     override fun visitPathStepIndexExpr(ctx: PartiQLParser.PathStepIndexExprContext) = PartiqlAst.build {

--- a/lang/src/org/partiql/lang/visitors/PartiQLVisitor.kt
+++ b/lang/src/org/partiql/lang/visitors/PartiQLVisitor.kt
@@ -573,16 +573,16 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
      *
      */
 
-    override fun visitMatchExpr(ctx: PartiQLParser.MatchExprContext) = PartiqlAst.build {
+    override fun visitGpmlPattern(ctx: PartiQLParser.GpmlPatternContext) = PartiqlAst.build {
         val selector = visitOrNull(ctx.matchSelector(), PartiqlAst.GraphMatchSelector::class)
         val pattern = visitMatchPattern(ctx.matchPattern())
-        graphMatchExpr(selector, listOf(pattern))
+        gpmlPattern(selector, listOf(pattern))
     }
 
-    override fun visitMatchExprList(ctx: PartiQLParser.MatchExprListContext) = PartiqlAst.build {
+    override fun visitGpmlPatternList(ctx: PartiQLParser.GpmlPatternListContext) = PartiqlAst.build {
         val selector = visitOrNull(ctx.matchSelector(), PartiqlAst.GraphMatchSelector::class)
         val patterns = ctx.matchPattern().map { pattern -> visitMatchPattern(pattern) }
-        graphMatchExpr(selector, patterns)
+        gpmlPattern(selector, patterns)
     }
 
     override fun visitMatchPattern(ctx: PartiQLParser.MatchPatternContext) = PartiqlAst.build {
@@ -744,15 +744,15 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
     override fun visitMatchSingle(ctx: PartiQLParser.MatchSingleContext) = PartiqlAst.build {
         val source = visitExpr(ctx.lhs)
         val metas = ctx.MATCH().getSourceMetaContainer()
-        val graphExpr = visitMatchExpr(ctx.matchExpr())
-        graphMatch(source, graphExpr, metas)
+        val gpmlPattern = visitGpmlPattern(ctx.gpmlPattern())
+        graphMatch(source, gpmlPattern, metas)
     }
 
     override fun visitMatchMultiple(ctx: PartiQLParser.MatchMultipleContext) = PartiqlAst.build {
         val source = visitExpr(ctx.lhs)
         val metas = ctx.MATCH().getSourceMetaContainer()
-        val graphExpr = visitMatchExprList(ctx.matchExprList())
-        graphMatch(source, graphExpr, metas)
+        val gpmlPattern = visitGpmlPatternList(ctx.gpmlPatternList())
+        graphMatch(source, gpmlPattern, metas)
     }
 
     override fun visitFromClauseSimpleExplicit(ctx: PartiQLParser.FromClauseSimpleExplicitContext) = PartiqlAst.build {

--- a/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserMatchTest.kt
@@ -18,7 +18,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
             project = projectList(projectExpr(lit(ionInt(1)))),
             from = graphMatch(
                 expr = id("my_graph"),
-                graphExpr = graphMatchExpr(
+                gpmlPattern = gpmlPattern(
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
@@ -44,7 +44,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
             project = projectStar(),
             from = graphMatch(
                 expr = id("my_graph"),
-                graphExpr = graphMatchExpr(
+                gpmlPattern = gpmlPattern(
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
@@ -69,7 +69,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
             project = projectList(projectExpr(lit(ionInt(1)))),
             from = graphMatch(
                 expr = id("my_graph"),
-                graphExpr = graphMatchExpr(
+                gpmlPattern = gpmlPattern(
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
@@ -95,7 +95,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
             project = projectList(projectExpr(expr = id("x"))),
             from = graphMatch(
                 expr = id("my_graph"),
-                graphExpr = graphMatchExpr(
+                gpmlPattern = gpmlPattern(
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
@@ -120,7 +120,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
             project = projectStar(),
             from = graphMatch(
                 expr = id("my_graph"),
-                graphExpr = graphMatchExpr(
+                gpmlPattern = gpmlPattern(
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
@@ -150,7 +150,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
             ),
             from = graphMatch(
                 expr = id("my_graph"),
-                graphExpr = graphMatchExpr(
+                gpmlPattern = gpmlPattern(
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
@@ -179,7 +179,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
             project = projectList(projectExpr(expr = id("x"), asAlias = "target")),
             from = graphMatch(
                 expr = id("my_graph"),
-                graphExpr = graphMatchExpr(
+                gpmlPattern = gpmlPattern(
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
@@ -210,7 +210,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
             project = projectList(projectExpr(lit(ionInt(1)))),
             from = graphMatch(
                 expr = id("g"),
-                graphExpr = graphMatchExpr(
+                gpmlPattern = gpmlPattern(
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
@@ -237,7 +237,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
                     project = projectList(projectExpr(id("a")), projectExpr(id("b"))),
                     from = graphMatch(
                         expr = id("g"),
-                        graphExpr = graphMatchExpr(
+                        gpmlPattern = gpmlPattern(
                             patterns = listOf(
                                 graphMatchPattern(
                                     quantifier = null,
@@ -440,7 +440,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
             ),
             from = graphMatch(
                 expr = id("my_graph"),
-                graphExpr = graphMatchExpr(
+                gpmlPattern = gpmlPattern(
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
@@ -486,7 +486,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
             ),
             from = graphMatch(
                 expr = id("g"),
-                graphExpr = graphMatchExpr(
+                gpmlPattern = gpmlPattern(
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
@@ -547,7 +547,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
             ),
             from = graphMatch(
                 expr = id("g"),
-                graphExpr = graphMatchExpr(
+                gpmlPattern = gpmlPattern(
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(
@@ -597,7 +597,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
                 project = projectList(projectExpr(id("a")), projectExpr(id("b"))),
                 from = graphMatch(
                     expr = id("g"),
-                    graphExpr = graphMatchExpr(
+                    gpmlPattern = gpmlPattern(
                         patterns = listOf(
                             graphMatchPattern(
                                 variable = "p",
@@ -634,7 +634,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
                 project = projectList(projectExpr(id("a")), projectExpr(id("b"))),
                 from = graphMatch(
                     expr = id("g"),
-                    graphExpr = graphMatchExpr(
+                    gpmlPattern = gpmlPattern(
                         patterns = listOf(
                             graphMatchPattern(
                                 parts = listOf(
@@ -681,7 +681,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
                 project = projectList(projectExpr(id("a")), projectExpr(id("b"))),
                 from = graphMatch(
                     expr = id("g"),
-                    graphExpr = graphMatchExpr(
+                    gpmlPattern = gpmlPattern(
                         patterns = listOf(
                             graphMatchPattern(
                                 variable = "pathVar",
@@ -724,7 +724,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
                 project = projectList(projectExpr(id("a")), projectExpr(id("b"))),
                 from = graphMatch(
                     expr = id("g"),
-                    graphExpr = graphMatchExpr(
+                    gpmlPattern = gpmlPattern(
                         patterns = listOf(
                             graphMatchPattern(
                                 variable = "pathVar",
@@ -782,7 +782,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
                 project = projectList(projectExpr(id("u"), asAlias = "banCandidate")),
                 from = graphMatch(
                     expr = id("g"),
-                    graphExpr = graphMatchExpr(
+                    gpmlPattern = gpmlPattern(
                         patterns = listOf(
                             graphMatchPattern(
                                 parts = listOf(
@@ -844,7 +844,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
                 project = projectList(projectExpr(id("p"))),
                 from = graphMatch(
                     expr = id("g"),
-                    graphExpr = graphMatchExpr(
+                    gpmlPattern = gpmlPattern(
                         patterns = listOf(
                             graphMatchPattern(
                                 restrictor = restrictor,
@@ -909,7 +909,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
                 project = projectList(projectExpr(id("p"))),
                 from = graphMatch(
                     expr = id("g"),
-                    graphExpr = graphMatchExpr(
+                    gpmlPattern = gpmlPattern(
                         selector = selector,
                         patterns = listOf(
                             graphMatchPattern(
@@ -993,7 +993,7 @@ class SqlParserMatchTest : SqlParserTestBase() {
         val match = PartiqlAst.build {
             graphMatch(
                 expr = id("graph"),
-                graphExpr = graphMatchExpr(
+                gpmlPattern = gpmlPattern(
                     patterns = listOf(
                         graphMatchPattern(
                             parts = listOf(

--- a/partiql-grammar/src/main/antlr/org/partiql/grammar/PartiQL.g4
+++ b/partiql-grammar/src/main/antlr/org/partiql/grammar/PartiQL.g4
@@ -296,10 +296,10 @@ limitClause
  *
  */
 
-matchExpr
+gpmlPattern
     : selector=matchSelector? matchPattern;
 
-matchExprList
+gpmlPatternList
     : selector=matchSelector? matchPattern ( COMMA matchPattern )*;
 
 matchPattern
@@ -391,8 +391,8 @@ tableUnpivot
     : UNPIVOT expr asIdent? atIdent? byIdent?;
 
 tableMatch
-    : lhs=expr MATCH matchExpr                              # MatchSingle
-    | lhs=expr MATCH PAREN_LEFT matchExprList PAREN_RIGHT   # MatchMultiple
+    : lhs=expr MATCH gpmlPattern                              # MatchSingle
+    | lhs=expr MATCH PAREN_LEFT gpmlPatternList PAREN_RIGHT   # MatchMultiple
     ;
 
 tableJoined[ParserRuleContext lhs]

--- a/partiql-grammar/src/main/antlr/org/partiql/grammar/PartiQL.g4
+++ b/partiql-grammar/src/main/antlr/org/partiql/grammar/PartiQL.g4
@@ -379,7 +379,6 @@ tableReference
 tableNonJoin
     : tableBaseReference
     | tableUnpivot
-    | tableMatch
     ;
 
 tableBaseReference
@@ -389,11 +388,6 @@ tableBaseReference
 
 tableUnpivot
     : UNPIVOT expr asIdent? atIdent? byIdent?;
-
-tableMatch
-    : lhs=expr MATCH gpmlPattern                              # MatchSingle
-    | lhs=expr MATCH PAREN_LEFT gpmlPatternList PAREN_RIGHT   # MatchMultiple
-    ;
 
 tableJoined[ParserRuleContext lhs]
     : tableCrossJoin[$lhs]
@@ -526,6 +520,7 @@ exprPrimary
     | functionCall               # ExprPrimaryBase
     | nullIf                     # ExprPrimaryBase
     | exprPrimary pathStep+      # ExprPrimaryPath
+    | exprPrimary matchPostfix   # ExprPrimaryMatch
     | caseExpr                   # ExprPrimaryBase
     | valueList                  # ExprPrimaryBase
     | values                     # ExprPrimaryBase
@@ -607,6 +602,11 @@ pathStep
     | BRACKET_LEFT all=ASTERISK BRACKET_RIGHT    # PathStepIndexAll
     | PERIOD key=symbolPrimitive                 # PathStepDotExpr
     | PERIOD all=ASTERISK                        # PathStepDotAll
+    ;
+
+matchPostfix
+    : MATCH gpmlPattern                              # MatchSingle
+    | MATCH PAREN_LEFT gpmlPatternList PAREN_RIGHT   # MatchMultiple
     ;
 
 parameter


### PR DESCRIPTION
## Description

In a graph query like 
```
    SELECT * FROM MyGraph MATCH (a)-[b]-(c)
```
the construct involving MATCH, instead of being understood as a special kind of a FROM source, 
is now understood as a new expression form. 
That is, `MyGraph MATCH (a)-[b]-(c)` is an expression that, given a graph-yielding expression and a graph pattern, produces a bag of structs (a "table") with attributes `a`, `b`, `c`. 

With this change, a MATCH expression can be a source in a FROM clause, as any other table-producing expression.  This happens to give variable-binding behavior that is different than under the earlier MATCH design. In particular, it is possible to write 
```
     SELECT x.* FROM MyGraph MATCH (a)-[b]-(c) AS x
```
which produces a table with columns `a`, `b`, `c`.

Only the ANTLR-based parser is properly supported in this PR.  
The old SqlParser got minimal changes to make it compile and still contains most of the earlier code for the original design of MATCH.  However, SqlParser now breaks when given MATCH-containing source, because the target PIG AST has changed.
*Please advise whether it is worth bringing SqlParser up to date.*

There are a few code comments marked with `PR-COMMENT`.  These highlight spots worthy of attention and  are meant to be either removed or converted to regular comments prior to merging.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**
  - Modified the earlier entry about the experimental graph query feature. 
- Any backward-incompatible changes? **[NO]**
  - The version-controlled behavior does change in a breaking way w.r.t. to prior commits, but they have not yet been released and the overall graph feature is experimental anyway.
- Any new external dependencies? **[NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.