### PR TITLE
Adds PIVOT projection to PartiQLPlanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - https://github.com/partiql/partiql-docs/issues/27
 - Logical plan representation of `INSERT` DML with `ON CONFLICT DO REPLACE EXCLUDED` based on [RFC-0011](https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md)
 - Enabled projection alias support for ORDER BY clause
+- Adds support for PIVOT in the planner consistent with `EvaluatingCompiler`
 
 #### Experimental Planner Additions
 

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -621,6 +621,10 @@ may then be further optimized by selecting better implementations of each operat
                 // TODO:  in the future, when the legacy AST compiler has been removed and the AST is no longer
                 // part of the public API, we should consider moving this definition to the partiql_ast domain.
                 (struct parts::(* struct_part 1))
+
+                // The PIVOT clause produces a single tuple whose attributes are the key and value expression evaluated
+                //   for all input tuples. The tuple is a value, not a bindings expr, hence why this isn't an operator.
+                (pivot input::bexpr key::expr value::expr)
             )
         )
 

--- a/lang/src/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
@@ -1558,15 +1558,13 @@ internal class StaticTypeInferenceVisitorTransform(
 
         override fun transformProjection(node: PartiqlAst.Projection): PartiqlAst.Projection {
             val newProjection = super.transformProjection(node)
-
-            val projectionType: StaticType = when (newProjection) {
+            val type = when (newProjection) {
                 is PartiqlAst.Projection.ProjectList -> {
                     val contentClosed = newProjection.projectItems.filterIsInstance<PartiqlAst.ProjectItem.ProjectAll>().all {
                         val exprType = it.expr.getStaticType() as? StructType
                             ?: TODO("Expected Struct type for PartiqlAst.ProjectItem.ProjectAll expr")
                         exprType.contentClosed
                     }
-
                     val projectionFields = mutableMapOf<String, StaticType>()
                     for (item in newProjection.projectItems) {
                         when (item) {
@@ -1596,10 +1594,9 @@ internal class StaticTypeInferenceVisitorTransform(
                         " This wouldn't be the case if SelectStarVisitorTransform ran before this."
                 )
                 is PartiqlAst.Projection.ProjectValue -> newProjection.value.getStaticType()
-                is PartiqlAst.Projection.ProjectPivot -> TODO("PartiqlAst.Projection.ProjectPivot is not implemented yet")
+                is PartiqlAst.Projection.ProjectPivot -> StaticType.STRUCT
             }
-
-            return newProjection.withStaticType(projectionType)
+            return newProjection.withStaticType(type)
         }
 
         private fun createVisitorTransformForNestedScope(): VisitorTransform {
@@ -1615,7 +1612,15 @@ internal class StaticTypeInferenceVisitorTransform(
             val projectionType = newNode.project.metas.staticType?.type
                 ?: error("Select project wasn't assigned a StaticTypeMeta for some reason")
 
-            return newNode.withStaticType(BagType(projectionType))
+            val selectType = when (newNode.project) {
+                is PartiqlAst.Projection.ProjectList,
+                is PartiqlAst.Projection.ProjectValue -> BagType(projectionType)
+                is PartiqlAst.Projection.ProjectStar ->
+                    error("expected SelectListItemStar transform to be ran before this")
+                is PartiqlAst.Projection.ProjectPivot -> projectionType
+            }
+
+            return newNode.withStaticType(selectType)
         }
 
         override fun transformExprSelect_where(node: PartiqlAst.Expr.Select): PartiqlAst.Expr? {

--- a/lang/test/org/partiql/lang/eval/EvaluatorStaticTypeTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorStaticTypeTests.kt
@@ -137,9 +137,6 @@ class EvaluatorStaticTypeTests {
             "projectOfUnpivotPath",
 
             // PIVOT not supported by STIR
-            "pivotFrom",
-            "pivotBadFieldType",
-            "pivotLiteralFieldNameFrom",
             "pivotUnpivotWithWhereLimit",
             "unpivotStructWithMissingField",
 

--- a/lang/test/org/partiql/lang/eval/EvaluatorTestSuite.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTestSuite.kt
@@ -583,6 +583,19 @@ internal val EVALUATOR_TEST_SUITE: IonResultTestSuite = defineTestSuite {
         )
 
         test(
+            "pivotMissingKeys",
+            "PIVOT x.v AT x.i FROM [ { 'a' : 'first', 'v' : 'John' }, {'i' : 'last', 'v' : 'doe' } ] AS x",
+            """
+              {
+                last: "doe"
+              }
+            """.trimIndent(),
+            compileOptionsBuilderBlock = {
+                typingMode(TypingMode.PERMISSIVE)
+            }
+        )
+
+        test(
             "pivotLiteralFieldNameFrom",
             """
               PIVOT a.name AT 'name' FROM animals AS a

--- a/lang/test/org/partiql/lang/eval/EvaluatorTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorTests.kt
@@ -61,10 +61,6 @@ class EvaluatorTests {
             // below this line use features not supported by the current physical algebra compiler.
             // most fail due to not supporting foundational nodes like id, global_id and scan yet.
             // PartiQL's test cases are not all that cleanly separated.
-            "pivotFrom", // TODO: Support PIVOT in physical plans
-            "pivotLiteralFieldNameFrom", // TODO: Support PIVOT in physical plans
-            "pivotBadFieldType", // TODO: Support PIVOT in physical plans
-            "pivotUnpivotWithWhereLimit", // TODO: Support PIVOT in physical plans
             "topLevelCountDistinct", // TODO: Support aggregates in physical plans
             "topLevelCount", // TODO: Support aggregates in physical plans
             "topLevelAllCount", // TODO: Support aggregates in physical plans

--- a/lang/test/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
@@ -237,10 +237,39 @@ class AstToLogicalVisitorTransformTests {
                     )
                 }
             ),
+            TestCase(
+                "PIVOT x.v AT x.a FROM << {'a': 'first', 'v': 'john'}, {'a': 'last', 'v': 'doe'} >> as x",
+                PartiqlLogical.build {
+                    query(
+                        pivot(
+                            input = scan(
+                                bag(
+                                    struct(
+                                        listOf(
+                                            structField(lit(ionString("a")), lit(ionString("first"))),
+                                            structField(lit(ionString("v")), lit(ionString("john"))),
+                                        )
+                                    ),
+                                    struct(
+                                        listOf(
+                                            structField(lit(ionString("a")), lit(ionString("last"))),
+                                            structField(lit(ionString("v")), lit(ionString("doe"))),
+                                        )
+                                    )
+                                ),
+                                asDecl = varDecl("x"),
+                            ),
+                            key = path(id("x"), listOf(pathExpr(lit(ionString("v"))))),
+                            value = path(id("x"), listOf(pathExpr(lit(ionString("a"))))),
+                        )
+                    )
+                }
+            )
         )
     }
 
     data class ProblemTestCase(val sql: String, val expectedProblem: Problem)
+
     @ParameterizedTest
     @ArgumentsSource(ArgumentsForProblemTests::class)
     fun `unimplemented feautres are blocked`(tc: ProblemTestCase) {
@@ -267,7 +296,6 @@ class AstToLogicalVisitorTransformTests {
             // SELECT queries are not implemented
             ProblemTestCase("SELECT b.* FROM bar AS b GROUP BY a", unimplementedProblem("GROUP BY", 1, 26)),
             ProblemTestCase("SELECT b.* FROM bar AS b HAVING x", unimplementedProblem("HAVING", 1, 33)),
-            ProblemTestCase("PIVOT v AT n FROM data AS d", unimplementedProblem("PIVOT", 1, 1)),
 
             // DDL is  not implemented
             ProblemTestCase("CREATE TABLE foo", unimplementedProblem("CREATE TABLE", 1, 1)),

--- a/lang/test/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransformTests.kt
@@ -448,6 +448,13 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                 Expectation.Problems(
                     problem(1, 35, PlanningProblemDetails.UndefinedVariable("barbat", caseSensitive = false))
                 )
+            ),
+            TestCase(
+                "PIVOT x.v AT x.a FROM << {'a': 'first', 'v': 'john'}, {'a': 'last', 'v': 'doe'} >> as x",
+                Expectation.Success(
+                    ResolvedId(1, 7) { localId(0) },
+                    ResolvedId(1, 14) { localId(0) }
+                ).withLocals(localVariable("x", 0))
             )
         )
     }


### PR DESCRIPTION
## Relevant Issues
#800 

## Description
Adds PIVOT projection expression to the logical domain

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Yes. PIVOT support in the planner is a new, unreleased change so it has been included in the CHANGELOG.md

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.