### PR TITLE
Final changes for REPLACE/UPSERT/INSERT EXCLUDED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing of `INSERT` DML with `ON CONFLICT DO REPLACE EXCLUDED` based on [RFC-0011](https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md)
 - Adds experimental parsing of `REPLACE INTO` and `UPSERT INTO` DML commands pending approval of the following RFC for moving out of experimental:
   - https://github.com/partiql/partiql-docs/issues/27
-- Logical plan representation of `INSERT` DML with `ON CONFLICT DO REPLACE EXCLUDED` based on [RFC-0011](https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md)
+- Logical plan representation and evaluation support for `INSERT` DML with `ON CONFLICT DO REPLACE EXCLUDED` and `REPLACE INTO` based on [RFC-0011](https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md)
+- Logical plan representation of `INSERT` DML with `ON CONFLICT DO UPDATE EXCLUDED` based on [RFC-0011](https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md)
 - Enabled projection alias support for ORDER BY clause
 - Adds support for PIVOT in the planner consistent with `EvaluatingCompiler`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       [#707](https://github.com/partiql/partiql-lang-kotlin/issues/707), [#683](https://github.com/partiql/partiql-lang-kotlin/issues/683),
       and [#730](https://github.com/partiql/partiql-lang-kotlin/issues/730)
 - Parsing of `INSERT` DML with `ON CONFLICT DO REPLACE EXCLUDED` based on [RFC-0011](https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md)
-- Adds experimental parsing of `REPLACE INTO` and `UPSERT INTO` DML commands pending approval of the following RFC for moving out of experimental:
-  - https://github.com/partiql/partiql-docs/issues/27
+- Adds a subset of `REPLACE INTO` and `UPSERT INTO` parsing based on [RFC-0030](https://github.com/partiql/partiql-docs/blob/main/RFCs/0030-partiql-upsert-replace.md)
+  - Parsing of target attributes is not supported yet and is pending [#841](https://github.com/partiql/partiql-lang-kotlin/issues/841)
 - Logical plan representation and evaluation support for `INSERT` DML with `ON CONFLICT DO REPLACE EXCLUDED` and `REPLACE INTO` based on [RFC-0011](https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md)
-- Logical plan representation of `INSERT` DML with `ON CONFLICT DO UPDATE EXCLUDED` based on [RFC-0011](https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md)
+- Logical plan representation of `INSERT` DML with `ON CONFLICT DO UPDATE EXCLUDED` and `UPSERT INTO` based on [RFC-0011](https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md)
 - Enabled projection alias support for ORDER BY clause
 - Adds support for PIVOT in the planner consistent with `EvaluatingCompiler`
 

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -701,8 +701,7 @@ may then be further optimized by selecting better implementations of each operat
                 (dml_insert)
                 (dml_delete)
                 (dml_replace)
-                // TODO:
-                // (dml_update)
+                (dml_update)
             )
         )
 

--- a/lang/src/org/partiql/lang/compiler/PartiQLCompilerDefault.kt
+++ b/lang/src/org/partiql/lang/compiler/PartiQLCompilerDefault.kt
@@ -97,6 +97,7 @@ internal class PartiQLCompilerDefault(
         return when (DmlAction.safeValueOf(action)) {
             DmlAction.INSERT -> PartiQLResult.Insert(target, rows)
             DmlAction.DELETE -> PartiQLResult.Delete(target, rows)
+            DmlAction.REPLACE -> PartiQLResult.Replace(target, rows)
             null -> error("Unknown DML Action `$action`")
         }
     }

--- a/lang/src/org/partiql/lang/eval/PartiQLResult.kt
+++ b/lang/src/org/partiql/lang/eval/PartiQLResult.kt
@@ -30,4 +30,9 @@ sealed class PartiQLResult {
         val target: String,
         val rows: Iterable<ExprValue>
     ) : PartiQLResult()
+
+    class Replace(
+        val target: String,
+        val rows: Iterable<ExprValue>
+    ) : PartiQLResult()
 }

--- a/lang/src/org/partiql/lang/planner/QueryPlan.kt
+++ b/lang/src/org/partiql/lang/planner/QueryPlan.kt
@@ -55,7 +55,8 @@ sealed class QueryResult {
  */
 enum class DmlAction {
     INSERT,
-    DELETE;
+    DELETE,
+    REPLACE;
 
     companion object {
         fun safeValueOf(v: String): DmlAction? = try {

--- a/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -177,9 +177,19 @@ internal class AstToLogicalVisitorTransform(
                             } else -> TODO("Only `DO REPLACE EXCLUDED` is supported in logical plan at the moment.")
                         }
                     }
-                    is PartiqlAst.ConflictAction.DoUpdate -> TODO(
-                        "`ON CONFLICT DO UPDATE` is not supported in logical plan yet."
-                    )
+                    is PartiqlAst.ConflictAction.DoUpdate -> {
+                        when (conflictAction.value) {
+                            PartiqlAst.OnConflictValue.Excluded() -> PartiqlLogical.build {
+                                dml(
+                                    target = dmlOp.target.toDmlTargetId(),
+                                    operation = dmlUpdate(),
+                                    rows = transformExpr(dmlOp.values),
+                                    metas = node.metas
+                                )
+                            }
+                            else -> TODO("Only `DO UPDATE EXCLUDED` is supported in logical plan at the moment.")
+                        }
+                    }
                     is PartiqlAst.ConflictAction.DoNothing -> TODO(
                         "`ON CONFLICT DO NOTHING` is not supported in logical plan yet."
                     )

--- a/lang/src/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransform.kt
@@ -139,8 +139,7 @@ internal class LogicalResolvedToDefaultPhysicalVisitorTransform(
         val action = when (node.operation) {
             is PartiqlLogicalResolved.DmlOperation.DmlInsert -> DmlAction.INSERT
             is PartiqlLogicalResolved.DmlOperation.DmlDelete -> DmlAction.DELETE
-            is PartiqlLogicalResolved.DmlOperation.DmlReplace ->
-                TODO("DmlReplace physical transform hasn't been implemented yet")
+            is PartiqlLogicalResolved.DmlOperation.DmlReplace -> DmlAction.REPLACE
         }.name.toLowerCase()
 
         return PartiqlPhysical.build {

--- a/lang/src/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransform.kt
+++ b/lang/src/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransform.kt
@@ -140,6 +140,8 @@ internal class LogicalResolvedToDefaultPhysicalVisitorTransform(
             is PartiqlLogicalResolved.DmlOperation.DmlInsert -> DmlAction.INSERT
             is PartiqlLogicalResolved.DmlOperation.DmlDelete -> DmlAction.DELETE
             is PartiqlLogicalResolved.DmlOperation.DmlReplace -> DmlAction.REPLACE
+            is PartiqlLogicalResolved.DmlOperation.DmlUpdate ->
+                TODO("DmlUpdate physical transform is not supported yet")
         }.name.toLowerCase()
 
         return PartiqlPhysical.build {

--- a/lang/src/org/partiql/lang/visitors/PartiQLVisitor.kt
+++ b/lang/src/org/partiql/lang/visitors/PartiQLVisitor.kt
@@ -249,7 +249,7 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
         )
     }
 
-    // TODO move from experimental; pending: https://github.com/partiql/partiql-docs/issues/27
+    // Based on https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md
     override fun visitUpsertCommand(ctx: PartiQLParser.UpsertCommandContext) = PartiqlAst.build {
         val asIdent = ctx.asIdent()
         // Based on the RFC, if alias exists the table must be hidden behind the alias, see:
@@ -263,7 +263,7 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
         )
     }
 
-    // FIXME: See `FIXME #001` in file `PartiQL.g4`.
+    // Based on https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md
     override fun visitInsertCommandReturning(ctx: PartiQLParser.InsertCommandReturningContext) = PartiqlAst.build {
         val metas = ctx.INSERT().getSourceMetaContainer()
         val target = visitPathSimple(ctx.pathSimple())

--- a/lang/src/org/partiql/lang/visitors/PartiQLVisitor.kt
+++ b/lang/src/org/partiql/lang/visitors/PartiQLVisitor.kt
@@ -237,8 +237,12 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
 
     // TODO move from experimental; pending: https://github.com/partiql/partiql-docs/issues/27
     override fun visitReplaceCommand(ctx: PartiQLParser.ReplaceCommandContext) = PartiqlAst.build {
+        val asIdent = ctx.asIdent()
+        // Based on the RFC, if alias exists the table must be hidden behind the alias, see:
+        // https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md#41-insert-parameters
+        val target = if (asIdent != null) visitAsIdent(asIdent) else visitSymbolPrimitive(ctx.symbolPrimitive())
         insert(
-            target = visitSymbolPrimitive(ctx.symbolPrimitive()),
+            target = target,
             values = visit(ctx.value, PartiqlAst.Expr::class),
             conflictAction = doReplace(excluded()),
             metas = ctx.REPLACE().getSourceMetaContainer()
@@ -247,8 +251,12 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
 
     // TODO move from experimental; pending: https://github.com/partiql/partiql-docs/issues/27
     override fun visitUpsertCommand(ctx: PartiQLParser.UpsertCommandContext) = PartiqlAst.build {
+        val asIdent = ctx.asIdent()
+        // Based on the RFC, if alias exists the table must be hidden behind the alias, see:
+        // https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md#41-insert-parameters
+        val target = if (asIdent != null) visitAsIdent(asIdent) else visitSymbolPrimitive(ctx.symbolPrimitive())
         insert(
-            target = visitSymbolPrimitive(ctx.symbolPrimitive()),
+            target = target,
             values = visit(ctx.value, PartiqlAst.Expr::class),
             conflictAction = doUpdate(excluded()),
             metas = ctx.UPSERT().getSourceMetaContainer()
@@ -307,6 +315,7 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
         when {
             ctx.NOTHING() != null -> doNothing()
             ctx.REPLACE() != null -> visitDoReplace(ctx.doReplace())
+            ctx.UPDATE() != null -> visitDoUpdate(ctx.doUpdate())
             else -> TODO("ON CONFLICT only supports `DO REPLACE` and `DO NOTHING` actions at the moment.")
         }
     }
@@ -317,6 +326,14 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
             else -> TODO("DO REPLACE doesn't support values other than `EXCLUDED` yet.")
         }
         doReplace(value)
+    }
+
+    override fun visitDoUpdate(ctx: PartiQLParser.DoUpdateContext) = PartiqlAst.build {
+        val value = when {
+            ctx.EXCLUDED() != null -> excluded()
+            else -> TODO("DO UPDATE doesn't support values other than `EXCLUDED` yet.")
+        }
+        doUpdate(value)
     }
 
     override fun visitPathSimple(ctx: PartiQLParser.PathSimpleContext) = PartiqlAst.build {

--- a/lang/test/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactory.kt
+++ b/lang/test/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactory.kt
@@ -93,7 +93,8 @@ internal class PartiQLCompilerPipelineFactory : PipelineFactory {
                 val statement = pipeline.compile(query)
                 return when (val result = statement.eval(session)) {
                     is PartiQLResult.Delete,
-                    is PartiQLResult.Insert -> error("DML is not supported by test suite")
+                    is PartiQLResult.Insert,
+                    is PartiQLResult.Replace -> error("DML is not supported by test suite")
                     is PartiQLResult.Value -> result.value
                 }
             }

--- a/lang/test/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
@@ -208,6 +208,68 @@ class AstToLogicalVisitorTransformTests {
                 }
             ),
             TestCase(
+                "INSERT INTO foo SELECT x.* FROM 1 AS x ON CONFLICT DO UPDATE EXCLUDED",
+                PartiqlLogical.build {
+                    dml(
+                        identifier("foo", caseInsensitive()),
+                        dmlUpdate(),
+                        bindingsToValues(
+                            struct(structFields(id("x", caseInsensitive(), unqualified()))),
+                            scan(lit(ionInt(1)), varDecl("x"))
+                        )
+                    )
+                }
+            ),
+            TestCase(
+                "INSERT INTO foo AS f <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO UPDATE EXCLUDED",
+                PartiqlLogical.build {
+                    PartiqlLogical.build {
+                        dml(
+                            identifier("f", caseInsensitive()),
+                            dmlUpdate(),
+                            bag(
+                                struct(
+                                    structField(lit(ionString("id")), lit(ionInt(1))),
+                                    structField(lit(ionString("name")), lit(ionString("bob")))
+                                )
+                            )
+                        )
+                    }
+                }
+            ),
+            TestCase(
+                "REPLACE INTO foo AS f <<{'id': 1, 'name':'bob'}>>",
+                PartiqlLogical.build {
+                    PartiqlLogical.build {
+                        dml(
+                            identifier("f", caseInsensitive()),
+                            dmlReplace(),
+                            bag(
+                                struct(
+                                    structField(lit(ionString("id")), lit(ionInt(1))),
+                                    structField(lit(ionString("name")), lit(ionString("bob")))
+                                )
+                            )
+                        )
+                    }
+                }
+            ),
+            TestCase(
+                "UPSERT INTO foo AS f SELECT x.* FROM 1 AS x",
+                PartiqlLogical.build {
+                    PartiqlLogical.build {
+                        dml(
+                            identifier("f", caseInsensitive()),
+                            dmlUpdate(),
+                            bindingsToValues(
+                                struct(structFields(id("x", caseInsensitive(), unqualified()))),
+                                scan(lit(ionInt(1)), varDecl("x"))
+                            )
+                        )
+                    }
+                }
+            ),
+            TestCase(
                 "DELETE FROM y AS y",
                 PartiqlLogical.build {
                     dml(

--- a/lang/test/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransformTests.kt
@@ -201,6 +201,38 @@ class LogicalResolvedToDefaultPhysicalVisitorTransformTests {
                 }
             ),
             DmlTestCase(
+                // INSERT INTO foo SELECT x.* FROM 1 AS x ON CONFLICT DO REPLACE EXCLUDED
+                PartiqlLogicalResolved.build {
+                    dml(
+                        uniqueId = "foo",
+                        operation = dmlReplace(),
+                        rows = bindingsToValues(
+                            struct(structFields(localId(0))),
+                            scan(lit(ionInt(1)), varDecl(0))
+                        )
+                    )
+                },
+                PartiqlPhysical.build {
+                    dmlQuery(
+                        struct(
+                            structField(DML_COMMAND_FIELD_ACTION, "replace"),
+                            structField(DML_COMMAND_FIELD_TARGET_UNIQUE_ID, lit(ionSymbol("foo"))),
+                            structField(
+                                DML_COMMAND_FIELD_ROWS,
+                                bindingsToValues(
+                                    struct(structFields(localId(0))),
+                                    scan(
+                                        i = DEFAULT_IMPL,
+                                        expr = lit(ionInt(1)),
+                                        asDecl = varDecl(0)
+                                    )
+                                )
+                            )
+                        )
+                    )
+                }
+            ),
+            DmlTestCase(
                 // DELETE FROM y AS y
                 PartiqlLogicalResolved.build {
                     dml(

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -2770,6 +2770,92 @@ class SqlParserTest : SqlParserTestBase() {
     )
 
     @Test
+    fun insertWithOnConflictUpdateExcludedWithLiteralValue() = assertExpression(
+        source = "INSERT into foo VALUES (1, 2), (3, 4) ON CONFLICT DO UPDATE EXCLUDED",
+        expectedPigAst = """
+        (dml
+            (operations
+                (dml_op_list
+                    (insert
+                        (id foo (case_insensitive) (unqualified))
+                        (bag
+                            (list
+                                (lit 1)
+                                (lit 2))
+                            (list
+                                (lit 3)
+                                (lit 4)))
+                        (do_update
+                            (excluded))))))
+        """,
+        targetParsers = setOf(ParserTypes.PARTIQL_PARSER),
+        roundTrip = false
+    )
+
+    @Test
+    fun insertWithOnConflictUpdateExcludedWithLiteralValueWithAlias() = assertExpression(
+        source = "INSERT into foo AS f <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO UPDATE EXCLUDED",
+        expectedPigAst = """
+            (dml
+                (operations
+                    (dml_op_list
+                        (insert
+                            (id f (case_insensitive) (unqualified))
+                            (bag
+                                (struct
+                                    (expr_pair
+                                        (lit "id")
+                                        (lit 1))
+                                    (expr_pair
+                                        (lit "name")
+                                        (lit "bob"))))
+                            (do_update
+                                (excluded))))))
+        """,
+        targetParsers = setOf(ParserTypes.PARTIQL_PARSER),
+        roundTrip = false
+    )
+
+    @Test
+    fun insertWithOnConflictUpdateExcludedWithSelect() = assertExpression(
+        source = "INSERT into foo SELECT bar.id, bar.name FROM bar ON CONFLICT DO UPDATE EXCLUDED",
+        expectedPigAst = """
+            (dml
+                (operations
+                    (dml_op_list
+                        (insert
+                            (id foo (case_insensitive) (unqualified))
+                            (select
+                                (project
+                                    (project_list
+                                        (project_expr
+                                            (path
+                                                (id bar (case_insensitive) (unqualified))
+                                                (path_expr
+                                                    (lit "id")
+                                                    (case_insensitive)))
+                                            null)
+                                        (project_expr
+                                            (path
+                                                (id bar (case_insensitive) (unqualified))
+                                                (path_expr
+                                                    (lit "name")
+                                                    (case_insensitive)))
+                                            null)))
+                                (from
+                                    (scan
+                                        (id bar (case_insensitive) (unqualified))
+                                        null
+                                        null
+                                        null)))
+                            (do_update
+                                (excluded))))))
+        """,
+        targetParsers = setOf(ParserTypes.PARTIQL_PARSER),
+        roundTrip = false
+    )
+
+    @Test
     fun insertWithOnConflictDoNothing() = assertExpression(
         source = "INSERT into foo <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO NOTHING",
         expectedPigAst = """
@@ -2910,6 +2996,30 @@ class SqlParserTest : SqlParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
+                            (bag
+                                (struct
+                                    (expr_pair
+                                        (lit "id")
+                                        (lit 1))
+                                    (expr_pair
+                                        (lit "name")
+                                        (lit "bob"))))
+                            (do_update
+                                (excluded))))))
+        """,
+        targetParsers = setOf(ParserTypes.PARTIQL_PARSER),
+        roundTrip = false
+    )
+
+    @Test
+    fun upsertCommandWithAsAlias() = assertExpression(
+        source = "UPSERT INTO foo As f <<{'id': 1, 'name':'bob'}>>",
+        expectedPigAst = """
+            (dml
+                (operations
+                    (dml_op_list
+                        (insert
+                            (id f (case_insensitive) (unqualified))
                             (bag
                                 (struct
                                     (expr_pair

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -2878,6 +2878,30 @@ class SqlParserTest : SqlParserTestBase() {
     )
 
     @Test
+    fun replaceCommandWithAsAlias() = assertExpression(
+        source = "REPLACE INTO foo As f <<{'id': 1, 'name':'bob'}>>",
+        expectedPigAst = """
+            (dml
+                (operations
+                    (dml_op_list
+                        (insert
+                            (id f (case_insensitive) (unqualified))
+                            (bag
+                                (struct
+                                    (expr_pair
+                                        (lit "id")
+                                        (lit 1))
+                                    (expr_pair
+                                        (lit "name")
+                                        (lit "bob"))))
+                            (do_replace
+                                (excluded))))))
+        """,
+        targetParsers = setOf(ParserTypes.PARTIQL_PARSER),
+        roundTrip = false
+    )
+
+    @Test
     fun upsertCommand() = assertExpression(
         source = "UPSERT INTO foo <<{'id': 1, 'name':'bob'}>>",
         expectedPigAst = """

--- a/partiql-grammar/src/main/antlr/org/partiql/grammar/PartiQL.g4
+++ b/partiql-grammar/src/main/antlr/org/partiql/grammar/PartiQL.g4
@@ -117,7 +117,7 @@ replaceCommand
 
 // TODO move from experimental; pending: https://github.com/partiql/partiql-docs/issues/27
 upsertCommand
-    : UPSERT INTO symbolPrimitive value=expr;
+    : UPSERT INTO symbolPrimitive asIdent? value=expr;
 
 removeCommand
     : REMOVE pathSimple;

--- a/partiql-grammar/src/main/antlr/org/partiql/grammar/PartiQL.g4
+++ b/partiql-grammar/src/main/antlr/org/partiql/grammar/PartiQL.g4
@@ -113,7 +113,7 @@ pathSimpleSteps
 
 // TODO move from experimental; pending: https://github.com/partiql/partiql-docs/issues/27
 replaceCommand
-    : REPLACE INTO symbolPrimitive value=expr;
+    : REPLACE INTO symbolPrimitive asIdent? value=expr;
 
 // TODO move from experimental; pending: https://github.com/partiql/partiql-docs/issues/27
 upsertCommand

--- a/partiql-grammar/src/main/antlr/org/partiql/grammar/PartiQL.g4
+++ b/partiql-grammar/src/main/antlr/org/partiql/grammar/PartiQL.g4
@@ -111,11 +111,13 @@ pathSimpleSteps
     | PERIOD key=symbolPrimitive                         # PathSimpleDotSymbol
     ;
 
-// TODO move from experimental; pending: https://github.com/partiql/partiql-docs/issues/27
+// Based on https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md
+// TODO add parsing of target attributes: https://github.com/partiql/partiql-lang-kotlin/issues/841
 replaceCommand
     : REPLACE INTO symbolPrimitive asIdent? value=expr;
 
-// TODO move from experimental; pending: https://github.com/partiql/partiql-docs/issues/27
+// Based on https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md
+// TODO add parsing of target attributes: https://github.com/partiql/partiql-lang-kotlin/issues/841
 upsertCommand
     : UPSERT INTO symbolPrimitive asIdent? value=expr;
 


### PR DESCRIPTION
## Relevant Issues
- Closes #704 

## Description
- This PR includes the following:
 - Support for `INSERT INTO tbl ... ON CONFLICT DO REPLACE EXCLUDED` and `REPLACE INTO tbl ...` evaluation.
 - Support for `INSERT INTO tbl ... ON CONFLICT DO UPDATE EXCLUDED` logical planning.
    - The reason that evaluation is excluded is b/c the logic is for update evaluation requires implementing merge with existing values which makes it more completed; since it's not part of the related ask (attached issue) we defer the implementation for now.
- Adds parsing support for `AS alias` for `UPSERT INTO` and `REPLACE INTO` statements.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Yes.

- Any backward-incompatible changes? **[YES/NO]**
No.

- Any new external dependencies? **[YES/NO]**
No.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.