### PR TITLE
Prepare v0.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The PartiQLParser now attempts to parse queries using the SLL Prediction Mode set by ANTLR
   - If unable to parse via SLL Prediction Mode, it attempts to parse using the slower LL Prediction Mode
   - Modifications have also been made to the ANTLR grammar to increase the speed of parsing joined table references
+  - Updates how the PartiQLParser handles parameter indexes to remove the double-pass while lexing
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Extends statement redaction to support `INSERT/REPLACE/UPSERT INTO`.
+- Adds simple auto-completion to the CLI.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+-->
+
+## [0.8.2] - 2022-11-28
+### Added
 - Extends statement redaction to support `INSERT/REPLACE/UPSERT INTO`.
 - Adds simple auto-completion to the CLI.
 
@@ -24,16 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - If unable to parse via SLL Prediction Mode, it attempts to parse using the slower LL Prediction Mode
   - Modifications have also been made to the ANTLR grammar to increase the speed of parsing joined table references
   - Updates how the PartiQLParser handles parameter indexes to remove the double-pass while lexing
-
-### Deprecated
-
-### Fixed
-
-### Removed
-
-### Security
--->
-
 
 ## [0.8.1] - 2022-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds simple auto-completion to the CLI.
 
 ### Changed
+- Now `CompileOption` uses `TypedOpParameter.HONOR_PARAMETERS` as default.
+- Updates the CLI Shell Highlighter to use the ANTLR generated lexer/parser for highlighting user queries
+- PartiQL MISSING in Ion representation now becomes ion null with annotation of `$missing`, instead of `$partiql_missing`
+- PartiQL BAG in Ion representation now becomes ion list with annotation of `$bag`, instead of `$partiql_bag`
+- PartiQL DATE in Ion representation now becomes ion timestamp with annotation of `$date`, instead of `$partiql_date`
+- PartiQL TIME in Ion representation now becomes ion struct with annotation of `$time`, instead of `$partiql_time`
+- Simplifies the aggregation operator in the experimental planner by removing the use of metas
+- Increases the performance of the PartiQLParser by changing the parsing strategy
+  - The PartiQLParser now attempts to parse queries using the SLL Prediction Mode set by ANTLR
+  - If unable to parse via SLL Prediction Mode, it attempts to parse using the slower LL Prediction Mode
+  - Modifications have also been made to the ANTLR grammar to increase the speed of parsing joined table references
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID      | Artifact ID           | Recommended Version |
 |---------------|-----------------------|---------------------|
-| `org.partiql` | `partiql-lang-kotlin` | `0.8.1`             | 
+| `org.partiql` | `partiql-lang-kotlin` | `0.8.2`             | 
 
 
 For Maven builds, add the following to your `pom.xml`:

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
 
 subprojects {
     group = 'org.partiql'
-    version = '0.8.1'
+    version = '0.8.2'
 }
 
 buildDir = new File(rootProject.projectDir, "gradle-build/" + project.name)

--- a/cli/src/org/partiql/shell/CompleterDefault.kt
+++ b/cli/src/org/partiql/shell/CompleterDefault.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.shell
+
+import org.jline.reader.Completer
+import org.jline.reader.impl.completer.AggregateCompleter
+import org.jline.reader.impl.completer.ArgumentCompleter
+import org.jline.reader.impl.completer.NullCompleter
+import org.jline.reader.impl.completer.StringsCompleter
+
+internal class CompleterDefault : AggregateCompleter(getAllCommands()) {
+    companion object {
+        private fun getAllCommands(): List<Completer> = listOf(
+            buildCompoundCommand("SELECT"),
+            buildCompoundCommand("REMOVE"),
+            buildCompoundCommand("UPSERT"),
+            buildCompoundCommand("REPLACE"),
+            buildCompoundCommand("EXEC"),
+            buildCompoundCommand("CREATE", listOf("INDEX", "TABLE")),
+            buildCompoundCommand("DROP", listOf("INDEX", "TABLE")),
+            buildCompoundCommand("INSERT", listOf("INTO")),
+        )
+
+        private fun buildCompoundCommand(primary: String, targets: List<String> = emptyList()) = ArgumentCompleter(
+            StringsCompleter(primary),
+            StringsCompleter(targets),
+            NullCompleter.INSTANCE
+        )
+    }
+}

--- a/cli/src/org/partiql/shell/Shell.kt
+++ b/cli/src/org/partiql/shell/Shell.kt
@@ -24,7 +24,7 @@ import org.jline.reader.History
 import org.jline.reader.LineReader
 import org.jline.reader.LineReaderBuilder
 import org.jline.reader.UserInterruptException
-import org.jline.reader.impl.completer.NullCompleter
+import org.jline.reader.impl.completer.AggregateCompleter
 import org.jline.terminal.TerminalBuilder
 import org.jline.utils.AttributedStringBuilder
 import org.jline.utils.AttributedStyle
@@ -127,10 +127,15 @@ class Shell(
             this.config.isMonochrome -> null
             else -> ShellHighlighter()
         }
+        val completer = AggregateCompleter(CompleterDefault())
         val reader = LineReaderBuilder.builder()
             .terminal(terminal)
             .parser(ShellParser)
