### PR TITLE
Fixes global_env in the shell

### DIFF
--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PartiQLCommand.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PartiQLCommand.kt
@@ -90,7 +90,7 @@ internal class PartiQLCommand(private val ion: IonSystem) : Runnable {
         }
         input.use { src ->
             output.use { out ->
-                Cli(ion, src, exec.inputFormat, out, exec.outputFormat, options.pipeline, options.globalEnvironment, queryWithoutShebang, exec.wrapIon).run()
+                Cli(ion, src, exec.inputFormat, out, exec.outputFormat, options.pipeline, options.environment, queryWithoutShebang, exec.wrapIon).run()
                 out.write(System.lineSeparator().toByteArray(Charsets.UTF_8))
             }
         }
@@ -101,7 +101,7 @@ internal class PartiQLCommand(private val ion: IonSystem) : Runnable {
      */
     private fun runShell(shell: ShellOptions = ShellOptions()) {
         val config = Shell.ShellConfiguration(isMonochrome = shell.isMonochrome)
-        Shell(System.out, options.pipeline, options.globalEnvironment, config).start()
+        Shell(System.out, options.pipeline, options.environment, config).start()
     }
 
     /**

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PipelineOptions.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pico/PipelineOptions.kt
@@ -28,22 +28,46 @@ import java.io.File
 
 internal class PipelineOptions {
 
-    @CommandLine.Option(names = ["-p", "--pipeline"], description = ["The type of pipeline to use: [\${COMPLETION-CANDIDATES}]"], paramLabel = "TYPE")
+    @CommandLine.Option(
+        names = ["-p", "--pipeline"],
+        description = ["The type of pipeline to use: [\${COMPLETION-CANDIDATES}]"],
+        paramLabel = "TYPE"
+    )
     var pipelineType: AbstractPipeline.PipelineType = AbstractPipeline.PipelineType.STANDARD
 
-    @CommandLine.Option(names = ["-e", "--environment"], description = ["File containing the global environment"], paramLabel = "FILE")
+    @CommandLine.Option(
+        names = ["-e", "--environment"],
+        description = ["File containing the global environment"],
+        paramLabel = "FILE"
+    )
     var environmentFile: File? = null
 
-    @CommandLine.Option(names = ["--typing-mode"], description = ["Specifies the typing mode: [\${COMPLETION-CANDIDATES}]"], paramLabel = "MODE")
+    @CommandLine.Option(
+        names = ["--typing-mode"],
+        description = ["Specifies the typing mode: [\${COMPLETION-CANDIDATES}]"],
+        paramLabel = "MODE"
+    )
     var typingMode: TypingMode = TypingMode.LEGACY
 
-    @CommandLine.Option(names = ["--typed-op-behavior"], description = ["Indicates how CAST should behave: [\${COMPLETION-CANDIDATES}]"], paramLabel = "OPT")
+    @CommandLine.Option(
+        names = ["--typed-op-behavior"],
+        description = ["Indicates how CAST should behave: [\${COMPLETION-CANDIDATES}]"],
+        paramLabel = "OPT"
+    )
     var typedOpBehavior: TypedOpBehavior = TypedOpBehavior.HONOR_PARAMETERS
 
-    @CommandLine.Option(names = ["--projection-iter-behavior"], description = ["Controls the behavior of ExprValue.iterator in the projection result: [\${COMPLETION-CANDIDATES}]"], paramLabel = "OPT")
+    @CommandLine.Option(
+        names = ["--projection-iter-behavior"],
+        description = ["Controls the behavior of ExprValue.iterator in the projection result: [\${COMPLETION-CANDIDATES}]"],
+        paramLabel = "OPT"
+    )
     var projIterBehavior: ProjectionIterationBehavior = ProjectionIterationBehavior.FILTER_MISSING
 
-    @CommandLine.Option(names = ["-u", "--undefined-variable-behavior"], description = ["Defines the behavior when a non-existent variable is referenced: [\${COMPLETION-CANDIDATES}]"], paramLabel = "OPT")
+    @CommandLine.Option(
+        names = ["-u", "--undefined-variable-behavior"],
+        description = ["Defines the behavior when a non-existent variable is referenced: [\${COMPLETION-CANDIDATES}]"],
+        paramLabel = "OPT"
+    )
     var undefinedVarBehavior: UndefinedVariableBehavior = UndefinedVariableBehavior.ERROR
 
     internal val pipeline: AbstractPipeline
@@ -58,14 +82,11 @@ internal class PipelineOptions {
             return AbstractPipeline.create(options)
         }
 
-    internal val globalEnvironment = when (environmentFile) {
-        null -> Bindings.empty()
-        else -> getEnvironment(environmentFile!!, pipeline)
-    }
-
-    private fun getEnvironment(environmentFile: File, pipeline: AbstractPipeline): Bindings<ExprValue> {
-        val configSource = environmentFile.readText(charset("UTF-8"))
-        val config = pipeline.compile(configSource, EvaluationSession.standard()) as PartiQLResult.Value
-        return config.value.bindings
-    }
+    internal val environment: Bindings<ExprValue>
+        get() {
+            if (environmentFile == null) return Bindings.empty()
+            val configSource = environmentFile!!.readText(charset("UTF-8"))
+            val config = pipeline.compile(configSource, EvaluationSession.standard()) as PartiQLResult.Value
+            return config.value.bindings
+        }
 }


### PR DESCRIPTION
## Relevant Issues

The `globalEnvironment` property of the `PipelineOption`s was initialized during object instantiation which means the `environmentFile` is always null — picocli has not bound input parameters/args to this object yet. By switching the `globalEnvironment` to a getter property, we check `environmentFile` on access.

## Description

```sql
> $ ./partiql-app/partiql-cli/build/install/partiql-cli/bin/partiql -e ./partiql-app/partiql-cli/archive/Tutorial/code/q1.env                                                                                               [±global_env ✓]
{ 
    'hr': { 
        'employees': <<
            -- a tuple is denoted by { ... } in the PartiQL data model
            { 'id': 3, 'name': 'Bob Smith',   'title': null }, 
            { 'id': 4, 'name': 'Susan Smith', 'title': 'Dev Mgr' },
            { 'id': 6, 'name': 'Jane Smith',  'title': 'Software Eng 2'}
        >>
    }
} 

Welcome to the PartiQL shell!
Typing mode: LEGACY
Using version: 0.9.2-SNAPSHOT-39a575d0
PartiQL> !global_env
   | 
===' 
{
  'hr': {
    'employees': <<
      {
        'id': 3,
        'name': 'Bob Smith',
        'title': NULL
      },
      {
        'id': 4,
        'name': 'Susan Smith',
        'title': 'Dev Mgr'
      },
      {
        'id': 6,
        'name': 'Jane Smith',
        'title': 'Software Eng 2'
      }
    >>
  }
}
--- 
OK!
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
 No

- Any new external dependencies? **[YES/NO]**
No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.