### PR TITLE
Adds SLL prediction mode to parser to reduce latency

### DIFF
--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'
+    testImplementation 'io.mockk:mockk:1.11.0'
 }
 
 // TODO update to conventional source layout

--- a/lang/src/org/partiql/lang/syntax/PartiQLParser.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLParser.kt
@@ -62,9 +62,8 @@ internal class PartiQLParser(
     }
 
     /**
-     * To reduce latency costs, the [PartiQLParser] attempts to use [PredictionMode.SLL] and falls back to
-     * [PredictionMode.LL] if a [ParseCancellationException] is thrown by the [BailErrorStrategy]. See [createParserSLL]
-     * and [createParserLL] for more information.
+     * As a performance optimization, first attempt to parse using ANTLR's fast, but less powerful [PredictionMode.SLL],
+     * falling back to the slower [PredictionMode.LL] that is capable of parsing all valid ANTLR grammars.
      */
     private fun parseQuery(input: String): ParseTree = try {
         parseUsingSLL(input)
@@ -110,8 +109,9 @@ internal class PartiQLParser(
     }
 
     /**
-     * Creates a [GeneratedParser] that uses [PredictionMode.LL]. This is the fastest prediction mode that guarantees
-     * correct parse results. Upon seeing a syntax error, this parser throws a [ParserException].
+     * Creates a [GeneratedParser] that uses [PredictionMode.LL]. This method is capable of parsing all valid inputs
+     * for a grammar, but is slower than [PredictionMode.SLL]. Upon seeing a syntax error, this parser throws a
+     * [ParserException].
      */
     private fun createParserLL(query: String): GeneratedParser {
         val stream = createTokenStream(query)

--- a/lang/test/org/partiql/lang/syntax/PartiQLParserSpyTest.kt
+++ b/lang/test/org/partiql/lang/syntax/PartiQLParserSpyTest.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.syntax
+
+import com.amazon.ion.IonSystem
+import com.amazon.ion.system.IonSystemBuilder
+import io.mockk.every
+import io.mockk.spyk
+import io.mockk.verify
+import org.antlr.v4.runtime.misc.ParseCancellationException
+import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.partiql.lang.domains.PartiqlAst
+
+/**
+ * This test class is used for spying the [PartiQLParser].
+ */
+internal class PartiQLParserSpyTest {
+
+    val ion: IonSystem = IonSystemBuilder.standard().build()
+    val parser = spyk<PartiQLParser>()
+
+    /**
+     * Shows that the PartiQLParser can parse different queries sequentially.
+     */
+    @org.junit.Test(expected = org.junit.Test.None::class)
+    fun twoQueries() {
+        val query00 = "SELECT a1 FROM t1"
+        val query01 = "SELECT a2 FROM t2"
+        parser.parseAstStatement(query00)
+        parser.parseAstStatement(query01)
+    }
+
+    /**
+     * Shows that the PartiQLParser can parse same queries sequentially.
+     */
+    @Test
+    fun twoSameQueries() {
+        val query00 = "SELECT a1 FROM t1"
+        val ast00 = parser.parseAstStatement(query00)
+        val ast01 = parser.parseAstStatement(query00)
+        assertEquals(ast00, ast01)
+    }
+
+    /**
+     * This test shows that SLL and LL parsing can happen sequentially
+     */
+    @Test
+    fun manuallyShowDoubleParsingSameQueriesWorks() {
+        val query00 = "SELECT a1 FROM t1"
+        val ast00 = PartiQLVisitor(ion).visit(parser.parseUsingSLL(query00))
+        val ast01 = PartiQLVisitor(ion).visit(parser.parseUsingLL(query00))
+        assertEquals(ast00, ast01)
+    }
+
+    /**
+     * This test shows that SLL and LL parsing can happen sequentially using different queries
+     */
+    @org.junit.Test(expected = org.junit.Test.None::class)
+    fun manuallyShowDoubleParsingWorks() {
+        val query00 = "SELECT a1 FROM t1"
+        val query01 = "SELECT a2 FROM t2"
+        PartiQLVisitor(ion).visit(parser.parseUsingSLL(query00))
+        PartiQLVisitor(ion).visit(parser.parseUsingLL(query01))
+    }
+
+    /**
+     * Shows that for simple queries, we'll only parse using the SLL parser.
+     */
+    @Test
+    fun sllParsesCorrectly() {
+        // Arrange
+        val query00 = "SELECT a FROM t"
+
+        // Act
+        val ast = parser.parseAstStatement(query00)
+
+        // Assert
+        verify(exactly = 1) { parser.parseUsingSLL(query00) }
+        verify(exactly = 0) { parser.parseUsingLL(query00) }
+        assertEquals(
+            ast,
+            PartiqlAst.build {
+                query(
+                    select(
+                        project = projectList(
+                            projectExpr(
+                                id("a", caseInsensitive(), unqualified())
+                            )
+                        ),
+                        from = scan(
+                            id("t", caseInsensitive(), unqualified())
+                        )
+                    )
+                )
+            }
+        )
+    }
+
+    /**
+     * Shows we can parse using LL after SLL throws a ParseCancellationException
+     */
+    @Test
+    fun sllThrowsException() {
+        // Arrange
+        val query00 = "SELECT a FROM t"
+        every {
+            parser.parseUsingSLL(query00)
+        } throws ParseCancellationException()
+
+        // Act
+        val ast = parser.parseAstStatement(query00)
+
+        // Assert
+        verify(exactly = 1) { parser.parseUsingSLL(query00) }
+        verify(exactly = 1) { parser.parseUsingLL(query00) }
+        assertEquals(
+            ast,
+            PartiqlAst.build {
+                query(
+                    select(
+                        project = projectList(
+                            projectExpr(
+                                id("a", caseInsensitive(), unqualified())
+                            )
+                        ),
+                        from = scan(
+                            id("t", caseInsensitive(), unqualified())
+                        )
+                    )
+                )
+            }
+        )
+    }
+
+    /**
+     * Shows that SLL parsing throws a ParseCancellationException
+     */
+    @Test
+    fun badQueryThrowsSLLCancellationException() {
+        val query00 = "1++++++++++++"
+        assertThrows<ParseCancellationException> {
+            parser.parseUsingSLL(query00)
+        }
+    }
+
+    /**
+     * Shows that LL parsing throws a ParserException
+     */
+    @Test
+    fun badQueryThrowsLLParserException() {
+        val query00 = "1++++++++++++"
+        assertThrows<ParserException> {
+            parser.parseUsingLL(query00)
+        }
+    }
+
+    /**
+     * Shows that the public API will parse a bad query twice using SLL and LL
+     */
+    @Test
+    fun badQueryThrowsParserException() {
+        val query00 = "1++++++++++++"
+        assertThrows<ParserException> {
+            parser.parseAstStatement(query00)
+        }
+        verify(exactly = 1) { parser.parseUsingSLL(query00) }
+        verify(exactly = 1) { parser.parseUsingLL(query00) }
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds SLL prediction mode to parser to reduce latency
- Ran benchmarks using the PartiQLParser (suffixed with New), the SqlParser (suffixed with Old), and the modified PartiQLParser (suffixed with Experimental). Here are the results:
```
Benchmark                                     Mode  Cnt     Score     Error  Units
ParserBenchmark.nestedSelectExperimental      avgt   20   124.236 ±   5.000  us/op
ParserBenchmark.nestedSelectNew               avgt   20  2525.692 ± 116.653  us/op
ParserBenchmark.nestedSelectOld               avgt   20   145.874 ±   9.847  us/op
ParserBenchmark.simpleSelectExperimental      avgt   20    10.384 ±   0.273  us/op
ParserBenchmark.simpleSelectNew               avgt   20    16.875 ±   1.262  us/op
ParserBenchmark.simpleSelectOld               avgt   20     7.428 ±   0.803  us/op
ParserBenchmark.thirtyPlusExperimental        avgt   20    55.882 ±   5.383  us/op
ParserBenchmark.thirtyPlusNew                 avgt   20   169.454 ±   5.332  us/op
ParserBenchmark.thirtyPlusOld                 avgt   20    51.452 ±   1.560  us/op
ParserBenchmark.thirtyPredicatesExperimental  avgt   20   160.670 ±   8.865  us/op
ParserBenchmark.thirtyPredicatesNew           avgt   20   381.240 ±  27.889  us/op
ParserBenchmark.thirtyPredicatesOld           avgt   20   216.799 ±  11.786  us/op
```
- Below are the results using commit `bbf9fb2`. `new` in this table denotes the modified PartiQLParser, and `old` denotes the SqlParser.
```
Benchmark                            Mode  Cnt    Score   Error  Units
ParserBenchmark.nestedSelectNew      avgt   20  141.777 ± 4.497  us/op
ParserBenchmark.nestedSelectOld      avgt   20  134.730 ± 2.370  us/op
ParserBenchmark.simpleSelectNew      avgt   20   12.700 ± 0.198  us/op
ParserBenchmark.simpleSelectOld      avgt   20    6.553 ± 0.094  us/op
ParserBenchmark.thirtyPlusNew        avgt   20   57.363 ± 2.841  us/op
ParserBenchmark.thirtyPlusOld        avgt   20   46.299 ± 0.727  us/op
ParserBenchmark.thirtyPredicatesNew  avgt   20  167.417 ± 2.725  us/op
ParserBenchmark.thirtyPredicatesOld  avgt   20  199.705 ± 4.061  us/op
```
- Below are the results using the latest revision (commit `e9c3611`) of this PR. 
```
Benchmark                            Mode  Cnt    Score    Error  Units
ParserBenchmark.nestedSelectNew      avgt   20  137.047 ±  4.944  us/op
ParserBenchmark.nestedSelectOld      avgt   20  132.624 ±  1.988  us/op
ParserBenchmark.simpleSelectNew      avgt   20   12.571 ±  0.716  us/op
ParserBenchmark.simpleSelectOld      avgt   20    7.338 ±  0.846  us/op
ParserBenchmark.thirtyPlusNew        avgt   20   56.738 ±  2.808  us/op
ParserBenchmark.thirtyPlusOld        avgt   20   46.203 ±  0.362  us/op
ParserBenchmark.thirtyPredicatesNew  avgt   20  168.559 ±  7.644  us/op
ParserBenchmark.thirtyPredicatesOld  avgt   20  209.509 ± 10.345  us/op
```
- See branch parser-jmh for more information.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
  - I can add later.
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **YES**
  - In order to prove that the SLL and LL parsers are able to work together, I added [MockK](https://mockk.io/) as a test dependency.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.