### PR TITLE
Adds 0.9 migration guide

### DIFF
--- a/docs/upgrades/v0.8-to-v0.9-upgrade.md
+++ b/docs/upgrades/v0.8-to-v0.9-upgrade.md
@@ -1,0 +1,54 @@
+# v0.9.x
+
+## New features
+* Adds simple auto-completion to the CLI.
+* Adds the IsListParenthesizedMeta meta to aid in differentiating between parenthesized and non*parenthesized lists
+* Adds support for HAVING clause in planner
+* Adds support for collection aggregation functions in the EvaluatingCompiler and experimental planner
+* Adds support for the syntactic sugar of using aggregations functions in place of their collection aggregation function
+  counterparts (in the experimental planner)
+* Experimental implementation for window function `Lag` and `Lead`.
+* Adds support for EXPLAIN
+* Adds continuous performance benchmarking to the CI for existing JMH benchmarks
+    * Benchmark results can be seen on the project's GitHub Pages site
+* Adds the `pipeline` flag to the CLI to provide experimental usage of the PartiQLCompilerPipeline
+* Added `ExprValue.toIonValue(ion: IonSystem)` in kotlin, and `ExprValueKt.toIonValue(value: ExprValue, ion: IonSystem)` in Java to transform one `ExprValue` to a corresponding `IonValue`.
+
+## Deprecated items
+* Marks the GroupKeyReferencesVisitorTransform as deprecated. There is no functionally equivalent class.
+* Marks `ionValue` property in `ExprValue` interface as deprecated. The functional equivalent method is `ExprValue.toIonValue(ion: IonSystem)` in kotlin, and `ExprValueKt.toIonValue(value: ExprValue, ion: IonSystem)` in Java.
+* Marks `Lexer`, `Token`, `TokenType`, `SourcePosition`, and `SourceSpan` as deprecated. These will be removed without
+  any replacement.
+* Marks approximately 60 `ErrorCode`'s as deprecated. These will be removed without any replacement.
+* Marks `Property.TOKEN_TYPE` as deprecated. Please use `Property.TOKEN_DESCRIPTION`.
+
+## Misc/bug fixes
+* Fixes the ThreadInterruptedTests by modifying the time to interrupt parses. Also adds better exception exposure to
+  facilitate debugging.
+
+## Breaking changes
+
+### Breaking behavioral changes
+
+N/A
+
+### Breaking API changes
+* Removes the deprecated V0 AST in the codebase.
+* Removes the deprecated MetaContainer in the codebase, removed interfaces and classes include:
+    * [MetaContainer] Interface
+    * [MetaContainerImpl]
+    * [MetaDeserialize]
+    * [MemoizedMetaDeserializer]
+* Removes the deprecated Rewriter/AstWalker/AstVisitor in the code base, removed interfaces and classes include:
+    * [AstRewriter] Interface & [AstRewriterBase] class
+    * [AstVisitor] Interface & [AstVisitorBase] class
+    * [AstWalker] class
+    * [MetaStrippingRewriter] class
+* Removes the deprecated ExprNode and related files in the code base.
+    * [Parser] API `parseExprNode(source: String): ExprNode` has been removed.
+    * [CompilerPipeline] API `compile(query: ExprNode): Expression` has been removed.
+    * [ExprNode] and [AstNode] have been removed.
+    * Functions related to conversions between ExprNode and PartiqlAst have been removed.
+* Removes the deprecated SqlParser and SqlLexer
+* Removes the `CallAgg` node from the Logical, LogicalResolved, and Physical plans.
+* Removes the experimental `PlannerPipeline` and replaces it with `PartiQLCompilerPipeline`.


### PR DESCRIPTION
Adds 0.9 migration guide from CHANGELOG since 0.8.2

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.