### PR TITLE
Default sort & null spec in evaluator, not parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ stage in the `PlannerPipeline` and to generate performance metrics for the indiv
 
 ### Changed
 - The default parser for all components of PartiQL is now the PartiQLParser -- see the deprecation of `SqlParser`
+- Parsing of `ORDER BY` clauses will no longer populate the AST with defaults for the 'sort specification'
+  (i.e., `ASC` or `DESC`) or 'nulls specification' (i.e., `NULLS FIRST` or `NULLS LAST`) when the are not provided in
+  the query text. Defaulting of sort order is moved to the evaluator.
 
 ### Deprecated
 - Deprecates `SqlLexer` and `SqlParser` to be replaced with the `PartiQLParserBuilder`.

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -2074,30 +2074,19 @@ internal class EvaluatingCompiler(
 
     private fun compileOrderByExpression(sortSpecs: List<PartiqlAst.SortSpec>): List<CompiledOrderByItem> =
         sortSpecs.map {
-            it.orderingSpec
-                ?: errNoContext(
-                    "SortSpec.orderingSpec was not specified",
-                    errorCode = ErrorCode.INTERNAL_ERROR,
-                    internal = true
-                )
-
-            it.nullsSpec
-                ?: errNoContext(
-                    "SortSpec.nullsSpec was not specified",
-                    errorCode = ErrorCode.INTERNAL_ERROR,
-                    internal = true
-                )
-
-            val comparator = when (it.orderingSpec) {
+            val comparator = when (it.orderingSpec ?: PartiqlAst.OrderingSpec.Asc()) {
                 is PartiqlAst.OrderingSpec.Asc ->
                     when (it.nullsSpec) {
                         is PartiqlAst.NullsSpec.NullsFirst -> NaturalExprValueComparators.NULLS_FIRST_ASC
                         is PartiqlAst.NullsSpec.NullsLast -> NaturalExprValueComparators.NULLS_LAST_ASC
+                        else -> NaturalExprValueComparators.NULLS_LAST_ASC
                     }
+
                 is PartiqlAst.OrderingSpec.Desc ->
                     when (it.nullsSpec) {
                         is PartiqlAst.NullsSpec.NullsFirst -> NaturalExprValueComparators.NULLS_FIRST_DESC
                         is PartiqlAst.NullsSpec.NullsLast -> NaturalExprValueComparators.NULLS_LAST_DESC
+                        else -> NaturalExprValueComparators.NULLS_FIRST_DESC
                     }
             }
 

--- a/lang/src/org/partiql/lang/eval/physical/PhysicalBexprToThunkConverter.kt
+++ b/lang/src/org/partiql/lang/eval/physical/PhysicalBexprToThunkConverter.kt
@@ -250,20 +250,20 @@ internal class PhysicalBexprToThunkConverter(
      * evaluation and leaving the [PartiqlPhysical.SortSpec]'s [PartiqlPhysical.Expr] to be evaluated later.
      */
     private fun compileSortSpecs(specs: List<PartiqlPhysical.SortSpec>): List<CompiledSortKey> = specs.map { spec ->
-        val comp = when (spec.orderingSpec) {
+        val comp = when (spec.orderingSpec ?: PartiqlPhysical.OrderingSpec.Asc()) {
             is PartiqlPhysical.OrderingSpec.Asc ->
                 when (spec.nullsSpec) {
                     is PartiqlPhysical.NullsSpec.NullsFirst -> NaturalExprValueComparators.NULLS_FIRST_ASC
                     is PartiqlPhysical.NullsSpec.NullsLast -> NaturalExprValueComparators.NULLS_LAST_ASC
                     null -> NaturalExprValueComparators.NULLS_LAST_ASC
                 }
+
             is PartiqlPhysical.OrderingSpec.Desc ->
                 when (spec.nullsSpec) {
                     is PartiqlPhysical.NullsSpec.NullsFirst -> NaturalExprValueComparators.NULLS_FIRST_DESC
                     is PartiqlPhysical.NullsSpec.NullsLast -> NaturalExprValueComparators.NULLS_LAST_DESC
-                    null -> NaturalExprValueComparators.NULLS_LAST_DESC
+                    null -> NaturalExprValueComparators.NULLS_FIRST_DESC
                 }
-            null -> NaturalExprValueComparators.NULLS_LAST_ASC
         }
         val value = exprConverter.convert(spec.expr).toValueExpr(spec.expr.metas.sourceLocationMeta)
         CompiledSortKey(comp, value)

--- a/lang/src/org/partiql/lang/syntax/SqlParser.kt
+++ b/lang/src/org/partiql/lang/syntax/SqlParser.kt
@@ -593,17 +593,19 @@ class SqlParser(
                         orderBy(
                             it.children[0].children.map {
                                 when (it.children.size) {
-                                    1 -> sortSpec(it.children[0].toAstExpr(), asc(), nullsLast())
+                                    1 -> sortSpec(it.children[0].toAstExpr(), null, null)
                                     2 -> when (it.children[1].type) {
                                         ParseType.ORDERING_SPEC -> {
                                             val orderingSpec = it.children[1].toOrderingSpec()
-                                            val defaultNullsSpec = when (orderingSpec) {
-                                                is PartiqlAst.OrderingSpec.Asc -> nullsLast()
-                                                is PartiqlAst.OrderingSpec.Desc -> nullsFirst()
-                                            }
-                                            sortSpec(it.children[0].toAstExpr(), orderingSpec, defaultNullsSpec)
+                                            sortSpec(it.children[0].toAstExpr(), orderingSpec, null)
                                         }
-                                        ParseType.NULLS_SPEC -> sortSpec(it.children[0].toAstExpr(), asc(), it.children[1].toNullsSpec())
+
+                                        ParseType.NULLS_SPEC -> sortSpec(
+                                            it.children[0].toAstExpr(),
+                                            null,
+                                            it.children[1].toNullsSpec()
+                                        )
+
                                         else -> errMalformedParseTree("Invalid ordering expressions syntax")
                                     }
                                     3 -> sortSpec(it.children[0].toAstExpr(), it.children[1].toOrderingSpec(), it.children[2].toNullsSpec())

--- a/lang/src/org/partiql/lang/visitors/PartiQLVisitor.kt
+++ b/lang/src/org/partiql/lang/visitors/PartiQLVisitor.kt
@@ -472,17 +472,16 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
     override fun visitOrderSortSpec(ctx: PartiQLParser.OrderSortSpecContext) = PartiqlAst.build {
         val expr = visit(ctx.expr(), PartiqlAst.Expr::class)
         val orderSpec = when {
-            ctx.dir == null -> asc()
+            ctx.dir == null -> null
             ctx.dir.type == PartiQLParser.ASC -> asc()
             ctx.dir.type == PartiQLParser.DESC -> desc()
             else -> throw ctx.dir.err("Invalid query syntax", ErrorCode.PARSE_INVALID_QUERY)
         }
         val nullSpec = when {
-            ctx.nulls == null && orderSpec is PartiqlAst.OrderingSpec.Desc -> nullsFirst()
-            ctx.nulls == null -> nullsLast()
+            ctx.nulls == null -> null
             ctx.nulls.type == PartiQLParser.FIRST -> nullsFirst()
             ctx.nulls.type == PartiQLParser.LAST -> nullsLast()
-            else -> nullsLast()
+            else -> throw ctx.dir.err("Invalid query syntax", ErrorCode.PARSE_INVALID_QUERY)
         }
         sortSpec(expr, orderingSpec = orderSpec, nullsSpec = nullSpec)
     }

--- a/lang/test/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
+++ b/lang/test/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
@@ -139,7 +139,7 @@ class AstToLogicalVisitorTransformTests {
                             struct(structFields(id("b"))),
                             sort(
                                 scan(id("bar"), varDecl("b")),
-                                sortSpec(id("y"), asc(), nullsLast())
+                                sortSpec(id("y"))
                             )
                         )
                     )

--- a/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
+++ b/lang/test/org/partiql/lang/syntax/SqlParserTest.kt
@@ -1699,8 +1699,8 @@ class SqlParserTest : SqlParserTestBase() {
                 (order_by 
                     (sort_spec 
                         (id rk1 (case_insensitive) (unqualified)) 
-                        (asc)
-                        (nulls_last)))))
+                        null
+                        null))))
         """
     )
 
@@ -1725,16 +1725,16 @@ class SqlParserTest : SqlParserTestBase() {
                 (order_by
                     (sort_spec 
                         (id rk1 (case_insensitive) (unqualified)) 
-                        (asc)
-                        (nulls_last)) 
+                        null
+                        null) 
                     (sort_spec 
                         (id rk2 (case_insensitive) (unqualified)) 
-                        (asc)
-                        (nulls_last)) 
+                        null
+                        null) 
                     (sort_spec 
                         (id rk3 (case_insensitive) (unqualified)) 
-                        (asc)
-                        (nulls_last)))))
+                        null
+                        null))))
         """
     )
 
@@ -1760,7 +1760,7 @@ class SqlParserTest : SqlParserTestBase() {
                     (sort_spec 
                         (id rk1 (case_insensitive) (unqualified)) 
                         (desc)
-                        (nulls_first)))))
+                        null))))
         """
     )
 
@@ -1786,106 +1786,107 @@ class SqlParserTest : SqlParserTestBase() {
                     (sort_spec 
                         (id rk1 (case_insensitive) (unqualified)) 
                         (asc)
-                        (nulls_last))
+                        null)
                     (sort_spec 
                         (id rk2 (case_insensitive) (unqualified)) 
                         (desc)
-                        (nulls_first)))))
+                        null))))
         """
     )
 
     @Test
