### PR TITLE
Remove STRING test format

### DIFF
--- a/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerDateTimeTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerDateTimeTests.kt
@@ -51,7 +51,7 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             query = tc.query,
             expectedResult = tc.expected,
-            expectedResultFormat = ExpectedResultFormat.STRING,
+            expectedResultFormat = ExpectedResultFormat.STRICT,
             compileOptionsBuilderBlock = tc.compileOptionsBlock
         ) { actualExprValue ->
             assertEquals(tc.expected, actualExprValue.toString())
@@ -163,7 +163,7 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
                 runEvaluatorTestCase(
                     query = tc.query,
                     expectedResult = tc.expected,
-                    expectedResultFormat = ExpectedResultFormat.STRING
+                    expectedResultFormat = ExpectedResultFormat.STRICT
                 )
             }
         }

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/MakeDateEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/MakeDateEvaluationTest.kt
@@ -22,7 +22,7 @@ class MakeDateEvaluationTest : EvaluatorTestBase() {
             query = testCase.source,
             expectedResult = testCase.expectedLegacyModeResult,
             expectedPermissiveModeResult = testCase.expectedPermissiveModeResult,
-            expectedResultFormat = ExpectedResultFormat.STRING,
+            expectedResultFormat = ExpectedResultFormat.STRICT,
             includePermissiveModeTest = false
         )
 

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/MakeTimeEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/MakeTimeEvaluationTest.kt
@@ -21,7 +21,7 @@ class MakeTimeEvaluationTest : EvaluatorTestBase() {
         runEvaluatorTestCase(
             query = testCase.source,
             expectedResult = testCase.expectedLegacyModeResult,
-            expectedResultFormat = ExpectedResultFormat.STRING,
+            expectedResultFormat = ExpectedResultFormat.STRICT,
             includePermissiveModeTest = false
         )
 

--- a/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/ExpectedResultFormat.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/ExpectedResultFormat.kt
@@ -25,15 +25,6 @@ enum class ExpectedResultFormat {
     PARTIQL,
 
     /**
-     * The expected value is an arbitrary string.  [org.partiql.lang.eval.ExprValue.toString]` is called on the result
-     * of the query and the expected/actual assertion is performed with regular string equality.
-     *
-     * This is suboptimal (really, don't use this in new tests) but it is easier to support this here than it is to
-     * refactor hundreds of expected values.
-     */
-    STRING,
-
-    /**
      * The expected value is expressed using PartiQL syntax, which is evaluated under the same pipeline & compile
      * options and session as the query under test. [ExprValue.strictEquals] is used here.
      *

--- a/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PipelineEvaluatorTestAdapter.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PipelineEvaluatorTestAdapter.kt
@@ -96,14 +96,6 @@ internal class PipelineEvaluatorTestAdapter(
                 }
                 Unit
             }
-            ExpectedResultFormat.STRING -> {
-                val actualResultString = actualExprValueResult.toString()
-                assertEquals(
-                    expectedResult,
-                    actualResultString,
-                    EvaluatorTestFailureReason.UNEXPECTED_QUERY_RESULT,
-                ) { tc.testDetails(note = note, actualResult = actualResultString) }
-            }
             ExpectedResultFormat.STRICT -> {
                 val expectedExprValueResult = assertDoesNotThrow(
                     EvaluatorTestFailureReason.FAILED_TO_EVALUATE_PARTIQL_EXPECTED_RESULT,

--- a/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PipelineEvaluatorTestAdapterTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PipelineEvaluatorTestAdapterTests.kt
@@ -133,7 +133,7 @@ class PipelineEvaluatorTestAdapterTests {
                 EvaluatorTestCase(
                     query = "SEXP(1, 2, 3)",
                     expectedResult = "`(1 2 3)`", // <-- ExprValue.toString() produces this
-                    expectedResultFormat = ExpectedResultFormat.STRING
+                    expectedResultFormat = ExpectedResultFormat.STRICT
                 ),
                 EvaluationSession.standard()
             )
@@ -171,7 +171,7 @@ class PipelineEvaluatorTestAdapterTests {
             EvaluatorTestCase(
                 query = "1",
                 expectedResult = "2",
-                expectedResultFormat = ExpectedResultFormat.STRING
+                expectedResultFormat = ExpectedResultFormat.STRICT
             )
         )
     }

--- a/test/partiql-randomized-tests/src/test/kotlin/org/partiql/lang/randomized/eval/EvaluatingCompilerDateTimeRandomizedTests.kt
+++ b/test/partiql-randomized-tests/src/test/kotlin/org/partiql/lang/randomized/eval/EvaluatingCompilerDateTimeRandomizedTests.kt
@@ -136,7 +136,7 @@ class EvaluatingCompilerDateTimeRandomizedTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             query = query,
             expectedResult = expected,
-            expectedResultFormat = ExpectedResultFormat.STRING
+            expectedResultFormat = ExpectedResultFormat.STRICT
         )
     }
 
@@ -148,7 +148,7 @@ class EvaluatingCompilerDateTimeRandomizedTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             query = query,
             expectedResult = expected,
-            expectedResultFormat = ExpectedResultFormat.STRING
+            expectedResultFormat = ExpectedResultFormat.STRICT
         )
     }
 
@@ -160,7 +160,7 @@ class EvaluatingCompilerDateTimeRandomizedTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             query = query,
             expectedResult = expected,
-            expectedResultFormat = ExpectedResultFormat.STRING
+            expectedResultFormat = ExpectedResultFormat.STRICT
         )
     }
 
@@ -172,7 +172,7 @@ class EvaluatingCompilerDateTimeRandomizedTests : EvaluatorTestBase() {
         runEvaluatorTestCase(
             query = query,
             expectedResult = expected,
-            expectedResultFormat = ExpectedResultFormat.STRING
+            expectedResultFormat = ExpectedResultFormat.STRICT
         )
     }
 }


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #560

## Description
- Remove `ExpectedTestFormat.STRING`. For those test cases which use this format, they are switched to use `ExpectedTestFormat.STRICT` . The `ExpectedTestFormat.STRING` compares actual & expected results in format of string, which is not really good in terms of maintaining tests. 

## Other Information
- Any backward-incompatible changes? **[YES/NO]**
  - No
- Any new external dependencies? **[YES/NO]**
  - No
