### PR TITLE
Update README following addition of partiql-tests git submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,21 @@ Be sure to replace `${version}` with the desired version.
 
 **Pre-requisite**: Building this project requires Java 11+.
 
-To build this project, clone this repository and from its root directory execute:
+This project uses a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to pull in 
+[partiql-tests](https://github.com/partiql/partiql-tests). The easiest way to pull everything in is to clone the 
+repository recursively:
+
+```bash
+$ git clone --recursive https://github.com/partiql/partiql-lang-kotlin.git
+```
+
+You can also initialize the submodules as follows:
+
+```bash
+$ git submodule update --init --recursive
+```
+
+To build this project, from the root directory execute:
 
 ```shell
 ./gradlew build


### PR DESCRIPTION
## Description
Updates the root README's build instructions following the addition of the git submodule, `partiql-tests`. Without pulling in the `partiql-tests` git submodule, developers may have ran into this build failure from the `test/partiql-tests-runner` gradle module:

```
TestRunner > validatePartiQLEvalEquivTestData(TestCase) > org.partiql.runner.TestRunner.initializationError FAILED
    org.junit.platform.commons.PreconditionViolationException: Configuration error: You must configure at least one set of arguments for this @ParameterizedTest
```

## Other Information
- Updated Unreleased Section in CHANGELOG: No, PR just updates README with additional instructions.
- Any backward-incompatible changes? No
- Any new external dependencies? No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.