-    fun orderBySingleIdWithoutOrderingAndNullsSpecShouldProduceAscNullsLastAsDefault() = assertExpression("SELECT x FROM tb ORDER BY rk1") {
+    fun orderBySingleIdWithoutOrderingAndNullsSpec() = assertExpression("SELECT x FROM tb ORDER BY rk1") {
         select(
             project = projectX,
             from = scan(id("tb")),
             order = orderBy(
                 listOf(
-                    sortSpec(id("rk1"), asc(), nullsLast())
+                    sortSpec(id("rk1"))
                 )
             )
         )
     }
 
     @Test
-    fun orderByMultipleIdWithoutOrderingAndNullsSpecShouldProduceAscNullsLastAsDefault() = assertExpression("SELECT x FROM tb ORDER BY rk1, rk2, rk3, rk4") {
+    fun orderByMultipleIdWithoutOrderingAndNullsSpec() =
+        assertExpression("SELECT x FROM tb ORDER BY rk1, rk2, rk3, rk4") {
+            select(
+                project = projectX,
+                from = scan(id("tb")),
+                order = orderBy(
+                    listOf(
+                        sortSpec(id("rk1")),
+                        sortSpec(id("rk2")),
+                        sortSpec(id("rk3")),
+                        sortSpec(id("rk4"))
+                    )
+                )
+            )
+        }
+
+    @Test
+    fun orderByWithAsc() = assertExpression("SELECT x FROM tb ORDER BY rk1 asc") {
         select(
             project = projectX,
             from = scan(id("tb")),
             order = orderBy(
                 listOf(
-                    sortSpec(id("rk1"), asc(), nullsLast()),
-                    sortSpec(id("rk2"), asc(), nullsLast()),
-                    sortSpec(id("rk3"), asc(), nullsLast()),
-                    sortSpec(id("rk4"), asc(), nullsLast())
+                    sortSpec(id("rk1"), asc())
                 )
             )
         )
     }
 
     @Test
-    fun orderByWithAscShouldProduceNullsLastAsDefault() = assertExpression("SELECT x FROM tb ORDER BY rk1 asc") {
+    fun orderByWithDesc() = assertExpression("SELECT x FROM tb ORDER BY rk1 desc") {
         select(
             project = projectX,
             from = scan(id("tb")),
             order = orderBy(
                 listOf(
-                    sortSpec(id("rk1"), asc(), nullsLast())
+                    sortSpec(id("rk1"), desc())
                 )
             )
         )
     }
 
     @Test
-    fun orderByWithDescShouldProduceNullsFirstAsDefault() = assertExpression("SELECT x FROM tb ORDER BY rk1 desc") {
+    fun orderByWithAscAndDesc() = assertExpression("SELECT x FROM tb ORDER BY rk1 desc, rk2 asc, rk3 asc, rk4 desc") {
         select(
             project = projectX,
             from = scan(id("tb")),
             order = orderBy(
                 listOf(
-                    sortSpec(id("rk1"), desc(), nullsFirst())
+                    sortSpec(id("rk1"), desc()),
+                    sortSpec(id("rk2"), asc()),
+                    sortSpec(id("rk3"), asc()),
+                    sortSpec(id("rk4"), desc())
                 )
             )
         )
     }
 
     @Test
-    fun orderByWithAscAndDescShouldProduceDefaultNullsSpec() = assertExpression("SELECT x FROM tb ORDER BY rk1 desc, rk2 asc, rk3 asc, rk4 desc") {
+    fun orderByNoAscOrDescWithNullsFirst() = assertExpression("SELECT x FROM tb ORDER BY rk1 NULLS FIRST") {
         select(
             project = projectX,
             from = scan(id("tb")),
             order = orderBy(
                 listOf(
-                    sortSpec(id("rk1"), desc(), nullsFirst()),
-                    sortSpec(id("rk2"), asc(), nullsLast()),
-                    sortSpec(id("rk3"), asc(), nullsLast()),
-                    sortSpec(id("rk4"), desc(), nullsFirst())
+                    sortSpec(id("rk1"), null, nullsFirst())
                 )
             )
         )
     }
 
     @Test
-    fun orderByAscMustBeDefaultIfOrderingSpecIsNotSpecifiedWithNullsFirst() = assertExpression("SELECT x FROM tb ORDER BY rk1 NULLS FIRST") {
+    fun orderByNoAscOrDescWithNullsLast() = assertExpression("SELECT x FROM tb ORDER BY rk1 NULLS LAST") {
         select(
             project = projectX,
             from = scan(id("tb")),
             order = orderBy(
                 listOf(
-                    sortSpec(id("rk1"), asc(), nullsFirst())
-                )
-            )
-        )
-    }
-
-    @Test
-    fun orderByAscMustBeDefaultIfOrderingSpecIsNotSpecifiedWithNullsLast() = assertExpression("SELECT x FROM tb ORDER BY rk1 NULLS LAST") {
-        select(
-            project = projectX,
-            from = scan(id("tb")),
-            order = orderBy(
-                listOf(
-                    sortSpec(id("rk1"), asc(), nullsLast())
+                    sortSpec(id("rk1"), null, nullsLast())
                 )
             )
         )
@@ -4705,7 +4706,7 @@ class SqlParserTest : SqlParserTestBase() {
         select(
             project = buildProject("x"),
             from = scan(id("a")),
-            order = PartiqlAst.OrderBy(listOf(PartiqlAst.SortSpec(id("y"), PartiqlAst.OrderingSpec.Desc(), PartiqlAst.NullsSpec.NullsFirst()))),
+            order = PartiqlAst.OrderBy(listOf(PartiqlAst.SortSpec(id("y"), PartiqlAst.OrderingSpec.Desc(), null))),
             limit = buildLit("10"),
             offset = buildLit("5")
         )


### PR DESCRIPTION
## Relevant Issues
- Closes #832 

## Description
- Moves defaulting of `ordering_spec` and `nulls_spec` within the `sort_spec` to evaluation time, rather than parse time.

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.