### PR TITLE
Updates the CLI Shell Highlighter to use ANTLR-generated lexer/parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Now `CompileOption` uses `TypedOpParameter.HONOR_PARAMETERS` as default.
+- Updates the CLI Shell Highlighter to use the ANTLR generated lexer/parser for highlighting user queries
 
 ### Deprecated
 

--- a/cli/src/org/partiql/shell/Shell.kt
+++ b/cli/src/org/partiql/shell/Shell.kt
@@ -26,6 +26,7 @@ import org.jline.reader.LineReaderBuilder
 import org.jline.reader.UserInterruptException
 import org.jline.reader.impl.completer.NullCompleter
 import org.jline.terminal.TerminalBuilder
+import org.jline.utils.AttributedString
 import org.jline.utils.AttributedStringBuilder
 import org.jline.utils.AttributedStyle
 import org.jline.utils.InfoCmp
@@ -66,6 +67,11 @@ private const val HELP = """
 !exit               Exits the shell
 !clear              Clears the screen
 """
+
+private val SUCCESS: AttributedStyle = AttributedStyle.DEFAULT.foreground(AttributedStyle.GREEN)
+private val ERROR: AttributedStyle = AttributedStyle.DEFAULT.foreground(AttributedStyle.RED)
+private val INFO: AttributedStyle = AttributedStyle.DEFAULT
+private val WARN: AttributedStyle = AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW)
 
 private val EXIT_DELAY: Duration = Duration(3000)
 
@@ -289,6 +295,16 @@ private fun History.Entry.pretty(): String {
         .append(entry.trimEnd())
         .toAnsi()
 }
+
+private fun ansi(string: String, style: AttributedStyle) = AttributedString(string, style).toAnsi()
+
+private fun PrintStream.success(string: String) = this.println(ansi(string, SUCCESS))
+
+private fun PrintStream.error(string: String) = this.println(ansi(string, ERROR))
+
+private fun PrintStream.info(string: String) = this.println(ansi(string, INFO))
+
+private fun PrintStream.warn(string: String) = this.println(ansi(string, WARN))
 
 private class ThreadInterrupter : Closeable {
     private val thread = Thread.currentThread()

--- a/lang/antlr/PartiQLTokens.g4
+++ b/lang/antlr/PartiQLTokens.g4
@@ -362,13 +362,16 @@ IDENTIFIER_QUOTED
  */
 
 WS
-    : WHITESPACE+ -> skip;
+    : WHITESPACE+ -> channel(HIDDEN);
 
 COMMENT_SINGLE
-    : '--' ~[\r\n]* '\r'? '\n'? -> skip;
+    : '--' ~[\r\n]* '\r'? '\n'? -> channel(HIDDEN);
 
 COMMENT_BLOCK
-    : '/*' .*? '*/' -> skip;
+    : '/*' .*? '*/' -> channel(HIDDEN);
+
+UNRECOGNIZED
+    : . ;
 
 /**
  *

--- a/lang/src/org/partiql/lang/syntax/PartiQLParser.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLParser.kt
@@ -94,9 +94,8 @@ internal class PartiQLParser(
         val lexer = getLexer(query)
         val tokenIndexToParameterIndex = mutableMapOf<Int, Int>()
         var parametersFound = 0
-        val tokens = CommonTokenStream(lexer)
-        tokens.fill()
-        val tokenIter = tokens.tokens.iterator()
+        val tokenStream = CommonTokenStream(lexer).also { it.fill() }
+        val tokenIter = tokenStream.tokens.iterator()
         while (tokenIter.hasNext()) {
             val token = tokenIter.next()
             if (token.type == GeneratedParser.QUESTION_MARK) {

--- a/lang/src/org/partiql/lang/syntax/PartiQLParser.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLParser.kt
@@ -95,9 +95,12 @@ internal class PartiQLParser(
         val tokenIndexToParameterIndex = mutableMapOf<Int, Int>()
         var parametersFound = 0
         val tokens = CommonTokenStream(lexer)
-        for (i in 0 until tokens.numberOfOnChannelTokens) {
-            if (tokens[i].type == GeneratedParser.QUESTION_MARK) {
-                tokenIndexToParameterIndex[tokens[i].tokenIndex] = ++parametersFound
+        tokens.fill()
+        val tokenIter = tokens.tokens.iterator()
+        while (tokenIter.hasNext()) {
+            val token = tokenIter.next()
+            if (token.type == GeneratedParser.QUESTION_MARK) {
+                tokenIndexToParameterIndex[token.tokenIndex] = ++parametersFound
             }
         }
         return tokenIndexToParameterIndex

--- a/lang/src/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -15,6 +15,7 @@
 package org.partiql.lang.syntax
 
 import com.amazon.ion.IntegerSize
+import com.amazon.ion.IonException
 import com.amazon.ion.IonInt
 import com.amazon.ion.IonSystem
 import com.amazon.ion.IonValue
@@ -1168,8 +1169,13 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
     }
 
     override fun visitLiteralIon(ctx: PartiQLParser.LiteralIonContext) = PartiqlAst.build {
+        val ionValue = try {
+            ion.singleValue(ctx.ION_CLOSURE().getStringValue()).toIonElement()
+        } catch (e: IonException) {
+            throw ParserException("Unable to parse Ion value.", ErrorCode.PARSE_UNEXPECTED_TOKEN, cause = e)
+        }
         lit(
-            ion.singleValue(ctx.ION_CLOSURE().getStringValue()).toIonElement(),
+            ionValue,
             ctx.ION_CLOSURE().getSourceMetaContainer() + metaContainerOf(IsIonLiteralMeta.instance)
         )
     }


### PR DESCRIPTION
## Relevant Issues
- Closes #748

## Description
- Updates the Shell Highlighter to use ANTLR generated lexer/parser instead of SqlParser
- There are several new additions to the PartiQLParser (DML and more) that are not able to be highlighted by the existing Shell Highlighter
- Changes made:
  - Created an UNRECOGNIZED token (which grabs anything not matching)
  - Pushed comments and whitespace to hidden channel (so we can reproduce in CLI)
  - Since we add to hidden channel, I needed to update the way we get parameter indexes because it uses a method that only tacks ON channel tokens.
  - Also found a bug with `visitLiteralIon` in `PartiQLVisitor` -- if Ion can't parse the value, it throws an unhandled exception, and we need to catch it (addressed in this PR as well)

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.