### PR TITLE
Removed type names from ExprValueType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ stage in the `PlannerPipeline` and to generate performance metrics for the indiv
 
 ### Removed
 - README.md badge for travisci
+- [ExprValueType.typeNames] as needed by the future work of legacy parser removal and OTS 
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ stage in the `PlannerPipeline` and to generate performance metrics for the indiv
 
 ### Removed
 - README.md badge for travisci
-- [ExprValueType.typeNames] as needed by the future work of legacy parser removal and OTS 
+- **Breaking Change**: removed [ExprValueType.typeNames] as needed by the future work of legacy parser removal and OTS 
 
 ### Security
 

--- a/lang/src/org/partiql/lang/eval/ExprValueType.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueType.kt
@@ -18,17 +18,14 @@ import com.amazon.ion.IonType
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.syntax.CORE_TYPE_NAME_ARITY_MAP
-import org.partiql.lang.syntax.TYPE_ALIASES
 
 /**
  * The core types of [ExprValue] that exist within the type system of the evaluator.
  * There is a correspondence to [IonType], but it isn't quite one-to-one.
  *
- * @param typeNames The normalized type names and aliases associated with the runtime type.
  * @param isRangedFrom Whether or not the `FROM` clause uses the value's iterator directly.
  */
 enum class ExprValueType(
-    val typeNames: List<String>,
     val isUnknown: Boolean = false,
     val isNumber: Boolean = false,
     val isText: Boolean = false,
@@ -36,80 +33,26 @@ enum class ExprValueType(
     val isSequence: Boolean = false,
     val isRangedFrom: Boolean = false
 ) {
-    MISSING(
-        typeNames = listOf("missing"),
-        isUnknown = true
-    ),
-    NULL(
-        typeNames = listOf("null"),
-        isUnknown = true
-    ),
-    BOOL(
-        typeNames = listOf("bool", "boolean")
-    ),
-    INT(
-        typeNames = listOf(
-            "int", "smallint", "integer2", "int2", "integer", "integer4", "int4", "integer8", "int8",
-            "bigint"
-        ),
-        isNumber = true
-    ),
-    FLOAT(
-        typeNames = listOf("float", "real", "double_precision"),
-        isNumber = true
-    ),
-    DECIMAL(
-        typeNames = listOf("dec", "decimal", "numeric"),
-        isNumber = true
-    ),
-    DATE(
-        typeNames = listOf("date")
-    ),
-    TIMESTAMP(
-        typeNames = listOf("timestamp")
-    ),
-    TIME(
-        typeNames = listOf("time")
-    ),
-    SYMBOL(
-        typeNames = listOf("symbol"),
-        isText = true
-    ),
-    STRING(
-        typeNames = listOf("string", "char", "varchar", "character", "character_varying"),
-        isText = true
-    ),
-    CLOB(
-        typeNames = listOf("clob"),
-        isLob = true
-    ),
-    BLOB(
-        typeNames = listOf("blob"),
-        isLob = true
-    ),
-    LIST(
-        typeNames = listOf("list"),
-        isSequence = true,
-        isRangedFrom = true
-    ),
-    SEXP(
-        typeNames = listOf("sexp"),
-        isSequence = true
-    ),
-    STRUCT(
-        typeNames = listOf("struct", "tuple")
-    ),
-    BAG(
-        typeNames = listOf("bag"),
-        isSequence = true,
-        isRangedFrom = true
-    );
+    MISSING(isUnknown = true),
+    NULL(isUnknown = true),
+    BOOL,
+    INT(isNumber = true),
+    FLOAT(isNumber = true),
+    DECIMAL(isNumber = true),
+    DATE,
+    TIMESTAMP,
+    TIME,
+    SYMBOL(isText = true),
+    STRING(isText = true),
+    CLOB(isLob = true),
+    BLOB(isLob = true),
+    LIST(isSequence = true, isRangedFrom = true),
+    SEXP(isSequence = true),
+    STRUCT,
+    BAG(isSequence = true, isRangedFrom = true);
 
     @Deprecated("Please use isUnknown instead", ReplaceWith("isUnknown"))
     fun isNull() = isUnknown
-
-    /** The canonical PartiQL textual names for the runtime type. */
-    val sqlTextNames = typeNames.map { it.toUpperCase().replace("_", " ") }
 
     /** Whether or not the given type is in the same type grouping as another. */
     fun isDirectlyComparableTo(other: ExprValueType): Boolean =
@@ -119,25 +62,6 @@ enum class ExprValueType(
             (isLob && other.isLob)
 
     companion object {
-        init {
-            // validate that this enum is consistent with the normalized type names and aliases
-            val lexerTypeNames = (CORE_TYPE_NAME_ARITY_MAP.keys union TYPE_ALIASES.keys)
-            val declaredTypeNames = mutableSetOf<String>()
-            values().flatMap { it.typeNames }.forEach {
-                if (it !in lexerTypeNames) {
-                    throw IllegalStateException("Declared type name does not exist in lexer: $it")
-                }
-                if (it in declaredTypeNames) {
-                    throw IllegalStateException("Duplicate declaration for $it")
-                }
-                declaredTypeNames.add(it)
-            }
-            val undeclaredTypeNames = lexerTypeNames - declaredTypeNames
-            if (undeclaredTypeNames.isNotEmpty()) {
-                throw IllegalStateException("Undeclared type names: $undeclaredTypeNames")
-            }
-        }
-
         private val ION_TYPE_MAP = enumValues<IonType>().asSequence()
             .map {
                 val ourType = when (it) {
@@ -147,7 +71,7 @@ enum class ExprValueType(
                 Pair(it, ourType)
             }.toMap()
 
-        /** Maps an [IonType] to an [ExprType]. */
+        /** Maps an [IonType] to an [ExprValueType]. */
         fun fromIonType(ionType: IonType): ExprValueType = ION_TYPE_MAP[ionType]!!
 
         private val LEX_TYPE_MAP = mapOf(

--- a/lang/test/org/partiql/lang/eval/CastTestBase.kt
+++ b/lang/test/org/partiql/lang/eval/CastTestBase.kt
@@ -42,25 +42,25 @@ data class NotImplemented(val expectedQuality: CastQuality) : CastQualityStatus(
  */
 data class FixSemantics(val expectedQuality: CastQuality) : CastQualityStatus()
 
-private val typeToTypeAliases = mapOf(
-    ExprValueType.MISSING to listOf("missing"),
-    ExprValueType.NULL to listOf("null"),
-    ExprValueType.BOOL to listOf("bool", "boolean"),
-    ExprValueType.INT to listOf("int", "smallint", "integer2", "int2", "integer", "integer4", "int4", "integer8", "int8", "bigint"),
-    ExprValueType.FLOAT to listOf("float", "real", "double precision"),
-    ExprValueType.DECIMAL to listOf("dec", "decimal", "numeric"),
-    ExprValueType.DATE to listOf("date"),
-    ExprValueType.TIMESTAMP to listOf("timestamp"),
-    ExprValueType.TIME to listOf("time"),
-    ExprValueType.SYMBOL to listOf("symbol"),
-    ExprValueType.STRING to listOf("string", "char", "varchar", "character", "character varying"),
-    ExprValueType.CLOB to listOf("clob"),
-    ExprValueType.BLOB to listOf("blob"),
-    ExprValueType.LIST to listOf("list"),
-    ExprValueType.SEXP to listOf("sexp"),
-    ExprValueType.STRUCT to listOf("struct", "tuple"),
-    ExprValueType.BAG to listOf("bag")
-)
+private fun ExprValueType.typeAliases(): List<String> = when (this) {
+    ExprValueType.MISSING -> listOf("missing")
+    ExprValueType.NULL -> listOf("null")
+    ExprValueType.BOOL -> listOf("bool", "boolean")
+    ExprValueType.INT -> listOf("int", "smallint", "integer2", "int2", "integer", "integer4", "int4", "integer8", "int8", "bigint")
+    ExprValueType.FLOAT -> listOf("float", "real", "double precision")
+    ExprValueType.DECIMAL -> listOf("dec", "decimal", "numeric")
+    ExprValueType.DATE -> listOf("date")
+    ExprValueType.TIMESTAMP -> listOf("timestamp")
+    ExprValueType.TIME -> listOf("time")
+    ExprValueType.SYMBOL -> listOf("symbol")
+    ExprValueType.STRING -> listOf("string", "char", "varchar", "character", "character varying")
+    ExprValueType.CLOB -> listOf("clob")
+    ExprValueType.BLOB -> listOf("blob")
+    ExprValueType.LIST -> listOf("list")
+    ExprValueType.SEXP -> listOf("sexp")
+    ExprValueType.STRUCT -> listOf("struct", "tuple")
+    ExprValueType.BAG -> listOf("bag")
+}
 
 abstract class CastTestBase : EvaluatorTestBase() {
 
@@ -259,7 +259,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
         fun List<(String) -> CastCase>.types(types: List<String>): List<CastCase> =
             this.flatMap { partial -> types.map { type -> partial(type) } }
 
-        val allTypeNames = ExprValueType.values().flatMap { typeToTypeAliases[it]!! }
+        val allTypeNames = ExprValueType.values().flatMap { it.typeAliases() }
 
         val commonTestCases =
             listOf(
@@ -267,7 +267,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("NULL", "null", CastQuality.LOSSLESS) {
                         assertEquals(ExprValueType.NULL, it.type)
                     }
-                ).types(allTypeNames - typeToTypeAliases[ExprValueType.MISSING]!!),
+                ).types(allTypeNames - ExprValueType.MISSING.typeAliases()),
                 listOf(
                     case("NULL", "null", CastQuality.LOSSLESS) {
                         assertEquals(ExprValueType.MISSING, it.type)
@@ -277,7 +277,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("MISSING", "null", CastQuality.LOSSLESS) {
                         assertEquals(ExprValueType.MISSING, it.type)
                     }
-                ).types(allTypeNames - typeToTypeAliases[ExprValueType.NULL]!!),
+                ).types(allTypeNames - ExprValueType.NULL.typeAliases()),
                 listOf(
                     case("MISSING", "null", CastQuality.LOSSLESS) {
                         assertEquals(ExprValueType.NULL, it.type)
@@ -398,7 +398,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<14>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<20>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(typeToTypeAliases[ExprValueType.INT]!!),
+                ).types(ExprValueType.INT.typeAliases()),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", "0e0", CastQuality.LOSSLESS),
@@ -443,7 +443,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`14e0`>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`20e0`>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(typeToTypeAliases[ExprValueType.FLOAT]!!),
+                ).types(ExprValueType.FLOAT.typeAliases()),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", "0d0", CastQuality.LOSSLESS),
@@ -489,7 +489,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`14d0`>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`20d0`>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!),
+                ).types(ExprValueType.DECIMAL.typeAliases()),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -525,7 +525,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("`{}`", ErrorCode.EVALUATOR_INVALID_CAST),
                     // bag
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(typeToTypeAliases[ExprValueType.DATE]!!),
+                ).types(ExprValueType.DATE.typeAliases()),
                 // Find more coverage for the "Cast as Time" tests in `castDateAndTime`.
                 listOf(
                     // booleans
@@ -562,7 +562,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("`{}`", ErrorCode.EVALUATOR_INVALID_CAST),
                     // bag
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(typeToTypeAliases[ExprValueType.TIME]!!),
+                ).types(ExprValueType.TIME.typeAliases()),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -591,7 +591,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("`{}`", ErrorCode.EVALUATOR_INVALID_CAST),
                     // bag
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(typeToTypeAliases[ExprValueType.TIMESTAMP]!!),
+                ).types(ExprValueType.TIMESTAMP.typeAliases()),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", "'false'", CastQuality.LOSSLESS),
@@ -635,7 +635,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`14d0`>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`20d0`>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(typeToTypeAliases[ExprValueType.SYMBOL]!!),
+                ).types(ExprValueType.SYMBOL.typeAliases()),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", "\"false\"", CastQuality.LOSSLESS),
@@ -724,7 +724,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`14d0`>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`20d0`>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(typeToTypeAliases[ExprValueType.CLOB]!!),
+                ).types(ExprValueType.CLOB.typeAliases()),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -768,7 +768,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`14d0`>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`20d0`>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(typeToTypeAliases[ExprValueType.BLOB]!!),
+                ).types(ExprValueType.BLOB.typeAliases()),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -812,7 +812,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", "[]", CastQuality.LOSSLESS), // TODO bag verification
                     case("<<`14d0`>>", "[14d0]", CastQuality.LOSSLESS), // TODO bag verification
                     case("<<`20d0`>>", "[20d0]", CastQuality.LOSSLESS) // TODO bag verification
