### PR TITLE
Adds the ListImplicit node to the AST

### DIFF
--- a/lang/src/main/kotlin/org/partiql/lang/ast/passes/StatementRedactor.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/ast/passes/StatementRedactor.kt
@@ -174,6 +174,7 @@ private class StatementRedactionVisitor(
         } else when (node) {
             is PartiqlAst.Expr.Lit -> redactLiteral(node)
             is PartiqlAst.Expr.List -> redactSeq(node)
+            is PartiqlAst.Expr.ListImplicit -> redactSeq(node)
             is PartiqlAst.Expr.Sexp -> redactSeq(node)
             is PartiqlAst.Expr.Bag -> redactSeq(node)
             is PartiqlAst.Expr.Struct -> redactStruct(node)
@@ -259,6 +260,7 @@ private class StatementRedactionVisitor(
     // once `bag`, `list`, and `sexp` modeled as described here: https://github.com/partiql/partiql-lang-kotlin/issues/239,
     // delete duplicated code
     private fun redactSeq(seq: PartiqlAst.Expr.List) = seq.values.map { redactExpr(it) }
+    private fun redactSeq(seq: PartiqlAst.Expr.ListImplicit) = seq.values.map { redactExpr(it) }
     private fun redactSeq(seq: PartiqlAst.Expr.Bag) = seq.values.map { redactExpr(it) }
     private fun redactSeq(seq: PartiqlAst.Expr.Sexp) = seq.values.map { redactExpr(it) }
 

--- a/lang/src/main/kotlin/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -407,6 +407,7 @@ internal class EvaluatingCompiler(
 
             // sequence constructors
             is PartiqlAst.Expr.List -> compileSeq(ExprValueType.LIST, expr.values, metas)
+            is PartiqlAst.Expr.ListImplicit -> compileSeq(ExprValueType.LIST, expr.values, metas)
             is PartiqlAst.Expr.Sexp -> compileSeq(ExprValueType.SEXP, expr.values, metas)
             is PartiqlAst.Expr.Bag -> compileSeq(ExprValueType.BAG, expr.values, metas)
 

--- a/lang/src/main/kotlin/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
@@ -1108,6 +1108,11 @@ internal class StaticTypeInferenceVisitorTransform(
             return transformSeq(seq, seq.values) { ListType(it) }
         }
 
+        override fun transformExprListImplicit(node: PartiqlAst.Expr.ListImplicit): PartiqlAst.Expr {
+            val seq = super.transformExprListImplicit(node) as PartiqlAst.Expr.ListImplicit
+            return transformSeq(seq, seq.values) { ListType(it) }
+        }
+
         override fun transformExprSexp(node: PartiqlAst.Expr.Sexp): PartiqlAst.Expr {
             val seq = super.transformExprSexp(node) as PartiqlAst.Expr.Sexp
             return transformSeq(seq, seq.values) { SexpType(it) }

--- a/lang/src/main/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -325,7 +325,7 @@ internal class AstToLogicalVisitorTransform(
                 // VALUES constructor.  Since parser uses the same nodes for the alternate syntactic representations
                 // `<< [ ... ] ... >>` and `BAG(LIST(...), ...)` those get blocked too.  This is probably just as well.
                 if (dmlOp.values is PartiqlAst.Expr.Bag) {
-                    dmlOp.values.values.firstOrNull { it is PartiqlAst.Expr.List }?.let {
+                    dmlOp.values.values.firstOrNull { it is PartiqlAst.Expr.List || it is PartiqlAst.Expr.ListImplicit }?.let {
                         problemHandler.handleProblem(
                             Problem(
                                 node.metas.sourceLocationMetaOrUnknown,
@@ -517,6 +517,13 @@ internal class AstToLogicalVisitorTransform(
                 }
             )
         }
+
+    override fun transformExprListImplicit(node: PartiqlAst.Expr.ListImplicit) = PartiqlLogical.build {
+        list(
+            node.values.map { transformExpr(it) },
+            node.metas
+        )
+    }
 }
 
 private fun PartiqlAst.FromSource.toBexpr(

--- a/lang/src/main/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
@@ -470,6 +470,11 @@ class ASTPrettyPrinter {
                 attrOfParent = attrOfParent,
                 children = toRecursionTreeList(node.values)
             )
+            is PartiqlAst.Expr.ListImplicit -> RecursionTree(
+                astType = "ListImplicit",
+                attrOfParent = attrOfParent,
+                children = toRecursionTreeList(node.values)
+            )
             is PartiqlAst.Expr.Sexp -> RecursionTree(
                 astType = "Sexp",
                 attrOfParent = attrOfParent,

--- a/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -890,7 +890,7 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
             val possibleRhs = visitExpr(ctx.expr())
             if (possibleRhs is PartiqlAst.Expr.Select || possibleRhs.metas.containsKey(IsValuesExprMeta.TAG))
                 possibleRhs
-            else list(possibleRhs)
+            else listImplicit(possibleRhs)
         } else {
             visit(ctx.rhs, PartiqlAst.Expr::class)
         }
@@ -990,18 +990,18 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
     }
 
     override fun visitValues(ctx: PartiQLParser.ValuesContext) = PartiqlAst.build {
-        val rows = visitOrEmpty(ctx.valueRow(), PartiqlAst.Expr.List::class)
+        val rows = visitOrEmpty(ctx.valueRow(), PartiqlAst.Expr.ListImplicit::class)
         bag(rows, ctx.VALUES().getSourceMetaContainer() + metaContainerOf(IsValuesExprMeta.instance))
     }
 
     override fun visitValueRow(ctx: PartiQLParser.ValueRowContext) = PartiqlAst.build {
         val expressions = visitOrEmpty(ctx.expr(), PartiqlAst.Expr::class)
-        list(expressions)
+        listImplicit(expressions)
     }
 
     override fun visitValueList(ctx: PartiQLParser.ValueListContext) = PartiqlAst.build {
         val expressions = visitOrEmpty(ctx.expr(), PartiqlAst.Expr::class)
-        list(expressions)
+        listImplicit(expressions)
     }
 
     /**

--- a/lang/src/main/pig/partiql.ion
+++ b/lang/src/main/pig/partiql.ion
@@ -132,6 +132,7 @@ may then be further optimized by selecting better implementations of each operat
             // https://github.com/partiql/partiql-lang-kotlin/issues/239
             (bag values::(* expr 0))
             (list values::(* expr 0))
+            (list_implicit values::(* expr 0))
             (sexp values::(* expr 0))
 
             // Constructors for DateTime types
@@ -593,6 +594,9 @@ may then be further optimized by selecting better implementations of each operat
             // Remove the call_window node from the `expr` sum type, because the call_window contains two parts:
             // Window specification and window function, we want to define a stand alone operator for this
             (exclude select struct call_window)
+
+            // This is only used for syntax purposes. Gets converted to a list.
+            (exclude list_implicit)
               
             // CallAgg's such as SUM, MIN, MAX, etc. either become calls to built-in-functions (example: call COLL_SUM)
             // or aggregate functions within the logical aggregate operator.

--- a/lang/src/test/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinterTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinterTest.kt
@@ -106,10 +106,10 @@ class ASTPrettyPrinterTest {
                         op1: Insert
                             target: Id foo (case_insensitive) (unqualified)
                             values: Bag
-                                List
+                                ListImplicit
                                     Lit 1
                                     Lit 2
-                                List
+                                ListImplicit
                                     Lit 3
                                     Lit 4
             """.trimIndent()

--- a/lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
@@ -64,7 +64,7 @@ class QueryPrettyPrinterTest {
     @Test
     fun insertValue() {
         checkPrettyPrintQuery(
-            "INSERT INTO foo VALUE (1, 2)", "INSERT INTO foo VALUE [ 1, 2 ]"
+            "INSERT INTO foo VALUE (1, 2)", "INSERT INTO foo VALUE (1, 2)"
         )
     }
 

--- a/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -139,25 +139,25 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun rowValueConstructorWithSimpleExpressions() = assertExpression(
         "(1, 2, 3, 4)",
-        """(list (lit 1) (lit 2) (lit 3) (lit 4))"""
+        """(list_implicit (lit 1) (lit 2) (lit 3) (lit 4))"""
     )
 
     @Test
     fun rowValueConstructorWithRowValueConstructors() = assertExpression(
         "((1, 2), (3, 4))",
-        """(list (list (lit 1) (lit 2)) (list (lit 3) (lit 4)))"""
+        """(list_implicit (list_implicit (lit 1) (lit 2)) (list_implicit (lit 3) (lit 4)))"""
     )
 
     @Test
     fun tableValueConstructorWithRowValueConstructors() = assertExpression(
         "VALUES (1, 2), (3, 4)",
-        """(bag (list (lit 1) (lit 2)) (list (lit 3) (lit 4)))"""
+        """(bag (list_implicit (lit 1) (lit 2)) (list_implicit (lit 3) (lit 4)))"""
     )
 
     @Test
     fun tableValueConstructorWithSingletonRowValueConstructors() = assertExpression(
         "VALUES (1), (2), (3)",
-        """(bag (list (lit 1)) (list (lit 2)) (list (lit 3)))"""
+        """(bag (list_implicit (lit 1)) (list_implicit (lit 2)) (list_implicit (lit 3)))"""
     )
 
     // ****************************************
@@ -669,7 +669,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         "a IN (1, 2, 3, 4)",
         """(in_collection
              (id a (case_insensitive) (unqualified))
-             (list (lit 1) (lit 2) (lit 3) (lit 4))
+             (list_implicit (lit 1) (lit 2) (lit 3) (lit 4))
            )
         """
     )
@@ -680,7 +680,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         """(not
           (in_collection
              (id a (case_insensitive) (unqualified))
-             (list (lit 1) (lit 2) (lit 3) (lit 4))))
+             (list_implicit (lit 1) (lit 2) (lit 3) (lit 4))))
         """
     )
 
@@ -688,8 +688,8 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     fun inOperatorWithImplicitValuesRowConstructor() = assertExpression(
         "(a, b) IN ((1, 2), (3, 4))",
         """(in_collection
-             (list (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))
-             (list (list (lit 1) (lit 2)) (list (lit 3) (lit 4)))
+             (list_implicit (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))
+             (list_implicit (list_implicit (lit 1) (lit 2)) (list_implicit (lit 3) (lit 4)))
            )
         """
     )
@@ -1721,10 +1721,10 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (insert
                         (id foo (case_insensitive) (unqualified))
                         (bag
-                            (list
+                            (list_implicit
                                 (lit 1)
                                 (lit 2))
-                            (list
+                            (list_implicit
                                 (lit 3)
                                 (lit 4)))
                         null)))
@@ -1898,10 +1898,10 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (insert
                         (id foo (case_insensitive) (unqualified))
                         (bag
-                            (list
+                            (list_implicit
                                 (lit 1)
                                 (lit 2))
-                            (list
+                            (list_implicit
                                 (lit 3)
                                 (lit 4)))
                         null))))
@@ -2197,10 +2197,10 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (insert
                         (id foo (case_insensitive) (unqualified))
                         (bag
-                            (list
+                            (list_implicit
                                 (lit 1)
                                 (lit 2))
-                            (list
+                            (list_implicit
                                 (lit 3)
                                 (lit 4)))
                         (do_replace
@@ -2277,10 +2277,10 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (insert
                         (id foo (case_insensitive) (unqualified))
                         (bag
-                            (list
+                            (list_implicit
                                 (lit 1)
                                 (lit 2))
-                            (list
+                            (list_implicit
                                 (lit 3)
                                 (lit 4)))
                         (do_update


### PR DESCRIPTION
## Relevant Issues
- None

## Background
- There is a customer use-case to differentiate between lists that are created using `[ , , , ]` and `( , , , )`.
- In our AST, we currently do not differentiate between the two.

## Description
- Adds a `ListImplicit` AST node (we can change the name -- I haven't thought much about it)
  - Might be a `Row` or `RowValue`, see the conversation below. The naming is subject to change.
- Modifies our tests to handle the `ListImplicit` node.
- Evaluation is the same as `List`

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
  - Not yet. Need to get feedback from others first.
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.