-            .completer(NullCompleter())
+            .completer(completer)
+            .option(LineReader.Option.GROUP_PERSIST, true)
+            .option(LineReader.Option.AUTO_LIST, true)
+            .option(LineReader.Option.CASE_INSENSITIVE, true)
+            .variable(LineReader.LIST_MAX, 10)
             .highlighter(highlighter)
             .expander(ShellExpander)
             .variable(LineReader.HISTORY_FILE, homeDir.resolve(".partiql/.history"))

--- a/lang/antlr/PartiQL.g4
+++ b/lang/antlr/PartiQL.g4
@@ -372,9 +372,11 @@ edgeAbbrev
  */
 
 tableReference
-    : lhs=tableReference tableJoined[$lhs.ctx] # TableRefBase
-    | tableNonJoin                             # TableRefBase
-    | PAREN_LEFT tableReference PAREN_RIGHT    # TableWrapped
+    : lhs=tableReference joinType? CROSS JOIN rhs=joinRhs     # TableCrossJoin
+    | lhs=tableReference COMMA rhs=joinRhs                    # TableCrossJoin
+    | lhs=tableReference joinType? JOIN rhs=joinRhs joinSpec  # TableQualifiedJoin
+    | tableNonJoin                                            # TableRefBase
+    | PAREN_LEFT tableReference PAREN_RIGHT                   # TableWrapped
     ;
 
 tableNonJoin
@@ -390,19 +392,6 @@ tableBaseReference
 
 tableUnpivot
     : UNPIVOT expr asIdent? atIdent? byIdent?;
-
-tableJoined[ParserRuleContext lhs]
-    : tableCrossJoin[$lhs]
-    | tableQualifiedJoin[$lhs]
-    ;
-
-tableCrossJoin[ParserRuleContext lhs]
-    : joinType? CROSS JOIN rhs=joinRhs
-    | COMMA rhs=joinRhs
-    ;
-
-tableQualifiedJoin[ParserRuleContext lhs]
-    : joinType? JOIN rhs=joinRhs joinSpec;
 
 joinRhs
     : tableNonJoin                           # JoinRhsBase

--- a/lang/build.gradle
+++ b/lang/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'
+    testImplementation 'io.mockk:mockk:1.11.0'
 }
 
 // TODO update to conventional source layout

