### PR TITLE
Revert "Marks GPML and WINDOW AST nodes as Experimental (#923)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - If unable to parse via SLL Prediction Mode, it attempts to parse using the slower LL Prediction Mode
   - Modifications have also been made to the ANTLR grammar to increase the speed of parsing joined table references
   - Updates how the PartiQLParser handles parameter indexes to remove the double-pass while lexing
-- WINDOW and GPML AST nodes are marked experimental and will produce compiler warnings
 - Changes the expected `Property`'s of `TOKEN_INFO` to use `Property.TOKEN_DESCRIPTION` instead of `Property.TOKEN_TYPE`
 
 ### Deprecated

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,7 +27,7 @@ object Versions {
     const val dokka = "1.6.10"
     const val kotlin = "1.5.+"
     const val ktlint = "10.2.1"
-    const val pig = "0.6.1"
+    const val pig = "0.6.0"
 }
 
 object Plugins {

--- a/extensions/build.gradle.kts
+++ b/extensions/build.gradle.kts
@@ -24,10 +24,3 @@ dependencies {
     implementation(Deps.awsSdkDynamodb)
     testImplementation(Deps.mockito)
 }
-
-// Version 1.7+ removes the requirement for such compiler option.
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions {
-        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-    }
-}

--- a/lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalBexprToThunkConverter.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalBexprToThunkConverter.kt
@@ -38,7 +38,6 @@ internal typealias PhysicalPlanThunk = Thunk<EvaluatorState>
 /** A specialization of [ThunkValue] that we use for evaluation of physical plans. */
 internal typealias PhysicalPlanThunkValue<T> = ThunkValue<EvaluatorState, T>
 