-                ).types(typeToTypeAliases[ExprValueType.LIST]!!),
+                ).types(ExprValueType.LIST.typeAliases()),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -856,7 +856,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", "()", CastQuality.LOSSLESS),
                     case("<<`14d0`>>", "(14d0)", CastQuality.LOSSLESS),
                     case("<<`20d0`>>", "(20d0)", CastQuality.LOSSLESS)
-                ).types(typeToTypeAliases[ExprValueType.SEXP]!!),
+                ).types(ExprValueType.SEXP.typeAliases()),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -900,7 +900,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`14d0`>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`20d0`>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(typeToTypeAliases[ExprValueType.STRUCT]!!),
+                ).types(ExprValueType.STRUCT.typeAliases()),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -944,7 +944,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", "[]", CastQuality.LOSSLESS), // TODO bag verification
                     case("<<`14d0`>>", "[14d0]", CastQuality.LOSSLESS), // TODO bag verification
                     case("<<`20d0`>>", "[20d0]", CastQuality.LOSSLESS) // TODO bag verification
-                ).types(typeToTypeAliases[ExprValueType.BAG]!!)
+                ).types(ExprValueType.BAG.typeAliases())
             ).flatten()
 
         val deviatingLegacyTestCases = listOf(
@@ -1003,7 +1003,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("-20.9", "-20", CastQuality.LOSSY),
                 case("1.5", "1", CastQuality.LOSSY),
                 case("2.5", "2", CastQuality.LOSSY)
-            ).types(typeToTypeAliases[ExprValueType.INT]!!),
+            ).types(ExprValueType.INT.typeAliases()),
             // SMALLINT tests
             listOf(
                 // over range
@@ -1054,7 +1054,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("'123'", "123.", CastQuality.LOSSLESS),
                 case("'1234'", "1234.", CastQuality.LOSSLESS),
                 case("'123.45'", "123.45", CastQuality.LOSSLESS)
-            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(3)" }),
+            ).types(ExprValueType.DECIMAL.typeAliases().map { "$it(3)" }),
             // DECIMAL(5,2) ; LEGACY mode does not respect DECIMAL's precison or scale
             listOf(
                 case("12", "12.", CastQuality.LOSSLESS),
@@ -1067,17 +1067,17 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("'1234'", "1234.", CastQuality.LOSSLESS),
                 case("'123.45'", "123.45", CastQuality.LOSSLESS),
                 case("'123.459'", "123.459", CastQuality.LOSSLESS)
-            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(5, 2)" }),
+            ).types(ExprValueType.DECIMAL.typeAliases().map { "$it(5, 2)" }),
             // DECIMAL(4,4) ; LEGACY mode does not respect DECIMAL's precison or scale; precision = scale is valid here
             listOf(
                 case("0.1", "1d-1", CastQuality.LOSSLESS),
                 case("0.1234", "0.1234", CastQuality.LOSSLESS),
                 case("0.12345", "0.12345", CastQuality.LOSSLESS)
-            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(4,4)" }),
+            ).types(ExprValueType.DECIMAL.typeAliases().map { "$it(4,4)" }),
             // DECIMAL(2, 4) ; LEGACY mode does not respect DECIMAL's precison or scale; precision < scale is valid in legacy mode
             listOf(
                 case("1", "1d0", CastQuality.LOSSLESS)
-            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(2,4)" }),
+            ).types(ExprValueType.DECIMAL.typeAliases().map { "$it(2,4)" }),
             // VARCHAR(4) legacy mode doesn't care about params
             listOf(
                 // from string types
@@ -1167,7 +1167,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("-20.9", "-21", CastQuality.LOSSY),
                 case("1.5", "2", CastQuality.LOSSY),
                 case("2.5", "2", CastQuality.LOSSY)
-            ).types(typeToTypeAliases[ExprValueType.INT]!!),
+            ).types(ExprValueType.INT.typeAliases()),
             // SMALLINT tests
             listOf(
                 // over range
@@ -1218,7 +1218,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("'123'", "123.", CastQuality.LOSSLESS),
                 case("'1234'", ErrorCode.EVALUATOR_CAST_FAILED),
                 case("'123.45'", "123.", CastQuality.LOSSY)
-            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(3)" }),
+            ).types(ExprValueType.DECIMAL.typeAliases().map { "$it(3)" }),
             // DECIMAL(5,2)
             listOf(
                 case("12", "12.00", CastQuality.LOSSLESS),
@@ -1231,17 +1231,17 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("'1234'", ErrorCode.EVALUATOR_CAST_FAILED),
                 case("'123.45'", "123.45", CastQuality.LOSSLESS),
                 case("'123.459'", "123.46", CastQuality.LOSSY)
-            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(5, 2)" }),
+            ).types(ExprValueType.DECIMAL.typeAliases().map { "$it(5, 2)" }),
             // DECIMAL(4,4) precision = scale is valid in honor_params
             listOf(
                 case("0.1", "1.000d-1", CastQuality.LOSSLESS),
                 case("0.1234", "0.1234", CastQuality.LOSSLESS),
                 case("0.12345", "0.1235", CastQuality.LOSSY)
-            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(4,4)" }),
+            ).types(ExprValueType.DECIMAL.typeAliases().map { "$it(4,4)" }),
             // DECIMAL(2, 4) is a compilation failure in this mode
             listOf(
                 case("1", ErrorCode.SEMANTIC_INVALID_DECIMAL_ARGUMENTS)
-            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(2,4)" }),
+            ).types(ExprValueType.DECIMAL.typeAliases().map { "$it(2,4)" }),
             // VARCHAR(4) should truncate to size <= 4
             listOf(
                 // from string types
@@ -1281,13 +1281,13 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("`+inf`", ErrorCode.EVALUATOR_CAST_FAILED),
                 case("`-inf`", ErrorCode.EVALUATOR_CAST_FAILED),
                 case("`nan`", ErrorCode.EVALUATOR_CAST_FAILED),
-            ).types(typeToTypeAliases[ExprValueType.INT]!! + typeToTypeAliases[ExprValueType.DECIMAL]!!),
+            ).types(ExprValueType.INT.typeAliases() + ExprValueType.DECIMAL.typeAliases()),
             // cast([`+inf` | `-inf` | `nan`] as FLOAT) returns the original value
             listOf(
                 case("`+inf`", "+inf", CastQuality.LOSSLESS),
                 case("`-inf`", "-inf", CastQuality.LOSSLESS),
                 case("`nan`", "nan", CastQuality.LOSSLESS)
-            ).types(typeToTypeAliases[ExprValueType.FLOAT]!!),
+            ).types(ExprValueType.FLOAT.typeAliases()),
             // cast([`+inf` | `-inf` | `nan`] as STRING) returns "Infinity", "-Infinity", and "NaN" respectively.
             // for casting behavor with parametered char, character, see [deviatingParamsTestCases] and [deviatingLegacyTestCases]
             listOf(
@@ -1300,20 +1300,20 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("`+inf`", "'Infinity'", CastQuality.LOSSLESS),
                 case("`-inf`", "'-Infinity'", CastQuality.LOSSLESS),
                 case("`nan`", "'NaN'", CastQuality.LOSSLESS)
-            ).types(typeToTypeAliases[ExprValueType.SYMBOL]!!),
+            ).types(ExprValueType.SYMBOL.typeAliases()),
             // cast([`+inf` | `-inf` | `nan`] as BOOLEAN) returns true, since none of which has value of 0.
             listOf(
                 case("`+inf`", "true", CastQuality.LOSSY),
                 case("`-inf`", "true", CastQuality.LOSSY),
                 case("`nan`", "true", CastQuality.LOSSY)
-            ).types(typeToTypeAliases[ExprValueType.BOOL]!!),
+            ).types(ExprValueType.BOOL.typeAliases()),
             listOf(
                 case("`+inf`", ErrorCode.EVALUATOR_INVALID_CAST),
                 case("`-inf`", ErrorCode.EVALUATOR_INVALID_CAST),
                 case("`nan`", ErrorCode.EVALUATOR_INVALID_CAST)
             ).types(
                 listOf(ExprValueType.INT, ExprValueType.DECIMAL, ExprValueType.FLOAT, ExprValueType.STRING, ExprValueType.SYMBOL, ExprValueType.BOOL)
-                    .map { typeToTypeAliases[it]!! }
+                    .map { it.typeAliases() }
                     .fold(allTypeNames) { allTypes, type -> allTypes - type }
             )
         ).flatten()
