### PR TITLE
Adds the IsListParenthesizedMeta to aid in differentiating list syntax's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Adds simple auto-completion to the CLI.
+- Adds the IsListParenthesizedMeta meta to aid in differentiating between parenthesized and non-parenthesized lists
 - Adds support for HAVING clause in planner
 - Adds support for collection aggregation functions in the EvaluatingCompiler and experimental planner
 - Adds support for the syntactic sugar of using aggregations functions in place of their collection aggregation function

--- a/lang/src/main/kotlin/org/partiql/lang/ast/IsListParenthesizedMeta.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/ast/IsListParenthesizedMeta.kt
@@ -1,0 +1,20 @@
+package org.partiql.lang.ast
+
+/**
+ * The [IsListParenthesizedMeta] is used to distinguish the two types of [org.partiql.lang.domains.PartiqlAst.Expr.List]
+ * syntax's:
+ *  1. [[ a, b, c ]]
+ *  2. ( a, b, c )
+ *
+ * The existence of this meta on a [org.partiql.lang.domains.PartiqlAst.Expr.List] node indicates that the list uses
+ * the second syntax above (using parenthesis).
+ */
+public class IsListParenthesizedMeta private constructor() : Meta {
+
+    override val tag = TAG
+
+    companion object {
+        const val TAG = "\$is_list_parenthesized"
+        val instance = IsListParenthesizedMeta()
+    }
+}

--- a/lang/src/main/kotlin/org/partiql/lang/ast/IsListParenthesizedMeta.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/ast/IsListParenthesizedMeta.kt
@@ -9,12 +9,6 @@ package org.partiql.lang.ast
  * The existence of this meta on a [org.partiql.lang.domains.PartiqlAst.Expr.List] node indicates that the list uses
  * the second syntax above (using parenthesis).
  */
-public class IsListParenthesizedMeta private constructor() : Meta {
-
-    override val tag = TAG
-
-    companion object {
-        const val TAG = "\$is_list_parenthesized"
-        val instance = IsListParenthesizedMeta()
-    }
+public object IsListParenthesizedMeta : Meta {
+    override val tag = "\$is_list_parenthesized"
 }

--- a/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -41,6 +41,7 @@ import org.antlr.v4.runtime.tree.TerminalNode
 import org.partiql.lang.ast.IsCountStarMeta
 import org.partiql.lang.ast.IsImplictJoinMeta
 import org.partiql.lang.ast.IsIonLiteralMeta
+import org.partiql.lang.ast.IsListParenthesizedMeta
 import org.partiql.lang.ast.IsPathIndexMeta
 import org.partiql.lang.ast.IsValuesExprMeta
 import org.partiql.lang.ast.LegacyLogicalNotMeta
@@ -890,7 +891,7 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
             val possibleRhs = visitExpr(ctx.expr())
             if (possibleRhs is PartiqlAst.Expr.Select || possibleRhs.metas.containsKey(IsValuesExprMeta.TAG))
                 possibleRhs
-            else list(possibleRhs)
+            else list(possibleRhs, metas = possibleRhs.metas + metaContainerOf(IsListParenthesizedMeta.instance))
         } else {
             visit(ctx.rhs, PartiqlAst.Expr::class)
         }