--- a/lang/src/org/partiql/lang/syntax/PartiQLParser.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLParser.kt
@@ -94,10 +94,11 @@ internal class PartiQLParser(
         val lexer = getLexer(query)
         val tokenIndexToParameterIndex = mutableMapOf<Int, Int>()
         var parametersFound = 0
-        val tokens = CommonTokenStream(lexer)
-        for (i in 0 until tokens.numberOfOnChannelTokens) {
-            if (tokens[i].type == GeneratedParser.QUESTION_MARK) {
-                tokenIndexToParameterIndex[tokens[i].tokenIndex] = ++parametersFound
+        val tokenIter = CommonTokenStream(lexer).also { it.fill() }.tokens.iterator()
+        while (tokenIter.hasNext()) {
+            val token = tokenIter.next()
+            if (token.type == GeneratedParser.QUESTION_MARK) {
+                tokenIndexToParameterIndex[token.tokenIndex] = ++parametersFound
             }
         }
         return tokenIndexToParameterIndex

--- a/lang/src/org/partiql/lang/syntax/PartiQLParser.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLParser.kt
@@ -21,12 +21,16 @@ import org.antlr.v4.runtime.BailErrorStrategy
 import org.antlr.v4.runtime.BaseErrorListener
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.ParserRuleContext
 import org.antlr.v4.runtime.RecognitionException
 import org.antlr.v4.runtime.Recognizer
 import org.antlr.v4.runtime.Token
+import org.antlr.v4.runtime.TokenSource
+import org.antlr.v4.runtime.TokenStream
 import org.antlr.v4.runtime.atn.PredictionMode
 import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.antlr.v4.runtime.tree.ParseTree
+import org.partiql.lang.SqlException
 import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.ast.toExprNode
 import org.partiql.lang.domains.PartiqlAst
@@ -34,9 +38,13 @@ import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.errors.PropertyValueMap
 import org.partiql.lang.types.CustomType
+import org.partiql.lang.util.checkThreadInterrupted
 import org.partiql.lang.util.getIonValue
 import org.partiql.lang.util.getPartiQLTokenType
+import java.io.InputStream
+import java.nio.channels.ClosedByInterruptException
 import java.nio.charset.StandardCharsets
+import kotlin.jvm.Throws
 import org.partiql.lang.syntax.antlr.PartiQLParser as GeneratedParser
 import org.partiql.lang.syntax.antlr.PartiQLTokens as GeneratedLexer
 
@@ -50,47 +58,66 @@ internal class PartiQLParser(
     val customTypes: List<CustomType> = listOf()
 ) : Parser {
 
+    @Throws(ParserException::class, InterruptedException::class)
     override fun parseAstStatement(source: String): PartiqlAst.Statement {
-        // TODO: Research use-case of parameters and implementation -- see https://github.com/partiql/partiql-docs/issues/23
-        val parameterIndexes = calculateTokenToParameterOrdinals(source)
-        val tree = try {
-            parseQuery(source)
-        } catch (e: StackOverflowError) {
-            val msg = "Input query too large. This error typically occurs when there are several nested " +
-                "expressions/predicates and can usually be fixed by simplifying expressions."
-            throw ParserException(msg, ErrorCode.PARSE_FAILED_STACK_OVERFLOW, cause = e)
+        try {
+            return parseQuery(source)
+        } catch (throwable: Throwable) {
+            when (throwable) {
+                is ParserException -> throw throwable
+                is SqlException -> throw ParserException(
+                    "Intercepted PartiQL exception.",
+                    throwable.errorCode,
+                    cause = throwable,
+                    errorContext = throwable.errorContext
+                )
+                is StackOverflowError -> {
+                    val msg = "Input query too large. This error typically occurs when there are several nested " +
+                        "expressions/predicates and can usually be fixed by simplifying expressions."
+                    throw ParserException(msg, ErrorCode.PARSE_FAILED_STACK_OVERFLOW, cause = throwable)
+                }
+                is InterruptedException -> throw throwable
+                else -> throw ParserException("Unhandled exception.", ErrorCode.INTERNAL_ERROR, cause = throwable)
+            }
         }
-        val visitor = PartiQLVisitor(ion, customTypes, parameterIndexes)
-        return visitor.visit(tree) as PartiqlAst.Statement
     }
 
     /**
-     * As a performance optimization, first attempt to parse using ANTLR's fast, but less powerful [PredictionMode.SLL],
-     * falling back to the slower [PredictionMode.LL] that is capable of parsing all valid ANTLR grammars.
+     * To reduce latency costs, the [PartiQLParser] attempts to use [PredictionMode.SLL] and falls back to
+     * [PredictionMode.LL] if a [ParseCancellationException] is thrown by the [BailErrorStrategy]. See [createParserSLL]
+     * and [createParserLL] for more information.
      */
-    private fun parseQuery(input: String): ParseTree = try {
-        parseUsingSLL(input)
+    private fun parseQuery(input: String) = try {
+        parseQuery(input) { createParserSLL(it) }
     } catch (ex: ParseCancellationException) {
-        parseUsingLL(input)
+        parseQuery(input) { createParserLL(it) }
     }
 
-    internal fun parseUsingSLL(input: String): org.partiql.lang.syntax.antlr.PartiQLParser.StatementContext {
-        val parser = createParserSLL(input)
-        return parser.statement()
+    /**
+     * Parses an input string [input] using whichever parser [parserInit] creates.
+     */
+    internal fun parseQuery(input: String, parserInit: (TokenStream) -> InterruptibleParser): PartiqlAst.Statement {
+        val queryStream = createInputStream(input)
+        val tokenStream = createTokenStream(queryStream)
+        val parser = parserInit(tokenStream)
+        val tree = parser.statement()
+        val visitor = PartiQLVisitor(ion, customTypes, tokenStream.parameterIndexes)
+        return visitor.visit(tree) as PartiqlAst.Statement
     }
 
-    internal fun parseUsingLL(input: String): org.partiql.lang.syntax.antlr.PartiQLParser.StatementContext {
-        val parser = createParserLL(input)
-        return parser.statement()
-    }
+    private fun createInputStream(input: String) = input.byteInputStream(StandardCharsets.UTF_8)
 
-    private fun createTokenStream(query: String): CommonTokenStream {
-        val inputStream = CharStreams.fromStream(query.byteInputStream(StandardCharsets.UTF_8), StandardCharsets.UTF_8)
-        val handler = TokenizeErrorListener(ion)
+    internal fun createTokenStream(queryStream: InputStream): CountingTokenStream {
+        val inputStream = try {
+            CharStreams.fromStream(queryStream)
+        } catch (ex: ClosedByInterruptException) {
+            throw InterruptedException()
+        }
+        val handler = TokenizeErrorListener()
         val lexer = GeneratedLexer(inputStream)
         lexer.removeErrorListeners()
         lexer.addErrorListener(handler)
-        return CommonTokenStream(lexer)
+        return CountingTokenStream(lexer)
     }
 
     /**
@@ -101,9 +128,8 @@ internal class PartiQLParser(
      * by parsing with [PredictionMode.LL] -- see [createParserLL] for more information.
      * See the JavaDocs for [PredictionMode.SLL] and [BailErrorStrategy] for more information.
      */
-    private fun createParserSLL(query: String): GeneratedParser {
-        val stream = createTokenStream(query)
-        val parser = GeneratedParser(stream)
+    internal fun createParserSLL(stream: TokenStream): InterruptibleParser {
+        val parser = InterruptibleParser(stream)
         parser.reset()
         parser.interpreter.predictionMode = PredictionMode.SLL
         parser.removeErrorListeners()
@@ -116,33 +142,13 @@ internal class PartiQLParser(
      * for a grammar, but is slower than [PredictionMode.SLL]. Upon seeing a syntax error, this parser throws a
      * [ParserException].
      */
-    private fun createParserLL(query: String): GeneratedParser {
-        val stream = createTokenStream(query)
-        val parser = GeneratedParser(stream)
+    internal fun createParserLL(stream: TokenStream): InterruptibleParser {
+        val parser = InterruptibleParser(stream)
         parser.reset()
         parser.interpreter.predictionMode = PredictionMode.LL
         parser.removeErrorListeners()
         parser.addErrorListener(ParseErrorListener(ion))
         return parser
-    }
-
-    /**
-     * Create a map where the key is the index of a '?' token relative to all tokens, and the value is the index of a
-     * '?' token relative to all other '?' tokens (starting at index 1). This is used for visiting.
-     * NOTE: This needs to create its own lexer. Cannot share with others due to consumption of token stream.
-     */
-    private fun calculateTokenToParameterOrdinals(query: String): Map<Int, Int> {
-        val stream = createTokenStream(query)
-        val tokenIndexToParameterIndex = mutableMapOf<Int, Int>()
-        var parametersFound = 0
-        val tokenIter = stream.also { it.fill() }.tokens.iterator()
-        while (tokenIter.hasNext()) {
-            val token = tokenIter.next()
-            if (token.type == GeneratedParser.QUESTION_MARK) {
-                tokenIndexToParameterIndex[token.tokenIndex] = ++parametersFound
-            }
-        }
-        return tokenIndexToParameterIndex
     }
 
     @Deprecated("Please use parseAstStatement() instead--ExprNode is deprecated.")
@@ -161,7 +167,7 @@ internal class PartiQLParser(
     /**
      * Catches Lexical errors (unidentified tokens) and throws a [LexerException]
      */
-    private class TokenizeErrorListener(val ion: IonSystem) : BaseErrorListener() {
+    private class TokenizeErrorListener : BaseErrorListener() {
         @Throws(LexerException::class)
         override fun syntaxError(
             recognizer: Recognizer<*, *>?,
@@ -198,6 +204,36 @@ internal class PartiQLParser(
             propertyValues[Property.TOKEN_TYPE] = getPartiQLTokenType(offendingSymbol as Token)
             propertyValues[Property.TOKEN_VALUE] = getIonValue(ion, offendingSymbol)
             throw ParserException(message = msg, errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN, errorContext = propertyValues, cause = e)
+        }
+    }
+
+    /**
+     * A wrapped [GeneratedParser] to allow thread interruption during parse.
+     */
+    internal class InterruptibleParser(input: TokenStream) : GeneratedParser(input) {
+        override fun enterRule(localctx: ParserRuleContext?, state: Int, ruleIndex: Int) {
+            checkThreadInterrupted()
+            super.enterRule(localctx, state, ruleIndex)
+        }
+    }
+
+    /**
+     * This token stream creates [parameterIndexes], which is a map, where the keys represent the
+     * indexes of all [GeneratedLexer.QUESTION_MARK]'s and the values represent their relative index amongst all other
+     * [GeneratedLexer.QUESTION_MARK]'s.
+     */
+    internal open class CountingTokenStream(tokenSource: TokenSource) : CommonTokenStream(tokenSource) {
+        // TODO: Research use-case of parameters and implementation -- see https://github.com/partiql/partiql-docs/issues/23
+        val parameterIndexes = mutableMapOf<Int, Int>()
+        private var parametersFound = 0
+        override fun LT(k: Int): Token? {
+            val token = super.LT(k)
+            token?.let {
+                if (it.type == GeneratedLexer.QUESTION_MARK && parameterIndexes.containsKey(token.tokenIndex).not()) {
+                    parameterIndexes[token.tokenIndex] = ++parametersFound
+                }
+            }
+            return token
         }
     }
 }

--- a/lang/src/org/partiql/lang/syntax/PartiQLParser.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLParser.kt
@@ -16,13 +16,16 @@ package org.partiql.lang.syntax
 
 import com.amazon.ion.IonSexp
 import com.amazon.ion.IonSystem
+import com.amazon.ion.system.IonSystemBuilder
+import org.antlr.v4.runtime.BailErrorStrategy
 import org.antlr.v4.runtime.BaseErrorListener
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
-import org.antlr.v4.runtime.Lexer
 import org.antlr.v4.runtime.RecognitionException
 import org.antlr.v4.runtime.Recognizer
 import org.antlr.v4.runtime.Token
+import org.antlr.v4.runtime.atn.PredictionMode
+import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.antlr.v4.runtime.tree.ParseTree
 import org.partiql.lang.ast.ExprNode
 import org.partiql.lang.ast.toExprNode
@@ -43,16 +46,15 @@ import org.partiql.lang.syntax.antlr.PartiQLTokens as GeneratedLexer
  * to convert the [ParseTree] into a [PartiqlAst.Statement].
  */
 internal class PartiQLParser(
-    private val ion: IonSystem,
+    private val ion: IonSystem = IonSystemBuilder.standard().build(),
     val customTypes: List<CustomType> = listOf()
 ) : Parser {
 
     override fun parseAstStatement(source: String): PartiqlAst.Statement {
         // TODO: Research use-case of parameters and implementation -- see https://github.com/partiql/partiql-docs/issues/23
         val parameterIndexes = calculateTokenToParameterOrdinals(source)
-        val lexer = getLexer(source)
         val tree = try {
-            parseQuery(lexer)
+            parseQuery(source)
         } catch (e: StackOverflowError) {
             val msg = "Input query too large. This error typically occurs when there are several nested " +
                 "expressions/predicates and can usually be fixed by simplifying expressions."
@@ -62,26 +64,65 @@ internal class PartiQLParser(
         return visitor.visit(tree) as PartiqlAst.Statement
     }
 
-    private fun parseQuery(lexer: Lexer): ParseTree {
-        val parser = getParser(lexer)
+    /**
+     * As a performance optimization, first attempt to parse using ANTLR's fast, but less powerful [PredictionMode.SLL],
+     * falling back to the slower [PredictionMode.LL] that is capable of parsing all valid ANTLR grammars.
+     */
+    private fun parseQuery(input: String): ParseTree = try {
+        parseUsingSLL(input)
+    } catch (ex: ParseCancellationException) {
+        parseUsingLL(input)
+    }
+
+    internal fun parseUsingSLL(input: String): org.partiql.lang.syntax.antlr.PartiQLParser.StatementContext {
+        val parser = createParserSLL(input)
         return parser.statement()
     }
 
-    private fun getLexer(source: String): Lexer {
-        val inputStream = CharStreams.fromStream(source.byteInputStream(StandardCharsets.UTF_8), StandardCharsets.UTF_8)
-        val lexer = GeneratedLexer(inputStream)
-        val handler = TokenizeErrorListener(ion)
-        lexer.removeErrorListeners()
-        lexer.addErrorListener(handler)
-        return lexer
+    internal fun parseUsingLL(input: String): org.partiql.lang.syntax.antlr.PartiQLParser.StatementContext {
+        val parser = createParserLL(input)
+        return parser.statement()
     }
 
-    private fun getParser(lexer: Lexer): GeneratedParser {
-        val tokens = CommonTokenStream(lexer)
-        val parser = GeneratedParser(tokens)
-        val handler = ParseErrorListener(ion)
+    private fun createTokenStream(query: String): CommonTokenStream {
+        val inputStream = CharStreams.fromStream(query.byteInputStream(StandardCharsets.UTF_8), StandardCharsets.UTF_8)
+        val handler = TokenizeErrorListener(ion)
+        val lexer = GeneratedLexer(inputStream)
+        lexer.removeErrorListeners()
+        lexer.addErrorListener(handler)
+        return CommonTokenStream(lexer)
+    }
+
+    /**
+     * Creates a [GeneratedParser] that uses [PredictionMode.SLL] and the [BailErrorStrategy]. The [GeneratedParser],
+     * upon seeing a syntax error, will throw a [ParseCancellationException] due to the [GeneratedParser.getErrorHandler]
+     * being a [BailErrorStrategy]. The purpose of this is to throw syntax errors as quickly as possible once encountered.
+     * As noted by the [PredictionMode.SLL] documentation, to guarantee results, it is useful to follow-up a failed parse
+     * by parsing with [PredictionMode.LL] -- see [createParserLL] for more information.
+     * See the JavaDocs for [PredictionMode.SLL] and [BailErrorStrategy] for more information.
+     */
+    private fun createParserSLL(query: String): GeneratedParser {
+        val stream = createTokenStream(query)
+        val parser = GeneratedParser(stream)
+        parser.reset()
+        parser.interpreter.predictionMode = PredictionMode.SLL
         parser.removeErrorListeners()
-        parser.addErrorListener(handler)
+        parser.errorHandler = BailErrorStrategy()
+        return parser
+    }
+
+    /**
+     * Creates a [GeneratedParser] that uses [PredictionMode.LL]. This method is capable of parsing all valid inputs
+     * for a grammar, but is slower than [PredictionMode.SLL]. Upon seeing a syntax error, this parser throws a
+     * [ParserException].
+     */
+    private fun createParserLL(query: String): GeneratedParser {
+        val stream = createTokenStream(query)
+        val parser = GeneratedParser(stream)
+        parser.reset()
+        parser.interpreter.predictionMode = PredictionMode.LL
+        parser.removeErrorListeners()
+        parser.addErrorListener(ParseErrorListener(ion))
         return parser
     }
 
@@ -91,10 +132,10 @@ internal class PartiQLParser(
      * NOTE: This needs to create its own lexer. Cannot share with others due to consumption of token stream.
      */
     private fun calculateTokenToParameterOrdinals(query: String): Map<Int, Int> {
-        val lexer = getLexer(query)
+        val stream = createTokenStream(query)
         val tokenIndexToParameterIndex = mutableMapOf<Int, Int>()
         var parametersFound = 0
-        val tokenIter = CommonTokenStream(lexer).also { it.fill() }.tokens.iterator()
+        val tokenIter = stream.also { it.fill() }.tokens.iterator()
         while (tokenIter.hasNext()) {
             val token = tokenIter.next()
             if (token.type == GeneratedParser.QUESTION_MARK) {

--- a/lang/src/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -56,6 +56,7 @@ import org.partiql.lang.syntax.antlr.PartiQLParser
 import org.partiql.lang.types.CustomType
 import org.partiql.lang.util.DATE_PATTERN_REGEX
 import org.partiql.lang.util.bigDecimalOf
+import org.partiql.lang.util.checkThreadInterrupted
 import org.partiql.lang.util.error
 import org.partiql.lang.util.getPrecisionFromTimeString
 import org.partiql.lang.util.ionValue
@@ -443,7 +444,10 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
 
     override fun visitLimitClause(ctx: PartiQLParser.LimitClauseContext): PartiqlAst.Expr = visit(ctx.arg, PartiqlAst.Expr::class)
 
-    override fun visitExpr(ctx: PartiQLParser.ExprContext) = visit(ctx.exprBagOp(), PartiqlAst.Expr::class)
+    override fun visitExpr(ctx: PartiQLParser.ExprContext): PartiqlAst.Expr {
+        checkThreadInterrupted()
+        return visit(ctx.exprBagOp(), PartiqlAst.Expr::class)
+    }
 
     override fun visitOffsetByClause(ctx: PartiQLParser.OffsetByClauseContext) = visit(ctx.arg, PartiqlAst.Expr::class)
 

--- a/lang/src/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/lang/src/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -1325,7 +1325,6 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
     override fun visitExprTermBase(ctx: PartiQLParser.ExprTermBaseContext?): PartiqlAst.PartiqlAstNode = super.visitExprTermBase(ctx)
     override fun visitCollection(ctx: PartiQLParser.CollectionContext?): PartiqlAst.PartiqlAstNode = super.visitCollection(ctx)
     override fun visitPredicateBase(ctx: PartiQLParser.PredicateBaseContext?): PartiqlAst.PartiqlAstNode = super.visitPredicateBase(ctx)
-    override fun visitTableJoined(ctx: PartiQLParser.TableJoinedContext?): PartiqlAst.PartiqlAstNode = super.visitTableJoined(ctx)
     override fun visitTableNonJoin(ctx: PartiQLParser.TableNonJoinContext?): PartiqlAst.PartiqlAstNode = super.visitTableNonJoin(ctx)
     override fun visitTableRefBase(ctx: PartiQLParser.TableRefBaseContext?): PartiqlAst.PartiqlAstNode = super.visitTableRefBase(ctx)
     override fun visitJoinRhsBase(ctx: PartiQLParser.JoinRhsBaseContext?): PartiqlAst.PartiqlAstNode = super.visitJoinRhsBase(ctx)

--- a/lang/test/org/partiql/lang/syntax/PartiQLParserSpyTest.kt
+++ b/lang/test/org/partiql/lang/syntax/PartiQLParserSpyTest.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.syntax
+
+import com.amazon.ion.IonSystem
+import com.amazon.ion.system.IonSystemBuilder
+import io.mockk.every
+import io.mockk.spyk
+import io.mockk.verify
+import org.antlr.v4.runtime.misc.ParseCancellationException
+import org.junit.Assert.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.partiql.lang.domains.PartiqlAst
+
+/**
+ * This test class is used for spying the [PartiQLParser].
+ */
+internal class PartiQLParserSpyTest {
+
+    val ion: IonSystem = IonSystemBuilder.standard().build()
+    val parser = spyk<PartiQLParser>()
+
+    /**
+     * Shows that the PartiQLParser can parse different queries sequentially.
+     */
+    @org.junit.Test(expected = org.junit.Test.None::class)
+    fun twoQueries() {
+        val query00 = "SELECT a1 FROM t1"
+        val query01 = "SELECT a2 FROM t2"
+        parser.parseAstStatement(query00)
+        parser.parseAstStatement(query01)
+    }
+
+    /**
+     * Shows that the PartiQLParser can parse same queries sequentially.
+     */
+    @Test
+    fun twoSameQueries() {
+        val query00 = "SELECT a1 FROM t1"
+        val ast00 = parser.parseAstStatement(query00)
+        val ast01 = parser.parseAstStatement(query00)
+        assertEquals(ast00, ast01)
+    }
+
+    /**
+     * This test shows that SLL and LL parsing can happen sequentially
+     */
+    @Test
+    fun manuallyShowDoubleParsingSameQueriesWorks() {
+        val query00 = "SELECT a1 FROM t1"
+        val ast00 = PartiQLVisitor(ion).visit(parser.parseUsingSLL(query00))
+        val ast01 = PartiQLVisitor(ion).visit(parser.parseUsingLL(query00))
+        assertEquals(ast00, ast01)
+    }
+
+    /**
+     * This test shows that SLL and LL parsing can happen sequentially using different queries
+     */
+    @org.junit.Test(expected = org.junit.Test.None::class)
+    fun manuallyShowDoubleParsingWorks() {
+        val query00 = "SELECT a1 FROM t1"
+        val query01 = "SELECT a2 FROM t2"
+        PartiQLVisitor(ion).visit(parser.parseUsingSLL(query00))
+        PartiQLVisitor(ion).visit(parser.parseUsingLL(query01))
+    }
+
+    /**
+     * Shows that for simple queries, we'll only parse using the SLL parser.
+     */
+    @Test
+    fun sllParsesCorrectly() {
+        // Arrange
+        val query00 = "SELECT a FROM t"
+
+        // Act
+        val ast = parser.parseAstStatement(query00)
+
+        // Assert
+        verify(exactly = 1) { parser.parseUsingSLL(query00) }
+        verify(exactly = 0) { parser.parseUsingLL(query00) }
+        assertEquals(
+            ast,
+            PartiqlAst.build {
+                query(
+                    select(
+                        project = projectList(
+                            projectExpr(
+                                id("a", caseInsensitive(), unqualified())
+                            )
+                        ),
+                        from = scan(
+                            id("t", caseInsensitive(), unqualified())
+                        )
+                    )
+                )
+            }
+        )
+    }
+
+    /**
+     * Shows we can parse using LL after SLL throws a ParseCancellationException
+     */
+    @Test
+    fun sllThrowsException() {
+        // Arrange
+        val query00 = "SELECT a FROM t"
+        every {
+            parser.parseUsingSLL(query00)
+        } throws ParseCancellationException()
+
+        // Act
+        val ast = parser.parseAstStatement(query00)
+
+        // Assert
+        verify(exactly = 1) { parser.parseUsingSLL(query00) }
+        verify(exactly = 1) { parser.parseUsingLL(query00) }
+        assertEquals(
+            ast,
+            PartiqlAst.build {
+                query(
+                    select(
+                        project = projectList(
+                            projectExpr(
+                                id("a", caseInsensitive(), unqualified())
+                            )
+                        ),
+                        from = scan(
+                            id("t", caseInsensitive(), unqualified())
+                        )
+                    )
+                )
+            }
+        )
+    }
+
+    /**
+     * Shows that SLL parsing throws a ParseCancellationException
+     */
+    @Test
+    fun badQueryThrowsSLLCancellationException() {
+        val query00 = "1++++++++++++"
+        assertThrows<ParseCancellationException> {
+            parser.parseUsingSLL(query00)
+        }
+    }
+
+    /**
+     * Shows that LL parsing throws a ParserException
+     */
+    @Test
+    fun badQueryThrowsLLParserException() {
+        val query00 = "1++++++++++++"
+        assertThrows<ParserException> {
+            parser.parseUsingLL(query00)
+        }
+    }
+
+    /**
+     * Shows that the public API will parse a bad query twice using SLL and LL
+     */
+    @Test
+    fun badQueryThrowsParserException() {
+        val query00 = "1++++++++++++"
+        assertThrows<ParserException> {
+            parser.parseAstStatement(query00)
+        }
+        verify(exactly = 1) { parser.parseUsingSLL(query00) }
+        verify(exactly = 1) { parser.parseUsingLL(query00) }
+    }
+}

--- a/lang/test/org/partiql/lang/syntax/PartiQLParserSpyTest.kt
+++ b/lang/test/org/partiql/lang/syntax/PartiQLParserSpyTest.kt
@@ -61,8 +61,8 @@ internal class PartiQLParserSpyTest {
     @Test
     fun manuallyShowDoubleParsingSameQueriesWorks() {
         val query00 = "SELECT a1 FROM t1"
-        val ast00 = PartiQLVisitor(ion).visit(parser.parseUsingSLL(query00))
-        val ast01 = PartiQLVisitor(ion).visit(parser.parseUsingLL(query00))
+        val ast00 = parser.parseQuery(query00) { parser.createParserSLL(it) }
+        val ast01 = parser.parseQuery(query00) { parser.createParserLL(it) }
         assertEquals(ast00, ast01)
     }
 
@@ -73,8 +73,8 @@ internal class PartiQLParserSpyTest {
     fun manuallyShowDoubleParsingWorks() {
         val query00 = "SELECT a1 FROM t1"
         val query01 = "SELECT a2 FROM t2"
-        PartiQLVisitor(ion).visit(parser.parseUsingSLL(query00))
-        PartiQLVisitor(ion).visit(parser.parseUsingLL(query01))
+        parser.parseQuery(query00) { parser.createParserSLL(it) }
+        parser.parseQuery(query01) { parser.createParserLL(it) }
     }
 
     /**
@@ -89,8 +89,8 @@ internal class PartiQLParserSpyTest {
         val ast = parser.parseAstStatement(query00)
 
         // Assert
-        verify(exactly = 1) { parser.parseUsingSLL(query00) }
-        verify(exactly = 0) { parser.parseUsingLL(query00) }
+        verify(exactly = 1) { parser.createParserSLL(any()) }
+        verify(exactly = 0) { parser.createParserLL(any()) }
         assertEquals(
             ast,
             PartiqlAst.build {
@@ -118,15 +118,15 @@ internal class PartiQLParserSpyTest {
         // Arrange
         val query00 = "SELECT a FROM t"
         every {
-            parser.parseUsingSLL(query00)
+            parser.createParserSLL(any())
         } throws ParseCancellationException()
 
         // Act
         val ast = parser.parseAstStatement(query00)
 
         // Assert
-        verify(exactly = 1) { parser.parseUsingSLL(query00) }
-        verify(exactly = 1) { parser.parseUsingLL(query00) }
+        verify(exactly = 1) { parser.createParserSLL(any()) }
+        verify(exactly = 1) { parser.createParserLL(any()) }
         assertEquals(
             ast,
             PartiqlAst.build {
@@ -153,7 +153,7 @@ internal class PartiQLParserSpyTest {
     fun badQueryThrowsSLLCancellationException() {
         val query00 = "1++++++++++++"
         assertThrows<ParseCancellationException> {
-            parser.parseUsingSLL(query00)
+            parser.parseQuery(query00) { parser.createParserSLL(it) }
         }
     }
 
@@ -164,7 +164,7 @@ internal class PartiQLParserSpyTest {
     fun badQueryThrowsLLParserException() {
         val query00 = "1++++++++++++"
         assertThrows<ParserException> {
-            parser.parseUsingLL(query00)
+            parser.parseQuery(query00) { parser.createParserLL(it) }
         }
     }
 
@@ -177,7 +177,7 @@ internal class PartiQLParserSpyTest {
         assertThrows<ParserException> {
             parser.parseAstStatement(query00)
         }
-        verify(exactly = 1) { parser.parseUsingSLL(query00) }
-        verify(exactly = 1) { parser.parseUsingLL(query00) }
+        verify(exactly = 1) { parser.createParserSLL(any()) }
+        verify(exactly = 1) { parser.createParserLL(any()) }
     }
 }

--- a/lang/test/org/partiql/lang/thread/ThreadInterruptedTests.kt
+++ b/lang/test/org/partiql/lang/thread/ThreadInterruptedTests.kt
@@ -5,6 +5,12 @@ package org.partiql.lang.thread
 
 import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionelement.api.ionInt
+import io.mockk.every
+import io.mockk.spyk
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.CommonToken
+import org.antlr.v4.runtime.Token
+import org.antlr.v4.runtime.TokenSource
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
@@ -29,7 +35,10 @@ import org.partiql.lang.ast.toExprNode
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.eval.CompileOptions
 import org.partiql.lang.eval.visitors.VisitorTransformBase
+import org.partiql.lang.syntax.PartiQLParser
 import org.partiql.lang.syntax.SqlParser
+import org.partiql.lang.syntax.antlr.PartiQLTokens
+import java.io.InputStream
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.thread
 
@@ -86,7 +95,7 @@ class ThreadInterruptedTests {
             plus(FakeList(n, variableA))
         }
 
-    private fun testThreadInterrupt(block: () -> Unit) {
+    private fun testThreadInterrupt(interruptAfter: Long = INTERRUPT_AFTER_MS, interruptWait: Long = WAIT_FOR_THREAD_TERMINATION_MS, block: () -> Unit) {
         val wasInterrupted = AtomicBoolean(false)
         val t = thread {
             try {
@@ -96,9 +105,9 @@ class ThreadInterruptedTests {
             }
         }
 
-        Thread.sleep(INTERRUPT_AFTER_MS)
+        Thread.sleep(interruptAfter)
         t.interrupt()
-        t.join(WAIT_FOR_THREAD_TERMINATION_MS)
+        t.join(interruptWait)
         assertTrue(wasInterrupted.get(), "Thread should have been interrupted.")
     }
 
@@ -181,6 +190,39 @@ class ThreadInterruptedTests {
     }
 
     @Test
+    fun parserPartiQL() {
+        val parser = spyk<PartiQLParser>()
+        val query = "hello world"
+        every {
+            parser.createTokenStream(any())
+        } returns EndlessTokenStream(PartiQLTokens(CharStreams.fromStream(InputStream.nullInputStream())))
+        testThreadInterrupt(5) { parser.run { parseAstStatement(query) } }
+    }
+
+    @Test
+    fun parserPartiQLUsingSLL() {
+        val parser = PartiQLParser()
+        val tokenStream = EndlessTokenStream(PartiQLTokens(CharStreams.fromStream(InputStream.nullInputStream())))
+        val sllParser = parser.createParserSLL(tokenStream)
+        testThreadInterrupt(5) { sllParser.run { statement() } }
+    }
+
+    @Test
+    fun parserPartiQLUsingLL() {
+        val parser = PartiQLParser()
+        val tokenStream = EndlessTokenStream(PartiQLTokens(CharStreams.fromStream(InputStream.nullInputStream())))
+        val llParser = parser.createParserLL(tokenStream)
+        testThreadInterrupt(5) { llParser.run { statement() } }
+    }
+
+    @Test
+    fun parserPartiQLTokenStream() {
+        val parser = PartiQLParser()
+        val endlessStream = EndlessInputStream()
+        testThreadInterrupt { parser.run { createTokenStream(endlessStream) } }
+    }
+
+    @Test
     fun visitorTransformBase() {
         val identityTransform = object : VisitorTransformBase() {}
         testThreadInterrupt {
@@ -218,6 +260,19 @@ class ThreadInterruptedTests {
         }
 
         assertTrue(accumulator != 0L)
+    }
+
+    private class EndlessInputStream : InputStream() {
+        override fun read(): Int {
+            return 1
+        }
+    }
+
+    private class EndlessTokenStream(source: TokenSource) : PartiQLParser.CountingTokenStream(source) {
+        override fun size(): Int = Int.MAX_VALUE
+        override fun LT(k: Int): Token {
+            return CommonToken(PartiQLTokens.PLUS)
+        }
     }
 }
 


### PR DESCRIPTION
## Description
- Prepares a patch release with parser improvements off of v0.8.1

## Other Information
- Updated Unreleased Section in CHANGELOG: Yes
- Any backward-incompatible changes? No
- Any new external dependencies? No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.