### PR TITLE
Fixes list/bag ExprValue creation in plan evaluator

### DIFF
--- a/lang/src/main/kotlin/org/partiql/lang/ast/IsOrderedMeta.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/ast/IsOrderedMeta.kt
@@ -1,0 +1,9 @@
+package org.partiql.lang.ast
+
+/**
+ * To reduce any extraneous passes over data, this [Meta] indicates whether the associated BindingsToValues Physical
+ * expression should be an ordered list or a bag.
+ */
+object IsOrderedMeta : Meta {
+    override val tag = "\$is_ordered"
+}

--- a/lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
@@ -268,7 +268,11 @@ internal class PhysicalPlanCompilerImpl(
         }
 
         return thunkFactory.thunkEnv(expr.metas) { env ->
+            // we create a snapshot for currentRegister to use during the evaluation
+            // this is to avoid issue when iterator planner result
+            val currentRegister = env.registers.clone()
             val elements = sequence {
+                env.load(currentRegister)
                 val relItr = bexprThunk(env)
                 while (relItr.nextRow()) {
                     yield(mapThunk(env))

--- a/lang/src/main/kotlin/org/partiql/lang/eval/visitors/AggregationVisitorTransform.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/eval/visitors/AggregationVisitorTransform.kt
@@ -105,7 +105,7 @@ internal class AggregationVisitorTransform(
 
     override fun transformExprSelect_group(node: PartiqlAst.Expr.Select): PartiqlAst.GroupBy? {
         // Return with Empty Context if without Group
-        val containsAggregations = AggregationFinder.containsAggregations(node.project)
+        val containsAggregations = AggregationFinder().containsAggregations(node.project)
         if (node.group == null) {
             val context = VisitorContext(emptyList(), null, containsAggregations)
             contextStack.add(context)
@@ -202,7 +202,8 @@ internal class AggregationVisitorTransform(
      * Recursively searches through a [PartiqlAst.Projection] to find [PartiqlAst.Expr.CallAgg]'s, but does NOT recurse
      * into [PartiqlAst.Expr.Select]. Designed to be called directly using [containsAggregations].
      */
-    private object AggregationFinder : PartiqlAst.Visitor() {
+    private class AggregationFinder : PartiqlAst.Visitor() {
+
         var hasAggregations: Boolean = false
 
         fun containsAggregations(node: PartiqlAst.Projection): Boolean {
@@ -276,7 +277,7 @@ internal class AggregationVisitorTransform(
         }
 
         /**
-         * IDs outside of aggregation functions should always be replaced with the Group Key uniue aliases. If no
+         * IDs outside of aggregation functions should always be replaced with the Group Key unique aliases. If no
          * replacement is found, we throw an EvaluationException.
          */
         private fun getReplacementForIdOutsideOfAggregationFunction(node: PartiqlAst.Expr.Id): PartiqlAst.Expr {

--- a/lang/src/test/kotlin/org/partiql/lang/compiler/memorydb/operators/GetByKeyProjectRelationalOperatorFactory.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/compiler/memorydb/operators/GetByKeyProjectRelationalOperatorFactory.kt
@@ -57,10 +57,16 @@ class GetByKeyProjectRelationalOperatorFactory : ProjectRelationalOperatorFactor
         // Parse the tableId so we don't have to at evaluation-time
         val tableId = UUID.fromString(impl.staticArgs.single().textValue)
 
+        var exhausted = false
+
         // Finally, return a RelationExpression which evaluates the key value expression and returns a
         // RelationIterator containing a single row corresponding to the key (or no rows if nothing matches)
         return RelationExpression { state ->
             // this code runs at evaluation-time.
+
+            if (exhausted) {
+                throw IllegalStateException("Exhausted result set")
+            }
 
             // Get the current database from the EvaluationSession context.
             // Please note that the state.session.context map is immutable, therefore it is not possible
@@ -73,6 +79,8 @@ class GetByKeyProjectRelationalOperatorFactory : ProjectRelationalOperatorFactor
 
             // get the record requested.
             val record = db.getRecordByKey(tableId, keyValue)
+
+            exhausted = true
 
             // if the record was not found, return an empty relation:
             if (record == null)

--- a/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerCollectionAggregationsTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerCollectionAggregationsTest.kt
@@ -172,8 +172,8 @@ internal class EvaluatingCompilerCollectionAggregationsTest : EvaluatorTestBase(
                 """,
                 expectedResult = """
                     <<
-                        {'k': [2, 4], 'coll_sum_a': 6, 'coll_sum_inner': <<6>>, 'sum_b': 30},
-                        {'k': [6, 7], 'coll_sum_a': 13, 'coll_sum_inner': <<13>>, 'sum_b': 20}
+                        {'k': [2, 4], 'coll_sum_a': 6, 'sum_b': 30,  'coll_sum_inner': <<6>>},
+                        {'k': [6, 7], 'coll_sum_a': 13,  'sum_b': 20, 'coll_sum_inner': <<13>>}
                     >>
                 """
             ),


### PR DESCRIPTION
## Relevant Issues

#966 
#951 

## Description

Description is in 966 and agg finder fix describe in 951. Peeking the sequence caused it to be instantiated prematurely, so we'll use John's original (and simpler) method of adding a meta to determine which ExprValue to create. The other fixes (it stopped at least? can't say definitively because ... nondeterministic) some nondeterministic behavior we were seeing

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
 No

- Any new external dependencies? **[YES/NO]**
No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.