@@ -1325,13 +1325,13 @@ abstract class CastTestBase : EvaluatorTestBase() {
         private val commonDateTimeTests = listOf(
             listOf(
                 case("DATE '2007-10-10'", "$DATE_ANNOTATION::2007-10-10", CastQuality.LOSSLESS)
-            ).types(typeToTypeAliases[ExprValueType.DATE]!!),
+            ).types(ExprValueType.DATE.typeAliases()),
             listOf(
                 case("DATE '2007-10-10'", "'2007-10-10'", CastQuality.LOSSLESS)
-            ).types(typeToTypeAliases[ExprValueType.SYMBOL]!!),
+            ).types(ExprValueType.SYMBOL.typeAliases()),
             listOf(
                 case("DATE '2007-10-10'", "\"2007-10-10\"", CastQuality.LOSSLESS)
-            ).types(typeToTypeAliases[ExprValueType.STRING]!!),
+            ).types(ExprValueType.STRING.typeAliases()),
             listOf(
                 // CAST(<TIME> AS <variants of TIME type>)
                 case("TIME '23:12:12.1267'", "TIME", "$TIME_ANNOTATION::{hour:23, minute:12, second:12.1267, timezone_hour:null.int, timezone_minute:null.int}", CastQuality.LOSSLESS),
@@ -1403,7 +1403,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("TIME (3) WITH TIME ZONE '23:12:12.1267'", "'23:12:12.127${defaultTimezoneOffset.getOffsetHHmm()}'", CastQuality.LOSSLESS),
                 case("TIME (3) WITH TIME ZONE '23:12:12.1267-05:30'", "'23:12:12.127-05:30'", CastQuality.LOSSLESS),
                 case("TIME (3) WITH TIME ZONE '23:12:12.1267+05:30'", "'23:12:12.127+05:30'", CastQuality.LOSSLESS)
-            ).types(typeToTypeAliases[ExprValueType.SYMBOL]!!),
+            ).types(ExprValueType.SYMBOL.typeAliases()),
             // CAST <TIME> AS STRING
             listOf(
                 case("TIME '23:12:12.1267'", "\"23:12:12.1267\"", CastQuality.LOSSLESS),
@@ -1418,11 +1418,11 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("TIME (3) WITH TIME ZONE '23:12:12.1267'", "\"23:12:12.127${defaultTimezoneOffset.getOffsetHHmm()}\"", CastQuality.LOSSLESS),
                 case("TIME (3) WITH TIME ZONE '23:12:12.1267-05:30'", "\"23:12:12.127-05:30\"", CastQuality.LOSSLESS),
                 case("TIME (3) WITH TIME ZONE '23:12:12.1267+05:30'", "\"23:12:12.127+05:30\"", CastQuality.LOSSLESS)
-            ).types(typeToTypeAliases[ExprValueType.STRING]!!)
+            ).types(ExprValueType.STRING.typeAliases())
         ).flatten() +
             listOf(ExprValueType.MISSING, ExprValueType.NULL, ExprValueType.BOOL, ExprValueType.INT, ExprValueType.FLOAT, ExprValueType.DECIMAL, ExprValueType.TIMESTAMP, ExprValueType.CLOB, ExprValueType.BLOB, ExprValueType.LIST, ExprValueType.SEXP, ExprValueType.STRUCT, ExprValueType.BAG)
                 .map {
-                    listOf(case("DATE '2007-10-10'", ErrorCode.EVALUATOR_INVALID_CAST)).types(typeToTypeAliases[it]!!)
+                    listOf(case("DATE '2007-10-10'", ErrorCode.EVALUATOR_INVALID_CAST)).types(it.typeAliases())
                 }.flatten()
 
         private val typingModes: Map<String, (CompileOptions.Builder) -> Unit> = mapOf(

--- a/lang/test/org/partiql/lang/eval/CastTestBase.kt
+++ b/lang/test/org/partiql/lang/eval/CastTestBase.kt
@@ -4,19 +4,6 @@ import org.partiql.lang.CompilerPipeline
 import org.partiql.lang.errors.ErrorBehaviorInPermissiveMode
 import org.partiql.lang.errors.ErrorCategory
 import org.partiql.lang.errors.ErrorCode
-import org.partiql.lang.eval.ExprValueType.BAG
-import org.partiql.lang.eval.ExprValueType.BLOB
-import org.partiql.lang.eval.ExprValueType.BOOL
-import org.partiql.lang.eval.ExprValueType.CLOB
-import org.partiql.lang.eval.ExprValueType.DECIMAL
-import org.partiql.lang.eval.ExprValueType.FLOAT
-import org.partiql.lang.eval.ExprValueType.INT
-import org.partiql.lang.eval.ExprValueType.LIST
-import org.partiql.lang.eval.ExprValueType.MISSING
-import org.partiql.lang.eval.ExprValueType.NULL
-import org.partiql.lang.eval.ExprValueType.SEXP
-import org.partiql.lang.eval.ExprValueType.STRUCT
-import org.partiql.lang.eval.ExprValueType.TIMESTAMP
 import org.partiql.lang.eval.evaluatortestframework.ExpectedResultFormat
 import org.partiql.lang.util.getOffsetHHmm
 import org.partiql.lang.util.honorTypedOpParameters
@@ -54,6 +41,26 @@ data class NotImplemented(val expectedQuality: CastQuality) : CastQualityStatus(
  * The necessary expected cast transformations are implemented, but currently do not conform to expected semantics
  */
 data class FixSemantics(val expectedQuality: CastQuality) : CastQualityStatus()
+
+private val typeToTypeAliases = mapOf(
+    ExprValueType.MISSING to listOf("missing"),
+    ExprValueType.NULL to listOf("null"),
+    ExprValueType.BOOL to listOf("bool", "boolean"),
+    ExprValueType.INT to listOf("int", "smallint", "integer2", "int2", "integer", "integer4", "int4", "integer8", "int8", "bigint"),
+    ExprValueType.FLOAT to listOf("float", "real", "double precision"),
+    ExprValueType.DECIMAL to listOf("dec", "decimal", "numeric"),
+    ExprValueType.DATE to listOf("date"),
+    ExprValueType.TIMESTAMP to listOf("timestamp"),
+    ExprValueType.TIME to listOf("time"),
+    ExprValueType.SYMBOL to listOf("symbol"),
+    ExprValueType.STRING to listOf("string", "char", "varchar", "character", "character varying"),
+    ExprValueType.CLOB to listOf("clob"),
+    ExprValueType.BLOB to listOf("blob"),
+    ExprValueType.LIST to listOf("list"),
+    ExprValueType.SEXP to listOf("sexp"),
+    ExprValueType.STRUCT to listOf("struct", "tuple"),
+    ExprValueType.BAG to listOf("bag")
+)
 
 abstract class CastTestBase : EvaluatorTestBase() {
 
@@ -252,7 +259,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
         fun List<(String) -> CastCase>.types(types: List<String>): List<CastCase> =
             this.flatMap { partial -> types.map { type -> partial(type) } }
 
-        val allTypeNames = ExprValueType.values().flatMap { it.sqlTextNames }
+        val allTypeNames = ExprValueType.values().flatMap { typeToTypeAliases[it]!! }
 
         val commonTestCases =
             listOf(
@@ -260,7 +267,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("NULL", "null", CastQuality.LOSSLESS) {
                         assertEquals(ExprValueType.NULL, it.type)
                     }
-                ).types(allTypeNames - "MISSING"),
+                ).types(allTypeNames - typeToTypeAliases[ExprValueType.MISSING]!!),
                 listOf(
                     case("NULL", "null", CastQuality.LOSSLESS) {
                         assertEquals(ExprValueType.MISSING, it.type)
@@ -270,7 +277,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("MISSING", "null", CastQuality.LOSSLESS) {
                         assertEquals(ExprValueType.MISSING, it.type)
                     }
-                ).types(allTypeNames - "NULL"),
+                ).types(allTypeNames - typeToTypeAliases[ExprValueType.NULL]!!),
                 listOf(
                     case("MISSING", "null", CastQuality.LOSSLESS) {
                         assertEquals(ExprValueType.NULL, it.type)
@@ -318,7 +325,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<true>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<false>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(ExprValueType.BOOL.sqlTextNames),
+                ).types(listOf("bool", "boolean")),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", "0", CastQuality.LOSSLESS),
@@ -391,7 +398,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<14>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<20>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(ExprValueType.INT.sqlTextNames),
+                ).types(typeToTypeAliases[ExprValueType.INT]!!),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", "0e0", CastQuality.LOSSLESS),
@@ -436,7 +443,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`14e0`>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`20e0`>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(ExprValueType.FLOAT.sqlTextNames),
+                ).types(typeToTypeAliases[ExprValueType.FLOAT]!!),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", "0d0", CastQuality.LOSSLESS),
@@ -482,7 +489,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`14d0`>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`20d0`>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(ExprValueType.DECIMAL.sqlTextNames),
+                ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -518,7 +525,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("`{}`", ErrorCode.EVALUATOR_INVALID_CAST),
                     // bag
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(ExprValueType.DATE.sqlTextNames),
+                ).types(typeToTypeAliases[ExprValueType.DATE]!!),
                 // Find more coverage for the "Cast as Time" tests in `castDateAndTime`.
                 listOf(
                     // booleans
@@ -555,7 +562,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("`{}`", ErrorCode.EVALUATOR_INVALID_CAST),
                     // bag
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(ExprValueType.TIME.sqlTextNames),
+                ).types(typeToTypeAliases[ExprValueType.TIME]!!),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -584,7 +591,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("`{}`", ErrorCode.EVALUATOR_INVALID_CAST),
                     // bag
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(ExprValueType.TIMESTAMP.sqlTextNames),
+                ).types(typeToTypeAliases[ExprValueType.TIMESTAMP]!!),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", "'false'", CastQuality.LOSSLESS),
@@ -628,7 +635,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`14d0`>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`20d0`>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(ExprValueType.SYMBOL.sqlTextNames),
+                ).types(typeToTypeAliases[ExprValueType.SYMBOL]!!),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", "\"false\"", CastQuality.LOSSLESS),
@@ -717,7 +724,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`14d0`>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`20d0`>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(ExprValueType.CLOB.sqlTextNames),
+                ).types(typeToTypeAliases[ExprValueType.CLOB]!!),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -761,7 +768,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`14d0`>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`20d0`>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(ExprValueType.BLOB.sqlTextNames),
+                ).types(typeToTypeAliases[ExprValueType.BLOB]!!),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -805,7 +812,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", "[]", CastQuality.LOSSLESS), // TODO bag verification
                     case("<<`14d0`>>", "[14d0]", CastQuality.LOSSLESS), // TODO bag verification
                     case("<<`20d0`>>", "[20d0]", CastQuality.LOSSLESS) // TODO bag verification