@@ -996,12 +997,12 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
 
     override fun visitValueRow(ctx: PartiQLParser.ValueRowContext) = PartiqlAst.build {
         val expressions = visitOrEmpty(ctx.expr(), PartiqlAst.Expr::class)
-        list(expressions)
+        list(expressions, metas = ctx.PAREN_LEFT().getSourceMetaContainer() + metaContainerOf(IsListParenthesizedMeta.instance))
     }
 
     override fun visitValueList(ctx: PartiQLParser.ValueListContext) = PartiqlAst.build {
         val expressions = visitOrEmpty(ctx.expr(), PartiqlAst.Expr::class)
-        list(expressions)
+        list(expressions, metas = ctx.PAREN_LEFT().getSourceMetaContainer() + metaContainerOf(IsListParenthesizedMeta.instance))
     }
 
     /**

--- a/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -891,7 +891,7 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
             val possibleRhs = visitExpr(ctx.expr())
             if (possibleRhs is PartiqlAst.Expr.Select || possibleRhs.metas.containsKey(IsValuesExprMeta.TAG))
                 possibleRhs
-            else list(possibleRhs, metas = possibleRhs.metas + metaContainerOf(IsListParenthesizedMeta.instance))
+            else list(possibleRhs, metas = possibleRhs.metas + metaContainerOf(IsListParenthesizedMeta))
         } else {
             visit(ctx.rhs, PartiqlAst.Expr::class)
         }
@@ -997,12 +997,12 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
 
     override fun visitValueRow(ctx: PartiQLParser.ValueRowContext) = PartiqlAst.build {
         val expressions = visitOrEmpty(ctx.expr(), PartiqlAst.Expr::class)
-        list(expressions, metas = ctx.PAREN_LEFT().getSourceMetaContainer() + metaContainerOf(IsListParenthesizedMeta.instance))
+        list(expressions, metas = ctx.PAREN_LEFT().getSourceMetaContainer() + metaContainerOf(IsListParenthesizedMeta))
     }
 
     override fun visitValueList(ctx: PartiQLParser.ValueListContext) = PartiqlAst.build {
         val expressions = visitOrEmpty(ctx.expr(), PartiqlAst.Expr::class)
-        list(expressions, metas = ctx.PAREN_LEFT().getSourceMetaContainer() + metaContainerOf(IsListParenthesizedMeta.instance))
+        list(expressions, metas = ctx.PAREN_LEFT().getSourceMetaContainer() + metaContainerOf(IsListParenthesizedMeta))
     }
 
     /**

--- a/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserMetaTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserMetaTests.kt
@@ -12,7 +12,7 @@ internal class PartiQLParserMetaTests : PartiQLParserTestBase() {
         val ast = parse(query) as PartiqlAst.Statement.Query
         val list = ast.expr as PartiqlAst.Expr.List
 
-        assert(list.metas.containsKey(IsListParenthesizedMeta.TAG))
+        assert(list.metas.containsKey(IsListParenthesizedMeta.tag))
     }
 
     @Test
@@ -21,7 +21,7 @@ internal class PartiQLParserMetaTests : PartiQLParserTestBase() {
         val ast = parse(query) as PartiqlAst.Statement.Query
         val list = ast.expr as PartiqlAst.Expr.List
 
-        assert(list.metas.containsKey(IsListParenthesizedMeta.TAG).not())
+        assert(list.metas.containsKey(IsListParenthesizedMeta.tag).not())
     }
 
     @Test
@@ -31,7 +31,7 @@ internal class PartiQLParserMetaTests : PartiQLParserTestBase() {
         val inCollection = ast.expr as PartiqlAst.Expr.InCollection
         val list = inCollection.operands[1] as PartiqlAst.Expr.List
 
-        assert(list.metas.containsKey(IsListParenthesizedMeta.TAG))
+        assert(list.metas.containsKey(IsListParenthesizedMeta.tag))
     }
 
     @Test
@@ -41,7 +41,7 @@ internal class PartiQLParserMetaTests : PartiQLParserTestBase() {
         val inCollection = ast.expr as PartiqlAst.Expr.InCollection
         val list = inCollection.operands[1] as PartiqlAst.Expr.List
 
-        assert(list.metas.containsKey(IsListParenthesizedMeta.TAG).not())
+        assert(list.metas.containsKey(IsListParenthesizedMeta.tag).not())
     }
 
     @Test
@@ -51,6 +51,6 @@ internal class PartiQLParserMetaTests : PartiQLParserTestBase() {
         val inCollection = ast.expr as PartiqlAst.Expr.InCollection
         val list = inCollection.operands[1] as PartiqlAst.Expr.List
 
-        assert(list.metas.containsKey(IsListParenthesizedMeta.TAG))
+        assert(list.metas.containsKey(IsListParenthesizedMeta.tag))
     }
 }

--- a/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserMetaTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserMetaTests.kt
@@ -1,0 +1,56 @@
+package org.partiql.lang.syntax
+
+import org.junit.jupiter.api.Test
+import org.partiql.lang.ast.IsListParenthesizedMeta
+import org.partiql.lang.domains.PartiqlAst
+
+internal class PartiQLParserMetaTests : PartiQLParserTestBase() {
+
+    @Test
+    fun listParenthesized() {
+        val query = "(0, 1, 2)"
+        val ast = parse(query) as PartiqlAst.Statement.Query
+        val list = ast.expr as PartiqlAst.Expr.List
+
+        assert(list.metas.containsKey(IsListParenthesizedMeta.TAG))
+    }
+
+    @Test
+    fun listParenthesizedNot() {
+        val query = "[0, 1, 2]"
+        val ast = parse(query) as PartiqlAst.Statement.Query
+        val list = ast.expr as PartiqlAst.Expr.List
+
+        assert(list.metas.containsKey(IsListParenthesizedMeta.TAG).not())
+    }
+
+    @Test
+    fun inListParenthesized() {
+        val query = "0 IN (0, 1, 2)"
+        val ast = parse(query) as PartiqlAst.Statement.Query
+        val inCollection = ast.expr as PartiqlAst.Expr.InCollection
+        val list = inCollection.operands[1] as PartiqlAst.Expr.List
+
+        assert(list.metas.containsKey(IsListParenthesizedMeta.TAG))
+    }
+
+    @Test
+    fun inListParenthesizedNot() {
+        val query = "0 IN [0, 1, 2]"
+        val ast = parse(query) as PartiqlAst.Statement.Query
+        val inCollection = ast.expr as PartiqlAst.Expr.InCollection
+        val list = inCollection.operands[1] as PartiqlAst.Expr.List
+
+        assert(list.metas.containsKey(IsListParenthesizedMeta.TAG).not())
+    }
+
+    @Test
+    fun inListParenthesizedSingleElement() {
+        val query = "0 IN (0)"
+        val ast = parse(query) as PartiqlAst.Statement.Query
+        val inCollection = ast.expr as PartiqlAst.Expr.InCollection
+        val list = inCollection.operands[1] as PartiqlAst.Expr.List
+
+        assert(list.metas.containsKey(IsListParenthesizedMeta.TAG))
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- Relevant to #925

## Description
- There is a customer use-case to differentiate between lists that are created using `[ , , , ]` and `( , , , )`.
- In our AST, we currently do not differentiate between the two.
- This adds a meta and adds it to our parsing.

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.