### PR TITLE
Add redaction for INSERT/UPSERT/REPLACE INTO << >>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Extends statement redaction to support `INSERT/REPLACE/UPSERT INTO`. 
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Extends statement redaction to support `INSERT/REPLACE/UPSERT INTO`. 
 
 ### Added
+- Extends statement redaction to support `INSERT/REPLACE/UPSERT INTO`.
 
 ### Changed
 

--- a/lang/src/org/partiql/lang/ast/passes/StatementRedactor.kt
+++ b/lang/src/org/partiql/lang/ast/passes/StatementRedactor.kt
@@ -289,8 +289,8 @@ private class StatementRedactionVisitor(
     }
 
     /**
-     * For [PartiqlAst.DmlOp.Insert], redacts every element of the BAG; for struct elements it
-     * follows the redaction rules that [redactStructInInsertValueOp] already applies.
+     * For [PartiqlAst.DmlOp.Insert], redacts every element of VALUES clause BAG value; for struct elements in the bag, it
+     * follows the redaction rules that [redactStructInInsertValueOp] applies.
      * For example, given:
      * INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}>>"
      * REPLACE INTO tb << { 'dummy1' : 'hashKey', 'dummy2' : 'rangeKey', 'dummyTestAttribute' : '123' } >>

--- a/lang/test/org/partiql/lang/ast/passes/StatementRedactorTest.kt
+++ b/lang/test/org/partiql/lang/ast/passes/StatementRedactorTest.kt
@@ -374,10 +374,6 @@ class StatementRedactorTest : SqlParserTestBase() {
             "REPLACE INTO testTable2 << { 'dummy1' : ***(Redacted), 'dummy2' : ***(Redacted), 'dummyTestAttribute' : ***(Redacted) } >>"
         ),
         RedactionTestCase(
-            "REPLACE INTO testTable2 << { 'dummy1' : 'hashKey', 'dummy2' : 'rangeKey', 'dummyTestAttribute' : '123' } >>",
-            "REPLACE INTO testTable2 << { 'dummy1' : ***(Redacted), 'dummy2' : ***(Redacted), 'dummyTestAttribute' : ***(Redacted) } >>"
-        ),
-        RedactionTestCase(
             "INSERT INTO testTable2 <<[2, 'some-name']>>",
             "INSERT INTO testTable2 <<[***(Redacted), ***(Redacted)]>>"
         ),

--- a/lang/test/org/partiql/lang/ast/passes/StatementRedactorTest.kt
+++ b/lang/test/org/partiql/lang/ast/passes/StatementRedactorTest.kt
@@ -357,6 +357,30 @@ class StatementRedactorTest : SqlParserTestBase() {
             "INSERT INTO tb VALUE << 'value1', 'value2' >>",
             "INSERT INTO tb VALUE << ***(Redacted), ***(Redacted) >>"
         ),
+        RedactionTestCase(
+            "INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': 'b' }>>",
+            "INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': ***(Redacted) }>>"
+        ),
+        RedactionTestCase(
+            "INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}>>",
+            "INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': { ***(Redacted): ***(Redacted) }}>>"
+        ),
+        RedactionTestCase(
+            "UPSERT INTO testTable2 << { 'dummy1' : 'hashKey', 'dummy2' : 'rangeKey', 'dummyTestAttribute' : '123' } >>",
+            "UPSERT INTO testTable2 << { 'dummy1' : ***(Redacted), 'dummy2' : ***(Redacted), 'dummyTestAttribute' : ***(Redacted) } >>"
+        ),
+        RedactionTestCase(
+            "REPLACE INTO testTable2 << { 'dummy1' : 'hashKey', 'dummy2' : 'rangeKey', 'dummyTestAttribute' : '123' } >>",
+            "REPLACE INTO testTable2 << { 'dummy1' : ***(Redacted), 'dummy2' : ***(Redacted), 'dummyTestAttribute' : ***(Redacted) } >>"
+        ),
+        RedactionTestCase(
+            "REPLACE INTO testTable2 << { 'dummy1' : 'hashKey', 'dummy2' : 'rangeKey', 'dummyTestAttribute' : '123' } >>",
+            "REPLACE INTO testTable2 << { 'dummy1' : ***(Redacted), 'dummy2' : ***(Redacted), 'dummyTestAttribute' : ***(Redacted) } >>"
+        ),
+        RedactionTestCase(
+            "INSERT INTO testTable2 <<[2, 'some-name']>>",
+            "INSERT INTO testTable2 <<[***(Redacted), ***(Redacted)]>>"
+        ),
         // Update Assignment
         RedactionTestCase(
             "update nonExistentTable set foo = 'bar' where attr1='testValue'",


### PR DESCRIPTION
## Relevant Issues
- Closes Issue #849 

## Description
This commit enables statement redaction for `INSERT`, `REPLACE`, and `UPSERT`.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Yes.

- Any backward-incompatible changes? **[YES/NO]**
No.

- Any new external dependencies? **[YES/NO]**
No.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.