-                ).types(ExprValueType.LIST.sqlTextNames),
+                ).types(typeToTypeAliases[ExprValueType.LIST]!!),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -849,7 +856,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", "()", CastQuality.LOSSLESS),
                     case("<<`14d0`>>", "(14d0)", CastQuality.LOSSLESS),
                     case("<<`20d0`>>", "(20d0)", CastQuality.LOSSLESS)
-                ).types(ExprValueType.SEXP.sqlTextNames),
+                ).types(typeToTypeAliases[ExprValueType.SEXP]!!),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -893,7 +900,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`14d0`>>", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("<<`20d0`>>", ErrorCode.EVALUATOR_INVALID_CAST)
-                ).types(ExprValueType.STRUCT.sqlTextNames),
+                ).types(typeToTypeAliases[ExprValueType.STRUCT]!!),
                 listOf(
                     // booleans
                     case("TRUE AND FALSE", ErrorCode.EVALUATOR_INVALID_CAST),
@@ -937,7 +944,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("<<>>", "[]", CastQuality.LOSSLESS), // TODO bag verification
                     case("<<`14d0`>>", "[14d0]", CastQuality.LOSSLESS), // TODO bag verification
                     case("<<`20d0`>>", "[20d0]", CastQuality.LOSSLESS) // TODO bag verification
-                ).types(ExprValueType.BAG.sqlTextNames)
+                ).types(typeToTypeAliases[ExprValueType.BAG]!!)
             ).flatten()
 
         val deviatingLegacyTestCases = listOf(
@@ -996,7 +1003,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("-20.9", "-20", CastQuality.LOSSY),
                 case("1.5", "1", CastQuality.LOSSY),
                 case("2.5", "2", CastQuality.LOSSY)
-            ).types(ExprValueType.INT.sqlTextNames),
+            ).types(typeToTypeAliases[ExprValueType.INT]!!),
             // SMALLINT tests
             listOf(
                 // over range
@@ -1047,7 +1054,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("'123'", "123.", CastQuality.LOSSLESS),
                 case("'1234'", "1234.", CastQuality.LOSSLESS),
                 case("'123.45'", "123.45", CastQuality.LOSSLESS)
-            ).types(ExprValueType.DECIMAL.sqlTextNames.map { "$it(3)" }),
+            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(3)" }),
             // DECIMAL(5,2) ; LEGACY mode does not respect DECIMAL's precison or scale
             listOf(
                 case("12", "12.", CastQuality.LOSSLESS),
@@ -1060,17 +1067,17 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("'1234'", "1234.", CastQuality.LOSSLESS),
                 case("'123.45'", "123.45", CastQuality.LOSSLESS),
                 case("'123.459'", "123.459", CastQuality.LOSSLESS)
-            ).types(ExprValueType.DECIMAL.sqlTextNames.map { "$it(5, 2)" }),
+            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(5, 2)" }),
             // DECIMAL(4,4) ; LEGACY mode does not respect DECIMAL's precison or scale; precision = scale is valid here
             listOf(
                 case("0.1", "1d-1", CastQuality.LOSSLESS),
                 case("0.1234", "0.1234", CastQuality.LOSSLESS),
                 case("0.12345", "0.12345", CastQuality.LOSSLESS)
-            ).types(ExprValueType.DECIMAL.sqlTextNames.map { "$it(4,4)" }),
+            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(4,4)" }),
             // DECIMAL(2, 4) ; LEGACY mode does not respect DECIMAL's precison or scale; precision < scale is valid in legacy mode
             listOf(
                 case("1", "1d0", CastQuality.LOSSLESS)
-            ).types(ExprValueType.DECIMAL.sqlTextNames.map { "$it(2,4)" }),
+            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(2,4)" }),
             // VARCHAR(4) legacy mode doesn't care about params
             listOf(
                 // from string types
@@ -1160,7 +1167,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("-20.9", "-21", CastQuality.LOSSY),
                 case("1.5", "2", CastQuality.LOSSY),
                 case("2.5", "2", CastQuality.LOSSY)
-            ).types(ExprValueType.INT.sqlTextNames),
+            ).types(typeToTypeAliases[ExprValueType.INT]!!),
             // SMALLINT tests
             listOf(
                 // over range
@@ -1211,7 +1218,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("'123'", "123.", CastQuality.LOSSLESS),
                 case("'1234'", ErrorCode.EVALUATOR_CAST_FAILED),
                 case("'123.45'", "123.", CastQuality.LOSSY)
-            ).types(ExprValueType.DECIMAL.sqlTextNames.map { "$it(3)" }),
+            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(3)" }),
             // DECIMAL(5,2)
             listOf(
                 case("12", "12.00", CastQuality.LOSSLESS),
@@ -1224,17 +1231,17 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("'1234'", ErrorCode.EVALUATOR_CAST_FAILED),
                 case("'123.45'", "123.45", CastQuality.LOSSLESS),
                 case("'123.459'", "123.46", CastQuality.LOSSY)
-            ).types(ExprValueType.DECIMAL.sqlTextNames.map { "$it(5, 2)" }),
+            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(5, 2)" }),
             // DECIMAL(4,4) precision = scale is valid in honor_params
             listOf(
                 case("0.1", "1.000d-1", CastQuality.LOSSLESS),
                 case("0.1234", "0.1234", CastQuality.LOSSLESS),
                 case("0.12345", "0.1235", CastQuality.LOSSY)
-            ).types(ExprValueType.DECIMAL.sqlTextNames.map { "$it(4,4)" }),
+            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(4,4)" }),
             // DECIMAL(2, 4) is a compilation failure in this mode
             listOf(
                 case("1", ErrorCode.SEMANTIC_INVALID_DECIMAL_ARGUMENTS)
-            ).types(ExprValueType.DECIMAL.sqlTextNames.map { "$it(2,4)" }),
+            ).types(typeToTypeAliases[ExprValueType.DECIMAL]!!.map { "$it(2,4)" }),
             // VARCHAR(4) should truncate to size <= 4
             listOf(
                 // from string types
@@ -1274,13 +1281,13 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("`+inf`", ErrorCode.EVALUATOR_CAST_FAILED),
                 case("`-inf`", ErrorCode.EVALUATOR_CAST_FAILED),
                 case("`nan`", ErrorCode.EVALUATOR_CAST_FAILED),
-            ).types(INT.sqlTextNames + DECIMAL.sqlTextNames),
+            ).types(typeToTypeAliases[ExprValueType.INT]!! + typeToTypeAliases[ExprValueType.DECIMAL]!!),
             // cast([`+inf` | `-inf` | `nan`] as FLOAT) returns the original value
             listOf(
                 case("`+inf`", "+inf", CastQuality.LOSSLESS),
                 case("`-inf`", "-inf", CastQuality.LOSSLESS),
                 case("`nan`", "nan", CastQuality.LOSSLESS)
-            ).types(FLOAT.sqlTextNames),
+            ).types(typeToTypeAliases[ExprValueType.FLOAT]!!),
             // cast([`+inf` | `-inf` | `nan`] as STRING) returns "Infinity", "-Infinity", and "NaN" respectively.
             // for casting behavor with parametered char, character, see [deviatingParamsTestCases] and [deviatingLegacyTestCases]
             listOf(
@@ -1293,22 +1300,21 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("`+inf`", "'Infinity'", CastQuality.LOSSLESS),
                 case("`-inf`", "'-Infinity'", CastQuality.LOSSLESS),
                 case("`nan`", "'NaN'", CastQuality.LOSSLESS)
-            ).types(ExprValueType.SYMBOL.sqlTextNames),
+            ).types(typeToTypeAliases[ExprValueType.SYMBOL]!!),
             // cast([`+inf` | `-inf` | `nan`] as BOOLEAN) returns true, since none of which has value of 0.
             listOf(
                 case("`+inf`", "true", CastQuality.LOSSY),
                 case("`-inf`", "true", CastQuality.LOSSY),
                 case("`nan`", "true", CastQuality.LOSSY)
-            ).types(BOOL.sqlTextNames),
+            ).types(typeToTypeAliases[ExprValueType.BOOL]!!),
             listOf(
                 case("`+inf`", ErrorCode.EVALUATOR_INVALID_CAST),
                 case("`-inf`", ErrorCode.EVALUATOR_INVALID_CAST),
                 case("`nan`", ErrorCode.EVALUATOR_INVALID_CAST)
             ).types(
-                listOf(INT, DECIMAL, FLOAT, ExprValueType.STRING, ExprValueType.SYMBOL, BOOL).fold(allTypeNames) {
-                    allTypes, type ->
-                    allTypes - type.sqlTextNames
-                }
+                listOf(ExprValueType.INT, ExprValueType.DECIMAL, ExprValueType.FLOAT, ExprValueType.STRING, ExprValueType.SYMBOL, ExprValueType.BOOL)
+                    .map { typeToTypeAliases[it]!! }
+                    .fold(allTypeNames) { allTypes, type -> allTypes - type }
             )
         ).flatten()
 