-@OptIn(org.partiql.pig.runtime.Experimental::class)
 internal class PhysicalBexprToThunkConverter(
     private val exprConverter: PhysicalPlanCompiler,
     private val valueFactory: ExprValueFactory,

--- a/lang/src/main/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -1,5 +1,3 @@
-@file:OptIn(Experimental::class)
-
 package org.partiql.lang.planner.transforms
 
 import com.amazon.ionelement.api.emptyMetaContainer
@@ -15,7 +13,6 @@ import org.partiql.lang.eval.physical.sourceLocationMetaOrUnknown
 import org.partiql.lang.eval.visitors.VisitorTransformBase
 import org.partiql.lang.planner.PlanningProblemDetails
 import org.partiql.lang.planner.handleUnimplementedFeature
-import org.partiql.pig.runtime.Experimental
 import org.partiql.pig.runtime.SymbolPrimitive
 import org.partiql.pig.runtime.toIonElement
 

--- a/lang/src/main/kotlin/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransform.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPhysicalVisitorTransform.kt
@@ -9,7 +9,6 @@ import org.partiql.lang.planner.DML_COMMAND_FIELD_ACTION
 import org.partiql.lang.planner.DML_COMMAND_FIELD_ROWS
 import org.partiql.lang.planner.DML_COMMAND_FIELD_TARGET_UNIQUE_ID
 import org.partiql.lang.planner.DmlAction
-import org.partiql.pig.runtime.Experimental
 
 /**
  * Transforms an instance of [PartiqlLogicalResolved.Statement] to [PartiqlPhysical.Statement],
@@ -27,7 +26,6 @@ internal fun PartiqlPhysical.Builder.structField(name: String, value: String) =
 internal fun PartiqlPhysical.Builder.structField(name: String, value: PartiqlPhysical.Expr) =
     structField(lit(ionSymbol(name)), value)
 
-@OptIn(Experimental::class)
 internal class LogicalResolvedToDefaultPhysicalVisitorTransform(
     val problemHandler: ProblemHandler
 ) : PartiqlLogicalResolvedToPartiqlPhysicalVisitorTransform() {

--- a/lang/src/main/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
@@ -14,7 +14,6 @@ import org.partiql.lang.eval.physical.sourceLocationMetaOrUnknown
 import org.partiql.lang.planner.GlobalResolutionResult
 import org.partiql.lang.planner.GlobalVariableResolver
 import org.partiql.lang.planner.PlanningProblemDetails
-import org.partiql.pig.runtime.Experimental
 import org.partiql.pig.runtime.asPrimitive
 
 /**
@@ -130,7 +129,6 @@ private fun GlobalResolutionResult.toResolvedVariable() =
  */
 private data class LocalScope(val varDecls: List<PartiqlLogical.VarDecl>)
 
-@OptIn(Experimental::class)
 internal data class LogicalToLogicalResolvedVisitorTransform(
     /** If set to `true`, do not log errors about undefined variables. Rewrite such variables to a `dynamic_id` node. */
     val allowUndefinedVariables: Boolean,

--- a/lang/src/main/kotlin/org/partiql/lang/planner/transforms/optimizations/ConcatWindowFunction.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/planner/transforms/optimizations/ConcatWindowFunction.kt
@@ -3,7 +3,6 @@ package org.partiql.lang.planner.transforms.optimizations
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.errors.ProblemHandler
 import org.partiql.lang.planner.PartiQLPhysicalPass
-import org.partiql.pig.runtime.Experimental
 
 // TODO: Remove from experimental once https://github.com/partiql/partiql-docs/issues/31 is resolved and a RFC is approved
 internal fun createConcatWindowFunctionPass(): PartiQLPhysicalPass =
@@ -42,7 +41,6 @@ private class ConcatWindowFunction : PartiQLPhysicalPass {
     }
 }
 
-@OptIn(Experimental::class)
 private fun PartiqlPhysical.Bexpr.Window.rewriteWindowExpression(): PartiqlPhysical.Bexpr {
     val modifiedWindowExpressionList = object : PartiqlPhysical.VisitorTransform() {
 

--- a/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -64,7 +64,6 @@ import org.partiql.lang.util.getPrecisionFromTimeString
 import org.partiql.lang.util.ionValue
 import org.partiql.lang.util.numberValue
 import org.partiql.lang.util.unaryMinus
-import org.partiql.pig.runtime.Experimental
 import org.partiql.pig.runtime.SymbolPrimitive
 import java.lang.IllegalArgumentException
 import java.math.BigInteger
@@ -80,7 +79,6 @@ import kotlin.reflect.cast
  * Extends ANTLR's generated [PartiQLBaseVisitor] to visit an ANTLR ParseTree and convert it into a PartiQL AST. This
  * class uses the [PartiqlAst.PartiqlAstNode] to represent all nodes within the new AST.
  */
-@OptIn(Experimental::class)
 internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomType> = listOf(), private val parameterIndexes: Map<Int, Int> = mapOf()) :
     PartiQLBaseVisitor<PartiqlAst.PartiqlAstNode>() {
 

--- a/lang/src/main/pig/partiql.ion
+++ b/lang/src/main/pig/partiql.ion
@@ -142,16 +142,14 @@ may then be further optimized by selecting better implementations of each operat
             (bag_op op::bag_op_type quantifier::set_quantifier operands::(* expr 2))
 
             // GPML graph pattern match:  <expr> MATCH <gpml_pattern>
-            experimental::(graph_match expr::expr gpml_pattern::gpml_pattern)
+            (graph_match expr::expr gpml_pattern::gpml_pattern)
 
             // Other expression types
             (path root::expr steps::(* path_step 1))
             (call func_name::symbol args::(* expr 1))
             (call_agg setq::set_quantifier func_name::symbol arg::expr)
-
-            // TODO: In the future, when we allow use of aggregation function as window function, we need to consider incorporate in setq
-            experimental::(call_window func_name::symbol over::over args::(* expr 1))
-
+            // TODO: In the feature, when we allow use of aggregation function as window function, we need to consider incorporate in setq
+            (call_window func_name::symbol over::over args::(* expr 1))
             (cast value::expr as_type::type)
             (can_cast value::expr as_type::type)
             (can_lossless_cast value::expr as_type::type)
@@ -247,7 +245,7 @@ may then be further optimized by selecting better implementations of each operat
         //
         // Fig. 5. Table of edge patterns:
         // https://arxiv.org/abs/2112.06217
-        experimental::(sum graph_match_direction
+        (sum graph_match_direction
              (edge_left)
              (edge_undirected)
              (edge_right)
@@ -257,7 +255,7 @@ may then be further optimized by selecting better implementations of each operat
              (edge_left_or_undirected_or_right))
 
         // A part of a graph pattern
-        experimental::(sum graph_match_pattern_part
+        (sum graph_match_pattern_part
              // A single node in a graph pattern.
              (node
                  prefilter::(? expr)   // an optional node pre-filter, e.g.: `WHERE c.name='Alarm'` in `MATCH (c WHERE c.name='Alarm')`
@@ -275,7 +273,7 @@ may then be further optimized by selecting better implementations of each operat
              (pattern pattern::graph_match_pattern))
 
         // A quantifier for graph edges or patterns. (e.g., the `{2,5}` in `MATCH (x)->{2,5}(y)`)
-        experimental::(product graph_match_quantifier lower::int upper::(? int))
+        (product graph_match_quantifier lower::int upper::(? int))
 
         // A path restrictor
         // | Keyword        | Description
@@ -286,13 +284,13 @@ may then be further optimized by selecting better implementations of each operat
         //
         // Fig. 7. Table of restrictors:
         // https://arxiv.org/abs/2112.06217
-        experimental::(sum graph_match_restrictor
+        (sum graph_match_restrictor
              (restrictor_trail)
              (restrictor_acyclic)
              (restrictor_simple))
 
         // A single graph match pattern.
-        experimental::(product graph_match_pattern
+        (product graph_match_pattern
              restrictor::(? graph_match_restrictor)
              prefilter::(? expr)    // an optional pattern pre-filter, e.g.: `WHERE a.name=b.name` in `MATCH [(a)->(b) WHERE a.name=b.name]`
              variable::(? symbol)   // the optional element variable of the pattern, e.g.: `p` in `MATCH p = (a) −[t]−> (b)`
@@ -311,7 +309,7 @@ may then be further optimized by selecting better implementations of each operat
         //
         // Fig. 8. Table of restrictors:
         // https://arxiv.org/abs/2112.06217
-        experimental::(sum graph_match_selector
+        (sum graph_match_selector
              (selector_any_shortest)
              (selector_all_shortest)
              (selector_any)
@@ -321,7 +319,7 @@ may then be further optimized by selecting better implementations of each operat
 
         // A graph pattern as defined in GPML
         // See https://arxiv.org/abs/2112.06217
-        experimental::(product gpml_pattern
+        (product gpml_pattern
                  selector::(? graph_match_selector)
                  patterns::(* graph_match_pattern 1))
 
@@ -373,13 +371,13 @@ may then be further optimized by selecting better implementations of each operat
         // OVER ([PARTITION BY <expr> [, <expr>]... ] [ORDER BY <sort_spec> [, <sort_spec>]... ])
         // TODO: In the future, we need to add support for custom declared frame clause
         // TODO: Remove from experimental once https://github.com/partiql/partiql-docs/issues/31 is resolved and a RFC is approved
-        experimental::(product over partition_by::(? window_partition_list ) order_by::(? window_sort_spec_list ) )
+        (product over partition_by::(? window_partition_list ) order_by::(? window_sort_spec_list ) )
 
         // <expr>[, <expr>]...
-        experimental::(product window_partition_list exprs::(* expr 1 ))
+        (product window_partition_list exprs::(* expr 1 ))
 
         // <sort_spec>[, <sort_spec>]...
-        experimental::(product window_sort_spec_list sort_specs::(* sort_spec 1 ))
+        (product window_sort_spec_list sort_specs::(* sort_spec 1 ))
 
         // Indicates if variable lookup should be case-sensitive or not.
         (sum case_sensitivity (case_sensitive) (case_insensitive))
@@ -671,7 +669,7 @@ may then be further optimized by selecting better implementations of each operat
             )
         )
 
-        (include experimental::(product window_expression decl::var_decl func_name::symbol args::(* expr 1)))
+        (include (product window_expression decl::var_decl func_name::symbol args::(* expr 1)))
 
         // Now we include new stuff, including PartiQL's relational algebra.
         (include

--- a/lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
@@ -24,13 +24,11 @@ import org.partiql.lang.planner.PlanningProblemDetails
 import org.partiql.lang.planner.unimplementedProblem
 import org.partiql.lang.syntax.PartiQLParser
 import org.partiql.lang.util.ArgumentsProviderBase
-import org.partiql.pig.runtime.Experimental
 
 /**
  * Test cases in this class might seem a little light--that's because [AstToLogicalVisitorTransform] is getting
  * heavily exercised during many other integration tests.  These should be considered "smoke tests".
  */
-@OptIn(Experimental::class)
 class AstToLogicalVisitorTransformTests {
     private val ion = IonSystemBuilder.standard().build()
     internal val parser = PartiQLParser(ion)

--- a/lang/src/test/kotlin/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass.kt
@@ -14,7 +14,6 @@ import org.partiql.lang.planner.DML_COMMAND_FIELD_ACTION
 import org.partiql.lang.planner.DML_COMMAND_FIELD_ROWS
 import org.partiql.lang.planner.DML_COMMAND_FIELD_TARGET_UNIQUE_ID
 import org.partiql.lang.util.ArgumentsProviderBase
-import org.partiql.pig.runtime.Experimental
 import kotlin.test.fail
 
 class LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass {
@@ -29,8 +28,6 @@ class LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass {
     }
 
     class ArgumentsForToPhysicalTests : ArgumentsProviderBase() {
-
-        @OptIn(Experimental::class)
         override fun getParameters() = listOf(
             BexprTestCase(
                 PartiqlLogicalResolved.build {

--- a/lang/src/test/kotlin/org/partiql/lang/planner/transforms/optimizations/ConcatWindowFunctionPassTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/planner/transforms/optimizations/ConcatWindowFunctionPassTest.kt
@@ -7,10 +7,8 @@ import org.partiql.annotations.PartiQLExperimental
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.planner.transforms.DEFAULT_IMPL
 import org.partiql.lang.util.ArgumentsProviderBase
-import org.partiql.pig.runtime.Experimental
 
 @PartiQLExperimental
-@OptIn(Experimental::class)
 class ConcatWindowFunctionPassTest {
     @ParameterizedTest
     @ArgumentsSource(Arguments::class)

--- a/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserMatchTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserMatchTest.kt
@@ -7,10 +7,8 @@ import org.junit.Ignore
 import org.junit.Test
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.domains.id
-import org.partiql.pig.runtime.Experimental
 import kotlin.test.assertFailsWith
 
-@OptIn(Experimental::class)
 class PartiQLParserMatchTest : PartiQLParserTestBase() {
 
     @Test


### PR DESCRIPTION
This reverts commit f605f2b157c8148268e8935505089f2b27bc12d5.

## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
- < A detailed description >

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - < If NO, why? >
- Any backward-incompatible changes? **[YES/NO]**
  - < If YES, why? >
  - < For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base. >
- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.