### PR TITLE
fix distinct issue

### DIFF
--- a/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -1751,7 +1751,7 @@ internal class EvaluatingCompiler(
 
                             val quantifiedRows = when (selectExpr.setq ?: PartiqlAst.SetQuantifier.All()) {
                                 // wrap the ExprValue to use ExprValue.equals as the equality
-                                is PartiqlAst.SetQuantifier.Distinct -> projectedRows.filter(createUniqueExprValueFilter())
+                                is PartiqlAst.SetQuantifier.Distinct -> projectedRows.distinct()
                                 is PartiqlAst.SetQuantifier.All -> projectedRows
                             }.let { rowsWithOffsetAndLimit(it, env) }
 

--- a/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
@@ -701,16 +701,14 @@ internal fun createUniqueExprValueFilter(): (ExprValue) -> Boolean {
 }
 
 fun Sequence<ExprValue>.distinct(): Sequence<ExprValue> {
-    val seen = TreeSet(DEFAULT_COMPARATOR)
     return sequence {
+        val seen = TreeSet(DEFAULT_COMPARATOR)
         this@distinct.forEach {
             if (!seen.contains(it)) {
                 seen.add(it.unnamedValue())
                 yield(it)
             }
         }
-        // clear out the seen set in case we need to call distinct multiple times, i.e. Type Inferencer
-        seen.clear()
     }
 }
 

--- a/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
+++ b/lang/src/org/partiql/lang/eval/ExprValueExtensions.kt
@@ -709,6 +709,8 @@ fun Sequence<ExprValue>.distinct(): Sequence<ExprValue> {
                 yield(it)
             }
         }
+        // clear out the seen set in case we need to call distinct multiple times, i.e. Type Inferencer
+        seen.clear()
     }
 }
 

--- a/lang/test/org/partiql/lang/eval/EvaluatorStaticTypeTests.kt
+++ b/lang/test/org/partiql/lang/eval/EvaluatorStaticTypeTests.kt
@@ -55,17 +55,10 @@ class EvaluatorStaticTypeTests {
             "unpivotMissingWithAsAndAt",
             "unpivotMissingCrossJoinWithAsAndAt",
 
-            // TODO: why are these failing due to unexpected (empty) result?
-            "selectDistinct",
+            // TODO: why are these failing?
             "selectDistinctStarBags",
             "selectDistinctStarLists",
             "selectDistinctStarMixed",
-            "selectDistinctSubQuery",
-            "selectDistinctWithSubQuery",
-            "selectDistinctStarStructs",
-            "selectDistinctValue",
-            "selectDistinctExpressionAndWhere",
-            "selectDistinctExpression",
             "nestedSelectJoinLimit",
 
             // STIR does not support path wildcards -i.e. `foo[*]` yet


### PR DESCRIPTION
## Relevant Issues
- [Closes] Issue #702 

## Description
- With this quick fix, we are able to run distinct on the same `sequence<ExprValue>` multiple times.
- A particular use case is running the query with type inferencer enabled. 
- 7 failed type inferencer test cases are passing now. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No, minor bug fix. 
- Any backward-incompatible changes? **[YES/NO]**
  - No.
- Any new external dependencies? **[YES/NO]**
  - No.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.