### PR TITLE
Removes double-pass to increase parsing performance, and adds interruption/exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The PartiQLParser now attempts to parse queries using the SLL Prediction Mode set by ANTLR
   - If unable to parse via SLL Prediction Mode, it attempts to parse using the slower LL Prediction Mode
   - Modifications have also been made to the ANTLR grammar to increase the speed of parsing joined table references
+  - Updates how the PartiQLParser handles parameter indexes to remove the double-pass while lexing
 
 ### Deprecated
 - Marks the GroupKeyReferencesVisitorTransform as deprecated. There is no functionally equivalent class.

--- a/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLParser.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLParser.kt
@@ -20,20 +20,28 @@ import org.antlr.v4.runtime.BailErrorStrategy
 import org.antlr.v4.runtime.BaseErrorListener
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.ParserRuleContext
 import org.antlr.v4.runtime.RecognitionException
 import org.antlr.v4.runtime.Recognizer
 import org.antlr.v4.runtime.Token
+import org.antlr.v4.runtime.TokenSource
+import org.antlr.v4.runtime.TokenStream
 import org.antlr.v4.runtime.atn.PredictionMode
 import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.antlr.v4.runtime.tree.ParseTree
+import org.partiql.lang.SqlException
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.errors.PropertyValueMap
 import org.partiql.lang.types.CustomType
+import org.partiql.lang.util.checkThreadInterrupted
 import org.partiql.lang.util.getIonValue
 import org.partiql.lang.util.getPartiQLTokenType
+import java.io.InputStream
+import java.nio.channels.ClosedByInterruptException
 import java.nio.charset.StandardCharsets
+import kotlin.jvm.Throws
 import org.partiql.lang.syntax.antlr.PartiQLParser as GeneratedParser
 import org.partiql.lang.syntax.antlr.PartiQLTokens as GeneratedLexer
 
