### PR TITLE
Makes PartiQLCompilerBuilder customFunctions, customProcedures, and c…

### DIFF
--- a/lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
@@ -121,31 +121,19 @@ class PartiQLCompilerBuilder private constructor() {
         this.options = options
     }
 
-    /**
-     * TODO This will be replaced by the open type system.
-     *  - https://github.com/partiql/partiql-lang-kotlin/milestone/4
-     */
-    internal fun customFunctions(customFunctions: List<ExprFunction>) = this.apply {
+    fun customFunctions(customFunctions: List<ExprFunction>) = this.apply {
         this.customFunctions = customFunctions
     }
 
-    /**
-     * TODO This will be replaced by the open type system.
-     *  - https://github.com/partiql/partiql-lang-kotlin/milestone/4
-     */
-    internal fun customTypes(customTypes: List<CustomType>) = this.apply {
+    fun customTypes(customTypes: List<CustomType>) = this.apply {
         this.customTypes = customTypes
     }
 
-    /**
-     * TODO This will be replaced by the open type system.
-     *  - https://github.com/partiql/partiql-lang-kotlin/milestone/4
-     */
-    internal fun customProcedures(customProcedures: List<StoredProcedure>) = this.apply {
+    fun customProcedures(customProcedures: List<StoredProcedure>) = this.apply {
         this.customProcedures = customProcedures
     }
 
-    internal fun customOperatorFactories(customOperatorFactories: List<RelationalOperatorFactory>) = this.apply {
+    fun customOperatorFactories(customOperatorFactories: List<RelationalOperatorFactory>) = this.apply {
         this.customOperatorFactories = customOperatorFactories
     }
 


### PR DESCRIPTION
…ustomOperatorFactories public

## Relevant Issues
#947 

## Description

We removed three public functions as these were intended to be replaced by ongoing work. These were never replaced, and we need to make them visible again.

## Other Information
No

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.