### PR TITLE
Adds support for shebang and fixes pipeline options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Adds ability to pipe queries to the CLI
+- Adds ability to run PartiQL files as executables by adding support for shebangs
 - Added numeric functions `abs`, `sqrt`, `exp`, `ln`, `pow`.
 
 ### Changed

--- a/docs/tutorials/Command Line Tutorial.md
+++ b/docs/tutorials/Command Line Tutorial.md
@@ -26,6 +26,8 @@ To view all available options, run the CLI with the `--help` option.
 
 ## Non-Interactive (Single Query Execution)
 
+### Using the Script
+
 To execute a single query, run:
 
 ```shell
@@ -33,6 +35,8 @@ To execute a single query, run:
 ```
 
 where `query.partiql` contains the PartiQL query to execute.
+
+### Using the `partiql` Command Directly
 
 Alternatively, you may pipe input into the native command:
 
@@ -42,6 +46,55 @@ echo "SELECT * FROM [0, 1, 2]" | ./partiql-app/partiql-cli/build/install/partiql
 
 # Via `cat`
 echo ~/Desktop/query.partiql | ./partiql-app/partiql-cli/build/install/partiql-cli/bin/partiql
+```
+
+### Running a PartiQL Executable File (Unix)
+
+Users can also create and run executable files containing PartiQL queries. To use this feature,
+please add `partiql` (the built executable) to your path:
+
+```shell
+# file: ~/.bashrc or ~/.zshrc
+# desc: Example configuration update of BASH or ZSH shells
+
+# Example adding gradle-built partiql command. Need to build the executable (see directions above).
+PATH_TO_PARTIQL_LANG_KOTLIN="${HOME}/partiql-lang-kotlin"
+PATH="$PATH_TO_PARTIQL_LANG_KOTLIN/partiql-app/partiql-cli/build/install/partiql-cli/bin:$PATH"
+export PATH
+```
+
+Once you have saved your configurations, remember to source your configuration file.
+```shell
+# For ZSH
+source ~/.zshrc
+
+# For Bash
+source ~/.bashrc
+```
+
+Now, with the `partiql` executable on your path, you can write PartiQL files such as the below file (`example.partiql`):
+```partiql
+#!/usr/bin/env partiql
+
+-- file: example.partiql
+-- desc: A simple PartiQL query
+
+SELECT t.a AS result
+FROM <<
+  { 'a': 1 },
+  { 'a': 9 },
+  { 'a': 4 },
+  { 'a': 6 }
+>> AS t
+WHERE a > 2
+ORDER BY a DESC
+```
+
+Now, you can convert this file into an executable and run it directly!
+```shell
+$ chmod +x ./example.partiql
+$ ./example.partiql
+[{'result': 9}, {'result': 6}, {'result': 4}]
 ```
 
 ## Interactive (Shell)

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PartiQLCommand.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PartiQLCommand.kt
@@ -63,10 +63,9 @@ internal class PartiQLCommand(private val ion: IonSystem) : Runnable {
     override fun run() {
         val command = executionOptions ?: ExecutionOptions()
         val shell = shellOptions ?: ShellOptions()
-        val stdin = System.`in`
         when {
             command.query != null -> runCli(command, command.query!!.inputStream())
-            stdin.available() > 0 -> runCli(command, stdin)
+            System.console() == null -> runCli(command, System.`in`)
             else -> runShell(shell)
         }
     }
@@ -89,10 +88,10 @@ internal class PartiQLCommand(private val ion: IonSystem) : Runnable {
             false -> query
             else -> queryLines.subList(1, queryLines.size).joinToString(System.lineSeparator())
         }
-        input.use {
-            output.use {
-                Cli(ion, input, exec.inputFormat, output, exec.outputFormat, options.pipeline, options.globalEnvironment, queryWithoutShebang, exec.wrapIon).run()
-                output.write(System.lineSeparator().toByteArray(Charsets.UTF_8))
+        input.use { src ->
+            output.use { out ->
+                Cli(ion, src, exec.inputFormat, out, exec.outputFormat, options.pipeline, options.globalEnvironment, queryWithoutShebang, exec.wrapIon).run()
+                out.write(System.lineSeparator().toByteArray(Charsets.UTF_8))
             }
         }
     }

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PipelineOptions.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PipelineOptions.kt
@@ -46,15 +46,17 @@ internal class PipelineOptions {
     @CommandLine.Option(names = ["-u", "--undefined-variable-behavior"], description = ["Defines the behavior when a non-existent variable is referenced: [\${COMPLETION-CANDIDATES}]"], paramLabel = "OPT")
     var undefinedVarBehavior: UndefinedVariableBehavior = UndefinedVariableBehavior.ERROR
 
-    private val pipelineOptions = AbstractPipeline.createPipelineOptions(
-        pipelineType,
-        typedOpBehavior,
-        projIterBehavior,
-        undefinedVarBehavior,
-        typingMode
-    )
-
-    internal val pipeline = AbstractPipeline.create(pipelineOptions)
+    internal val pipeline: AbstractPipeline
+        get() {
+            val options = AbstractPipeline.createPipelineOptions(
+                pipelineType,
+                typedOpBehavior,
+                projIterBehavior,
+                undefinedVarBehavior,
+                typingMode
+            )
+            return AbstractPipeline.create(options)
+        }
 
     internal val globalEnvironment = when (environmentFile) {
         null -> Bindings.empty()


### PR DESCRIPTION
## Relevant Issues
- Closes #952 

## Description
- Adds support for shebang
- Fixes ability to use passed options for the pipeline.
- Adjusts how we determine whether STDIN is present by using `System.console()` -- this allows partiql to pipe its output to another partiql command.
- With the addition of standard input processing (from #946), we can seemingly add support for shebangs. Essentially, if a user specifies a shebang with the path to the `partiql` executable, this PR allows them to run PartiQL executable files.
- This can help some of our customers write queries in a fast-paced manner

## Usage
- Users of this feature will need to have the gradle-produced executable (`partiql`) on their PATH.
- Here's an example:
<img width="541" alt="Screen Shot 2023-01-03 at 1 43 26 PM" src="https://user-images.githubusercontent.com/40360967/210446258-76b88fb4-fb85-4691-8bc7-5a5d300da822.png">

- And here's an example of piping its output to itself:
<img width="685" alt="Screen Shot 2023-01-05 at 5 34 08 PM" src="https://user-images.githubusercontent.com/40360967/210911737-20ea3e5a-ca99-4a2e-bce5-95ffa9934de4.png">

- And another example with pretty printing:
<img width="564" alt="Screen Shot 2023-01-03 at 1 45 15 PM" src="https://user-images.githubusercontent.com/40360967/210446497-a1a1e9d8-b683-4969-87cf-a3eea6340cac.png">

- And here's an example with the experimental pipeline:
<img width="569" alt="Screen Shot 2023-01-03 at 2 00 03 PM" src="https://user-images.githubusercontent.com/40360967/210448408-75ac0d53-52ae-40f3-ab36-807edc9cba78.png">

## Open Questions
- Windows doesn't support shebangs -- I'm curious what we should do in this scenario.

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.