### PR TITLE
Bumps partiql-isl-kotlin to 0.2.2

### DIFF
--- a/lib/partiql-isl/build.gradle
+++ b/lib/partiql-isl/build.gradle
@@ -24,7 +24,7 @@ plugins {
 }
 
 // lib subprojects are _currently_ versioned independently of partiql-lang-kotlin
-version = "0.2.1"
+version = "0.2.2"
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 dependencies {


### PR DESCRIPTION
## Relevant Issues
Version bump with no changes simplifies 0.8.0 release. Starting at 1.0.0 we should consider having vended libs share the library version as this is avoid these bumps and is common elsewhere

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.