### PR TITLE
Removed `ION_WITHOUT_ANNOTATION` test format

### DIFF
--- a/lang/src/test/kotlin/org/partiql/lang/eval/CastTestBase.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/CastTestBase.kt
@@ -66,7 +66,7 @@ private fun ExprValueType.typeAliases(): List<String> = when (this) {
 abstract class CastTestBase : EvaluatorTestBase() {
 
     fun ConfiguredCastCase.assertCase(
-        expectedResultFormat: ExpectedResultFormat = ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS
+        expectedResultFormat: ExpectedResultFormat = ExpectedResultFormat.ION
     ) {
         when (castCase.expected) {
             null -> {
@@ -277,12 +277,12 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     }
                 ).types(allTypeNames - ExprValueType.MISSING.typeAliases()),
                 listOf(
-                    case("NULL", "null", CastQuality.LOSSLESS) {
+                    case("NULL", "$MISSING_ANNOTATION::null", CastQuality.LOSSLESS) {
                         assertEquals(ExprValueType.MISSING, it.type)
                     }
                 ).types(listOf("MISSING")),
                 listOf(
-                    case("MISSING", "null", CastQuality.LOSSLESS) {
+                    case("MISSING", "$MISSING_ANNOTATION::null", CastQuality.LOSSLESS) {
                         assertEquals(ExprValueType.MISSING, it.type)
                     }
                 ).types(allTypeNames - ExprValueType.NULL.typeAliases()),
@@ -817,9 +817,9 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("`{a:12d0}`", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("{'b':`-4d0`}", ErrorCode.EVALUATOR_INVALID_CAST),
                     // bag
-                    case("<<>>", "[]", CastQuality.LOSSLESS), // TODO bag verification
-                    case("<<`14d0`>>", "[14d0]", CastQuality.LOSSLESS), // TODO bag verification
-                    case("<<`20d0`>>", "[20d0]", CastQuality.LOSSLESS) // TODO bag verification
+                    case("<<>>", "[]", CastQuality.LOSSLESS),
+                    case("<<`14d0`>>", "[14d0]", CastQuality.LOSSLESS),
+                    case("<<`20d0`>>", "[20d0]", CastQuality.LOSSLESS)
                 ).types(ExprValueType.LIST.typeAliases()),
                 listOf(
                     // booleans
@@ -936,22 +936,22 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("`{{MS4w}}`", ErrorCode.EVALUATOR_INVALID_CAST), // 1.0
                     case("`{{MmUxMA==}}`", ErrorCode.EVALUATOR_INVALID_CAST), // 2e10
                     // list
-                    case("`[]`", "[]", CastQuality.LOSSLESS), // TODO bag verification
-                    case("['hello']", "[\"hello\"]", CastQuality.LOSSLESS), // TODO bag verification
-                    case("`[-2d0, 0d0]`", "[-2d0, 0d0]", CastQuality.LOSSLESS), // TODO bag verification
+                    case("`[]`", "$BAG_ANNOTATION::[]", CastQuality.LOSSLESS),
+                    case("['hello']", "$BAG_ANNOTATION::[\"hello\"]", CastQuality.LOSSLESS),
+                    case("`[-2d0, 0d0]`", "$BAG_ANNOTATION::[-2d0, 0d0]", CastQuality.LOSSLESS),
                     // sexp
-                    case("`()`", "[]", CastQuality.LOSSLESS), // TODO bag verification
-                    case("`(1d0)`", "[1d0]", CastQuality.LOSSLESS), // TODO bag verification
-                    case("`(0d0)`", "[0d0]", CastQuality.LOSSLESS), // TODO bag verification
+                    case("`()`", "$BAG_ANNOTATION::[]", CastQuality.LOSSLESS),
+                    case("`(1d0)`", "$BAG_ANNOTATION::[1d0]", CastQuality.LOSSLESS),
+                    case("`(0d0)`", "$BAG_ANNOTATION::[0d0]", CastQuality.LOSSLESS),
                     // struct
                     case("`{}`", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("{}", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("`{a:12d0}`", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("{'b':`-4d0`}", ErrorCode.EVALUATOR_INVALID_CAST),
                     // bag
-                    case("<<>>", "[]", CastQuality.LOSSLESS), // TODO bag verification
-                    case("<<`14d0`>>", "[14d0]", CastQuality.LOSSLESS), // TODO bag verification
-                    case("<<`20d0`>>", "[20d0]", CastQuality.LOSSLESS) // TODO bag verification
+                    case("<<>>", "$BAG_ANNOTATION::[]", CastQuality.LOSSLESS),
+                    case("<<`14d0`>>", "$BAG_ANNOTATION::[14d0]", CastQuality.LOSSLESS),
+                    case("<<`20d0`>>", "$BAG_ANNOTATION::[20d0]", CastQuality.LOSSLESS)
                 ).types(ExprValueType.BAG.typeAliases())
             ).flatten()
 
@@ -1451,7 +1451,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 // Note that we do not convert cases where the error is semantic (i.e. static)
                 case.expectedErrorCode != null && case.expectedErrorCode.category != ErrorCategory.SEMANTIC -> {
                     // rewrite error code cases to `MISSING` for permissive mode
-                    case.copy(expected = "null", expectedErrorCode = null) {
+                    case.copy(expected = "$MISSING_ANNOTATION::null", expectedErrorCode = null) {
                         assertEquals(ExprValueType.MISSING, it.type)
                     }
                 }
@@ -1524,7 +1524,7 @@ abstract class CastTestBase : EvaluatorTestBase() {
                 val identityValue = eval(castCase.source)
                 val newCastCase = castCase.copy(
                     type = "ANY",
-                    expected = identityValue.toIonValue(ion).cloneAndRemoveBagAndMissingAnnotations().toString(),
+                    expected = identityValue.toIonValue(ion).toString(),
                     expectedErrorCode = null
                 ) {
                     assertEquals(identityValue.type, it.type)

--- a/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerCustomAnyOfTypeOperationTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerCustomAnyOfTypeOperationTests.kt
@@ -45,7 +45,7 @@ class EvaluatingCompilerCustomAnyOfTypeOperationTests : CastTestBase() {
                 case("NULL", "null", CastQuality.LOSSLESS) {
                     assertEquals(ExprValueType.NULL, it.type)
                 },
-                case("MISSING", "null", FixSemantics(CastQuality.LOSSY)) {
+                case("MISSING", "$MISSING_ANNOTATION::null", FixSemantics(CastQuality.LOSSY)) {
                     assertEquals(ExprValueType.MISSING, it.type)
                 },
                 // bool
@@ -89,7 +89,7 @@ class EvaluatingCompilerCustomAnyOfTypeOperationTests : CastTestBase() {
                 ),
                 case("`(a b [2099-01-21T12:34:56Z, {{Ymxhcmc=}}])`", ErrorCode.EVALUATOR_CAST_FAILED),
                 // bag
-                case("<<99, 20000, MISSING>>", "[99, 20000, null]", FixSemantics(CastQuality.LOSSY)) {
+                case("<<99, 20000, MISSING>>", "[99, 20000, $MISSING_ANNOTATION::null]", FixSemantics(CastQuality.LOSSY)) {
                     assertEquals(ExprValueType.LIST, it.type)
                     assertEquals(ExprValueType.MISSING, it.ordinalBindings[2]?.type)
                 },

--- a/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerExceptionsTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerExceptionsTest.kt
@@ -143,7 +143,7 @@ class EvaluatingCompilerExceptionsTest : EvaluatorTestBase() {
     fun missingAlias() =
         // Same query as previous test--but DO NOT throw exception this time because of UndefinedVariableBehavior.MISSING
         runEvaluatorTestCase(
-            sqlWithUndefinedVariable, expectedResult = "[null]",
+            sqlWithUndefinedVariable, expectedResult = "$BAG_ANNOTATION::[$MISSING_ANNOTATION::null]",
             target = EvaluatorTestTarget.COMPILER_PIPELINE,
             compileOptionsBuilderBlock = { undefinedVariable(UndefinedVariableBehavior.MISSING) }
         )
@@ -164,7 +164,7 @@ class EvaluatingCompilerExceptionsTest : EvaluatorTestBase() {
     fun missingQuotedAlias() =
         // Same query as previous test--but DO NOT throw exception this time because of UndefinedVariableBehavior.MISSING
         runEvaluatorTestCase(
-            sqlWithUndefinedQuotedVariable, expectedResult = "[null]",
+            sqlWithUndefinedQuotedVariable, expectedResult = "$BAG_ANNOTATION::[$MISSING_ANNOTATION::null]",
             target = EvaluatorTestTarget.COMPILER_PIPELINE,
             compileOptionsBuilderBlock = { undefinedVariable(UndefinedVariableBehavior.MISSING) }
         )

--- a/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerFromSourceByTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerFromSourceByTests.kt
@@ -49,26 +49,26 @@ class EvaluatingCompilerFromSourceByTests : EvaluatorTestBase() {
     fun rangeOverListWithBy() = runEvaluatorTestCase(
         "SELECT VALUE addr FROM someList BY addr",
         session,
-        "\$bag::[101,102,103]"
+        "$BAG_ANNOTATION::[101,102,103]"
     )
 
     @Test
     fun rangeOverBagWithBy() = runEvaluatorTestCase(
         "SELECT VALUE addr FROM someBag BY addr",
         session,
-        "\$bag::[111,112,113]"
+        "$BAG_ANNOTATION::[111,112,113]"
     )
     @Test
     fun rangeOverListWithAsAndAt() = runEvaluatorTestCase(
         "SELECT VALUE [i, v, z] FROM someList AS v AT i BY z",
         session,
-        "\$bag::[[0,1,101],[1,2,102],[2,3,103]]"
+        "$BAG_ANNOTATION::[[0,1,101],[1,2,102],[2,3,103]]"
     )
     @Test
     fun rangeOverBagWithAsAndAt() = runEvaluatorTestCase(
         "SELECT VALUE [i, v, z] FROM someBag AS v AT i BY z",
         session,
-        "\$bag::[[\$missing::null,11,111],[\$missing::null,12,112],[\$missing::null,13,113]]"
+        "$BAG_ANNOTATION::[[$MISSING_ANNOTATION::null,11,111],[$MISSING_ANNOTATION::null,12,112],[$MISSING_ANNOTATION::null,13,113]]"
     )
 
     @Test
@@ -77,7 +77,7 @@ class EvaluatingCompilerFromSourceByTests : EvaluatorTestBase() {
         // the result of the inner query is a bag, so i should always be MISSING
         // However, addr should still contain an address since the items of that bag are unchanged
         session,
-        "\$bag::[[\$missing::null,101,1],[\$missing::null,102,2],[\$missing::null,103,3]]"
+        "$BAG_ANNOTATION::[[$MISSING_ANNOTATION::null,101,1],[$MISSING_ANNOTATION::null,102,2],[$MISSING_ANNOTATION::null,103,3]]"
     )
 
     @Test
@@ -85,6 +85,6 @@ class EvaluatingCompilerFromSourceByTests : EvaluatorTestBase() {
         "SELECT VALUE [i, addr, v] FROM (SELECT VALUE v + 1000 FROM someList AS v) AS v AT i BY addr",
         // However, since we + 1000 to v in the inner query, we create a new value that does not have an address.
         session,
-        "\$bag::[[\$missing::null,\$missing::null,1001],[\$missing::null,\$missing::null,1002],[\$missing::null,\$missing::null,1003]]"
+        "$BAG_ANNOTATION::[[$MISSING_ANNOTATION::null,$MISSING_ANNOTATION::null,1001],[$MISSING_ANNOTATION::null,$MISSING_ANNOTATION::null,1002],[$MISSING_ANNOTATION::null,$MISSING_ANNOTATION::null,1003]]"
     )
 }

--- a/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerFromSourceByTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerFromSourceByTests.kt
@@ -49,26 +49,26 @@ class EvaluatingCompilerFromSourceByTests : EvaluatorTestBase() {
     fun rangeOverListWithBy() = runEvaluatorTestCase(
         "SELECT VALUE addr FROM someList BY addr",
         session,
-        """[101, 102, 103]"""
+        "\$bag::[101,102,103]"
     )
 
     @Test
     fun rangeOverBagWithBy() = runEvaluatorTestCase(
         "SELECT VALUE addr FROM someBag BY addr",
         session,
-        """[111, 112, 113]"""
+        "\$bag::[111,112,113]"
     )
     @Test
     fun rangeOverListWithAsAndAt() = runEvaluatorTestCase(
         "SELECT VALUE [i, v, z] FROM someList AS v AT i BY z",
         session,
-        """[[0, 1, 101], [1, 2, 102], [2, 3, 103]]"""
+        "\$bag::[[0,1,101],[1,2,102],[2,3,103]]"
     )
     @Test
     fun rangeOverBagWithAsAndAt() = runEvaluatorTestCase(
         "SELECT VALUE [i, v, z] FROM someBag AS v AT i BY z",
         session,
-        """[[null, 11, 111], [null, 12, 112], [null, 13, 113]]"""
+        "\$bag::[[\$missing::null,11,111],[\$missing::null,12,112],[\$missing::null,13,113]]"
     )
 
     @Test
@@ -77,7 +77,7 @@ class EvaluatingCompilerFromSourceByTests : EvaluatorTestBase() {
         // the result of the inner query is a bag, so i should always be MISSING
         // However, addr should still contain an address since the items of that bag are unchanged
         session,
-        """[[null, 101, 1], [null, 102, 2], [null, 103, 3]]"""
+        "\$bag::[[\$missing::null,101,1],[\$missing::null,102,2],[\$missing::null,103,3]]"
     )
 
     @Test
@@ -85,6 +85,6 @@ class EvaluatingCompilerFromSourceByTests : EvaluatorTestBase() {
         "SELECT VALUE [i, addr, v] FROM (SELECT VALUE v + 1000 FROM someList AS v) AS v AT i BY addr",
         // However, since we + 1000 to v in the inner query, we create a new value that does not have an address.
         session,
-        """[[null, null, 1001], [null, null, 1002], [null, null, 1003]]"""
+        "\$bag::[[\$missing::null,\$missing::null,1001],[\$missing::null,\$missing::null,1002],[\$missing::null,\$missing::null,1003]]"
     )
 }

--- a/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerLimitTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerLimitTests.kt
@@ -15,7 +15,7 @@ class EvaluatingCompilerLimitTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             "SELECT * FROM foo LIMIT 0",
             session,
-            "\$bag::[]"
+            "$BAG_ANNOTATION::[]"
         )
 
     @Test
@@ -23,7 +23,7 @@ class EvaluatingCompilerLimitTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             "SELECT * FROM foo LIMIT 1",
             session,
-            "\$bag::[{a:1}]"
+            "$BAG_ANNOTATION::[{a:1}]"
         )
 
     @Test
@@ -31,7 +31,7 @@ class EvaluatingCompilerLimitTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             "SELECT * FROM foo LIMIT 2",
             session,
-            "\$bag::[{a:1},{a:2}]"
+            "$BAG_ANNOTATION::[{a:1},{a:2}]"
         )
 
     @Test
@@ -39,7 +39,7 @@ class EvaluatingCompilerLimitTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             "SELECT * FROM foo LIMIT ${Integer.MAX_VALUE}",
             session,
-            "\$bag::[{a:1},{a:2},{a:3},{a:4},{a:5}]"
+            "$BAG_ANNOTATION::[{a:1},{a:2},{a:3},{a:4},{a:5}]"
         )
 
     @Test
@@ -47,7 +47,7 @@ class EvaluatingCompilerLimitTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             "SELECT * FROM foo LIMIT ${Long.MAX_VALUE}",
             session,
-            "\$bag::[{a:1},{a:2},{a:3},{a:4},{a:5}]"
+            "$BAG_ANNOTATION::[{a:1},{a:2},{a:3},{a:4},{a:5}]"
         )
 
     @Test
@@ -71,7 +71,7 @@ class EvaluatingCompilerLimitTests : EvaluatorTestBase() {
     fun `LIMIT applied after GROUP BY`() =
         runEvaluatorTestCase(
             "SELECT g FROM `[{foo: 1, bar: 10}, {foo: 1, bar: 11}]` AS f GROUP BY f.foo GROUP AS g LIMIT 1",
-            expectedResult = "\$bag::[{g:\$bag::[{f:{foo:1,bar:10}},{f:{foo:1,bar:11}}]}]",
+            expectedResult = "$BAG_ANNOTATION::[{g:$BAG_ANNOTATION::[{f:{foo:1,bar:10}},{f:{foo:1,bar:11}}]}]",
             target = EvaluatorTestTarget.COMPILER_PIPELINE // planner & physical plan have no support for GROUP BY (yet)
         )
 }

--- a/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerLimitTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerLimitTests.kt
@@ -15,7 +15,7 @@ class EvaluatingCompilerLimitTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             "SELECT * FROM foo LIMIT 0",
             session,
-            "[]"
+            "\$bag::[]"
         )
 
     @Test
@@ -23,7 +23,7 @@ class EvaluatingCompilerLimitTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             "SELECT * FROM foo LIMIT 1",
             session,
-            "[{a: 1}]"
+            "\$bag::[{a:1}]"
         )
 
     @Test
@@ -31,7 +31,7 @@ class EvaluatingCompilerLimitTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             "SELECT * FROM foo LIMIT 2",
             session,
-            "[{a: 1}, {a: 2}]"
+            "\$bag::[{a:1},{a:2}]"
         )
 
     @Test
@@ -39,7 +39,7 @@ class EvaluatingCompilerLimitTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             "SELECT * FROM foo LIMIT ${Integer.MAX_VALUE}",
             session,
-            "[ { a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 } ]"
+            "\$bag::[{a:1},{a:2},{a:3},{a:4},{a:5}]"
         )
 
     @Test
@@ -47,7 +47,7 @@ class EvaluatingCompilerLimitTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             "SELECT * FROM foo LIMIT ${Long.MAX_VALUE}",
             session,
-            "[ { a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 } ]"
+            "\$bag::[{a:1},{a:2},{a:3},{a:4},{a:5}]"
         )
 
     @Test
@@ -71,7 +71,7 @@ class EvaluatingCompilerLimitTests : EvaluatorTestBase() {
     fun `LIMIT applied after GROUP BY`() =
         runEvaluatorTestCase(
             "SELECT g FROM `[{foo: 1, bar: 10}, {foo: 1, bar: 11}]` AS f GROUP BY f.foo GROUP AS g LIMIT 1",
-            expectedResult = """[ { 'g': [ { 'f': { 'foo': 1, 'bar': 10 } }, { 'f': { 'foo': 1, 'bar': 11 } } ] } ]""",
+            expectedResult = "\$bag::[{g:\$bag::[{f:{foo:1,bar:10}},{f:{foo:1,bar:11}}]}]",
             target = EvaluatorTestTarget.COMPILER_PIPELINE // planner & physical plan have no support for GROUP BY (yet)
         )
 }

--- a/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerUnknownValuesTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerUnknownValuesTest.kt
@@ -626,7 +626,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun aggregateSumWithNull() = runEvaluatorTestCase(
         "SELECT sum(x.n) from nullSample as x",
         nullSample,
-        "[{_1: 4}]",
+        "$BAG_ANNOTATION::[{_1: 4}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -634,7 +634,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun aggregateSumWithMissing() = runEvaluatorTestCase(
         "SELECT sum(x.n) from missingSample as x",
         missingSample,
-        "[{_1: 3}]",
+        "$BAG_ANNOTATION::[{_1: 3}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -642,7 +642,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun aggregateSumWithMissingAndNull() = runEvaluatorTestCase(
         "SELECT sum(x.n) from missingAndNullSample as x",
         missingAndNullSample,
-        "[{_1: 9}]",
+        "$BAG_ANNOTATION::[{_1: 9}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -650,7 +650,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun aggregateMinWithNull() = runEvaluatorTestCase(
         "SELECT min(x.n) from nullSample as x",
         nullSample,
-        "[{_1: 1}]",
+        "$BAG_ANNOTATION::[{_1: 1}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -658,7 +658,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun aggregateMinWithMissing() = runEvaluatorTestCase(
         "SELECT min(x.n) from missingSample as x",
         missingSample,
-        "[{_1: 1}]",
+        "$BAG_ANNOTATION::[{_1: 1}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -666,7 +666,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun aggregateMinWithMissingAndNull() = runEvaluatorTestCase(
         "SELECT min(x.n) from missingAndNullSample as x",
         missingAndNullSample,
-        "[{_1: 2}]",
+        "$BAG_ANNOTATION::[{_1: 2}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -674,7 +674,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun aggregateAvgWithNull() = runEvaluatorTestCase(
         "SELECT avg(x.n) from nullSample as x",
         nullSample,
-        "[{_1: 2.}]",
+        "$BAG_ANNOTATION::[{_1: 2.}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -682,7 +682,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun aggregateAvgWithMissing() = runEvaluatorTestCase(
         "SELECT avg(x.n) from missingSample as x",
         missingSample,
-        "[{_1: 1.5}]",
+        "$BAG_ANNOTATION::[{_1: 1.5}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -690,7 +690,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun aggregateAvgWithMissingAndNull() = runEvaluatorTestCase(
         "SELECT avg(x.n) from missingAndNullSample as x",
         missingAndNullSample,
-        "[{_1: 3.}]",
+        "$BAG_ANNOTATION::[{_1: 3.}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -698,7 +698,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun aggregateCountWithNull() = runEvaluatorTestCase(
         "SELECT count(x.n) from nullSample as x",
         nullSample,
-        "[{_1: 2}]",
+        "$BAG_ANNOTATION::[{_1: 2}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -706,7 +706,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun aggregateCountWithMissing() = runEvaluatorTestCase(
         "SELECT count(x.n) from missingSample as x",
         missingSample,
-        "[{_1: 2}]",
+        "$BAG_ANNOTATION::[{_1: 2}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -714,14 +714,14 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun aggregateCountWithMissingAndNull() = runEvaluatorTestCase(
         "SELECT count(x.n) from missingAndNullSample as x",
         missingAndNullSample,
-        "[{_1: 3}]",
+        "$BAG_ANNOTATION::[{_1: 3}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
     @Test
     fun countEmpty() = runEvaluatorTestCase(
         "SELECT count(*) from `[]`",
-        expectedResult = "[{_1: 0}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: 0}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -729,14 +729,14 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun countEmptyTuple() =
         runEvaluatorTestCase(
             "SELECT count(*) from `[{}]`",
-            expectedResult = "[{_1: 1}]",
+            expectedResult = "$BAG_ANNOTATION::[{_1: 1}]",
             target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
         )
 
     @Test
     fun sumEmpty() = runEvaluatorTestCase(
         "SELECT sum(x.i) from `[]` as x",
-        expectedResult = "[{_1: null}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: null}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -744,14 +744,14 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun sumEmptyTuple() =
         runEvaluatorTestCase(
             "SELECT sum(x.i) from `[{}]` as x",
-            expectedResult = "[{_1: null}]",
+            expectedResult = "$BAG_ANNOTATION::[{_1: null}]",
             target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
         )
 
     @Test
     fun avgEmpty() = runEvaluatorTestCase(
         "SELECT avg(x.i) from `[]` as x",
-        expectedResult = "[{_1: null}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: null}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -759,41 +759,41 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun avgEmptyTuple() =
         runEvaluatorTestCase(
             "SELECT avg(x.i) from `[{}]` as x",
-            expectedResult = "[{_1: null}]",
+            expectedResult = "$BAG_ANNOTATION::[{_1: null}]",
             target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
         )
 
     @Test
     fun avgSomeEmptyTuples() = runEvaluatorTestCase(
         "SELECT avg(x.i) from `[{i: 1}, {}, {i:3}]` as x",
-        expectedResult = "[{_1: 2.}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: 2.}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
     @Test
     fun avgSomeEmptyAndNullTuples() = runEvaluatorTestCase(
         "SELECT avg(x.i) from `[{i: 1}, {}, {i:null}, {i:3}]` as x",
-        expectedResult = "[{_1: 2.}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: 2.}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
     @Test
     fun minSomeEmptyTuples() = runEvaluatorTestCase(
         "SELECT min(x.i) from `[{i: null}, {}, {i:3}]` as x",
-        expectedResult = "[{_1: 3}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: 3}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
     @Test
     fun maxSomeEmptyTuples() = runEvaluatorTestCase(
         "SELECT max(x.i) from `[{i: null}, {}, {i:3}, {i:10}]` as x",
-        expectedResult = "[{_1: 10}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: 10}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
     @Test
     fun minEmpty() = runEvaluatorTestCase(
         "SELECT min(x.i) from `[]` as x",
-        expectedResult = "[{_1: null}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: null}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -801,14 +801,14 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun minEmptyTuple() =
         runEvaluatorTestCase(
             "SELECT min(x.i) from `[{}]` as x",
-            expectedResult = "[{_1: null}]",
+            expectedResult = "$BAG_ANNOTATION::[{_1: null}]",
             target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
         )
 
     @Test
     fun maxEmpty() = runEvaluatorTestCase(
         "SELECT max(x.i) from `[]` as x",
-        expectedResult = "[{_1: null}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: null}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -816,42 +816,42 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun maxEmptyTuple() =
         runEvaluatorTestCase(
             "SELECT max(x.i) from `[{}]` as x",
-            expectedResult = "[{_1: null}]",
+            expectedResult = "$BAG_ANNOTATION::[{_1: null}]",
             target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
         )
 
     @Test
     fun maxSomeEmptyTuple() = runEvaluatorTestCase(
         "SELECT max(x.i) from `[{}, {i:1}, {}, {i:2}]` as x",
-        expectedResult = "[{_1: 2}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: 2}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
     @Test
     fun minSomeEmptyTuple() = runEvaluatorTestCase(
         "SELECT min(x.i) from `[{}, {i:1}, {}, {i:2}]` as x",
-        expectedResult = "[{_1: 1}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: 1}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
     @Test
     fun sumSomeEmptyTuple() = runEvaluatorTestCase(
         "SELECT sum(x.i) from `[{}, {i:1}, {}, {i:2}]` as x",
-        expectedResult = "[{_1: 3}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: 3}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
     @Test
     fun countSomeEmptyTuple() = runEvaluatorTestCase(
         "SELECT count(x.i) from `[{}, {i:1}, {}, {i:2}]` as x",
-        expectedResult = "[{_1: 2}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: 2}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
     @Test
     fun countStar() = runEvaluatorTestCase(
         "SELECT count(*) from `[{}, {i:1}, {}, {i:2}]` as x",
-        expectedResult = "[{_1: 4}]",
+        expectedResult = "$BAG_ANNOTATION::[{_1: 4}]",
         target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
     )
 
@@ -859,7 +859,7 @@ class EvaluatingCompilerUnknownValuesTest : EvaluatorTestBase() {
     fun countLiteral() =
         runEvaluatorTestCase(
             "SELECT count(1) from `[{}, {}, {}, {}]` as x",
-            expectedResult = "[{_1: 4}]",
+            expectedResult = "$BAG_ANNOTATION::[{_1: 4}]",
             target = EvaluatorTestTarget.COMPILER_PIPELINE, // planner & phys. alg. have no support for aggregates (yet)
         )
 }

--- a/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatorTestBase.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatorTestBase.kt
@@ -67,7 +67,7 @@ abstract class EvaluatorTestBase : TestBase() {
         session: EvaluationSession = EvaluationSession.standard(),
         expectedResult: String,
         expectedPermissiveModeResult: String = expectedResult,
-        expectedResultFormat: ExpectedResultFormat = ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS,
+        expectedResultFormat: ExpectedResultFormat = ExpectedResultFormat.ION,
         includePermissiveModeTest: Boolean = true,
         target: EvaluatorTestTarget = EvaluatorTestTarget.ALL_PIPELINES,
         compileOptionsBuilderBlock: CompileOptions.Builder.() -> Unit = { },

--- a/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatorTestSuite.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatorTestSuite.kt
@@ -188,7 +188,7 @@ internal val EVALUATOR_TEST_SUITE: IonResultTestSuite = defineTestSuite {
         test("pathNullDotName", "(NULL).a IS MISSING", "true")
         test("pathIndexing", "stores[0].books[2].title", "\"C\"")
         test("pathIndexListLiteral", "[1, 2, 3][1]", "2")
-        test("pathIndexBagLiteral", "<<1, 2, 3>>[1]", "\$missing::null")
+        test("pathIndexBagLiteral", "<<1, 2, 3>>[1]", "$MISSING_ANNOTATION::null")
         test("pathFieldStructLiteral", "{'a': 1, 'b': 2, 'b': 3}.a", "1")
         test("pathIndexStructLiteral", "{'a': 1, 'b': 2, 'b': 3}[1]", "2")
         test("pathIndexStructOutOfBoundsLowLiteral", "{'a': 1, 'b': 2, 'b': 3}[-1]", "$MISSING_ANNOTATION::null")

--- a/lang/src/test/kotlin/org/partiql/lang/eval/LikePredicateTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/LikePredicateTest.kt
@@ -43,55 +43,55 @@ class LikePredicateTest : EvaluatorTestBase() {
 
     @Test
     fun emptyTextUnderscorePattern() =
-        runEvaluatorTestCase("""SELECT * FROM `[true]` as a WHERE '' LIKE '_'  """, animals, "[]")
+        runEvaluatorTestCase("""SELECT * FROM `[true]` as a WHERE '' LIKE '_'  """, animals, "$BAG_ANNOTATION::[]")
 
     @Test
     fun emptyTextPercentPattern() = runEvaluatorTestCase(
         """SELECT * FROM `[true]` as a WHERE '' LIKE '%'  """, animals,
-        "[{_1: true}]"
+        "$BAG_ANNOTATION::[{_1: true}]"
     )
 
     @Test
     fun allLiteralsAndEscapeIsNull() = runEvaluatorTestCase(
         """SELECT * FROM animals as a WHERE 'A' LIKE 'B' ESCAPE null """,
         animals,
-        "[]"
+        "$BAG_ANNOTATION::[]"
     )
 
     @Test
     fun valueLiteralPatternNull() =
-        runEvaluatorTestCase("""SELECT * FROM animals as a WHERE 'A' LIKE null """, animals, "[]")
+        runEvaluatorTestCase("""SELECT * FROM animals as a WHERE 'A' LIKE null """, animals, "$BAG_ANNOTATION::[]")
 
     @Test
     fun valueNullPatternLiteral() =
-        runEvaluatorTestCase("""SELECT * FROM animals as a WHERE null LIKE 'A' """, animals, "[]")
+        runEvaluatorTestCase("""SELECT * FROM animals as a WHERE null LIKE 'A' """, animals, "$BAG_ANNOTATION::[]")
 
     @Test
     fun valueNullPatternLiteralEscapeNull() = runEvaluatorTestCase(
         """SELECT * FROM animals as a WHERE null LIKE 'A' ESCAPE null""",
         animals,
-        "[]"
+        "$BAG_ANNOTATION::[]"
     )
 
     @Test
     fun valueNullPatternNullEscapeLiteral() = runEvaluatorTestCase(
         """SELECT * FROM animals as a WHERE null LIKE null ESCAPE '['""",
         animals,
-        "[]"
+        "$BAG_ANNOTATION::[]"
     )
 
     @Test
     fun valueLiteralPatternNullEscapeNull() = runEvaluatorTestCase(
         """SELECT * FROM animals as a WHERE 'A' LIKE null ESCAPE null""",
         animals,
-        "[]"
+        "$BAG_ANNOTATION::[]"
     )
 
     @Test
     fun valueNullPatternNullEscapeNull() = runEvaluatorTestCase(
         """SELECT * FROM animals as a WHERE null LIKE null ESCAPE null""",
         animals,
-        "[]"
+        "$BAG_ANNOTATION::[]"
     )
 
     @Test
@@ -115,12 +115,12 @@ class LikePredicateTest : EvaluatorTestBase() {
 
         // Run the test with the given parameters
         fun runTest(whereClause: String, vararg types: Param) {
-            val input = """[{num: 1, str: "string", esc: "\\"}]"""
+            val input = """$BAG_ANNOTATION::[{num: 1, str: "string", esc: "\\"}]"""
             val session = mapOf("Object" to input).toSession()
             val query = "Select * From Object a Where " + whereClause
 
             when (types.map { it.type }.minByOrNull { it.precedence }) {
-                NULL -> runEvaluatorTestCase(query, session, "[]")
+                NULL -> runEvaluatorTestCase(query, session, "$BAG_ANNOTATION::[]")
                 STR -> runEvaluatorTestCase(query, session, input)
                 INT -> {
                     runEvaluatorErrorTestCase(
@@ -146,7 +146,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """ SELECT * FROM animals WHERE '' LIKE '' """,
         animals,
         """
-             [
+             $BAG_ANNOTATION::[
                 {name: "Kumo", type: "dog"},
                 {name:"Mochi",type:"dog"},
                 {name:"Lilikoi",type:"unicorn"}
@@ -159,7 +159,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """ SELECT * FROM animals WHERE 'Kumo' LIKE '' """,
         animals,
         """
-             []
+             $BAG_ANNOTATION::[]
             """
     )
 
@@ -168,7 +168,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE 'Kumo' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -181,7 +181,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE 'KuMo' """,
         animals,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 
@@ -190,7 +190,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'xxx' LIKE 'Kumo' """,
         animals,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 
@@ -199,7 +199,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE 'K_mo' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -212,7 +212,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kuumo' LIKE 'K_mo' """,
         animals,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 
@@ -221,7 +221,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'KKumo' LIKE 'K_mo' """,
         animals,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 
@@ -230,7 +230,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE 'K__o' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -243,7 +243,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE '_u_o' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -256,7 +256,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE 'Kum_' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -269,7 +269,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE 'Ku%o' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -282,7 +282,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'KKumo' LIKE 'Ku%o' """,
         animals,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 
@@ -291,7 +291,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumol' LIKE 'Ku%o' """,
         animals,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 
@@ -300,7 +300,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE 'K%%o' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -313,7 +313,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE 'K%m%' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -326,7 +326,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE '%umo' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -339,7 +339,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE 'Kum%' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -352,7 +352,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE 'K_%mo' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -365,7 +365,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE 'K_m%' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -378,7 +378,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE '____' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -391,7 +391,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE 'Kumo' LIKE '%' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -404,7 +404,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE '' LIKE '%' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -417,7 +417,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE '%' LIKE '[%' ESCAPE '[' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -430,7 +430,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE '100%' LIKE '1%[%' ESCAPE '[' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name:"Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -443,7 +443,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE '100%' LIKE '1%\%' ESCAPE '\' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -456,7 +456,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE '100%' LIKE '1__[%' ESCAPE '[' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -469,7 +469,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE '%100' LIKE '[%%' ESCAPE '[' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -482,7 +482,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE '%100' LIKE '[%_00' ESCAPE '[' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -495,7 +495,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE '%1XX' LIKE '[%_00' ESCAPE '[' """,
         animals,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 
@@ -504,7 +504,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE '1_000_000%' LIKE '1[_000[_000[%' ESCAPE '[' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -517,7 +517,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE '1_000_000%' LIKE '1[____[_%[%' ESCAPE '[' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -530,7 +530,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE '1_000_000%' LIKE '_[_%[_%[%' ESCAPE '[' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -543,7 +543,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE a.name LIKE 'Kumo' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"}
           ]
         """
@@ -554,7 +554,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE a.name || 'xx' LIKE '%xx' """,
         animals,
         """
-          [
+          $BAG_ANNOTATION::[
             {name: "Kumo", type: "dog"},
             {name:"Mochi",type:"dog"},
             {name:"Lilikoi",type:"unicorn"}
@@ -571,7 +571,7 @@ class LikePredicateTest : EvaluatorTestBase() {
                   ]` as a
                WHERE a.name LIKE a.pattern """,
         expectedResult = """
-                  [
+                  $BAG_ANNOTATION::[
                      { name:"Abcd" },
                      { name:"100"}
                   ]
@@ -587,7 +587,7 @@ class LikePredicateTest : EvaluatorTestBase() {
                   ]` as a
                WHERE a.name LIKE a.pattern ESCAPE '\' """,
         expectedResult = """
-                  [
+                  $BAG_ANNOTATION::[
                      { name:"Abcd" },
                      { name:"100%"}
                   ]
@@ -603,7 +603,7 @@ class LikePredicateTest : EvaluatorTestBase() {
                   ]` as a
                WHERE a.name LIKE a.pattern ESCAPE a.escapeChar """,
         expectedResult = """
-                  [
+                  $BAG_ANNOTATION::[
                      { name:"Abcd" },
                      { name:"100%"}
                   ]
@@ -619,7 +619,7 @@ class LikePredicateTest : EvaluatorTestBase() {
                   ]` as a
                WHERE a.name NOT LIKE a.pattern ESCAPE a.escapeChar """,
         expectedResult = """
-                  [
+                  $BAG_ANNOTATION::[
                      { name:"Abcd" },
                      { name:"1000%"}
                   ]
@@ -678,22 +678,22 @@ class LikePredicateTest : EvaluatorTestBase() {
 
     @Test
     fun valueIsNull() =
-        runEvaluatorTestCase("SELECT * FROM <<>> AS a WHERE null LIKE 'a' ESCAPE '['", expectedResult = "[]")
+        runEvaluatorTestCase("SELECT * FROM <<>> AS a WHERE null LIKE 'a' ESCAPE '['", expectedResult = "$BAG_ANNOTATION::[]")
 
     @Test
     fun patternIsNull() =
-        runEvaluatorTestCase("SELECT * FROM <<>> AS a WHERE 'a' LIKE null ESCAPE '['", expectedResult = "[]")
+        runEvaluatorTestCase("SELECT * FROM <<>> AS a WHERE 'a' LIKE null ESCAPE '['", expectedResult = "$BAG_ANNOTATION::[]")
 
     @Test
     fun escapeIsNull() =
-        runEvaluatorTestCase("SELECT * FROM <<>> AS a WHERE 'a' LIKE 'a' ESCAPE null", expectedResult = "[]")
+        runEvaluatorTestCase("SELECT * FROM <<>> AS a WHERE 'a' LIKE 'a' ESCAPE null", expectedResult = "$BAG_ANNOTATION::[]")
 
     @Test
     fun nonLiteralsMissingValue() = runEvaluatorTestCase(
         """SELECT * FROM animals as a WHERE a.xxx LIKE '%' """,
         animals,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 
@@ -702,7 +702,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE a.name LIKE a.xxx """,
         animals,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 
@@ -711,7 +711,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animals as a WHERE a.name LIKE '%' ESCAPE a.xxx""",
         animals,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 
@@ -720,7 +720,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animalsWithNulls as a WHERE a.name LIKE '%' """,
         animalsWithNulls,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 
@@ -729,7 +729,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animalsWithNulls as a WHERE a.type LIKE a.name """,
         animalsWithNulls,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 
@@ -738,7 +738,7 @@ class LikePredicateTest : EvaluatorTestBase() {
         """SELECT * FROM animalsWithNulls as a WHERE a.type LIKE '%' ESCAPE a.name""",
         animalsWithNulls,
         """
-          []
+          $BAG_ANNOTATION::[]
         """
     )
 

--- a/lang/src/test/kotlin/org/partiql/lang/eval/QuotedIdentifierTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/QuotedIdentifierTests.kt
@@ -123,9 +123,9 @@ class QuotedIdentifierTests : EvaluatorTestBase() {
 
     @Test
     fun selectFromTablesQuotedIdsAreCaseSensitive() {
-        runEvaluatorTestCase("SELECT * FROM \"Abc\"", sessionWithCaseVaryingTables, "[{n:1}]")
-        runEvaluatorTestCase("SELECT * FROM \"aBc\"", sessionWithCaseVaryingTables, "[{n:2}]")
-        runEvaluatorTestCase("SELECT * FROM \"abC\"", sessionWithCaseVaryingTables, "[{n:3}]")
+        runEvaluatorTestCase("SELECT * FROM \"Abc\"", sessionWithCaseVaryingTables, "$BAG_ANNOTATION::[{n:1}]")
+        runEvaluatorTestCase("SELECT * FROM \"aBc\"", sessionWithCaseVaryingTables, "$BAG_ANNOTATION::[{n:2}]")
+        runEvaluatorTestCase("SELECT * FROM \"abC\"", sessionWithCaseVaryingTables, "$BAG_ANNOTATION::[{n:3}]")
     }
 
     @Test
@@ -133,7 +133,7 @@ class QuotedIdentifierTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             "SELECT \"Abc\".n AS a, \"aBc\".n AS b, \"abC\".n AS c FROM a as Abc, b as aBc, c as abC",
             simpleSessionWithTables,
-            "[{a:1, b:2, c:3}]"
+            "$BAG_ANNOTATION::[{a:1, b:2, c:3}]"
         )
 
     @Test
@@ -141,10 +141,10 @@ class QuotedIdentifierTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             "SELECT \"Abc\".n AS a, \"aBc\".n AS b, \"abC\".n AS c FROM a as \"Abc\", b as \"aBc\", c as \"abC\"",
             simpleSessionWithTables,
-            "[{a:1, b:2, c:3}]"
+            "$BAG_ANNOTATION::[{a:1, b:2, c:3}]"
         )
 
-    val tableWithCaseVaryingFields = "[{ Abc: 1, aBc: 2, abC: 3}]"
+    val tableWithCaseVaryingFields = "$BAG_ANNOTATION::[{ Abc: 1, aBc: 2, abC: 3}]"
 
     @Test
     fun quotedStructFieldsAreCaseSensitive() =
@@ -270,41 +270,41 @@ class QuotedIdentifierTests : EvaluatorTestBase() {
     fun pathWildcard_quotedId() = runEvaluatorTestCase(
         """ "stores"[0]."books"[*]."title" """,
         stores.toSession(),
-        """["A", "B", "C", "D"]"""
+        """$BAG_ANNOTATION::["A", "B", "C", "D"]"""
     )
 
     @Test
     fun pathUnpivotWildcard_quotedId() = runEvaluatorTestCase(
         """ "friends"."kumo"."likes".*."type" """,
         friends.toSession(),
-        """["dog", "human"]"""
+        """$BAG_ANNOTATION::["dog", "human"]"""
     )
 
     @Test
     fun pathDoubleWildCard_quotedId() = runEvaluatorTestCase(
         """ "stores"[*]."books"[*]."title" """,
         stores.toSession(),
-        """["A", "B", "C", "D", "A", "E", "F"]"""
+        """$BAG_ANNOTATION::["A", "B", "C", "D", "A", "E", "F"]"""
     )
 
     @Test
     fun pathDoubleUnpivotWildCard_quotedId() = runEvaluatorTestCase(
         """ "friends".*."likes".*."type" """,
         friends.toSession(),
-        """["dog", "human", "dog", "cat"]"""
+        """$BAG_ANNOTATION::["dog", "human", "dog", "cat"]"""
     )
 
     @Test
     fun pathWildCardOverScalar_quotedId() = runEvaluatorTestCase(
         """ "s"[*] """,
         globalHello.toSession(),
-        """["hello"]"""
+        """$BAG_ANNOTATION::["hello"]"""
     )
 
     @Test
     fun pathUnpivotWildCardOverScalar_quotedId() = runEvaluatorTestCase(
         """ "s".*  """,
         globalHello.toSession(),
-        """["hello"]"""
+        """$BAG_ANNOTATION::["hello"]"""
     )
 }

--- a/lang/src/test/kotlin/org/partiql/lang/eval/SimpleEvaluatingCompilerTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/SimpleEvaluatingCompilerTests.kt
@@ -28,46 +28,46 @@ class SimpleEvaluatingCompilerTests : EvaluatorTestBase() {
 
     @Test
     fun selectValue() {
-        runEvaluatorTestCase("SELECT VALUE someScalar FROM someScalar", session, "[1]")
+        runEvaluatorTestCase("SELECT VALUE someScalar FROM someScalar", session, "$BAG_ANNOTATION::[1]")
     }
 
     @Test
     fun selectValueWithAsAlias() {
-        runEvaluatorTestCase("SELECT VALUE s FROM someScalar as s", session, "[1]")
+        runEvaluatorTestCase("SELECT VALUE s FROM someScalar as s", session, "$BAG_ANNOTATION::[1]")
     }
 
     @Test
     fun selectStar() {
-        runEvaluatorTestCase("SELECT * FROM `[{a: 100, b: 101}]`", expectedResult = "[{a: 100, b: 101}]")
+        runEvaluatorTestCase("SELECT * FROM `[{a: 100, b: 101}]`", expectedResult = "$BAG_ANNOTATION::[{a: 100, b: 101}]")
     }
 
     @Test
     fun selectStarWhere() {
         runEvaluatorTestCase(
             "SELECT * FROM `[{a: 100, b: 1000}, {a: 101, b: 1001}]` WHERE a > 100",
-            expectedResult = "[{a: 101, b: 1001}]"
+            expectedResult = "$BAG_ANNOTATION::[{a: 101, b: 1001}]"
         )
     }
 
     @Test
     fun selectList() {
-        runEvaluatorTestCase("SELECT a, b FROM `[{a: 100, b: 101}]`", expectedResult = "[{a: 100, b: 101}]")
+        runEvaluatorTestCase("SELECT a, b FROM `[{a: 100, b: 101}]`", expectedResult = "$BAG_ANNOTATION::[{a: 100, b: 101}]")
     }
 
     @Test
     fun selectListWithBinaryExpr() {
-        runEvaluatorTestCase("SELECT a + b FROM `[{a: 100, b: 101}]`", expectedResult = "[{_1: 201}]")
+        runEvaluatorTestCase("SELECT a + b FROM `[{a: 100, b: 101}]`", expectedResult = "$BAG_ANNOTATION::[{_1: 201}]")
     }
 
     @Test
     fun selectListWithBinaryExprAndAlias() {
-        runEvaluatorTestCase("SELECT a + b AS c FROM `[{a: 100, b: 101}]`", expectedResult = "[{c: 201}]")
+        runEvaluatorTestCase("SELECT a + b AS c FROM `[{a: 100, b: 101}]`", expectedResult = "$BAG_ANNOTATION::[{c: 201}]")
     }
 
     @Test
     fun unpivot() = runEvaluatorTestCase(
         "SELECT name, val FROM UNPIVOT `{a:1, b:2, c:3, d:4, e:5, f:6}` AS val AT name",
-        expectedResult = """[
+        expectedResult = """$BAG_ANNOTATION::[
                     {name:"a",val:1},
                     {name:"b",val:2},
                     {name:"c",val:3},
@@ -82,7 +82,7 @@ class SimpleEvaluatingCompilerTests : EvaluatorTestBase() {
     @Test
     fun simpleJoin() = runEvaluatorTestCase(
         """SELECT * FROM `[{a: 1}, {a: 2}]` AS t1 INNER CROSS JOIN `[{b: 1, c: "one" }, {b: 2, c: "two" }]`""",
-        expectedResult = """[
+        expectedResult = """$BAG_ANNOTATION::[
                     {a:1,b:1,c:"one"},
                     {a:1,b:2,c:"two"},
                     {a:2,b:1,c:"one"},
@@ -100,7 +100,7 @@ class SimpleEvaluatingCompilerTests : EvaluatorTestBase() {
     fun joinWithoutScopeQualifier() = runEvaluatorTestCase(
         """SELECT g2 FROM table_1 AS g, g.a AS g2""",
         session = sessionWithG,
-        expectedResult = "[{g2:\"from global variable g\"}]"
+        expectedResult = "$BAG_ANNOTATION::[{g2:\"from global variable g\"}]"
     )
 
     /** Demonstrates that with the scope qualifier ('@'), the `g` in `@g.a' refers to local `g`. */
@@ -108,7 +108,7 @@ class SimpleEvaluatingCompilerTests : EvaluatorTestBase() {
     fun joinWithScopeQualifier() = runEvaluatorTestCase(
         """SELECT g2 FROM table_1 AS g, @g.a AS g2""",
         session = sessionWithG,
-        expectedResult = "[{g2:{b:1}},{g2:{b:2}}]"
+        expectedResult = "$BAG_ANNOTATION::[{g2:{b:1}},{g2:{b:2}}]"
     )
 
     @Test
@@ -118,7 +118,7 @@ class SimpleEvaluatingCompilerTests : EvaluatorTestBase() {
             FROM `[{a: 1}, {a: 2}]` AS t1
                 INNER JOIN `[{b: 1, c: "one" }, {b: 2, c:"two" }]` AS t2
                     ON t1.a = t2.b""",
-        expectedResult = """[
+        expectedResult = """$BAG_ANNOTATION::[
                     {a:1,b:1,c:"one"},
                     {a:2,b:2,c:"two"}
                 ]"""
@@ -127,7 +127,7 @@ class SimpleEvaluatingCompilerTests : EvaluatorTestBase() {
     @Test
     fun tableAliases() = runEvaluatorTestCase(
         "SELECT _2 FROM `[{_1: a, _2: 1}, {_1: a, _2: 'a'}, {_1: a, _2: 3}]` WHERE _2 = 21",
-        expectedResult = "[]"
+        expectedResult = "$BAG_ANNOTATION::[]"
     )
 
     @Test

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/CharLengthEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/CharLengthEvaluationTest.kt
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -16,7 +17,7 @@ class CharLengthEvaluationTest : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(PassCases::class)
     fun charLengthPassTests(testCase: ExprFunctionTestCase) =
-        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult)
+        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult, expectedPermissiveModeResult = testCase.expectedPermissiveModeResult)
 
     class PassCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
@@ -28,7 +29,7 @@ class CharLengthEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("char_length('ab')", "2"),
             ExprFunctionTestCase("char_length('abcdefghijklmnopqrstuvwxyz')", "26"),
             ExprFunctionTestCase("char_length(null)", "null"),
-            ExprFunctionTestCase("char_length(missing)", "null"),
+            ExprFunctionTestCase("char_length(missing)", "null", "$MISSING_ANNOTATION::null"),
             ExprFunctionTestCase("char_length('ȴȵ💩💋')", "4"),
             ExprFunctionTestCase("char_length('😁😞😸😸')", "4"),
             ExprFunctionTestCase("char_length('話家身圧費谷料村能計税金')", "12"),

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/CharacterLengthEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/CharacterLengthEvaluationTest.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -17,7 +18,7 @@ class CharacterLengthEvaluationTest : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(PassCases::class)
     fun characterLengthPassTests(testCase: ExprFunctionTestCase) =
-        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult)
+        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult, expectedPermissiveModeResult = testCase.expectedPermissiveModeResult)
 
     class PassCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
@@ -29,7 +30,7 @@ class CharacterLengthEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("character_length('ab')", "2"),
             ExprFunctionTestCase("character_length('abcdefghijklmnopqrstuvwxyz')", "26"),
             ExprFunctionTestCase("character_length(null)", "null"),
-            ExprFunctionTestCase("character_length(missing)", "null"),
+            ExprFunctionTestCase("character_length(missing)", "null", "$MISSING_ANNOTATION::null"),
             ExprFunctionTestCase("character_length('ȴȵ💩💋')", "4"),
             ExprFunctionTestCase("character_length('😁😞😸😸')", "4"),
             ExprFunctionTestCase("character_length('話家身圧費谷料村能計税金')", "12"),

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/ConcatEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/ConcatEvaluationTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.util.ArgumentsProviderBase
 import org.partiql.lang.util.propertyValueMapOf
@@ -15,7 +16,7 @@ class ConcatEvaluationTest : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(ConcatPassCases::class)
     fun runPassTests(testCase: ExprFunctionTestCase) =
-        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult)
+        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult, expectedPermissiveModeResult = testCase.expectedPermissiveModeResult)
 
     class ConcatPassCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
@@ -31,7 +32,7 @@ class ConcatEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("'a' || `b`", "\"ab\""), // 2nd arg: Ion symbol ``
             ExprFunctionTestCase("'a' || `'b'`", "\"ab\""), // 2nd arg: Ion symbol `''`
             ExprFunctionTestCase("'a' || null", "null"), // 2nd arg: null
-            ExprFunctionTestCase("'a' || missing", "null"), // 2nd arg: missing
+            ExprFunctionTestCase("'a' || missing", "null", "$MISSING_ANNOTATION::null"), // 2nd arg: missing
 
             // 1st arg: Ion String
             ExprFunctionTestCase("`\"a\"` || 'b'", "\"ab\""), // 2nd arg: String
@@ -39,7 +40,7 @@ class ConcatEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("`\"a\"` || `b`", "\"ab\""), // 2nd arg: Ion symbol ``
             ExprFunctionTestCase("`\"a\"` || `'b'`", "\"ab\""), // 2nd arg: Ion symbol `''`
             ExprFunctionTestCase("`\"a\"` || null", "null"), // 2nd arg: null
-            ExprFunctionTestCase("`\"a\"` || missing", "null"), // 2nd arg: missing
+            ExprFunctionTestCase("`\"a\"` || missing", "null", "$MISSING_ANNOTATION::null"), // 2nd arg: missing
 
             // 1st arg: Ion symbol (``)
             ExprFunctionTestCase("`a` || 'b'", "\"ab\""), // 2nd arg: String
@@ -47,7 +48,7 @@ class ConcatEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("`a` || `b`", "\"ab\""), // 2nd arg: Ion symbol ``
             ExprFunctionTestCase("`a` || `'b'`", "\"ab\""), // 2nd arg: Ion symbol `''`
             ExprFunctionTestCase("`a` || null", "null"), // 2nd arg: null
-            ExprFunctionTestCase("`a` || missing", "null"), // 2nd arg: missing
+            ExprFunctionTestCase("`a` || missing", "null", "$MISSING_ANNOTATION::null"), // 2nd arg: missing
 
             // 1st arg: Ion symbol (``)
             ExprFunctionTestCase("`'a'` || 'b'", "\"ab\""), // 2nd arg: String
@@ -55,7 +56,7 @@ class ConcatEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("`'a'` || `b`", "\"ab\""), // 2nd arg: Ion symbol ``
             ExprFunctionTestCase("`'a'` || `'b'`", "\"ab\""), // 2nd arg: Ion symbol `''`
             ExprFunctionTestCase("`'a'` || null", "null"), // 2nd arg: null
-            ExprFunctionTestCase("`'a'` || missing", "null"), // 2nd arg: missing
+            ExprFunctionTestCase("`'a'` || missing", "null", "$MISSING_ANNOTATION::null"), // 2nd arg: missing
 
             // 1st arg: null
             ExprFunctionTestCase("null || 'b'", "null"), // 2nd arg: String
@@ -63,15 +64,15 @@ class ConcatEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("null || `b`", "null"), // 2nd arg: Ion symbol ``
             ExprFunctionTestCase("null || `'b'`", "null"), // 2nd arg: Ion symbol `''`
             ExprFunctionTestCase("null || null", "null"), // 2nd arg: null
-            ExprFunctionTestCase("null || missing", "null"), // 2nd arg: missing
+            ExprFunctionTestCase("null || missing", "null", "$MISSING_ANNOTATION::null"), // 2nd arg: missing
 
             // 1st arg: missing
-            ExprFunctionTestCase("missing || 'b'", "null"), // 2nd arg: String
-            ExprFunctionTestCase("missing || `\"b\"`", "null"), // 2nd arg: Ion String
-            ExprFunctionTestCase("missing || `b`", "null"), // 2nd arg: Ion symbol ``
-            ExprFunctionTestCase("missing || `'b'`", "null"), // 2nd arg: Ion symbol `''`
-            ExprFunctionTestCase("missing || null", "null"), // 2nd arg: null
-            ExprFunctionTestCase("missing || missing", "null"), // 2nd arg: missing
+            ExprFunctionTestCase("missing || 'b'", "null", "$MISSING_ANNOTATION::null"), // 2nd arg: String
+            ExprFunctionTestCase("missing || `\"b\"`", "null", "$MISSING_ANNOTATION::null"), // 2nd arg: Ion String
+            ExprFunctionTestCase("missing || `b`", "null", "$MISSING_ANNOTATION::null"), // 2nd arg: Ion symbol ``
+            ExprFunctionTestCase("missing || `'b'`", "null", "$MISSING_ANNOTATION::null"), // 2nd arg: Ion symbol `''`
+            ExprFunctionTestCase("missing || null", "null", "$MISSING_ANNOTATION::null"), // 2nd arg: null
+            ExprFunctionTestCase("missing || missing", "null", "$MISSING_ANNOTATION::null"), // 2nd arg: missing
 
             // Test for more characters in strings
             ExprFunctionTestCase("'' || 'a'", "\"a\""),

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/DateAddEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/DateAddEvaluationTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -18,14 +19,14 @@ class DateAddEvaluationTest : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(DateAddPassCases::class)
     fun runPassTests(testCase: ExprFunctionTestCase) =
-        runEvaluatorTestCase(testCase.source, testCase.session, testCase.expectedLegacyModeResult)
+        runEvaluatorTestCase(testCase.source, testCase.session, testCase.expectedLegacyModeResult, expectedPermissiveModeResult = testCase.expectedPermissiveModeResult)
 
     class DateAddPassCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
             ExprFunctionTestCase("date_add(second, null, `2017-01-10T05:30:55Z`)", "null"),
             ExprFunctionTestCase("date_add(second, 1, null)", "null"),
-            ExprFunctionTestCase("date_add(second, missing, `2017-01-10T05:30:55Z`)", "null"),
-            ExprFunctionTestCase("date_add(second, 1, missing)", "null"),
+            ExprFunctionTestCase("date_add(second, missing, `2017-01-10T05:30:55Z`)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("date_add(second, 1, missing)", "null", "$MISSING_ANNOTATION::null"),
             ExprFunctionTestCase("date_add(year, `1`, `2017T`)", "2018T"),
             ExprFunctionTestCase(
                 "date_add(second, a, b)",

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/DateDiffEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/DateDiffEvaluationTest.kt
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -27,8 +28,8 @@ class DateDiffEvaluationTest : EvaluatorTestBase() {
         override fun getParameters(): List<Any> = listOf(
             ExprFunctionTestCase("date_diff(second, null, `2017-01-10T05:30:55Z`)", "null"),
             ExprFunctionTestCase("date_diff(second, `2016-01-10T05:30:55Z`, null)", "null"),
-            ExprFunctionTestCase("date_diff(second, missing, `2017-01-10T05:30:55Z`)", "null"),
-            ExprFunctionTestCase("date_diff(second, `2016-01-10T05:30:55Z`, missing)", "null"),
+            ExprFunctionTestCase("date_diff(second, missing, `2017-01-10T05:30:55Z`)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("date_diff(second, `2016-01-10T05:30:55Z`, missing)", "null", "$MISSING_ANNOTATION::null"),
             ExprFunctionTestCase(
                 "date_diff(year, a, b)",
                 "1",

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/ExtractEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/ExtractEvaluationTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -23,7 +24,8 @@ class ExtractEvaluationTest : EvaluatorTestBase() {
     fun runPassTests(testCase: ExprFunctionTestCase) = runEvaluatorTestCase(
         query = testCase.source,
         session = testCase.session,
-        expectedResult = testCase.expectedLegacyModeResult
+        expectedResult = testCase.expectedLegacyModeResult,
+        expectedPermissiveModeResult = testCase.expectedPermissiveModeResult
     )
 
     class ExtractPassCases : ArgumentsProviderBase() {
@@ -36,14 +38,14 @@ class ExtractEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("extract(second FROM null)", "null"),
             ExprFunctionTestCase("extract(timezone_hour FROM null)", "null"),
             ExprFunctionTestCase("extract(timezone_minute FROM null)", "null"),
-            ExprFunctionTestCase("extract(year FROM missing)", "null"),
-            ExprFunctionTestCase("extract(month FROM missing)", "null"),
-            ExprFunctionTestCase("extract(day FROM missing)", "null"),
-            ExprFunctionTestCase("extract(hour FROM missing)", "null"),
-            ExprFunctionTestCase("extract(minute FROM missing)", "null"),
-            ExprFunctionTestCase("extract(second FROM missing)", "null"),
-            ExprFunctionTestCase("extract(timezone_hour FROM missing)", "null"),
-            ExprFunctionTestCase("extract(timezone_minute FROM missing)", "null"),
+            ExprFunctionTestCase("extract(year FROM missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("extract(month FROM missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("extract(day FROM missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("extract(hour FROM missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("extract(minute FROM missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("extract(second FROM missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("extract(timezone_hour FROM missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("extract(timezone_minute FROM missing)", "null", "$MISSING_ANNOTATION::null"),
             ExprFunctionTestCase("extract(second FROM a)", "55.", session = mapOf("a" to "2017-01-10T05:30:55Z").toSession()),
             // just year
             ExprFunctionTestCase("extract(year FROM `2017T`)", "2017."),

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/FilterDistinctEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/FilterDistinctEvaluationTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
+import org.partiql.lang.eval.BAG_ANNOTATION
 import org.partiql.lang.eval.EvaluatorTestBase
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArity
@@ -25,15 +26,15 @@ class FilterDistinctEvaluationTest : EvaluatorTestBase() {
         override fun getParameters(): List<Any> = listOf(
 
             // These three tests ensure we can accept lists, bags, s-expressions and structs
-            ExprFunctionTestCase("filter_distinct([0, 0, 1])", "[0, 1]"), // list
-            ExprFunctionTestCase("filter_distinct(<<0, 0, 1>>)", "[0, 1]"), // bag
-            ExprFunctionTestCase("filter_distinct(SEXP(0, 0, 1))", "[0, 1]"), // s-exp
-            ExprFunctionTestCase("filter_distinct({'a': 0, 'b': 0, 'c': 1})", "[0, 1]"), // struct
+            ExprFunctionTestCase("filter_distinct([0, 0, 1])", "$BAG_ANNOTATION::[0, 1]"), // list
+            ExprFunctionTestCase("filter_distinct(<<0, 0, 1>>)", "$BAG_ANNOTATION::[0, 1]"), // bag
+            ExprFunctionTestCase("filter_distinct(SEXP(0, 0, 1))", "$BAG_ANNOTATION::[0, 1]"), // s-exp
+            ExprFunctionTestCase("filter_distinct({'a': 0, 'b': 0, 'c': 1})", "$BAG_ANNOTATION::[0, 1]"), // struct
 
             // Some "smoke tests" to ensure the basic plumbing is working right.
-            ExprFunctionTestCase("filter_distinct(['foo', 'foo', 1, 1, `symbol`, `symbol`])", "[\"foo\", 1, symbol]"),
-            ExprFunctionTestCase("filter_distinct([{ 'a': 1 }, { 'a': 1 }, { 'a': 1 }])", "[{ 'a': 1 }]"),
-            ExprFunctionTestCase("filter_distinct([[1, 1], [1, 1], [2, 2]])", "[[1,1], [2, 2]]"),
+            ExprFunctionTestCase("filter_distinct(['foo', 'foo', 1, 1, `symbol`, `symbol`])", "$BAG_ANNOTATION::[\"foo\", 1, symbol]"),
+            ExprFunctionTestCase("filter_distinct([{ 'a': 1 }, { 'a': 1 }, { 'a': 1 }])", "$BAG_ANNOTATION::[{ 'a': 1 }]"),
+            ExprFunctionTestCase("filter_distinct([[1, 1], [1, 1], [2, 2]])", "$BAG_ANNOTATION::[[1,1], [2, 2]]"),
         )
     }
 

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/FromUnixTimeFunctionTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/FromUnixTimeFunctionTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -18,7 +19,8 @@ class FromUnixTimeFunctionTest : EvaluatorTestBase() {
     @ArgumentsSource(FromUnixTimePassCases::class)
     fun runPassTests(tc: ExprFunctionTestCase) = runEvaluatorTestCase(
         tc.source,
-        expectedResult = tc.expectedLegacyModeResult
+        expectedResult = tc.expectedLegacyModeResult,
+        expectedPermissiveModeResult = tc.expectedPermissiveModeResult
     )
 
     class FromUnixTimePassCases : ArgumentsProviderBase() {
@@ -43,7 +45,7 @@ class FromUnixTimeFunctionTest : EvaluatorTestBase() {
             ExprFunctionTestCase("from_unixtime(`1577836800`)", "2020-01-01T00:00:00-00:00"),
             // Null or missing
             ExprFunctionTestCase("from_unixtime(null)", "null"),
-            ExprFunctionTestCase("from_unixtime(missing)", "null"),
+            ExprFunctionTestCase("from_unixtime(missing)", "null", "$MISSING_ANNOTATION::null"),
         )
     }
 

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/LowerEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/LowerEvaluationTest.kt
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -16,7 +17,8 @@ class LowerEvaluationTest : EvaluatorTestBase() {
     @ArgumentsSource(LowerPassCases::class)
     fun runPassTests(tc: ExprFunctionTestCase) = runEvaluatorTestCase(
         tc.source,
-        expectedResult = tc.expectedLegacyModeResult
+        expectedResult = tc.expectedLegacyModeResult,
+        expectedPermissiveModeResult = tc.expectedPermissiveModeResult
     )
 
     class LowerPassCases : ArgumentsProviderBase() {
@@ -29,7 +31,7 @@ class LowerEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("lower('ABCDEF')", "\"abcdef\""),
             ExprFunctionTestCase("lower('abcdef')", "\"abcdef\""),
             ExprFunctionTestCase("lower(null)", "null"),
-            ExprFunctionTestCase("lower(missing)", "null"),
+            ExprFunctionTestCase("lower(missing)", "null", "$MISSING_ANNOTATION::null"),
             ExprFunctionTestCase("lower('123\$%(*&')", "\"123\$%(*&\""),
             ExprFunctionTestCase("lower('ȴȵ💩Z💋')", "\"ȴȵ💩z💋\""),
             ExprFunctionTestCase("lower('話家身圧費谷料村能計税金')", "\"話家身圧費谷料村能計税金\"")

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/SizeEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/SizeEvaluationTest.kt
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -16,7 +17,7 @@ class SizeEvaluationTest : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(SizePassCases::class)
     fun runPassTests(testCase: ExprFunctionTestCase) =
-        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult)
+        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult, expectedPermissiveModeResult = testCase.expectedPermissiveModeResult)
 
     class SizePassCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
@@ -35,7 +36,7 @@ class SizeEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("size({})", "0"),
             ExprFunctionTestCase("size(`{}`)", "0"),
             ExprFunctionTestCase("size(null)", "null"),
-            ExprFunctionTestCase("size(missing)", "null")
+            ExprFunctionTestCase("size(missing)", "null", "$MISSING_ANNOTATION::null")
         )
     }
 

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/SubstringEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/SubstringEvaluationTest.kt
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -15,7 +16,7 @@ class SubstringEvaluationTest : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(SubstringPassCases::class)
     fun runPassTests(testCase: ExprFunctionTestCase) =
-        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult)
+        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult, expectedPermissiveModeResult = testCase.expectedPermissiveModeResult)
 
     class SubstringPassCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
@@ -45,10 +46,10 @@ class SubstringEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("substring(null FROM 1 FOR 1)", "null"),
             ExprFunctionTestCase("substring('abc' FROM null FOR 1)", "null"),
             ExprFunctionTestCase("substring('abc' FROM 1 FOR null)", "null"),
-            ExprFunctionTestCase("substring(missing FROM 1)", "null"),
-            ExprFunctionTestCase("substring('abc' FROM missing)", "null"),
-            ExprFunctionTestCase("substring(missing FROM 1 FOR 1)", "null"),
-            ExprFunctionTestCase("substring('abc' FROM missing FOR 1)", "null"),
+            ExprFunctionTestCase("substring(missing FROM 1)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("substring('abc' FROM missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("substring(missing FROM 1 FOR 1)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("substring('abc' FROM missing FOR 1)", "null", "$MISSING_ANNOTATION::null"),
             ExprFunctionTestCase("substring('' FROM -1)", "\"\""),
             ExprFunctionTestCase("substring('' FROM 0)", "\"\""),
             ExprFunctionTestCase("substring('' FROM 99)", "\"\""),
@@ -79,11 +80,11 @@ class SubstringEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("substring(null, 1, 1)", "null"),
             ExprFunctionTestCase("substring('abc', null, 1)", "null"),
             ExprFunctionTestCase("substring('abc', 1, null)", "null"),
-            ExprFunctionTestCase("substring(missing, 1)", "null"),
-            ExprFunctionTestCase("substring('abc', missing)", "null"),
-            ExprFunctionTestCase("substring(missing, 1, 1)", "null"),
-            ExprFunctionTestCase("substring('abc', missing, 1)", "null"),
-            ExprFunctionTestCase("substring('abc', 1, missing)", "null"),
+            ExprFunctionTestCase("substring(missing, 1)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("substring('abc', missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("substring(missing, 1, 1)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("substring('abc', missing, 1)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("substring('abc', 1, missing)", "null", "$MISSING_ANNOTATION::null"),
             ExprFunctionTestCase("substring('', -1)", "\"\""),
             ExprFunctionTestCase("substring('', 0)", "\"\""),
             ExprFunctionTestCase("substring('', 99)", "\"\""),

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/ToStringEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/ToStringEvaluationTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -20,7 +21,7 @@ class ToStringEvaluationTest : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(ToStringPassCases::class)
     fun runPassTests(testCase: ExprFunctionTestCase) =
-        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult)
+        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult, expectedPermissiveModeResult = testCase.expectedPermissiveModeResult)
 
     class ToStringPassCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
@@ -35,8 +36,8 @@ class ToStringEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("to_string(`0001-03-09`, 'y')", "\"1\""),
             ExprFunctionTestCase("to_string(`9999-03-09`, null)", "null"),
             ExprFunctionTestCase("to_string(null, 'M/d/y')", "null"),
-            ExprFunctionTestCase("to_string(`9999-03-09`, missing)", "null"),
-            ExprFunctionTestCase("to_string(missing, 'M/d/y')", "null"),
+            ExprFunctionTestCase("to_string(`9999-03-09`, missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("to_string(missing, 'M/d/y')", "null", "$MISSING_ANNOTATION::null"),
             ExprFunctionTestCase("to_string(`1969-07-20T20:18Z`, 'MMMM d, y')", "\"July 20, 1969\""),
             ExprFunctionTestCase("to_string(`1969-07-20T20:18Z`, 'MMM d, yyyy')", "\"Jul 20, 1969\""),
             ExprFunctionTestCase("to_string(`1969-07-20T20:18Z`, 'M-d-yy')", "\"7-20-69\""),

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/ToTimestampEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/ToTimestampEvaluationTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -20,7 +21,7 @@ class ToTimestampEvaluationTest : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(ToTimestampPassCases::class)
     fun runPassTests(testCase: ExprFunctionTestCase) =
-        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult)
+        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult, expectedPermissiveModeResult = testCase.expectedPermissiveModeResult)
 
     class ToTimestampPassCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
@@ -45,9 +46,9 @@ class ToTimestampEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("to_timestamp(null, 'M-d-yyyy')", "null"),
             ExprFunctionTestCase("to_timestamp('07-20-1969', null)", "null"),
             ExprFunctionTestCase("to_timestamp(null, null)", "null"),
-            ExprFunctionTestCase("to_timestamp(missing)", "null"),
-            ExprFunctionTestCase("to_timestamp(missing, 'M-d-yyyy')", "null"),
-            ExprFunctionTestCase("to_timestamp('07-20-1969', missing)", "null"),
+            ExprFunctionTestCase("to_timestamp(missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("to_timestamp(missing, 'M-d-yyyy')", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("to_timestamp('07-20-1969', missing)", "null", "$MISSING_ANNOTATION::null"),
             ExprFunctionTestCase("to_timestamp(null, null)", "null")
         )
     }

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/TrimEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/TrimEvaluationTest.kt
@@ -5,7 +5,9 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
+import org.partiql.lang.eval.BAG_ANNOTATION
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -19,7 +21,7 @@ class TrimEvaluationTest : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(CharLengthPassCases::class)
     fun runPassTests(testCase: ExprFunctionTestCase) =
-        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult)
+        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult, expectedPermissiveModeResult = testCase.expectedPermissiveModeResult)
 
     class CharLengthPassCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
@@ -57,7 +59,7 @@ class TrimEvaluationTest : EvaluatorTestBase() {
                     SELECT trim(both el from '   1ab1  ') AS trimmed 
                     FROM <<' 1'>> AS el 
                 """.trimIndent(),
-                "[{trimmed:\"ab\"}]"
+                "$BAG_ANNOTATION::[{trimmed:\"ab\"}]"
             ),
             ExprFunctionTestCase("trim('12' from '1212b1212')", "\"b\""),
             ExprFunctionTestCase("trim('12' from '1212b')", "\"b\""),
@@ -67,11 +69,11 @@ class TrimEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("trim(null from '')", "null"),
             ExprFunctionTestCase("trim('' from null)", "null"),
             ExprFunctionTestCase("trim(null)", "null"),
-            ExprFunctionTestCase("trim(both missing from '')", "null"),
-            ExprFunctionTestCase("trim(both '' from missing)", "null"),
-            ExprFunctionTestCase("trim(missing from '')", "null"),
-            ExprFunctionTestCase("trim('' from missing)", "null"),
-            ExprFunctionTestCase("trim(missing)", "null"),
+            ExprFunctionTestCase("trim(both missing from '')", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("trim(both '' from missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("trim(missing from '')", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("trim('' from missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("trim(missing)", "null", "$MISSING_ANNOTATION::null"),
             // test for upper case trim spec
             ExprFunctionTestCase("trim(BOTH from '   string   ')", "\"string\""),
             ExprFunctionTestCase("trim(LEADING from '   string   ')", "\"string   \""),

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/UpperEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/UpperEvaluationTest.kt
@@ -4,6 +4,7 @@ import org.junit.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
@@ -16,7 +17,7 @@ class UpperEvaluationTest : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(UpperPassCases::class)
     fun runPassTests(testCase: ExprFunctionTestCase) =
-        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult)
+        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult, expectedPermissiveModeResult = testCase.expectedPermissiveModeResult)
 
     class UpperPassCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
@@ -28,7 +29,7 @@ class UpperEvaluationTest : EvaluatorTestBase() {
             ExprFunctionTestCase("upper('abcdef')", "\"ABCDEF\""),
             ExprFunctionTestCase("upper('ABCDEF')", "\"ABCDEF\""),
             ExprFunctionTestCase("upper(null)", "null"),
-            ExprFunctionTestCase("upper(missing)", "null"),
+            ExprFunctionTestCase("upper(missing)", "null", "$MISSING_ANNOTATION::null"),
             ExprFunctionTestCase("upper('123\$%(*&')", "\"123\$%(*&\""),
             ExprFunctionTestCase("upper('ȴȵ💩z💋')", "\"ȴȵ💩Z💋\""),
             ExprFunctionTestCase("upper('話家身圧費谷料村能計税金')", "\"話家身圧費谷料村能計税金\"")

--- a/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/ExpectedResultFormat.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/ExpectedResultFormat.kt
@@ -16,15 +16,6 @@ enum class ExpectedResultFormat {
     ION,
 
     /**
-     * The expected value is expressed in Ion but does not contain the `$bag` or `$missing` annotations.
-     * Otherwise, standard Ion equivalence is used to assert the expected result matches.
-     *
-     * This is for older test cases that existed prior to these attributes and which not been updated yet.  Yes, this is
-     * technical debt, but at this time it is easier to support them than it is to migrate each test individually.
-     */
-    ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS,
-
-    /**
      * The expected value is expressed using PartiQL syntax, which is evaluated under the same pipeline and compile
      * options and session as the query under test. PartiQL equivalence is used to compare the result.
      *

--- a/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PipelineEvaluatorTestAdapter.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PipelineEvaluatorTestAdapter.kt
@@ -8,7 +8,6 @@ import org.partiql.lang.errors.ErrorBehaviorInPermissiveMode
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.TypingMode
-import org.partiql.lang.eval.cloneAndRemoveBagAndMissingAnnotations
 import org.partiql.lang.eval.exprEquals
 import org.partiql.lang.eval.toIonValue
 
@@ -66,7 +65,7 @@ internal class PipelineEvaluatorTestAdapter(
             }
 
         when (tc.expectedResultFormat) {
-            ExpectedResultFormat.ION, ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS -> {
+            ExpectedResultFormat.ION -> {
                 val expectedIonResult = assertDoesNotThrow(
                     EvaluatorTestFailureReason.FAILED_TO_PARSE_ION_EXPECTED_RESULT,
                     { tc.testDetails(note = note) }
@@ -74,12 +73,7 @@ internal class PipelineEvaluatorTestAdapter(
                     ION.singleValue(expectedResult)
                 }
 
-                val actualIonResult = actualExprValueResult.toIonValue(ION).let {
-                    if (tc.expectedResultFormat == ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS)
-                        it.cloneAndRemoveBagAndMissingAnnotations()
-                    else
-                        it
-                }
+                val actualIonResult = actualExprValueResult.toIonValue(ION)
                 assertEquals(
                     expectedIonResult,
                     actualIonResult,

--- a/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PipelineEvaluatorTestAdapterTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PipelineEvaluatorTestAdapterTests.kt
@@ -127,111 +127,6 @@ class PipelineEvaluatorTestAdapterTests {
     }
 
     @Test
-    fun `runEvaluatorTestCase - expected result matches - ExpectedResultFormat-ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS mode (int)`() {
-        assertDoesNotThrow("happy path - should not throw") {
-            astPipelineTestAdapter.runEvaluatorTestCase(
-                EvaluatorTestCase(
-                    query = "1",
-                    expectedResult = "1",
-                    expectedResultFormat = ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS
-                ),
-                EvaluationSession.standard()
-            )
-        }
-    }
-
-    @Test
-    fun `runEvaluatorTestCase - different permissive mode result - ExpectedResultFormat-ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS`() {
-        assertDoesNotThrow("happy path - should not throw") {
-            astPipelineTestAdapter.runEvaluatorTestCase(
-                EvaluatorTestCase(
-                    query = "1 + MISSING",
-                    expectedResult = "null",
-                    // note: In this ExpectedResultFormat we lose the fact that this is MISSING and not an
-                    // ordinary Ion null. This is unfortunate, but expected.
-                    expectedPermissiveModeResult = "null",
-                    expectedResultFormat = ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS
-                ),
-                EvaluationSession.standard()
-            )
-        }
-    }
-
-    @Test
-    fun `runEvaluatorTestCase - expected result matches - ExpectedResultFormat-ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS mode (bag)`() {
-        assertDoesNotThrow("happy path - should not throw") {
-            astPipelineTestAdapter.runEvaluatorTestCase(
-                EvaluatorTestCase(
-                    query = "<<1>>",
-                    // note: In this ExpectedResultFormat we lose the fact that this a BAG and not an
-                    // ordinary Ion list. This is unfortunate, but expected.
-                    expectedResult = "[1]",
-                    expectedResultFormat = ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS
-                ),
-                EvaluationSession.standard()
-            )
-        }
-    }
-
-    @Test
-    fun `runEvaluatorTestCase - expected result matches - ExpectedResultFormat-ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS mode (missing)`() {
-        assertDoesNotThrow("happy path - should not throw") {
-            astPipelineTestAdapter.runEvaluatorTestCase(
-                EvaluatorTestCase(
-                    query = "MISSING",
-                    // note: In this ExpectedResultFormat we lose the fact that this MISSING and not an
-                    // ordinary Ion null. This is unfortunate, but expected.
-                    expectedResult = "null",
-                    expectedResultFormat = ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS
-                ),
-                EvaluationSession.standard()
-            )
-        }
-    }
-
-    @Test
-    fun `runEvaluatorTestCase - expected result matches - ExpectedResultFormat-ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS mode (date)`() {
-        assertDoesNotThrow("happy path - should not throw") {
-            astPipelineTestAdapter.runEvaluatorTestCase(
-                EvaluatorTestCase(
-                    query = "DATE '2001-01-01'",
-                    expectedResult = "$DATE_ANNOTATION::2001-01-01",
-                    expectedResultFormat = ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS
-                ),
-                EvaluationSession.standard()
-            )
-        }
-    }
-
-    @Test
-    fun `runEvaluatorTestCase - expected result matches - ExpectedResultFormat-ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS mode (time)`() {
-        assertDoesNotThrow("happy path - should not throw") {
-            astPipelineTestAdapter.runEvaluatorTestCase(
-                EvaluatorTestCase(
-                    query = "TIME '12:12:01'",
-                    expectedResult = "$TIME_ANNOTATION::{hour:12,minute:12,second:1.,timezone_hour:null.int,timezone_minute:null.int}",
-                    expectedResultFormat = ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS
-                ),
-                EvaluationSession.standard()
-            )
-        }
-    }
-
-    @Test
-    fun `runEvaluatorTestCase - expected result matches - ExpectedResultFormat-ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS mode`() {
-        assertDoesNotThrow("happy path - should not throw") {
-            astPipelineTestAdapter.runEvaluatorTestCase(
-                EvaluatorTestCase(
-                    query = "<<1>>",
-                    expectedResult = "[1]",
-                    expectedResultFormat = ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS
-                ),
-                EvaluationSession.standard()
-            )
-        }
-    }
-
-    @Test
     fun `runEvaluatorTestCase - expected result matches - ExpectedResultFormat-STRING mode`() {
         assertDoesNotThrow("happy path - should not throw") {
             astPipelineTestAdapter.runEvaluatorTestCase(
@@ -253,18 +148,6 @@ class PipelineEvaluatorTestAdapterTests {
                 query = "1",
                 expectedResult = "2",
                 expectedResultFormat = ExpectedResultFormat.ION
-            )
-        )
-    }
-
-    @Test
-    fun `runEvaluatorTestCase - expected result does not match - ExpectedResultFormat-ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS mode`() {
-        assertTestFails(
-            EvaluatorTestFailureReason.UNEXPECTED_QUERY_RESULT,
-            EvaluatorTestCase(
-                query = "1",
-                expectedResult = "2",
-                expectedResultFormat = ExpectedResultFormat.ION_WITHOUT_BAG_AND_MISSING_ANNOTATIONS
             )
         )
     }


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #560 
- POC PR: https://github.com/partiql/partiql-lang-kotlin/pull/892 

## Description
- Removed `ION_WITHOUT_ANNOTATION` test format. Changed those test runners which used it to using `ION` test format. Later, we need to figure out what test cases need to get transformed from `ION` to `STRICT`. 
- The only adjustment to the affected test cases was adding `$BAG_ANNOTATION` and `$MISSING_ANNOTATION` to expected Ion results, since these annotations are no longer removed from the actual results by the test runners.
- Some test cases now have to specify `expectedPermissiveModeResult` argument of `runEvaluatorTestCase`, since the expected result in legacy mode (generally, `NULL`) differs from the expected result in permissive mode (generally, `MISSING`). This was a testing bug, previously masked away by the erasure of the annotations in the runners.

## Other Information
No backward incompatible changes. 