@@ -1319,13 +1325,13 @@ abstract class CastTestBase : EvaluatorTestBase() {
         private val commonDateTimeTests = listOf(
             listOf(
                 case("DATE '2007-10-10'", "$DATE_ANNOTATION::2007-10-10", CastQuality.LOSSLESS)
-            ).types(ExprValueType.DATE.sqlTextNames),
+            ).types(typeToTypeAliases[ExprValueType.DATE]!!),
             listOf(
                 case("DATE '2007-10-10'", "'2007-10-10'", CastQuality.LOSSLESS)
-            ).types(ExprValueType.SYMBOL.sqlTextNames),
+            ).types(typeToTypeAliases[ExprValueType.SYMBOL]!!),
             listOf(
                 case("DATE '2007-10-10'", "\"2007-10-10\"", CastQuality.LOSSLESS)
-            ).types(ExprValueType.STRING.sqlTextNames),
+            ).types(typeToTypeAliases[ExprValueType.STRING]!!),
             listOf(
                 // CAST(<TIME> AS <variants of TIME type>)
                 case("TIME '23:12:12.1267'", "TIME", "$TIME_ANNOTATION::{hour:23, minute:12, second:12.1267, timezone_hour:null.int, timezone_minute:null.int}", CastQuality.LOSSLESS),
@@ -1397,7 +1403,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("TIME (3) WITH TIME ZONE '23:12:12.1267'", "'23:12:12.127${defaultTimezoneOffset.getOffsetHHmm()}'", CastQuality.LOSSLESS),
                 case("TIME (3) WITH TIME ZONE '23:12:12.1267-05:30'", "'23:12:12.127-05:30'", CastQuality.LOSSLESS),
                 case("TIME (3) WITH TIME ZONE '23:12:12.1267+05:30'", "'23:12:12.127+05:30'", CastQuality.LOSSLESS)
-            ).types(ExprValueType.SYMBOL.sqlTextNames),
+            ).types(typeToTypeAliases[ExprValueType.SYMBOL]!!),
             // CAST <TIME> AS STRING
             listOf(
                 case("TIME '23:12:12.1267'", "\"23:12:12.1267\"", CastQuality.LOSSLESS),
@@ -1412,11 +1418,11 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 case("TIME (3) WITH TIME ZONE '23:12:12.1267'", "\"23:12:12.127${defaultTimezoneOffset.getOffsetHHmm()}\"", CastQuality.LOSSLESS),
                 case("TIME (3) WITH TIME ZONE '23:12:12.1267-05:30'", "\"23:12:12.127-05:30\"", CastQuality.LOSSLESS),
                 case("TIME (3) WITH TIME ZONE '23:12:12.1267+05:30'", "\"23:12:12.127+05:30\"", CastQuality.LOSSLESS)
-            ).types(ExprValueType.STRING.sqlTextNames)
+            ).types(typeToTypeAliases[ExprValueType.STRING]!!)
         ).flatten() +
