### PR TITLE
Fixes ability to reference data on disk multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixes ability to reference data on disk multiple times
+
 ### Removed
 - The deprecated `IonValue` property in `ExprValue` interface is now removed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ExprValueFactory` interface marked as deprecated. Equivalent `ExprValue` construction methods are implemented in the `ExprValue` interface as static methods. 
 
 ### Fixed
-
-- Fixes ability to reference data on disk multiple times
+- Fixes ability to reference data on disk multiple times from the CLI. Specifically, multiple references to data using
+  the `--in` and `-i` flags and the `read_file()` are fixed.
 
 ### Removed
 - The deprecated `IonValue` property in `ExprValue` interface is now removed.

--- a/lang/src/test/resources/expr-value-factory-tests/bag.ion
+++ b/lang/src/test/resources/expr-value-factory-tests/bag.ion
@@ -1,4 +1,0 @@
-// This is used for the ExprValueFactoryTest to test whether we can create a bag from a sequence of Ion values
-0
-1
-2

--- a/lang/src/test/resources/expr-value-factory-tests/bag.ion
+++ b/lang/src/test/resources/expr-value-factory-tests/bag.ion
@@ -1,0 +1,4 @@
+// This is used for the ExprValueFactoryTest to test whether we can create a bag from a sequence of Ion values
+0
+1
+2

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/functions/ReadFile.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/functions/ReadFile.kt
@@ -29,8 +29,7 @@ import org.partiql.lang.eval.io.DelimitedValues.ConversionMode
 import org.partiql.lang.eval.stringValue
 import org.partiql.lang.types.FunctionSignature
 import org.partiql.lang.types.StaticType
-import java.io.FileInputStream
-import java.io.InputStream
+import java.io.File
 import java.io.InputStreamReader
 
 internal class ReadFile(private val ion: IonSystem) : ExprFunction {
@@ -45,9 +44,9 @@ internal class ReadFile(private val ion: IonSystem) : ExprFunction {
         ConversionMode.values().find { it.name.toLowerCase() == name }
             ?: throw IllegalArgumentException("Unknown conversion: $name")
 
-    private fun fileReadHandler(csvFormat: CSVFormat): (InputStream, Bindings<ExprValue>) -> ExprValue = { input, bindings ->
+    private fun fileReadHandler(csvFormat: CSVFormat): (File, Bindings<ExprValue>) -> ExprValue = { input, bindings ->
         val encoding = bindings[BindingName("encoding", BindingCase.SENSITIVE)]?.stringValue() ?: "UTF-8"
-        val reader = InputStreamReader(input, encoding)
+        val reader = InputStreamReader(input.inputStream(), encoding)
         val conversion = bindings[BindingName("conversion", BindingCase.SENSITIVE)]?.stringValue() ?: "none"
 
         val hasHeader = bindings[BindingName("header", BindingCase.SENSITIVE)]?.booleanValue() ?: false
@@ -73,18 +72,32 @@ internal class ReadFile(private val ion: IonSystem) : ExprFunction {
         ExprValue.newBag(seq)
     }
 
-    private fun ionReadHandler(): (InputStream, Bindings<ExprValue>) -> ExprValue = { input, _ ->
-        IonReaderBuilder.standard().build(input).use { reader ->
-            val value = when (reader.next()) {
-                null -> ExprValue.missingValue
-                else -> ExprValue.newFromIonReader(ion, reader)
+    private fun ionReadHandler(): (File, Bindings<ExprValue>) -> ExprValue = { file, bindings ->
+        when (bindings[BindingName("wrap-ion", BindingCase.SENSITIVE)]?.booleanValue() ?: false) {
+            true -> {
+                val stream = file.inputStream()
+                val inputIonValue = ion.iterate(ion.newReader(stream)).asSequence().map { ExprValue.of(it) }.asIterable()
+                val iterable = object : Iterable<ExprValue> {
+                    override fun iterator(): Iterator<ExprValue> {
+                        return inputIonValue.iterator()
+                    }
+                }
+                ExprValue.newBag(iterable)
             }
-            if (reader.next() != null) {
-                val message = "As of v0.7.0, PartiQL requires that Ion files contain only a single Ion value for " +
-                    "processing. Please consider wrapping multiple values in a list."
-                throw IllegalStateException(message)
+            false -> {
+                IonReaderBuilder.standard().build(file.inputStream()).use { reader ->
+                    val value = when (reader.next()) {
+                        null -> ExprValue.missingValue
+                        else -> ExprValue.newFromIonReader(ion, reader)
+                    }
+                    if (reader.next() != null) {
+                        val message = "PartiQL requires that Ion files contain only a single Ion value for " +
+                            "processing. Please consider using option 'wrap-ion'."
+                        throw IllegalStateException(message)
+                    }
+                    value
+                }
             }
-            value
         }
     }
 
@@ -102,10 +115,10 @@ internal class ReadFile(private val ion: IonSystem) : ExprFunction {
     override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         val fileName = required[0].stringValue()
         val fileType = "ion"
-        val handler: (InputStream, Bindings<ExprValue>) -> ExprValue = readHandlers[fileType] ?: throw IllegalArgumentException("Unknown file type: $fileType")
+        val handler: (File, Bindings<ExprValue>) -> ExprValue = readHandlers[fileType] ?: throw IllegalArgumentException("Unknown file type: $fileType")
         // TODO we should take care to clean up this `FileInputStream` properly
         //  https://github.com/partiql/partiql-lang-kotlin/issues/518
-        val fileInput = FileInputStream(fileName)
+        val fileInput = File(fileName)
         return handler(fileInput, Bindings.empty())
     }
 
@@ -115,7 +128,7 @@ internal class ReadFile(private val ion: IonSystem) : ExprFunction {
         val handler = readHandlers[fileType] ?: throw IllegalArgumentException("Unknown file type: $fileType")
         // TODO we should take care to clean up this `FileInputStream` properly
         //  https://github.com/partiql/partiql-lang-kotlin/issues/518
-        val fileInput = FileInputStream(fileName)
+        val fileInput = File(fileName)
         return handler(fileInput, opt.bindings)
     }
 }

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PartiQLCommand.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PartiQLCommand.kt
@@ -17,11 +17,10 @@ package org.partiql.cli.pico
 import com.amazon.ion.IonSystem
 import org.partiql.cli.query.Cli
 import org.partiql.cli.shell.Shell
-import org.partiql.cli.utils.EmptyInputStream
+import org.partiql.cli.utils.InputSource
 import org.partiql.cli.utils.UnclosableOutputStream
 import picocli.CommandLine
 import java.io.File
-import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.InputStream
 
@@ -74,10 +73,7 @@ internal class PartiQLCommand(private val ion: IonSystem) : Runnable {
      * Runs the CLI
      */
     private fun runCli(exec: ExecutionOptions, stream: InputStream) {
-        val input = when (exec.inputFile) {
-            null -> EmptyInputStream()
-            else -> FileInputStream(exec.inputFile!!)
-        }
+        val input = exec.inputFile?.let { InputSource.FileSource(it) }
         val output = when (exec.outputFile) {
             null -> UnclosableOutputStream(System.out)
             else -> FileOutputStream(exec.outputFile!!)

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PartiQLCommand.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PartiQLCommand.kt
@@ -84,11 +84,9 @@ internal class PartiQLCommand(private val ion: IonSystem) : Runnable {
             false -> query
             else -> queryLines.subList(1, queryLines.size).joinToString(System.lineSeparator())
         }
-        input.use { src ->
-            output.use { out ->
-                Cli(ion, src, exec.inputFormat, out, exec.outputFormat, options.pipeline, options.environment, queryWithoutShebang, exec.wrapIon).run()
-                out.write(System.lineSeparator().toByteArray(Charsets.UTF_8))
-            }
+        output.use { out ->
+            Cli(ion, input, exec.inputFormat, out, exec.outputFormat, options.pipeline, options.environment, queryWithoutShebang, exec.wrapIon).run()
+            out.write(System.lineSeparator().toByteArray(Charsets.UTF_8))
         }
     }
 

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pipeline/AbstractPipeline.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pipeline/AbstractPipeline.kt
@@ -58,7 +58,11 @@ internal sealed class AbstractPipeline(open val options: PipelineOptions) {
         internal fun standard(): AbstractPipeline {
             return create(PipelineOptions())
         }
-
+        internal fun createDefaultCliFunctions(ion: IonSystem): List<ExprFunction> = listOf(
+            ReadFile(ion),
+            WriteFile(ion),
+            QueryDDB(ion)
+        )
         internal fun createPipelineOptions(
             pipeline: PipelineType,
             typedOpBehavior: TypedOpBehavior,
@@ -67,11 +71,6 @@ internal sealed class AbstractPipeline(open val options: PipelineOptions) {
             permissiveMode: TypingMode
         ): PipelineOptions {
             val ion = IonSystemBuilder.standard().build()
-            val functions: List<ExprFunction> = listOf(
-                ReadFile(ion),
-                WriteFile(ion),
-                QueryDDB(ion)
-            )
             val parser = PartiQLParserBuilder().ionSystem(ion).build()
             return PipelineOptions(
                 pipeline,
@@ -81,7 +80,7 @@ internal sealed class AbstractPipeline(open val options: PipelineOptions) {
                 projectionIteration,
                 undefinedVariable,
                 permissiveMode,
-                functions = functions
+                functions = createDefaultCliFunctions(ion)
             )
         }
     }
@@ -94,7 +93,7 @@ internal sealed class AbstractPipeline(open val options: PipelineOptions) {
         val projectionIterationBehavior: ProjectionIterationBehavior = ProjectionIterationBehavior.FILTER_MISSING,
         val undefinedVariableBehavior: UndefinedVariableBehavior = UndefinedVariableBehavior.ERROR,
         val typingMode: TypingMode = TypingMode.LEGACY,
-        val functions: List<ExprFunction> = emptyList()
+        val functions: List<ExprFunction> = createDefaultCliFunctions(ion)
     )
 
     internal enum class PipelineType {

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/utils/DelimitedFileIterable.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/utils/DelimitedFileIterable.kt
@@ -1,0 +1,35 @@
+package org.partiql.cli.utils
+
+import com.amazon.ion.IonSystem
+import org.apache.commons.csv.CSVFormat
+import org.partiql.cli.functions.ReadFile.Companion.conversionModeFor
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.io.DelimitedValues
+import java.io.InputStreamReader
+
+/**
+ * A closeable, iterable wrapper over an [InputSource] containing Ion values. With an [DelimitedFileIterable],
+ * it is possible to create a new [Iterator] of [ExprValue]'s from an [InputSource] containing a sequence of delimited
+ * values. By leveraging [InputSource]'s ability to re-open streams, the [DelimitedFileIterable] is able to create
+ * iterators at the beginning of the [InputSource.stream].
+ */
+internal class DelimitedFileIterable(
+    private val ion: IonSystem,
+    private val input: InputSource,
+    private val format: CSVFormat,
+    private val encoding: String,
+    private val conversion: String
+) : Iterable<ExprValue>, AutoCloseable {
+
+    private val readers: MutableList<InputStreamReader> = mutableListOf()
+
+    override fun iterator(): Iterator<ExprValue> {
+        val reader = InputStreamReader(input.stream(), encoding)
+        readers.add(reader)
+        return DelimitedValues.exprValue(ion, reader, format, conversionModeFor(conversion)).iterator()
+    }
+
+    override fun close() {
+        readers.forEach { it.close() }
+    }
+}

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/utils/InputSource.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/utils/InputSource.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.cli.utils
+
+import java.io.File
+import java.io.InputStream
+
+internal sealed class InputSource {
+
+    internal abstract fun stream(): InputStream
+
+    internal class FileSource(private val file: File) : InputSource() {
+        override fun stream(): InputStream = file.inputStream()
+    }
+
+    internal class StringSource(private val string: String) : InputSource() {
+        override fun stream(): InputStream = string.byteInputStream(Charsets.UTF_8)
+    }
+}

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/utils/InputSource.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/utils/InputSource.kt
@@ -17,14 +17,26 @@ package org.partiql.cli.utils
 import java.io.File
 import java.io.InputStream
 
+/**
+ * Represents a re-openable source containing input data. By calling [stream], the [InputSource] opens a stream at the
+ * beginning of the represented data.
+ */
 internal sealed class InputSource {
 
     internal abstract fun stream(): InputStream
 
+    /**
+     * Represents a re-openable source wrapping a file's contents. By calling [stream], the [FileSource] opens a stream
+     * at the beginning of the [file]
+     */
     internal class FileSource(private val file: File) : InputSource() {
         override fun stream(): InputStream = file.inputStream()
     }
 
+    /**
+     * Represents a re-openable source wrapping a string's contents. By calling [stream], the [StringSource] opens a stream
+     * at the beginning of the [string]
+     */
     internal class StringSource(private val string: String) : InputSource() {
         override fun stream(): InputStream = string.byteInputStream(Charsets.UTF_8)
     }

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/utils/InputSourceIterable.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/utils/InputSourceIterable.kt
@@ -1,0 +1,28 @@
+package org.partiql.cli.utils
+
+import com.amazon.ion.IonReader
+import com.amazon.ion.IonSystem
+import com.amazon.ion.system.IonReaderBuilder
+import org.partiql.lang.eval.ExprValue
+
+/**
+ * A closeable, iterable wrapper over an [InputSource] containing Ion values. With an [InputSourceIterable],
+ * it is possible to create a new [Iterator] of [ExprValue]'s from an [InputSource] containing a sequence of Ion
+ * values. By leveraging [InputSource]'s ability to re-open streams, the [InputSourceIterable] is able to create
+ * iterators at the beginning of the [InputSource.stream].
+ */
+internal class InputSourceIterable(
+    private val ion: IonSystem,
+    private val input: InputSource
+) : Iterable<ExprValue>, AutoCloseable {
+
+    private val readers = mutableListOf<IonReader>()
+
+    override fun iterator(): Iterator<ExprValue> {
+        val reader = IonReaderBuilder.standard().build(input.stream())
+        readers.add(reader)
+        return ion.iterate(reader).asSequence().map { ExprValue.of(it) }.iterator()
+    }
+
+    override fun close() = readers.forEach { it.close() }
+}

--- a/partiql-app/partiql-cli/src/test/kotlin/org/partiql/cli/CliTest.kt
+++ b/partiql-app/partiql-cli/src/test/kotlin/org/partiql/cli/CliTest.kt
@@ -24,11 +24,14 @@ import org.partiql.cli.pico.PartiQLCommand
 import org.partiql.cli.pipeline.AbstractPipeline
 import org.partiql.lang.eval.BAG_ANNOTATION
 import org.partiql.lang.eval.EvaluationException
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.MISSING_ANNOTATION
+import org.partiql.lang.eval.PartiQLResult
 import org.partiql.lang.eval.ProjectionIterationBehavior
 import org.partiql.lang.eval.TypedOpBehavior
 import org.partiql.lang.eval.TypingMode
 import org.partiql.lang.eval.UndefinedVariableBehavior
+import org.partiql.lang.eval.exprEquals
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -161,8 +164,12 @@ class CliTest {
         val wrappedInputResult = makeCliAndGetResult(query, wrappedInput, wrapIon = true, outputFormat = PartiQLCommand.OutputFormat.PARTIQL)
         val ionInputResult = makeCliAndGetResult(query, input, inputFormat = PartiQLCommand.InputFormat.ION, outputFormat = PartiQLCommand.OutputFormat.PARTIQL)
 
-        assertEquals(expected, wrappedInputResult)
-        assertEquals(expected, ionInputResult)
+        // Gather results and evaluate
+        val expectedPartiQL = AbstractPipeline.standard().compile(expected, EvaluationSession.standard()) as PartiQLResult.Value
+        val wrappedResult = AbstractPipeline.standard().compile(wrappedInputResult, EvaluationSession.standard()) as PartiQLResult.Value
+        val ionResult = AbstractPipeline.standard().compile(ionInputResult, EvaluationSession.standard()) as PartiQLResult.Value
+        assert(expectedPartiQL.value.exprEquals(wrappedResult.value))
+        assert(expectedPartiQL.value.exprEquals(ionResult.value))
     }
 
     @Test

--- a/partiql-app/partiql-cli/src/test/kotlin/org/partiql/cli/CliTestUtility.kt
+++ b/partiql-app/partiql-cli/src/test/kotlin/org/partiql/cli/CliTestUtility.kt
@@ -10,6 +10,7 @@ import org.partiql.cli.utils.InputSource
 import org.partiql.lang.eval.Bindings
 import org.partiql.lang.eval.ExprValue
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.OutputStream
 
 /**
@@ -26,13 +27,40 @@ internal fun makeCliAndGetResult(
     pipeline: AbstractPipeline = AbstractPipeline.standard(),
     wrapIon: Boolean = false
 ): String {
-    val stream = when (input) {
-        null -> InputSource.StringSource("")
-        else -> InputSource.StringSource(input)
-    }
+    val source = InputSource.StringSource(input ?: "")
     val cli = Cli(
         ion,
-        stream,
+        source,
+        inputFormat,
+        output,
+        outputFormat,
+        pipeline,
+        bindings,
+        query,
+        wrapIon
+    )
+    cli.run()
+    return output.toString()
+}
+
+/**
+ * Initializes a CLI and runs the passed-in query
+ */
+internal fun makeCliAndGetResult(
+    query: String,
+    input: File,
+    inputFormat: PartiQLCommand.InputFormat = PartiQLCommand.InputFormat.ION,
+    bindings: Bindings<ExprValue> = Bindings.empty(),
+    outputFormat: PartiQLCommand.OutputFormat = PartiQLCommand.OutputFormat.ION_TEXT,
+    output: OutputStream = ByteArrayOutputStream(),
+    ion: IonSystem = IonSystemBuilder.standard().build(),
+    pipeline: AbstractPipeline = AbstractPipeline.standard(),
+    wrapIon: Boolean = false
+): String {
+    val source = InputSource.FileSource(input)
+    val cli = Cli(
+        ion,
+        source,
         inputFormat,
         output,
         outputFormat,

--- a/partiql-app/partiql-cli/src/test/kotlin/org/partiql/cli/CliTestUtility.kt
+++ b/partiql-app/partiql-cli/src/test/kotlin/org/partiql/cli/CliTestUtility.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.partiql.cli.pico.PartiQLCommand
 import org.partiql.cli.pipeline.AbstractPipeline
 import org.partiql.cli.query.Cli
-import org.partiql.cli.utils.EmptyInputStream
+import org.partiql.cli.utils.InputSource
 import org.partiql.lang.eval.Bindings
 import org.partiql.lang.eval.ExprValue
 import java.io.ByteArrayOutputStream
@@ -26,9 +26,13 @@ internal fun makeCliAndGetResult(
     pipeline: AbstractPipeline = AbstractPipeline.standard(),
     wrapIon: Boolean = false
 ): String {
+    val stream = when (input) {
+        null -> InputSource.StringSource("")
+        else -> InputSource.StringSource(input)
+    }
     val cli = Cli(
         ion,
-        input?.byteInputStream(Charsets.UTF_8) ?: EmptyInputStream(),
+        stream,
         inputFormat,
         output,
         outputFormat,

--- a/partiql-app/partiql-cli/src/test/kotlin/org/partiql/cli/functions/ReadFileTest.kt
+++ b/partiql-app/partiql-cli/src/test/kotlin/org/partiql/cli/functions/ReadFileTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.partiql.cli.utils.TestUtils
 import org.partiql.lang.eval.BAG_ANNOTATION
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
@@ -118,16 +119,6 @@ class ReadFileTest {
         assertThrows<IllegalStateException> {
             function.callWithOptional(session, args, additionalOptions)
         }
-    }
-    @Test
-    fun readUnwrappedIon() {
-        writeFile("data.ion", "1 2")
-
-        val args = listOf("\"${dirPath("data.ion")}\"").map { it.exprValue() }
-        val additionalOptions = "{type:\"ion\", 'wrap-ion':true}".exprValue()
-        val actual = function.callWithOptional(session, args, additionalOptions)
-        val expected = "[1, 2]"
-        assertValues(expected, actual)
     }
 
     @Test
@@ -331,6 +322,26 @@ class ReadFileTest {
         val actual = function.callWithOptional(session, args, additionalOptions)
         val expected = "[{id:\"1,\",name:\"Bob\",balance:\"10000.00\"}]"
 
+        assertValues(expected, actual)
+    }
+
+    @Test
+    fun readUnwrappedIon() {
+        val filePath = TestUtils.getResourceFile(TestUtils.ResourceFileNames.TEST_BAG).absolutePath
+        val args = listOf("\"$filePath\"").map { it.exprValue() }
+        val additionalOptions = "{type:\"ion\", 'wrap-ion':true}".exprValue()
+        val actual = function.callWithOptional(session, args, additionalOptions)
+        val expected = "[{a:0},{a:1},{a:2}]"
+        assertValues(expected, actual)
+    }
+
+    @Test
+    fun readWrappedIon() {
+        val filePath = TestUtils.getResourceFile(TestUtils.ResourceFileNames.WRAPPED_VALUES).absolutePath
+        val args = listOf("\"$filePath\"").map { it.exprValue() }
+        val additionalOptions = "{type:\"ion\"}".exprValue()
+        val actual = function.callWithOptional(session, args, additionalOptions)
+        val expected = "[{a:0},{a:1},{a:2}]"
         assertValues(expected, actual)
     }
 }

--- a/partiql-app/partiql-cli/src/test/kotlin/org/partiql/cli/functions/ReadFileTest.kt
+++ b/partiql-app/partiql-cli/src/test/kotlin/org/partiql/cli/functions/ReadFileTest.kt
@@ -119,6 +119,16 @@ class ReadFileTest {
             function.callWithOptional(session, args, additionalOptions)
         }
     }
+    @Test
+    fun readUnwrappedIon() {
+        writeFile("data.ion", "1 2")
+
+        val args = listOf("\"${dirPath("data.ion")}\"").map { it.exprValue() }
+        val additionalOptions = "{type:\"ion\", 'wrap-ion':true}".exprValue()
+        val actual = function.callWithOptional(session, args, additionalOptions)
+        val expected = "[1, 2]"
+        assertValues(expected, actual)
+    }
 
     @Test
     fun readCsv() {

--- a/partiql-app/partiql-cli/src/test/kotlin/org/partiql/cli/utils/TestUtils.kt
+++ b/partiql-app/partiql-cli/src/test/kotlin/org/partiql/cli/utils/TestUtils.kt
@@ -1,0 +1,17 @@
+package org.partiql.cli.utils
+
+import java.io.File
+import java.net.URL
+
+internal object TestUtils {
+
+    internal object ResourceFileNames {
+        const val TEST_BAG = "test-bag.ion"
+        const val WRAPPED_VALUES = "wrapped-values.ion"
+    }
+
+    internal fun getResourceFile(name: String): File {
+        val resource: URL = javaClass.classLoader.getResource(name)!!
+        return File(resource.toURI())
+    }
+}

--- a/partiql-app/partiql-cli/src/test/resources/test-bag.ion
+++ b/partiql-app/partiql-cli/src/test/resources/test-bag.ion
@@ -1,0 +1,4 @@
+// Ion file for testing purposes.
+{ a: 0 }
+{ a: 1 }
+{ a: 2 }

--- a/partiql-app/partiql-cli/src/test/resources/wrapped-values.ion
+++ b/partiql-app/partiql-cli/src/test/resources/wrapped-values.ion
@@ -1,0 +1,6 @@
+// Used for testing
+[
+  { a: 0 },
+  { a: 1 },
+  { a: 2 }
+]


### PR DESCRIPTION
## Relevant Issues
- Closes #936 
- Closes #518 

## Issue Description
- Whenever we pass in an input file, the data cannot be access twice due to how we use sequences.
  - When we pass in a file, we essentially use the IonReader to create a sequence of IonValues
  - Then, we create a `newBag` with the resulting sequence.
- The above flow would not allow referencing data twice because it is a sequence (can only be consumed once)

## Included Changes
- This PR proposes that we establish a re-openable stream and an implementation of Iterable that uses the re-openable stream.
  - So, in the context of this PR, we take in a file, create a re-openable stream (InputSource), wrap the stream with the new iterable (InputSourceIterable for Ion files, DelimitedFileIterable for CSV files), and use it for the creation of the ExprValue.
  - With this, when we want to iterate a file's values multiple times, we are able to start at the beginning of the file each time.

## Other Changes
- Since we've revamped how we're handling streams, this implementation also resolves our inability to close file streams seen in #518
- I've also added testing to test joins between Ion files containing single values and sequences of values. See `CliTest.kt`

## Example Usage
- See the updated usage of `read_file`:
<img width="906" alt="Screen Shot 2023-01-09 at 10 47 18 AM" src="https://user-images.githubusercontent.com/40360967/211384472-e15a600c-d193-49bb-ab10-5d9e2c7e9c4b.png">

- See the updated usage of using `--input`:
<img width="1121" alt="Screen Shot 2023-01-09 at 10 49 59 AM" src="https://user-images.githubusercontent.com/40360967/211384916-82369f55-02ef-41e8-a423-ae766c1639a9.png">

- As you can see, there aren't any issues regarding consumption of the input sequence.

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.