### PR TITLE
Makes SqlException.errorContext non-nullable, resolving Issue #616.

### DIFF
--- a/lang/src/org/partiql/lang/SqlException.kt
+++ b/lang/src/org/partiql/lang/SqlException.kt
@@ -18,7 +18,6 @@ import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.errors.PropertyValueMap
 import org.partiql.lang.errors.UNKNOWN
-import org.partiql.lang.util.propertyValueMapOf
 
 /**
  * General exception class for the interpreter.
@@ -34,18 +33,15 @@ import org.partiql.lang.util.propertyValueMapOf
  *
  * @param message the message for this exception
  * @param errorCode the error code for this exception
- * @param errorContextArg context for this error, includes details like line & character offsets, among others.
- * TODO: https://github.com/partiql/partiql-lang-kotlin/issues/616
+ * @param errorContext context for this error, includes details like line & character offsets, among others.
  * @param cause for this exception
  */
 open class SqlException(
     override var message: String,
     val errorCode: ErrorCode,
-    errorContextArg: PropertyValueMap? = null,
+    val errorContext: PropertyValueMap,
     cause: Throwable? = null
 ) : RuntimeException(message, cause) {
-
-    val errorContext: PropertyValueMap = errorContextArg ?: propertyValueMapOf()
 
     /**
      * Indicates if this exception is due to an internal error or not.

--- a/lang/src/org/partiql/lang/ast/passes/SemanticException.kt
+++ b/lang/src/org/partiql/lang/ast/passes/SemanticException.kt
@@ -27,7 +27,7 @@ import org.partiql.lang.util.propertyValueMapOf
 class SemanticException(
     message: String = "",
     errorCode: ErrorCode,
-    errorContext: PropertyValueMap?,
+    errorContext: PropertyValueMap,
     cause: Throwable? = null
 ) : SqlException(message, errorCode, errorContext, cause) {
 

--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -138,7 +138,7 @@ internal class EvaluatingCompiler(
     private val compilationContextStack = Stack<CompilationContext>()
 
     private val currentCompilationContext: CompilationContext
-        get() = compilationContextStack.peek() ?: throw EvaluationException(
+        get() = compilationContextStack.peek() ?: errNoContext(
             "compilationContextStack was empty.", ErrorCode.EVALUATOR_UNEXPECTED_VALUE, internal = true
         )
 
@@ -662,6 +662,7 @@ internal class EvaluatingCompiler(
                     throw EvaluationException(
                         cause = e,
                         errorCode = ErrorCode.EVALUATOR_ARITHMETIC_EXCEPTION,
+                        errorContext = errorContextFrom(metas),
                         internal = true
                     )
                 }
@@ -677,7 +678,7 @@ internal class EvaluatingCompiler(
         val computeThunk = thunkFactory.thunkFold(metas, argThunks) { lValue, rValue ->
             val denominator = rValue.numberValue()
             if (denominator.isZero()) {
-                err("% by zero", ErrorCode.EVALUATOR_MODULO_BY_ZERO, null, false)
+                err("% by zero", ErrorCode.EVALUATOR_MODULO_BY_ZERO, errorContextFrom(metas), false)
             }
 
             (lValue.numberValue() % denominator).exprValue()
@@ -999,7 +1000,7 @@ internal class EvaluatingCompiler(
                         "${func.signature.arity.last} arguments, received: ${funcArgThunks.size}"
             }
 
-            throw EvaluationException(
+            err(
                 message,
                 ErrorCode.EVALUATOR_INCORRECT_NUMBER_OF_ARGUMENTS_TO_FUNC_CALL,
                 errorContext,
@@ -1082,7 +1083,7 @@ internal class EvaluatingCompiler(
                             when (val value = env.current[bindingName]) {
                                 null -> {
                                     if (fromSourceNames.any { bindingName.isEquivalentTo(it) }) {
-                                        throw EvaluationException(
+                                        err(
                                             "Variable not in GROUP BY or aggregation function: ${bindingName.name}",
                                             ErrorCode.EVALUATOR_VARIABLE_NOT_INCLUDED_IN_GROUP_BY,
                                             errorContextFrom(metas).also {
@@ -1100,7 +1101,7 @@ internal class EvaluatingCompiler(
                                             is PartiqlAst.CaseSensitivity.CaseInsensitive ->
                                                 Pair(ErrorCode.EVALUATOR_BINDING_DOES_NOT_EXIST, "")
                                         }
-                                        throw EvaluationException(
+                                        err(
                                             "No such binding: ${bindingName.name}.$hint",
                                             errorCode,
                                             errorContextFrom(metas).also {
@@ -1150,7 +1151,7 @@ internal class EvaluatingCompiler(
         return { env ->
             val params = env.session.parameters
             if (params.size <= index) {
-                throw EvaluationException(
+                err(
                     "Unbound parameter for ordinal: $ordinal",
                     ErrorCode.EVALUATOR_UNBOUND_PARAMETER,
                     errorContextFrom(metas).also {
@@ -1282,7 +1283,7 @@ internal class EvaluatingCompiler(
 
                 locationMeta?.let { fillErrorContext(errorContext, it) }
 
-                throw EvaluationException(
+                err(
                     "Validation failure for $asType",
                     ErrorCode.EVALUATOR_CAST_FAILED,
                     errorContext,
@@ -2113,10 +2114,9 @@ internal class EvaluatingCompiler(
                 val env = resolveEnvironment(row, offsetLocationMeta)
                 orderByItem.thunk(env)
             }
-        } ?: err(
+        } ?: errNoContext(
             "Order BY comparator cannot be null",
             ErrorCode.EVALUATOR_ORDER_BY_NULL_COMPARATOR,
-            null,
             internal = true
         )
 
@@ -2915,7 +2915,7 @@ internal class EvaluatingCompiler(
                         "${procedure.signature.arity.last} arguments, received: ${args.size}"
             }
 
-            throw EvaluationException(
+            err(
                 message,
                 ErrorCode.EVALUATOR_INCORRECT_NUMBER_OF_ARGUMENTS_TO_PROCEDURE_CALL,
                 errorContext,

--- a/lang/src/org/partiql/lang/eval/Exceptions.kt
+++ b/lang/src/org/partiql/lang/eval/Exceptions.kt
@@ -29,7 +29,7 @@ import org.partiql.lang.util.to
 open class EvaluationException(
     message: String,
     errorCode: ErrorCode,
-    errorContext: PropertyValueMap? = null,
+    errorContext: PropertyValueMap = PropertyValueMap(),
     cause: Throwable? = null,
     override val internal: Boolean
 ) : SqlException(message, errorCode, errorContext, cause) {
@@ -37,7 +37,7 @@ open class EvaluationException(
     constructor(
         cause: Throwable,
         errorCode: ErrorCode,
-        errorContext: PropertyValueMap? = null,
+        errorContext: PropertyValueMap = PropertyValueMap(),
         internal: Boolean
     ) : this(
         message = cause.message ?: "<NO MESSAGE>",
@@ -51,10 +51,11 @@ open class EvaluationException(
 /**
  * Shorthand for throwing function evaluation. Separated from [err] to avoid loosing the context unintentionally
  */
-internal fun errNoContext(message: String, errorCode: ErrorCode, internal: Boolean): Nothing = err(message, errorCode, null, internal)
+internal fun errNoContext(message: String, errorCode: ErrorCode, internal: Boolean): Nothing =
+    err(message, errorCode, PropertyValueMap(), internal)
 
 /** Shorthand for throwing evaluation with context with an error code.. */
-internal fun err(message: String, errorCode: ErrorCode, errorContext: PropertyValueMap?, internal: Boolean): Nothing =
+internal fun err(message: String, errorCode: ErrorCode, errorContext: PropertyValueMap, internal: Boolean): Nothing =
     throw EvaluationException(message, errorCode, errorContext, internal = internal)
 
 internal fun expectedArgTypeErrorMsg(types: List<ExprValueType>): String = when (types.size) {

--- a/lang/src/org/partiql/lang/eval/builtins/MakeDateExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/MakeDateExprFunction.kt
@@ -52,7 +52,7 @@ internal class MakeDateExprFunction(val valueFactory: ExprValueFactory) : ExprFu
             err(
                 message = "Date field value out of range. $year-$month-$day",
                 errorCode = ErrorCode.EVALUATOR_DATE_FIELD_OUT_OF_RANGE,
-                errorContext = null,
+                errorContext = propertyValueMapOf(),
                 internal = false
             )
         }

--- a/lang/src/org/partiql/lang/eval/builtins/MakeTimeExprFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/MakeTimeExprFunction.kt
@@ -60,7 +60,7 @@ internal class MakeTimeExprFunction(val valueFactory: ExprValueFactory) : ExprFu
             err(
                 message = e.message,
                 errorCode = ErrorCode.EVALUATOR_TIME_FIELD_OUT_OF_RANGE,
-                errorContext = null,
+                errorContext = e.errorContext,
                 internal = false
             )
         }

