### PR TITLE
Re-adds CLI Main, and adds newline to CLI output

### DIFF
--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+@file:JvmName("Main")
+
+@file:Suppress("DEPRECATION")
+
+package org.partiql.cli
+
+import com.amazon.ion.system.IonSystemBuilder
+import org.partiql.cli.pico.PartiQLCommand
+import picocli.CommandLine
+import kotlin.system.exitProcess
+
+/**
+ * Runs the PartiQL CLI.
+ */
+fun main(args: Array<String>) {
+    val ion = IonSystemBuilder.standard().build()
+    val command = CommandLine(PartiQLCommand(ion))
+    val exitCode = command.execute(*args)
+    exitProcess(exitCode)
+}

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PartiQLCommand.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PartiQLCommand.kt
@@ -83,6 +83,7 @@ internal class PartiQLCommand(private val ion: IonSystem) : Runnable {
         input.use {
             output.use {
                 Cli(ion, input, exec.inputFormat, output, exec.outputFormat, options.pipeline, options.globalEnvironment, query, exec.wrapIon).run()
+                output.write(System.lineSeparator().toByteArray(Charsets.UTF_8))
             }
         }
     }


### PR DESCRIPTION
## Description
- With PR #922 merged, it accidentally removed the Main.kt file. This re-adds the file.
- Also, adds a newline character to the CLI output. This is because the CLI output always had a `%` at the end of output, which means that the output didn't end in a newline.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
  - No. It's a fix, and doesn't change functionality.
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.