### PR TITLE
Fixes ThreadInterruptedTests and shows child-thrown exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Marks the GroupKeyReferencesVisitorTransform as deprecated. There is no functionally equivalent class.
 
 ### Fixed
+- Fixes the ThreadInterruptedTests by modifying the time to interrupt parses. Also adds better exception exposure to
+facilitate debugging.
 
 ### Removed
 - Removes the deprecated V0 AST in the codebase.

--- a/lang/src/test/kotlin/org/partiql/lang/thread/ThreadInterruptedTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/thread/ThreadInterruptedTests.kt
@@ -62,14 +62,15 @@ class ThreadInterruptedTests {
 
     private fun testThreadInterrupt(interruptAfter: Long = INTERRUPT_AFTER_MS, interruptWait: Long = WAIT_FOR_THREAD_TERMINATION_MS, block: () -> Unit) {
         val wasInterrupted = AtomicBoolean(false)
-        val t = thread {
+        val t = thread(start = false) {
             try {
                 block()
             } catch (_: InterruptedException) {
                 wasInterrupted.set(true)
             }
         }
-
+        t.setUncaughtExceptionHandler { _, ex -> throw ex }
+        t.start()
         Thread.sleep(interruptAfter)
         t.interrupt()
         t.join(interruptWait)
@@ -83,7 +84,7 @@ class ThreadInterruptedTests {
         every {
             parser.createTokenStream(any())
         } returns EndlessTokenStream(PartiQLTokens(CharStreams.fromStream(InputStream.nullInputStream())))
-        testThreadInterrupt(5) { parser.run { parseAstStatement(query) } }
+        testThreadInterrupt(2) { parser.run { parseAstStatement(query) } }
     }
 
     @Test
@@ -91,7 +92,7 @@ class ThreadInterruptedTests {
         val parser = PartiQLParser()
         val tokenStream = EndlessTokenStream(PartiQLTokens(CharStreams.fromStream(InputStream.nullInputStream())))
         val sllParser = parser.createParserSLL(tokenStream)
-        testThreadInterrupt(5) { sllParser.run { statement() } }
+        testThreadInterrupt(2) { sllParser.run { statement() } }
     }
 
     @Test
@@ -99,7 +100,7 @@ class ThreadInterruptedTests {
         val parser = PartiQLParser()
         val tokenStream = EndlessTokenStream(PartiQLTokens(CharStreams.fromStream(InputStream.nullInputStream())))
         val llParser = parser.createParserLL(tokenStream)
-        testThreadInterrupt(5) { llParser.run { statement() } }
+        testThreadInterrupt(2) { llParser.run { statement() } }
     }
 
     @Test


### PR DESCRIPTION
## Relevant Issues
- Closes #911 

## Description
- The interrupted tests hide whatever exceptions may be thrown, and in the case of the internal method of ParseUsingSLL, it was occasionally throwing a StackOverflowError. This is handled by the public API, but the internal method doesn't handle it.
- Modified the thread interrupted test to throw the unhandled child thread exceptions to increase visibility if the tests ever fail.
- I also decreased the time for the parsing tests to 2 ms instead of 5 ms. Tested it several times locally -- no issue.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.