@@ -47,47 +55,66 @@ internal class PartiQLParser(
     val customTypes: List<CustomType> = listOf()
 ) : Parser {
 
+    @Throws(ParserException::class, InterruptedException::class)
     override fun parseAstStatement(source: String): PartiqlAst.Statement {
-        // TODO: Research use-case of parameters and implementation -- see https://github.com/partiql/partiql-docs/issues/23
-        val parameterIndexes = calculateTokenToParameterOrdinals(source)
-        val tree = try {
-            parseQuery(source)
-        } catch (e: StackOverflowError) {
-            val msg = "Input query too large. This error typically occurs when there are several nested " +
-                "expressions/predicates and can usually be fixed by simplifying expressions."
-            throw ParserException(msg, ErrorCode.PARSE_FAILED_STACK_OVERFLOW, cause = e)
+        try {
+            return parseQuery(source)
+        } catch (throwable: Throwable) {
+            when (throwable) {
+                is ParserException -> throw throwable
+                is SqlException -> throw ParserException(
+                    "Intercepted PartiQL exception.",
+                    throwable.errorCode,
+                    cause = throwable,
+                    errorContext = throwable.errorContext
+                )
+                is StackOverflowError -> {
+                    val msg = "Input query too large. This error typically occurs when there are several nested " +
+                        "expressions/predicates and can usually be fixed by simplifying expressions."
+                    throw ParserException(msg, ErrorCode.PARSE_FAILED_STACK_OVERFLOW, cause = throwable)
+                }
+                is InterruptedException -> throw throwable
+                else -> throw ParserException("Unhandled exception.", ErrorCode.INTERNAL_ERROR, cause = throwable)
+            }
         }
-        val visitor = PartiQLVisitor(ion, customTypes, parameterIndexes)
-        return visitor.visit(tree) as PartiqlAst.Statement
     }
 
     /**
-     * As a performance optimization, first attempt to parse using ANTLR's fast, but less powerful [PredictionMode.SLL],
-     * falling back to the slower [PredictionMode.LL] that is capable of parsing all valid ANTLR grammars.
+     * To reduce latency costs, the [PartiQLParser] attempts to use [PredictionMode.SLL] and falls back to
+     * [PredictionMode.LL] if a [ParseCancellationException] is thrown by the [BailErrorStrategy]. See [createParserSLL]
+     * and [createParserLL] for more information.
      */
-    private fun parseQuery(input: String): ParseTree = try {
-        parseUsingSLL(input)
+    private fun parseQuery(input: String) = try {
+        parseQuery(input) { createParserSLL(it) }
     } catch (ex: ParseCancellationException) {
-        parseUsingLL(input)
+        parseQuery(input) { createParserLL(it) }
     }
 
-    internal fun parseUsingSLL(input: String): org.partiql.lang.syntax.antlr.PartiQLParser.StatementContext {
-        val parser = createParserSLL(input)
-        return parser.statement()
+    /**
+     * Parses an input string [input] using whichever parser [parserInit] creates.
+     */
+    internal fun parseQuery(input: String, parserInit: (TokenStream) -> InterruptibleParser): PartiqlAst.Statement {
+        val queryStream = createInputStream(input)
+        val tokenStream = createTokenStream(queryStream)
+        val parser = parserInit(tokenStream)
+        val tree = parser.statement()
+        val visitor = PartiQLVisitor(ion, customTypes, tokenStream.parameterIndexes)
+        return visitor.visit(tree) as PartiqlAst.Statement
     }
 
-    internal fun parseUsingLL(input: String): org.partiql.lang.syntax.antlr.PartiQLParser.StatementContext {
-        val parser = createParserLL(input)
-        return parser.statement()
-    }
+    private fun createInputStream(input: String) = input.byteInputStream(StandardCharsets.UTF_8)
 
-    private fun createTokenStream(query: String): CommonTokenStream {
-        val inputStream = CharStreams.fromStream(query.byteInputStream(StandardCharsets.UTF_8), StandardCharsets.UTF_8)
-        val handler = TokenizeErrorListener(ion)
+    internal fun createTokenStream(queryStream: InputStream): CountingTokenStream {
+        val inputStream = try {
+            CharStreams.fromStream(queryStream)
+        } catch (ex: ClosedByInterruptException) {
+            throw InterruptedException()
+        }
+        val handler = TokenizeErrorListener()
         val lexer = GeneratedLexer(inputStream)
         lexer.removeErrorListeners()
         lexer.addErrorListener(handler)
-        return CommonTokenStream(lexer)
+        return CountingTokenStream(lexer)
     }
 
     /**
@@ -98,9 +125,8 @@ internal class PartiQLParser(
      * by parsing with [PredictionMode.LL] -- see [createParserLL] for more information.
      * See the JavaDocs for [PredictionMode.SLL] and [BailErrorStrategy] for more information.
      */
-    private fun createParserSLL(query: String): GeneratedParser {
-        val stream = createTokenStream(query)
-        val parser = GeneratedParser(stream)
+    internal fun createParserSLL(stream: TokenStream): InterruptibleParser {
+        val parser = InterruptibleParser(stream)
         parser.reset()
         parser.interpreter.predictionMode = PredictionMode.SLL
         parser.removeErrorListeners()
@@ -113,9 +139,8 @@ internal class PartiQLParser(
      * for a grammar, but is slower than [PredictionMode.SLL]. Upon seeing a syntax error, this parser throws a
      * [ParserException].
      */
-    private fun createParserLL(query: String): GeneratedParser {
-        val stream = createTokenStream(query)
-        val parser = GeneratedParser(stream)
+    internal fun createParserLL(stream: TokenStream): InterruptibleParser {
+        val parser = InterruptibleParser(stream)
         parser.reset()
         parser.interpreter.predictionMode = PredictionMode.LL
         parser.removeErrorListeners()
@@ -124,28 +149,9 @@ internal class PartiQLParser(
     }
 
     /**
-     * Create a map where the key is the index of a '?' token relative to all tokens, and the value is the index of a
-     * '?' token relative to all other '?' tokens (starting at index 1). This is used for visiting.
-     * NOTE: This needs to create its own lexer. Cannot share with others due to consumption of token stream.
-     */
-    private fun calculateTokenToParameterOrdinals(query: String): Map<Int, Int> {
-        val stream = createTokenStream(query)
-        val tokenIndexToParameterIndex = mutableMapOf<Int, Int>()
-        var parametersFound = 0
-        val tokenIter = stream.also { it.fill() }.tokens.iterator()
-        while (tokenIter.hasNext()) {
-            val token = tokenIter.next()
-            if (token.type == GeneratedParser.QUESTION_MARK) {
-                tokenIndexToParameterIndex[token.tokenIndex] = ++parametersFound
-            }
-        }
-        return tokenIndexToParameterIndex
-    }
-
-    /**
      * Catches Lexical errors (unidentified tokens) and throws a [LexerException]
      */
-    private class TokenizeErrorListener(val ion: IonSystem) : BaseErrorListener() {
+    private class TokenizeErrorListener : BaseErrorListener() {
         @Throws(LexerException::class)
         override fun syntaxError(
             recognizer: Recognizer<*, *>?,
@@ -182,6 +188,35 @@ internal class PartiQLParser(
             propertyValues[Property.TOKEN_TYPE] = getPartiQLTokenType(offendingSymbol as Token)
             propertyValues[Property.TOKEN_VALUE] = getIonValue(ion, offendingSymbol)
             throw ParserException(message = msg, errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN, errorContext = propertyValues, cause = e)
+        }
+    }
+
+    /**
+     * A wrapped [GeneratedParser] to allow thread interruption during parse.
+     */
+    internal class InterruptibleParser(input: TokenStream) : GeneratedParser(input) {
+        override fun enterRule(localctx: ParserRuleContext?, state: Int, ruleIndex: Int) {
+            checkThreadInterrupted()
+            super.enterRule(localctx, state, ruleIndex)
+        }
+    }
+
+    /**
+     * This token stream creates [parameterIndexes], which is a map with key-value pairs, where the keys represent the
+     * indexes of all [GeneratedLexer.QUESTION_MARK]'s and the values represent their relative index amongst all other
+     * [GeneratedLexer.QUESTION_MARK]'s.
+     */
+    internal open class CountingTokenStream(tokenSource: TokenSource) : CommonTokenStream(tokenSource) {
+        val parameterIndexes = mutableMapOf<Int, Int>()
+        private var parametersFound = 0
+        override fun LT(k: Int): Token? {
+            val token = super.LT(k)
+            token?.let {
+                if (it.type == GeneratedLexer.QUESTION_MARK && parameterIndexes.containsKey(token.tokenIndex).not()) {
+                    parameterIndexes[token.tokenIndex] = ++parametersFound
+                }
+            }
+            return token
         }
     }
 }

--- a/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLParser.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLParser.kt
@@ -202,11 +202,12 @@ internal class PartiQLParser(
     }
 
     /**
-     * This token stream creates [parameterIndexes], which is a map with key-value pairs, where the keys represent the
+     * This token stream creates [parameterIndexes], which is a map, where the keys represent the
      * indexes of all [GeneratedLexer.QUESTION_MARK]'s and the values represent their relative index amongst all other
      * [GeneratedLexer.QUESTION_MARK]'s.
      */
     internal open class CountingTokenStream(tokenSource: TokenSource) : CommonTokenStream(tokenSource) {
+        // TODO: Research use-case of parameters and implementation -- see https://github.com/partiql/partiql-docs/issues/23
         val parameterIndexes = mutableMapOf<Int, Int>()
         private var parametersFound = 0
         override fun LT(k: Int): Token? {

--- a/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -57,6 +57,7 @@ import org.partiql.lang.syntax.antlr.PartiQLParser
 import org.partiql.lang.types.CustomType
 import org.partiql.lang.util.DATE_PATTERN_REGEX
 import org.partiql.lang.util.bigDecimalOf
+import org.partiql.lang.util.checkThreadInterrupted
 import org.partiql.lang.util.error
 import org.partiql.lang.util.getPrecisionFromTimeString
 import org.partiql.lang.util.ionValue
@@ -444,7 +445,10 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
 
     override fun visitLimitClause(ctx: PartiQLParser.LimitClauseContext): PartiqlAst.Expr = visit(ctx.arg, PartiqlAst.Expr::class)
 
-    override fun visitExpr(ctx: PartiQLParser.ExprContext) = visit(ctx.exprBagOp(), PartiqlAst.Expr::class)
+    override fun visitExpr(ctx: PartiQLParser.ExprContext): PartiqlAst.Expr {
+        checkThreadInterrupted()
+        return visit(ctx.exprBagOp(), PartiqlAst.Expr::class)
+    }
 
     override fun visitOffsetByClause(ctx: PartiQLParser.OffsetByClauseContext) = visit(ctx.arg, PartiqlAst.Expr::class)
 

--- a/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserSpyTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserSpyTest.kt
@@ -61,8 +61,8 @@ internal class PartiQLParserSpyTest {
     @Test
     fun manuallyShowDoubleParsingSameQueriesWorks() {
         val query00 = "SELECT a1 FROM t1"
-        val ast00 = PartiQLVisitor(ion).visit(parser.parseUsingSLL(query00))
-        val ast01 = PartiQLVisitor(ion).visit(parser.parseUsingLL(query00))
+        val ast00 = parser.parseQuery(query00) { parser.createParserSLL(it) }
+        val ast01 = parser.parseQuery(query00) { parser.createParserLL(it) }
         assertEquals(ast00, ast01)
     }
 
@@ -73,8 +73,8 @@ internal class PartiQLParserSpyTest {
     fun manuallyShowDoubleParsingWorks() {
         val query00 = "SELECT a1 FROM t1"
         val query01 = "SELECT a2 FROM t2"
-        PartiQLVisitor(ion).visit(parser.parseUsingSLL(query00))
-        PartiQLVisitor(ion).visit(parser.parseUsingLL(query01))
+        parser.parseQuery(query00) { parser.createParserSLL(it) }
+        parser.parseQuery(query01) { parser.createParserLL(it) }
     }
 
     /**
@@ -89,8 +89,8 @@ internal class PartiQLParserSpyTest {
         val ast = parser.parseAstStatement(query00)
 
         // Assert
-        verify(exactly = 1) { parser.parseUsingSLL(query00) }
-        verify(exactly = 0) { parser.parseUsingLL(query00) }
+        verify(exactly = 1) { parser.createParserSLL(any()) }
+        verify(exactly = 0) { parser.createParserLL(any()) }
         assertEquals(
             ast,
             PartiqlAst.build {
@@ -118,15 +118,15 @@ internal class PartiQLParserSpyTest {
         // Arrange
         val query00 = "SELECT a FROM t"
         every {
-            parser.parseUsingSLL(query00)
+            parser.createParserSLL(any())
         } throws ParseCancellationException()
 
         // Act
         val ast = parser.parseAstStatement(query00)
 
         // Assert
-        verify(exactly = 1) { parser.parseUsingSLL(query00) }
-        verify(exactly = 1) { parser.parseUsingLL(query00) }
+        verify(exactly = 1) { parser.createParserSLL(any()) }
+        verify(exactly = 1) { parser.createParserLL(any()) }
         assertEquals(
             ast,
             PartiqlAst.build {
@@ -153,7 +153,7 @@ internal class PartiQLParserSpyTest {
     fun badQueryThrowsSLLCancellationException() {
         val query00 = "1++++++++++++"
         assertThrows<ParseCancellationException> {
-            parser.parseUsingSLL(query00)
+            parser.parseQuery(query00) { parser.createParserSLL(it) }
         }
     }
 
@@ -164,7 +164,7 @@ internal class PartiQLParserSpyTest {
     fun badQueryThrowsLLParserException() {
         val query00 = "1++++++++++++"
         assertThrows<ParserException> {
-            parser.parseUsingLL(query00)
+            parser.parseQuery(query00) { parser.createParserLL(it) }
         }
     }
 
@@ -177,7 +177,7 @@ internal class PartiQLParserSpyTest {
         assertThrows<ParserException> {
             parser.parseAstStatement(query00)
         }
-        verify(exactly = 1) { parser.parseUsingSLL(query00) }
-        verify(exactly = 1) { parser.parseUsingLL(query00) }
+        verify(exactly = 1) { parser.createParserSLL(any()) }
+        verify(exactly = 1) { parser.createParserLL(any()) }
     }
 }

--- a/lang/src/test/kotlin/org/partiql/lang/thread/ThreadInterruptedTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/thread/ThreadInterruptedTests.kt
@@ -3,6 +3,12 @@ package org.partiql.lang.thread
 
 import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionelement.api.ionInt
+import io.mockk.every
+import io.mockk.spyk
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.CommonToken
+import org.antlr.v4.runtime.Token
+import org.antlr.v4.runtime.TokenSource
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
@@ -13,6 +19,9 @@ import org.partiql.lang.StepContext
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.eval.CompileOptions
 import org.partiql.lang.eval.visitors.VisitorTransformBase
+import org.partiql.lang.syntax.PartiQLParser
+import org.partiql.lang.syntax.antlr.PartiQLTokens
+import java.io.InputStream
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.thread
 
@@ -51,7 +60,7 @@ class ThreadInterruptedTests {
             plus(FakeList(n, variableA))
         }
 
-    private fun testThreadInterrupt(block: () -> Unit) {
+    private fun testThreadInterrupt(interruptAfter: Long = INTERRUPT_AFTER_MS, interruptWait: Long = WAIT_FOR_THREAD_TERMINATION_MS, block: () -> Unit) {
         val wasInterrupted = AtomicBoolean(false)
         val t = thread {
             try {
@@ -61,10 +70,43 @@ class ThreadInterruptedTests {
             }
         }
 
-        Thread.sleep(INTERRUPT_AFTER_MS)
+        Thread.sleep(interruptAfter)
         t.interrupt()
-        t.join(WAIT_FOR_THREAD_TERMINATION_MS)
+        t.join(interruptWait)
         assertTrue(wasInterrupted.get(), "Thread should have been interrupted.")
+    }
+
+    @Test
+    fun parserPartiQL() {
+        val parser = spyk<PartiQLParser>()
+        val query = "hello world"
+        every {
+            parser.createTokenStream(any())
+        } returns EndlessTokenStream(PartiQLTokens(CharStreams.fromStream(InputStream.nullInputStream())))
+        testThreadInterrupt(5) { parser.run { parseAstStatement(query) } }
+    }
+
+    @Test
+    fun parserPartiQLUsingSLL() {
+        val parser = PartiQLParser()
+        val tokenStream = EndlessTokenStream(PartiQLTokens(CharStreams.fromStream(InputStream.nullInputStream())))
+        val sllParser = parser.createParserSLL(tokenStream)
+        testThreadInterrupt(5) { sllParser.run { statement() } }
+    }
+
+    @Test
+    fun parserPartiQLUsingLL() {
+        val parser = PartiQLParser()
+        val tokenStream = EndlessTokenStream(PartiQLTokens(CharStreams.fromStream(InputStream.nullInputStream())))
+        val llParser = parser.createParserLL(tokenStream)
+        testThreadInterrupt(5) { llParser.run { statement() } }
+    }
+
+    @Test
+    fun parserPartiQLTokenStream() {
+        val parser = PartiQLParser()
+        val endlessStream = EndlessInputStream()
+        testThreadInterrupt { parser.run { createTokenStream(endlessStream) } }
     }
 
     @Test
@@ -105,6 +147,19 @@ class ThreadInterruptedTests {
         }
 
         assertTrue(accumulator != 0L)
+    }
+
+    private class EndlessInputStream : InputStream() {
+        override fun read(): Int {
+            return 1
+        }
+    }
+
+    private class EndlessTokenStream(source: TokenSource) : PartiQLParser.CountingTokenStream(source) {
+        override fun size(): Int = Int.MAX_VALUE
+        override fun LT(k: Int): Token {
+            return CommonToken(PartiQLTokens.PLUS)
+        }
     }
 }
 


### PR DESCRIPTION
## Relevant Issues
- Related To #710, #895
- Resolves #747 

## Description
- Removes double-pass to increase parsing performance
- Adds interruption handling to both parse methods (LL and SLL)
  - We discussed the importance of allowing our customers to fail quickly -- but that's out of the scope of a patch release.
  - With these changes, we want to make our parser faster -- while also ensuring they can always interrupt the parse at any point if they desire. We also include interruption handling for creating the token stream.
- Adds more exception handling
  -  With this, we'd like to make sure that our public APIs are always throwing the correct exceptions, so for `parseAstStatement`, we catch all to make sure our public API is never broken.

## Benchmarking Analysis
- With local benchmarking, the recent changes in the PartiQLParser have reduced the added time between parsing using SqlParser and PartiQLParser to ~28%.
- With these changes, the same tests have seen the added time at ~15%.

## Benchmarking Results

Raw benchmark results for 10 iterations, 2 forks, 5 warm-ups for 31 tests ranging in length/features/complexity.
| Test    | SqlParser   | PartiQLParser | Time Difference |
|---------|-------------|---------------|-----------------|
| 0       | 6.495       | 9.96          | 53%             |
| 1       | 28.623      | 58.405        | 104%            |
| 2       | 14.366      | 16.683        | 16%             |
| 3       | 53.845      | 57.578        | 7%              |
| 4       | 24.938      | 28.558        | 15%             |
| 5       | 84.142      | 82.802        | -2%             |
| 6       | 10.746      | 14.402        | 34%             |
| 7       | 33.772      | 44.056        | 30%             |
| 8       | 28.438      | 66.866        | 135%            |
| 9       | 47.667      | 99.428        | 109%            |
| 10      | 56.663      | 70.928        | 25%             |
| 11      | 45.946      | 64.939        | 41%             |
| 12      | 192.699     | 137.09        | -29%            |
| 13      | 45.598      | 45.772        | 0%              |
| 14      | 132.207     | 109.9         | -17%            |
| 15      | 36.994      | 37.646        | 2%              |
| 16      | 8.919       | 5.692         | -36%            |
| 17      | 18.075      | 20.713        | 15%             |
| 18      | 21.69       | 17.351        | -20%            |
| 19      | 163.964     | 170.27        | 4%              |
| 20      | 60.289      | 51.006        | -15%            |
| 21      | 32.053      | 30.716        | -4%             |
| 22      | 27.125      | 29.417        | 8%              |
| 23      | 46.31       | 53.164        | 15%             |
| 24      | 86.379      | 99.729        | 15%             |
| 25      | 87.048      | 75.623        | -13%            |
| 26      | 174.253     | 202.104       | 16%             |
| 27      | 103.761     | 86.619        | -17%            |
| 28      | 165.024     | 148.118       | -10%            |
| 29      | 474.43      | 355.534       | -25%            |
| 30      | 1132.715    | 1180.907      | 4%              |
| AVERAGE | 111.1346452 | 111.9992258   | 15%             |

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
  - Not yet
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.