### PR TITLE
Adds collection aggregation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds simple auto-completion to the CLI.
 - Adds support for HAVING clause in planner
+- Adds support for collection aggregation functions in the EvaluatingCompiler and experimental planner
+- Adds support for the syntactic sugar of using aggregations functions in place of their collection aggregation function
+  counterparts (in the experimental planner)
 
 ### Changed
 - Now `CompileOption` uses `TypedOpParameter.HONOR_PARAMETERS` as default.
@@ -53,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - [AstVisitor] Interface & [AstVisitorBase] class
   - [AstWalker] class
   - [MetaStrippingRewriter] class
+- **Breaking**: Removes the `CallAgg` node from the Logical, LogicalResolved, and Physical plans
 
 ### Security
 

--- a/lang/resources/org/partiql/type-domains/partiql.ion
+++ b/lang/resources/org/partiql/type-domains/partiql.ion
@@ -589,6 +589,10 @@ may then be further optimized by selecting better implementations of each operat
         (with expr
             // Remove the select and struct node from the `expr` sum type, which will be replaced below.
             (exclude select struct)
+              
+            // CallAgg's such as SUM, MIN, MAX, etc. either become calls to built-in-functions (example: call COLL_SUM)
+            // or aggregate functions within the logical aggregate operator.
+            (exclude call_agg)
 
             (include
                 // Invokes `exp` once in the context of every binding tuple returned by `query`, returning a

--- a/lang/src/org/partiql/lang/eval/builtins/BuiltinFunctions.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/BuiltinFunctions.kt
@@ -58,7 +58,7 @@ internal fun createBuiltinFunctions(valueFactory: ExprValueFactory) =
         SizeExprFunction(valueFactory),
         FromUnixTimeFunction(valueFactory),
         UnixTimestampFunction(valueFactory)
-    ) + MathFunctions.create(valueFactory)
+    ) + MathFunctions.create(valueFactory) + CollectionAggregationFunction.createAll(valueFactory)
 
 internal fun createExists(valueFactory: ExprValueFactory): ExprFunction = object : ExprFunction {
     override val signature = FunctionSignature(

--- a/lang/src/org/partiql/lang/eval/builtins/CollectionAggregationFunction.kt
+++ b/lang/src/org/partiql/lang/eval/builtins/CollectionAggregationFunction.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.eval.builtins
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprFunction
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueFactory
+import org.partiql.lang.eval.physical.operators.Accumulator
+import org.partiql.lang.eval.stringValue
+import org.partiql.lang.types.AnyOfType
+import org.partiql.lang.types.FunctionSignature
+import org.partiql.lang.types.StaticType
+import kotlin.reflect.full.primaryConstructor
+
+/**
+ * This class represents an aggregation function call (such as AVG, MAX, MIN, etc) -- but is meant to be operated outside
+ * of the relational algebra implementation of `aggregate`. In other words, the [CollectionAggregationFunction] allows
+ * users to call aggregation functions such as "AVG" on collections of scalars. While a user may use the function with the
+ * "Direct Usage" below, this function is also used within PartiQL to convert aggregate function calls that are outside
+ * of the scope of the relational algebra operator of aggregations. AKA -- we use this when the aggregation function calls
+ * are made outside of the projection clause, the HAVING clause, and ORDER BY clause.
+ *
+ * Direct Usage: coll_{AGGREGATE}('all', [0, 1, 2, 3])
+ * where ${AGGREGATE} can be replaced with MAX, MIN, AVG, COUNT, and SUM
+ *
+ * Example (Direct) Usage:
+ * ```
+ * SELECT a AS inputA, COLL_AVG(a) AS averagedA
+ * FROM << {'a': [0, 1]}, {'a': [10, 11]} >>
+ * WHERE COLL_AVG(a) > 0.5
+ * ```
+ *
+ * Example (Indirect) Usage:
+ * ```
+ * SELECT a
+ * FROM << {'a': [0, 1]}, {'a': [10, 11]} >>
+ * WHERE AVG(a) > 0.5
+ * ```
+ *
+ * The above indirect example shows how this is leveraged. The WHERE clause does not allow aggregation functions to be passed to the
+ * aggregate operator, so we internally convert the AVG to a [CollectionAggregationFunction] (which is just an expression
+ * function call).
+ */
+internal sealed class CollectionAggregationFunction(private val valueFactory: ExprValueFactory) : ExprFunction {
+
+    internal abstract val aggregationName: String
+
+    enum class Parameters(val index: Int, val type: StaticType) {
+        QUANTIFIER(0, StaticType.STRING),
+        ARGUMENT(1, AnyOfType(setOf(StaticType.LIST, StaticType.BAG, StaticType.STRUCT, StaticType.SEXP)))
+    }
+
+    companion object {
+        internal const val collectionAggregationPrefix = "coll_"
+        internal fun createAll(valueFactory: ExprValueFactory): List<CollectionAggregationFunction> =
+            CollectionAggregationFunction::class.sealedSubclasses.map { subClass ->
+                subClass.primaryConstructor?.call(valueFactory)!!
+            }
+    }
+
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
+        val inputSequence = required[Parameters.ARGUMENT.index]
+        val quantifier = getQuantifier(required[Parameters.QUANTIFIER.index].stringValue())
+        val accumulator = Accumulator.create(aggregationName, quantifier, valueFactory)
+        inputSequence.asSequence().forEach { exprValue -> accumulator.next(exprValue) }
+        return accumulator.compute()
+    }
+
+    private fun getQuantifier(quantifierText: String) = when (quantifierText.toLowerCase().trim()) {
+        "all" -> PartiqlPhysical.SetQuantifier.All()
+        "distinct" -> PartiqlPhysical.SetQuantifier.Distinct()
+        else -> throw IllegalArgumentException("Unrecognized set quantifier: $quantifierText")
+    }
+
+    internal fun getFunctionSignature(aggregationName: String) = FunctionSignature(
+        name = "$collectionAggregationPrefix$aggregationName",
+        requiredParameters = listOf(Parameters.QUANTIFIER.type, Parameters.ARGUMENT.type),
+        returnType = StaticType.NUMERIC
+    )
+}
+
+internal class CollectionMaxFunction(valueFactory: ExprValueFactory) : CollectionAggregationFunction(valueFactory) {
+    override val aggregationName: String = "max"
+    override val signature = getFunctionSignature(this.aggregationName)
+}
+
+internal class CollectionMinFunction(valueFactory: ExprValueFactory) : CollectionAggregationFunction(valueFactory) {
+    override val aggregationName: String = "min"
+    override val signature = getFunctionSignature(this.aggregationName)
+}
+
+internal class CollectionAvgFunction(valueFactory: ExprValueFactory) : CollectionAggregationFunction(valueFactory) {
+    override val aggregationName: String = "avg"
+    override val signature = getFunctionSignature(this.aggregationName)
+}
+
+internal class CollectionSumFunction(valueFactory: ExprValueFactory) : CollectionAggregationFunction(valueFactory) {
+    override val aggregationName: String = "sum"
+    override val signature = getFunctionSignature(this.aggregationName)
+}
+internal class CollectionCountFunction(valueFactory: ExprValueFactory) : CollectionAggregationFunction(valueFactory) {
+    override val aggregationName: String = "count"
+    override val signature = getFunctionSignature(this.aggregationName)
+}

--- a/lang/src/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
+++ b/lang/src/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
@@ -210,7 +210,6 @@ internal class PhysicalPlanCompilerImpl(
             is PartiqlPhysical.Expr.SearchedCase -> compileSearchedCase(expr, metas)
             is PartiqlPhysical.Expr.Path -> compilePath(expr, metas)
             is PartiqlPhysical.Expr.Struct -> compileStruct(expr)
-            is PartiqlPhysical.Expr.CallAgg -> compileCallAgg(expr, metas)
             is PartiqlPhysical.Expr.Parameter -> compileParameter(expr, metas)
             is PartiqlPhysical.Expr.Date -> compileDate(expr, metas)
             is PartiqlPhysical.Expr.LitTime -> compileLitTime(expr, metas)
@@ -1414,9 +1413,6 @@ internal class PhysicalPlanCompilerImpl(
             )
         }
     }
