### PR TITLE
Update README, CHANGELOG, gradle builds following v0.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,13 +78,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds simple auto-completion to the CLI.
 
 ### Changed
-- Now `CompileOption` uses `TypedOpParameter.HONOR_PARAMETERS` as default.
-- Updates the CLI Shell Highlighter to use the ANTLR generated lexer/parser for highlighting user queries
-- PartiQL MISSING in Ion representation now becomes ion null with annotation of `$missing`, instead of `$partiql_missing`
-- PartiQL BAG in Ion representation now becomes ion list with annotation of `$bag`, instead of `$partiql_bag`
-- PartiQL DATE in Ion representation now becomes ion timestamp with annotation of `$date`, instead of `$partiql_date`
-- PartiQL TIME in Ion representation now becomes ion struct with annotation of `$time`, instead of `$partiql_time`
-- Simplifies the aggregation operator in the experimental planner by removing the use of metas
 - Increases the performance of the PartiQLParser by changing the parsing strategy
   - The PartiQLParser now attempts to parse queries using the SLL Prediction Mode set by ANTLR
   - If unable to parse via SLL Prediction Mode, it attempts to parse using the slower LL Prediction Mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 
+## [0.8.2] - 2022-11-28
+### Added
+- Adds simple auto-completion to the CLI.
+
+### Changed
+- Now `CompileOption` uses `TypedOpParameter.HONOR_PARAMETERS` as default.
+- Updates the CLI Shell Highlighter to use the ANTLR generated lexer/parser for highlighting user queries
+- PartiQL MISSING in Ion representation now becomes ion null with annotation of `$missing`, instead of `$partiql_missing`
+- PartiQL BAG in Ion representation now becomes ion list with annotation of `$bag`, instead of `$partiql_bag`
+- PartiQL DATE in Ion representation now becomes ion timestamp with annotation of `$date`, instead of `$partiql_date`
+- PartiQL TIME in Ion representation now becomes ion struct with annotation of `$time`, instead of `$partiql_time`
+- Simplifies the aggregation operator in the experimental planner by removing the use of metas
+- Increases the performance of the PartiQLParser by changing the parsing strategy
+  - The PartiQLParser now attempts to parse queries using the SLL Prediction Mode set by ANTLR
+  - If unable to parse via SLL Prediction Mode, it attempts to parse using the slower LL Prediction Mode
+  - Modifications have also been made to the ANTLR grammar to increase the speed of parsing joined table references
+  - Updates how the PartiQLParser handles parameter indexes to remove the double-pass while lexing
+
 ## [0.8.1] - 2022-10-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID      | Artifact ID           | Recommended Version |
 |---------------|-----------------------|---------------------|
-| `org.partiql` | `partiql-lang-kotlin` | `0.8.1`             | 
+| `org.partiql` | `partiql-lang-kotlin` | `0.8.2`             | 
 
 
 For Maven builds, add the following to your `pom.xml`:

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ allprojects {
 
 subprojects {
     group = 'org.partiql'
-    version = '0.8.2-SNAPSHOT'
+    version = '0.8.3-SNAPSHOT'
 }
 
 buildDir = new File(rootProject.projectDir, "gradle-build/" + project.name)

--- a/version-upgrade/v0.7-to-v0.8-upgrade/upgraded-examples/build.gradle
+++ b/version-upgrade/v0.7-to-v0.8-upgrade/upgraded-examples/build.gradle
@@ -22,5 +22,5 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.8.2")
 
-    testImplementation("org.partiql:partiql-lang-kotlin:0.8.0")
+    testImplementation("org.partiql:partiql-lang-kotlin:0.8.2")
 }


### PR DESCRIPTION
## Description
- Updates the README, CHANGELOG, gradle builds following v0.8.2 release

## Other Information
- Updated Unreleased Section in CHANGELOG: No. No code changes in released projects.
- Any backward-incompatible changes? No
- Any new external dependencies? No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.