### PR TITLE
fix subquery execution

### DIFF
--- a/lang/src/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
+++ b/lang/src/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
@@ -288,7 +288,11 @@ internal class PhysicalPlanCompilerImpl(
 
         return thunkFactory.thunkEnv(expr.metas) { env ->
             var relationType: RelationType? = null
+            // we create a snapshot for currentRegister to use during the evaluation
+            // this is to avoid issue when iterator planner result
+            val currentRegister = env.registers.clone()
             val elements = sequence {
+                env.load(currentRegister)
                 val relItr = bexprThunk(env)
                 relationType = relItr.relType
                 while (relItr.nextRow()) {

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerGroupByTest.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerGroupByTest.kt
@@ -16,12 +16,10 @@ package org.partiql.lang.eval
 
 import junitparams.Parameters
 import org.junit.Test
-import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestCase
 import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestTarget
-import org.partiql.lang.util.ArgumentsProviderBase
 import org.partiql.lang.util.propertyValueMapOf
 
 class EvaluatingCompilerGroupByTest : EvaluatorTestBase() {
@@ -971,16 +969,13 @@ class EvaluatingCompilerGroupByTest : EvaluatorTestBase() {
         ),
     )
 
-    // TODO: These tests are FAILING. These need to be addressed. Uncomment @ParameterizedTest to test
-    // @ParameterizedTest
-    @ArgumentsSource(FailingTestsArgsProvider::class)
-    fun failingTests(tc: EvaluatorTestCase) = runTest(tc, session)
-    class FailingTestsArgsProvider : ArgumentsProviderBase() {
-        override fun getParameters(): List<Any> = listOf(
-            // TODO: Please reference https://github.com/partiql/partiql-lang-kotlin/issues/833 for context.
-            EvaluatorTestCase(
-                groupName = "SELECT with nested aggregates (complex)",
-                query = """
+    @Test
+    @Parameters
+    fun groupByNestedAggregationTest(tc: EvaluatorTestCase) = runTest(tc, session)
+    fun parametersForGroupByNestedAggregationTest() = listOf(
+        EvaluatorTestCase(
+            groupName = "SELECT with nested aggregates (complex)",
+            query = """
                 SELECT
                     i2 AS outerKey,
                     g2 AS outerGroupAs,
@@ -999,7 +994,7 @@ class EvaluatingCompilerGroupByTest : EvaluatorTestBase() {
                 ) AS innerQuery
                 GROUP BY innerQuery.i AS i2, innerQuery.g AS g2
             """,
-                expectedResult = """
+            expectedResult = """
                 <<
                     {
                         'outerKey': 1,
@@ -1015,10 +1010,9 @@ class EvaluatingCompilerGroupByTest : EvaluatorTestBase() {
                     }
                 >>
             """,
-                targetPipeline = EvaluatorTestTarget.PLANNER_PIPELINE
-            ),
-        )
-    }
+            targetPipeline = EvaluatorTestTarget.PLANNER_PIPELINE
+        ),
+    )
 
     @Test
     @Parameters

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerOrderByTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerOrderByTests.kt
@@ -317,18 +317,14 @@ class EvaluatingCompilerOrderByTests : EvaluatorTestBase() {
         session = session
     )
 
-    // TODO: These tests are FAILING. These need to be addressed. Uncomment @ParameterizedTest to test
-    // @ParameterizedTest
-    @ArgumentsSource(FailingTestsProvider::class)
-    fun failingTests(tc: EvaluatorTestCase) = runEvaluatorTestCase(
+    @ParameterizedTest
+    @ArgumentsSource(OrderBySubqueryTestsProvider::class)
+    fun orderBySubqueryTests(tc: EvaluatorTestCase) = runEvaluatorTestCase(
         tc = tc.copy(excludeLegacySerializerAssertions = true),
         session = session
     )
-    class FailingTestsProvider : ArgumentsProviderBase() {
+    class OrderBySubqueryTestsProvider : ArgumentsProviderBase() {
         override fun getParameters() = listOf(
-            // TODO: Please reference https://github.com/partiql/partiql-lang-kotlin/issues/833 for context.
-            //  For this, we need to clone the ExprValue during the SORT operator factory. This has to do with the shared
-            //  global state registers.
             EvaluatorTestCase(
                 query = """
                     SELECT supplierId_nulls
@@ -362,7 +358,7 @@ class EvaluatingCompilerOrderByTests : EvaluatorTestBase() {
                     FROM products_sparse
                     GROUP BY supplierId_nulls
                     ORDER BY
-                        (SELECT t FROM products_sparse GROUP BY supplierId_nulls ORDER BY supplierIds_nulls ASC NULLS FIRST)
+                        (SELECT 1 FROM products_sparse GROUP BY supplierId_nulls ORDER BY supplierId_nulls ASC NULLS FIRST)
                     DESC NULLS FIRST
                 """,
                 "[{'supplierId_nulls': NULL}, {'supplierId_nulls': 10}, {'supplierId_nulls': 11}]"


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue https://github.com/partiql/partiql-lang-kotlin/issues/833

## Description
In this PR, a temporary resolution to fix iterating on the planner result was added. 

The way we achieve this is by "hard" reset the state before yielding `exprValue` in the bindingsToValues function. 

This patch fixes incorrect result when using subqueries (in testing and in pipeline breaking operators). 

As an evident, the failing tests for `GROUP BY` and `ORDER BY` are now passing. 

A long term solution can be having the operator to yield bindings instead of modifying a global mutable array list(register). 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No, Bug fix in the experimental Planner. 
- Any backward-incompatible changes? **[YES/NO]**
  - No. 
  - < For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base. >
- Any new external dependencies? **[YES/NO]**
- No
## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.