--- a/lang/src/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
+++ b/lang/src/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
@@ -525,7 +525,7 @@ internal class PhysicalPlanCompilerImpl(
         val computeThunk = thunkFactory.thunkFold(metas, argThunks) { lValue, rValue ->
             val denominator = rValue.numberValue()
             if (denominator.isZero()) {
-                err("% by zero", ErrorCode.EVALUATOR_MODULO_BY_ZERO, errorContext = null, internal = false)
+                err("% by zero", ErrorCode.EVALUATOR_MODULO_BY_ZERO, errorContextFrom(metas), internal = false)
             }
 
             (lValue.numberValue() % denominator).exprValue()

--- a/lang/src/org/partiql/lang/eval/physical/operators/SortOperatorFactoryDefault.kt
+++ b/lang/src/org/partiql/lang/eval/physical/operators/SortOperatorFactoryDefault.kt
@@ -16,7 +16,7 @@ package org.partiql.lang.eval.physical.operators
 
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.eval.ExprValue
-import org.partiql.lang.eval.err
+import org.partiql.lang.eval.errNoContext
 import org.partiql.lang.eval.physical.EvaluatorState
 import org.partiql.lang.eval.relation.RelationIterator
 import org.partiql.lang.eval.relation.RelationType
@@ -73,10 +73,9 @@ private fun getSortingComparator(sortKeys: List<CompiledSortKey>, state: Evaluat
             state.load(row)
             sortKey.value(state)
         }
-    } ?: err(
+    } ?: errNoContext(
         "Order BY comparator cannot be null",
         ErrorCode.EVALUATOR_ORDER_BY_NULL_COMPARATOR,
-        null,
         internal = true
     )
 }

