### PR TITLE
Remove state from planner

### DIFF
--- a/lang/src/org/partiql/lang/planner/PartiQLPlannerDefault.kt
+++ b/lang/src/org/partiql/lang/planner/PartiQLPlannerDefault.kt
@@ -36,13 +36,13 @@ internal class PartiQLPlannerDefault(
     private val options: PartiQLPlanner.Options
 ) : PartiQLPlanner {
 
-    private val problemHandler = ProblemCollector()
-
     override fun plan(statement: PartiqlAst.Statement): PartiQLPlanner.Result {
+
+        val problemHandler = ProblemCollector()
 
         // Step 1. Normalize the AST
         val normalized = callback.doEvent("normalize_ast", statement) {
-            statement.normalize()
+            statement.normalize(problemHandler)
         }
         if (problemHandler.hasErrors) {
             return PartiQLPlanner.Result.Error(problemHandler.problems)
@@ -50,7 +50,7 @@ internal class PartiQLPlannerDefault(
 
         // Step 2. AST -> LogicalPlan
         val logicalPlan = callback.doEvent("ast_to_logical", normalized) {
-            normalized.toLogicalPlan()
+            normalized.toLogicalPlan(problemHandler)
         }
         if (problemHandler.hasErrors) {
             return PartiQLPlanner.Result.Error(problemHandler.problems)
@@ -58,7 +58,7 @@ internal class PartiQLPlannerDefault(
 
         // Step 3. Replace variable references
         val resolvedLogicalPlan = callback.doEvent("logical_to_logical_resolved", logicalPlan) {
-            logicalPlan.toResolvedPlan()
+            logicalPlan.toResolvedPlan(problemHandler)
         }
         if (problemHandler.hasErrors) {
             return PartiQLPlanner.Result.Error(problemHandler.problems)
@@ -66,7 +66,7 @@ internal class PartiQLPlannerDefault(
 
         // Step 4. LogicalPlan -> PhysicalPlan
         val physicalPlan = callback.doEvent("logical_resolved_to_physical", resolvedLogicalPlan) {
-            resolvedLogicalPlan.toPhysicalPlan()
+            resolvedLogicalPlan.toPhysicalPlan(problemHandler)
         }
         if (problemHandler.hasErrors) {
             return PartiQLPlanner.Result.Error(problemHandler.problems)
@@ -97,7 +97,7 @@ internal class PartiQLPlannerDefault(
      *  2. Synthesizes unspecified `FROM <expr> AS ...` aliases
      *  3. Changes `SELECT * FROM a, b` to SELECT a.*, b.* FROM a, b`
      */
-    private fun PartiqlAst.Statement.normalize(): PartiqlAst.Statement {
+    private fun PartiqlAst.Statement.normalize(problems: ProblemCollector): PartiqlAst.Statement {
         val transform = PipelinedVisitorTransform(
             SelectListItemAliasVisitorTransform(),
             FromSourceAliasVisitorTransform(),
@@ -109,10 +109,8 @@ internal class PartiQLPlannerDefault(
     /**
      * See [AstToLogicalVisitorTransform]
      */
-    private fun PartiqlAst.Statement.toLogicalPlan(): PartiqlLogical.Plan {
-        val transform = AstToLogicalVisitorTransform(
-            problemHandler = problemHandler
-        )
+    private fun PartiqlAst.Statement.toLogicalPlan(problems: ProblemCollector): PartiqlLogical.Plan {
+        val transform = AstToLogicalVisitorTransform(problems)
         return PartiqlLogical.Plan(
             stmt = transform.transformStatement(this),
             version = PartiQLPlanner.PLAN_VERSION.asPrimitive()
@@ -122,11 +120,11 @@ internal class PartiQLPlannerDefault(
     /**
      * See [LogicalToLogicalResolvedVisitorTransform]
      */
-    private fun PartiqlLogical.Plan.toResolvedPlan(): PartiqlLogicalResolved.Plan {
+    private fun PartiqlLogical.Plan.toResolvedPlan(problems: ProblemCollector): PartiqlLogicalResolved.Plan {
         val (planWithAllocatedVariables, allLocals) = this.allocateVariableIds()
         val transform = LogicalToLogicalResolvedVisitorTransform(
             allowUndefinedVariables = options.allowedUndefinedVariables,
-            problemHandler = problemHandler,
+            problemHandler = problems,
             globals = globalVariableResolver,
         )
         return transform.transformPlan(planWithAllocatedVariables).copy(locals = allLocals)
@@ -135,8 +133,8 @@ internal class PartiQLPlannerDefault(
     /**
      * See [LogicalResolvedToDefaultPhysicalVisitorTransform]
      */
-    private fun PartiqlLogicalResolved.Plan.toPhysicalPlan(): PartiqlPhysical.Plan {
-        val transform = LogicalResolvedToDefaultPhysicalVisitorTransform(problemHandler)
+    private fun PartiqlLogicalResolved.Plan.toPhysicalPlan(problems: ProblemCollector): PartiqlPhysical.Plan {
+        val transform = LogicalResolvedToDefaultPhysicalVisitorTransform(problems)
         return transform.transformPlan(this)
     }
 }


### PR DESCRIPTION
## Relevant Issues
N/A

## Description
The problem collector was mistakenly re-used between multiple plan calls. This was not caught in the unit tests, but I noticed in the shell.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No
- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.