-
-    @Suppress("UNUSED_PARAMETER")
-    private fun compileCallAgg(expr: PartiqlPhysical.Expr.CallAgg, metas: MetaContainer): PhysicalPlanThunk = TODO("call_agg")
 
     private fun compilePath(expr: PartiqlPhysical.Expr.Path, metas: MetaContainer): PhysicalPlanThunk {
         val rootThunk = compileAstExpr(expr.root)

--- a/lang/src/org/partiql/lang/planner/validators/PartiqlLogicalValidator.kt
+++ b/lang/src/org/partiql/lang/planner/validators/PartiqlLogicalValidator.kt
@@ -4,7 +4,6 @@ import com.amazon.ionelement.api.IntElement
 import com.amazon.ionelement.api.IntElementSize
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.TextElement
-import org.partiql.lang.ast.IsCountStarMeta
 import org.partiql.lang.ast.passes.SemanticException
 import org.partiql.lang.domains.PartiqlLogical
 import org.partiql.lang.domains.addSourceLocation
@@ -58,19 +57,6 @@ class PartiqlLogicalValidator(private val typedOpBehavior: TypedOpBehavior) : Pa
 
     override fun visitTypeNumericType(node: PartiqlLogical.Type.NumericType) {
         validateDecimalOrNumericType(node.scale, node.precision, node.metas)
-    }
-
-    override fun visitExprCallAgg(node: PartiqlLogical.Expr.CallAgg) {
-        val setQuantifier = node.setq
-        val metas = node.metas
-        if (setQuantifier is PartiqlLogical.SetQuantifier.Distinct && metas.containsKey(IsCountStarMeta.TAG)) {
-            err(
-                "COUNT(DISTINCT *) is not supported",
-                ErrorCode.EVALUATOR_COUNT_DISTINCT_STAR,
-                errorContextFrom(metas),
-                internal = false
-            )
-        }
     }
 
     override fun visitExprStruct(node: PartiqlLogical.Expr.Struct) {

--- a/lang/test/org/partiql/lang/eval/EvaluatingCompilerCollectionAggregationsTest.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatingCompilerCollectionAggregationsTest.kt
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.eval
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.partiql.lang.errors.ErrorCode
+import org.partiql.lang.eval.builtins.toSession
+import org.partiql.lang.eval.evaluatortestframework.EvaluatorErrorTestCase
+import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestCase
+import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestTarget
+import org.partiql.lang.util.ArgumentsProviderBase
+
+internal class EvaluatingCompilerCollectionAggregationsTest : EvaluatorTestBase() {
+
+    companion object {
+        private val SESSION = mapOf(
+            "table_05" to """
+                [
+                    {a: [2, 4], b: 10},
+                    {a: [2, 4], b: 20},
+                    {a: [6, 7], b: 20}
+                ]
+            """,
+            "table_06" to """
+                [
+                    {a: [80, 90], b: 55},
+                    {a: [80, 90], b: 65},
+                    {a: [30, 40], b: 45}
+                ]
+            """,
+        ).toSession()
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ValidTestArguments::class)
+    fun validTests(tc: EvaluatorTestCase) {
+        val newTc = tc.copy(targetPipeline = EvaluatorTestTarget.PLANNER_PIPELINE)
+        runEvaluatorTestCase(newTc, SESSION)
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ErrorTestArguments::class)
+    fun errorTests(tc: EvaluatorErrorTestCase) {
+        val newTc = tc.copy(targetPipeline = EvaluatorTestTarget.PLANNER_PIPELINE)
+        runEvaluatorErrorTestCase(newTc, SESSION)
+    }
+
+    internal class ValidTestArguments : ArgumentsProviderBase() {
+        override fun getParameters() = listOf(
+            EvaluatorTestCase(
+                groupName = "Simple top-level explicit call",
+                query = """
+                    COLL_SUM('all', [1, 1, 2])
+                """,
+                expectedResult = "4"
+            ),
+            EvaluatorTestCase(
+                groupName = "Simple top-level explicit call (using distinct)",
+                query = """
+                    COLL_SUM('distinct', [1, 1, 2])
+                """,
+                expectedResult = "3"
+            ),
+            EvaluatorTestCase(
+                groupName = "Top-level call with all aggregation functions (using 'all')",
+                query = """
+                    COLL_SUM('all', [1, 1, 2])       -- 4
+                    + COLL_AVG('all', [2, 2, 2])     -- + 2
+                    + COLL_MIN('all', [1, 1, 2])     -- + 1
+                    + COLL_MAX('all', [1, 1, 2])     -- + 2
+                    + COLL_COUNT('all', [1, 1, 2])   -- + 3 = 12
+                """,
+                expectedResult = "12"
+            ),
+            EvaluatorTestCase(
+                groupName = "Top-level call with all aggregation functions (using 'distinct')",
+                query = """
+                    COLL_SUM('distinct', [1, 1, 2])       -- 3
+                    + COLL_AVG('distinct', [1, 1, 2])     -- + 1.5
+                    + COLL_MIN('distinct', [1, 1, 2])     -- + 1
+                    + COLL_MAX('distinct', [1, 1, 2])     -- + 2
+                    + COLL_COUNT('distinct', [1, 1, 2])   -- + 2 = 9.5
+                """,
+                expectedResult = "9.5"
+            ),
+            EvaluatorTestCase(
+                groupName = "Simple top-level implicit call (using implicit ALL)",
+                query = """
+                    SUM([1, 1, 2])
+                """,
+                expectedResult = "4"
+            ),
+            EvaluatorTestCase(
+                groupName = "Simple top-level implicit call (using explicit ALL)",
+                query = """
+                    SUM(ALL [1, 1, 2])
+                """,
+                expectedResult = "4"
+            ),
+            EvaluatorTestCase(
+                groupName = "Simple top-level implicit call (using distinct)",
+                query = """
+                    SUM(DISTINCT [1, 1, 2])
+                """,
+                expectedResult = "3"
+            ),
+            EvaluatorTestCase(
+                groupName = "As operand to binary operation",
+                query = """
+                    1 + COLL_AVG('all', [1, 2])
+                """,
+                expectedResult = "2.5"
+            ),
+            EvaluatorTestCase(
+                groupName = "Within projection list",
+                query = """
+                    SELECT k, COLL_SUM('all', k) AS coll_sum_a, SUM(t.b) AS sum_b
+                    FROM table_05 AS t
+                    GROUP BY t.a AS k
+                """,
+                expectedResult = """
+                    <<
+                        {'k': [2, 4], 'coll_sum_a': 6, 'sum_b': 30},
+                        {'k': [6, 7], 'coll_sum_a': 13, 'sum_b': 20}
+                    >>
+                """
+            ),
+            EvaluatorTestCase(
+                groupName = "Within FROM",
+                query = """
+                    SELECT COLL_SUM('distinct', k) AS new_k, SUM(sum_b) AS total_sum_b
+                    FROM (
+                        SELECT k AS k, COLL_SUM('all', k) AS coll_sum_a, SUM(t.b) AS sum_b
+                        FROM table_05 AS t
+                        GROUP BY t.a AS k
+                    ) AS nested_t
+                    GROUP BY k AS k
+                """,
+                expectedResult = """
+                    <<
+                        {'new_k': 6, 'total_sum_b': 30},
+                        {'new_k': 13, 'total_sum_b': 20}
+                    >>
+                """
+            ),
+            EvaluatorTestCase(
+                groupName = "Nested example",
+                query = """
+                    SELECT
+                        k,
+                        COLL_SUM('all', k) AS coll_sum_a,
+                        SUM(t.b) AS sum_b,
+                        (
+                            SELECT VALUE COLL_SUM('all', k)
+                            FROM [0]
+                        ) AS coll_sum_inner
+                    FROM table_05 AS t
+                    GROUP BY t.a AS k
+                """,
+                expectedResult = """
+                    <<
+                        {'k': [2, 4], 'coll_sum_a': 6, 'coll_sum_inner': <<6>>, 'sum_b': 30},
+                        {'k': [6, 7], 'coll_sum_a': 13, 'coll_sum_inner': <<13>>, 'sum_b': 20}
+                    >>
+                """
+            ),
+            EvaluatorTestCase(
+                groupName = "Within ORDER BY clause",
+                query = """
+                    SELECT k, COLL_SUM('all', k) AS coll_sum_a, SUM(t.b) AS sum_b
+                    FROM table_05 AS t
+                    GROUP BY t.a AS k
+                    ORDER BY COLL_SUM('all', k) DESC
+                """,
+                expectedResult = """
+                    [
+                        {'k': [6, 7], 'coll_sum_a': 13, 'sum_b': 20},
+                        {'k': [2, 4], 'coll_sum_a': 6, 'sum_b': 30}
+                    ]
+                """
+            ),
+            EvaluatorTestCase(
+                groupName = "Nested example with ORDER BY clause",
+                query = """
+                    SELECT
+                        k,
+                        COLL_SUM('all', k) AS coll_sum_a,
+                        SUM(t.b) AS sum_b,
+                        (
+                            SELECT COLL_AVG('all', k2) AS coll_avg_inner_k, AVG(t.b) AS avg_inner_b
+                            FROM table_06 AS t
+                            GROUP BY t.a AS k2
+                            ORDER BY COLL_AVG('all', k2)
+                        ) AS coll_sum_inner
+                    FROM table_05 AS t
+                    GROUP BY t.a AS k
+                """,
+                expectedResult = """
+                    <<
+                        {
+                            'k': [2, 4],
+                            'coll_sum_a': 6,
+                            'coll_sum_inner': [
+                                { 'coll_avg_inner_k': 35, 'avg_inner_b': 45 },
+                                { 'coll_avg_inner_k': 85, 'avg_inner_b': 60 }
+                            ],
+                            'sum_b': 30
+                        },
+                        {
+                            'k': [6, 7],
+                            'coll_sum_a': 13,
+                            'coll_sum_inner': [
+                                { 'coll_avg_inner_k': 35, 'avg_inner_b': 45 },
+                                { 'coll_avg_inner_k': 85, 'avg_inner_b': 60 }
+                            ],
+                            'sum_b': 20
+                        }
+                    >>
+                """
+            ),
+            EvaluatorTestCase(
+                groupName = "Within HAVING clause",
+                query = """
+                    SELECT k, COLL_SUM('all', k) AS coll_sum_a, SUM(t.b) AS sum_b
+                    FROM table_05 AS t
+                    GROUP BY t.a AS k
+                    HAVING COLL_SUM('all', k) > 10
+                """,
+                expectedResult = """
+                    <<
+                        {'k': [6, 7], 'coll_sum_a': 13, 'sum_b': 20}
+                    >>
+                """
+            ),
+        )
+    }
+
+    internal class ErrorTestArguments : ArgumentsProviderBase() {
+        override fun getParameters() = listOf(
+            EvaluatorErrorTestCase(
+                groupName = "Lack of set quantifier",
+                query = "COLL_SUM([1,2])",
+                expectedErrorCode = ErrorCode.EVALUATOR_INCORRECT_NUMBER_OF_ARGUMENTS_TO_FUNC_CALL
+            ),
+            EvaluatorErrorTestCase(
+                groupName = "Lack of argument",
+                query = "COLL_SUM('all')",
+                expectedErrorCode = ErrorCode.EVALUATOR_INCORRECT_NUMBER_OF_ARGUMENTS_TO_FUNC_CALL
+            ),
+            EvaluatorErrorTestCase(
+                groupName = "Not an actual aggregation function",
+                query = "COLL_AVERAGE('all', [1, 2])",
+                expectedErrorCode = ErrorCode.EVALUATOR_NO_SUCH_FUNCTION
+            ),
+            EvaluatorErrorTestCase(
+                groupName = "Not using collection of numbers",
+                query = "COLL_AVG('all', ['s', 'h'])",
+                expectedErrorCode = ErrorCode.EVALUATOR_INVALID_ARGUMENTS_FOR_AGG_FUNCTION
+            ),
+            EvaluatorErrorTestCase(
+                groupName = "Not using collection of numbers #2",
+                query = "COLL_AVG('all', [1, 2, 'h'])",
+                expectedErrorCode = ErrorCode.EVALUATOR_INVALID_ARGUMENTS_FOR_AGG_FUNCTION
+            ),
+            EvaluatorErrorTestCase(
+                groupName = "Not using collection of numbers #3",
+                query = "AVG([1, 2, 'h'])",
+                expectedErrorCode = ErrorCode.EVALUATOR_INVALID_ARGUMENTS_FOR_AGG_FUNCTION
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- Closes #837 

## Description
- Adds collection aggregation functions (COLL_SUM, COLL_AVG, COLL_MIN, etc)
- Creates a sealed class `CollectionAggregationFunction`, where each implementation just leverages the aggregation logic used by the aggregate operator. See Accumulator. We also add these to the built-in functions.
- Modifies the AstToLogical:
  - In the normal flow, all CallAggs in a SFW query will be sent to the aggregate operator and replaced with identifiers
  - After this happens, we just need to replace any remaining aggregation functions with the equivalent collection aggregation function.
  - Similarly, we also need to replace any CallAggs that are outside of the SFW query. So, this PR also does that.

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **YES** -- CallAgg is removed from Logical/Physical Plan
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.