--- a/lang/test/org/partiql/lang/eval/ExceptionWrappingTest.kt
+++ b/lang/test/org/partiql/lang/eval/ExceptionWrappingTest.kt
@@ -6,6 +6,7 @@ import org.junit.Test
 import org.partiql.lang.CompilerPipeline
 import org.partiql.lang.ast.passes.SemanticException
 import org.partiql.lang.errors.ErrorCode
+import org.partiql.lang.errors.PropertyValueMap
 import org.partiql.lang.types.FunctionSignature
 import org.partiql.lang.types.StaticType
 
@@ -26,7 +27,7 @@ class ExceptionWrappingTest {
 
     private val throwSemanticExceptionExprFunction = object : ExprFunction {
         override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
-            throw SemanticException("Intentionally throw a SemanticException", ErrorCode.SEMANTIC_AMBIGUOUS_BINDING, null)
+            throw SemanticException("Intentionally throw a SemanticException", ErrorCode.SEMANTIC_AMBIGUOUS_BINDING, PropertyValueMap())
         }
 
         override val signature: FunctionSignature


### PR DESCRIPTION
## Relevant Issues
- Closes Issue #616

## Description

This is a simple PR: There was an in-code TODO at SqlException, pointing at Issue #616.
The suggestion was to change the field to non-nullable, switching from null to an empty PropertyValueMap as the declared default.  It turned out that many use sites have already provided non-null actuals, so even a default is not necessary in a few places.  The only subclass that had use sites with null actuals (coming through the default) was EvaluationException, so its default did get changed rather than removed. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - This is an internal change.
- Any backward-incompatible changes? **[NO]**
- Any new external dependencies? **[NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.