### PR TITLE
Removes use of passed context to improve latency of parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PartiQL DATE in Ion representation now becomes ion timestamp with annotation of `$date`, instead of `$partiql_date`
 - PartiQL TIME in Ion representation now becomes ion struct with annotation of `$time`, instead of `$partiql_time`
 - Simplifies the aggregation operator in the experimental planner by removing the use of metas
+- Increases the performance of the PartiQLParser by changing the parsing strategy
+  - The PartiQLParser now attempts to parse queries using the SLL Prediction Mode set by ANTLR
+  - If unable to parse via SLL Prediction Mode, it attempts to parse using the slower LL Prediction Mode
+  - Modifications have also been made to the ANTLR grammar to increase the speed of parsing joined table references
 
 ### Deprecated
 - Marks the GroupKeyReferencesVisitorTransform as deprecated. There is no functionally equivalent class.

--- a/lang/antlr/PartiQL.g4
+++ b/lang/antlr/PartiQL.g4
@@ -372,9 +372,11 @@ edgeAbbrev
  */
 
 tableReference
-    : lhs=tableReference tableJoined[$lhs.ctx] # TableRefBase
-    | tableNonJoin                             # TableRefBase
-    | PAREN_LEFT tableReference PAREN_RIGHT    # TableWrapped
+    : lhs=tableReference joinType? CROSS JOIN rhs=joinRhs     # TableCrossJoin
+    | lhs=tableReference COMMA rhs=joinRhs                    # TableCrossJoin
+    | lhs=tableReference joinType? JOIN rhs=joinRhs joinSpec  # TableQualifiedJoin
+    | tableNonJoin                                            # TableRefBase
+    | PAREN_LEFT tableReference PAREN_RIGHT                   # TableWrapped
     ;
 
 tableNonJoin
@@ -390,19 +392,6 @@ tableBaseReference
 
 tableUnpivot
     : UNPIVOT expr asIdent? atIdent? byIdent?;
-
-tableJoined[ParserRuleContext lhs]
-    : tableCrossJoin[$lhs]
-    | tableQualifiedJoin[$lhs]
-    ;
-
-tableCrossJoin[ParserRuleContext lhs]
-    : joinType? CROSS JOIN rhs=joinRhs
-    | COMMA rhs=joinRhs
-    ;
-
-tableQualifiedJoin[ParserRuleContext lhs]
-    : joinType? JOIN rhs=joinRhs joinSpec;
 
 joinRhs
     : tableNonJoin                           # JoinRhsBase

--- a/lang/src/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -1331,7 +1331,6 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
     override fun visitExprTermBase(ctx: PartiQLParser.ExprTermBaseContext?): PartiqlAst.PartiqlAstNode = super.visitExprTermBase(ctx)
     override fun visitCollection(ctx: PartiQLParser.CollectionContext?): PartiqlAst.PartiqlAstNode = super.visitCollection(ctx)
     override fun visitPredicateBase(ctx: PartiQLParser.PredicateBaseContext?): PartiqlAst.PartiqlAstNode = super.visitPredicateBase(ctx)
-    override fun visitTableJoined(ctx: PartiQLParser.TableJoinedContext?): PartiqlAst.PartiqlAstNode = super.visitTableJoined(ctx)
     override fun visitTableNonJoin(ctx: PartiQLParser.TableNonJoinContext?): PartiqlAst.PartiqlAstNode = super.visitTableNonJoin(ctx)
     override fun visitTableRefBase(ctx: PartiQLParser.TableRefBaseContext?): PartiqlAst.PartiqlAstNode = super.visitTableRefBase(ctx)
     override fun visitJoinRhsBase(ctx: PartiQLParser.JoinRhsBaseContext?): PartiqlAst.PartiqlAstNode = super.visitJoinRhsBase(ctx)


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Removes use of passed context to improve latency of parse
- While evaluating the effectiveness of SLL vs LL parsing, I noticed that almost all queries were seeing dramatically decreased latency. By examining the grammar, `PartiQL.g4`, I noted and tested several rules that would break the rules of SLL:
  - there are no empty right hand sides
  - each alternative of a non-terminal symbol begins with a unique terminal symbol
  - the grammar is not left recursive
- Beyond this, I was looking for oddly formulated rule definitions.
- There was a single rule that takes advantage of ANTLR's context-passing feature. I tested the feature using the following query: `SELECT a FROM a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p`. See the results below:

| Name | Mode | Count | Score | +/- Error | Units |
| -- | -- | -- | -- | -- | -- |
| PartiQLParser | avgt | 20 | 94598.178 | 7220.772 | microsec / op |
- After making the changes in this PR:

| Name | Mode | Count | Score | +/- Error | Units |
| -- | -- | -- | -- | -- | -- |
| PartiQLParser | avgt | 20 | 69.896 | 3.403 | microsec / op |

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.