-            listOf(MISSING, NULL, BOOL, INT, FLOAT, DECIMAL, TIMESTAMP, CLOB, BLOB, LIST, SEXP, STRUCT, BAG)
+            listOf(ExprValueType.MISSING, ExprValueType.NULL, ExprValueType.BOOL, ExprValueType.INT, ExprValueType.FLOAT, ExprValueType.DECIMAL, ExprValueType.TIMESTAMP, ExprValueType.CLOB, ExprValueType.BLOB, ExprValueType.LIST, ExprValueType.SEXP, ExprValueType.STRUCT, ExprValueType.BAG)
                 .map {
-                    listOf(case("DATE '2007-10-10'", ErrorCode.EVALUATOR_INVALID_CAST)).types(it.sqlTextNames)
+                    listOf(case("DATE '2007-10-10'", ErrorCode.EVALUATOR_INVALID_CAST)).types(typeToTypeAliases[it]!!)
                 }.flatten()
 
         private val typingModes: Map<String, (CompileOptions.Builder) -> Unit> = mapOf(


### PR DESCRIPTION
## Background
In legacy parser, type names are considered as keywords and stored [here](https://github.com/partiql/partiql-lang-kotlin/blob/2e19331afc8e6b4bdfced0ec78dcdc81553e2e9d/lang/src/org/partiql/lang/syntax/LexerConstants.kt). The property [`ExprValueType.typeNames`](https://github.com/partiql/partiql-lang-kotlin/blob/2e19331afc8e6b4bdfced0ec78dcdc81553e2e9d/lang/src/org/partiql/lang/eval/ExprValueType.kt#L31) duplicates those type names and [this part of code](https://github.com/partiql/partiql-lang-kotlin/blob/2e19331afc8e6b4bdfced0ec78dcdc81553e2e9d/lang/src/org/partiql/lang/eval/ExprValueType.kt#L122-L139) ensures type names defined in lexer and `ExprValueType` are the same. 

## Motivation
As we are going to remove legacy parser, also, since we want to make type names (type aliases) user-defined in OTS, there is a need to remove the property `ExprValueType.typeNames` and the related hard-coded type names. 

## Changes
1. **Breaking Change**: Removed type names stored in `ExprValueType`. 
2. Defined `typeToTypeAliases` table locally in `CastTestBase.kt`



