### PR TITLE
rename-to-randomized

### DIFF
--- a/test/partiql-randomized-tests/test/org.partiql.lang.randomized/eval/EvaluatingCompilerDateTimeRandomizedTests.kt
+++ b/test/partiql-randomized-tests/test/org.partiql.lang.randomized/eval/EvaluatingCompilerDateTimeRandomizedTests.kt
@@ -17,7 +17,7 @@ internal const val SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR
 internal const val NANOS_PER_SECOND = 1000000000
 internal const val MAX_PRECISION_FOR_TIME = 9
 
-class EvaluatingCompilerDateTimeFuzzTests : EvaluatorTestBase() {
+class EvaluatingCompilerDateTimeRandomizedTests : EvaluatorTestBase() {
 
     abstract class RandomTestsProvider() : ArgumentsProviderBase() {
         private val randomTestsSize = 50000

--- a/test/partiql-randomized-tests/test/org.partiql.lang.randomized/eval/EvaluatingCompilerIntRandomizedTest.kt
+++ b/test/partiql-randomized-tests/test/org.partiql.lang.randomized/eval/EvaluatingCompilerIntRandomizedTest.kt
@@ -25,7 +25,7 @@ import java.util.Random
  * introduction of [StaticType].  The behavior described in these tests is still how the we should handle
  * integer arithmetic in the absence of [StaticType] information.
  */
-class EvaluatingCompilerIntFuzzTest : EvaluatorTestBase() {
+class EvaluatingCompilerIntRandomizedTest : EvaluatorTestBase() {
     companion object {
         private val RANDOM = Random()
 

--- a/test/partiql-randomized-tests/test/org.partiql.lang.randomized/syntax/PartiQLParserDateTimeRandomizedTests.kt
+++ b/test/partiql-randomized-tests/test/org.partiql.lang.randomized/syntax/PartiQLParserDateTimeRandomizedTests.kt
@@ -4,7 +4,7 @@ import org.junit.Test
 import org.partiql.lang.syntax.PartiQLParserTestBase
 import java.util.Random
 
-class PartiQLParserDateTimeFuzzTests : PartiQLParserTestBase() {
+class PartiQLParserDateTimeRandomizedTests : PartiQLParserTestBase() {
 
     private data class Date(val year: Int, val month: Int, val day: Int)
 


### PR DESCRIPTION
## Relevant Issues
- N/A

## Description
- A quick PR to change the randomized test class name from `fuzz test` to `randomized test`. Sorry about missing this change in the previous PR. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No
- Any backward-incompatible changes? **[YES/NO]**
  - No.
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base. >
- Any new external dependencies? **[YES/NO]**
  - No.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.