### PR TITLE
Modified custom procedure example to remove the use of `ionValue`

### DIFF
--- a/examples/src/kotlin/org/partiql/examples/CustomProceduresExample.kt
+++ b/examples/src/kotlin/org/partiql/examples/CustomProceduresExample.kt
@@ -27,8 +27,9 @@ import java.math.RoundingMode
 private val ion = IonSystemBuilder.standard().build()
 
 /**
- * A simple custom stored procedure that calculates the moon weight for each crewmate of the given crew, and returns
- * them in a list
+ * A simple custom stored procedure that calculates and returns the moon weight for each crewmate of the given crew.
+ * This procedure also returns the number of crewmates we calculated the moon weight for, returning -1 if no crew is
+ * found.
  */
 class CalculateCrewMoonWeight(private val valueFactory: ExprValueFactory) : StoredProcedure {
     private val MOON_GRAVITATIONAL_CONSTANT = BigDecimal(1.622 / 9.81)
@@ -65,9 +66,8 @@ class CalculateCrewMoonWeight(private val valueFactory: ExprValueFactory) : Stor
         val crewBindings = sessionGlobals[BindingName(crewName.stringValue(), BindingCase.INSENSITIVE)]
             ?: return valueFactory.newInt(-1)
 
-        // Now that we've confirmed the given `crewName` is in the session's global bindings, we calculate and store
+        // Now that we've confirmed the given `crewName` is in the session's global bindings, we calculate and return
         // the moon weight for each crewmate in the crew.
-        // In addition, we keep a running a tally of how many crewmates we do this for.
         val result = mutableListOf<ExprValue>()
         for (crewmateBinding in crewBindings) {
             val nameBindingName = BindingName("name", BindingCase.INSENSITIVE)

--- a/examples/test/org/partiql/examples/CustomProceduresExampleTest.kt
+++ b/examples/test/org/partiql/examples/CustomProceduresExampleTest.kt
@@ -12,13 +12,8 @@ class CustomProceduresExampleTest : BaseExampleTest() {
         |    [{'name': 'Neil', 'mass': 80.5}, {'name': 'Buzz', 'mass': 72.3}, {'name': 'Michael', 'mass': 89.9}]
         |Crew 2:
         |    [{'name': 'James', 'mass': 77.1}, {'name': 'Spock', 'mass': 81.6}]
-        |Number of calculated moon weights:
-        |    3
-        |Updated global session bindings:
-        |Crew 1:
-        |    [{'name': 'Neil', 'mass': 80.5, 'moonWeight': 13.3}, {'name': 'Buzz', 'mass': 72.3, 'moonWeight': 12.0}, {'name': 'Michael', 'mass': 89.9, 'moonWeight': 14.9}]
-        |Crew 2:
-        |    [{'name': 'James', 'mass': 77.1}, {'name': 'Spock', 'mass': 81.6}]
+        |Calculated moon weights:
+        |    [{'name': 'Neil', 'moonWeight': 13.3}, {'name': 'Buzz', 'moonWeight': 12.0}, {'name': 'Michael', 'moonWeight': 14.9}]
         |
     """.trimMargin()
 }


### PR DESCRIPTION
## Description
- Remove the dependency on `ionValue` property in the custom procedure example
