### PR TITLE
Add workflow step to download previously created conformance report

### DIFF
--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -24,9 +24,7 @@ jobs:
       - name: gradle test of the conformance tests (can fail) and save to Ion file
         continue-on-error: true
         run: gradle :test:partiql-tests-runner:test --tests "*ConformanceTestsReportRunner" -PconformanceReport
-      # Upload conformance report for future viewing and comparison with future runs -- this hasn't yet been included.
-      # Since the conformance report is uploaded as part of `push` events, we could download it in the
-      # `conformance-report-comparison` for `pull-request` events, which could save build time for the target branch.
+      # Upload conformance report for future viewing and comparison with future runs.
       - name: Upload `conformance_test_results.ion`
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -66,13 +66,14 @@ jobs:
           workflow: conformance-report.yml
           commit: ${{ github.event.pull_request.base.sha }}
       # (If download of target branch report fails) Run the conformance tests (i.e. `gradle test`) and save to an Ion file.
-      - uses: actions/checkout@v3
+      - name: (If download of target branch conformance report fails) Checkout target branch
+        uses: actions/checkout@v3
         if: ${{ steps.download-report.outcome == 'failure' }}
         with:
           submodules: recursive
           path: ${{ github.event.pull_request.base.sha }}
           ref: ${{ github.event.pull_request.base.sha }}
-      - name: gradle test of the conformance tests (can fail) and save to Ion file
+      - name: (If download of target branch conformance report fails) Generate conformance test report for target branch
         if: ${{ steps.download-report.outcome == 'failure' }}
         continue-on-error: true
         run: |

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -60,20 +60,32 @@ jobs:
           distribution: 'corretto'
           java-version: 17
           cache: gradle
+      - name: Download `conformance_test_results.ion` from target branch
+        uses: dawidd6/action-download-artifact@v2
+        id: download-report
+        continue-on-error: true
+        with:
+          workflow: conformance-report.yml
+          commit: ${{ github.event.pull_request.base.sha }}
+      # (If download of target branch report fails) Run the conformance tests (i.e. `gradle test`) and save to an Ion file.
       - uses: actions/checkout@v3
+        if: ${{ steps.download-report.outcome == 'failure' }}
         with:
           submodules: recursive
           path: ${{ github.event.pull_request.base.sha }}
           ref: ${{ github.event.pull_request.base.sha }}
-      # Run the conformance tests (i.e. `gradle test`) and save to an Ion file.
       - name: gradle test of the conformance tests (can fail) and save to Ion file
+        if: ${{ steps.download-report.outcome == 'failure' }}
         continue-on-error: true
         run: |
           cd ${{ github.event.pull_request.base.sha }}
           gradle :test:partiql-tests-runner:test --tests "*ConformanceTestsReportRunner" -PconformanceReport
+          mkdir -p $GITHUB_WORKSPACE/artifact
+          cp -r $GITHUB_WORKSPACE/${{ github.event.pull_request.base.sha }}/$PATH_TO_TEST_RUNNER/$CONFORMANCE_REPORT_NAME $GITHUB_WORKSPACE/artifact/$CONFORMANCE_REPORT_NAME
       # Run conformance report comparison. Generates `comparison_report.md`
-      - run: |
-          ARGS="$GITHUB_WORKSPACE/${{ github.event.pull_request.base.sha }}/$PATH_TO_TEST_RUNNER/$CONFORMANCE_REPORT_NAME $CONFORMANCE_REPORT_NAME ${{ github.event.pull_request.base.sha }} $GITHUB_SHA $COMPARISON_REPORT_NAME"
+      - name: Run conformance report comparison. Generates `comparison_report.md`
+        run: |
+          ARGS="./artifact/$CONFORMANCE_REPORT_NAME $CONFORMANCE_REPORT_NAME ${{ github.event.pull_request.base.sha }} $GITHUB_SHA $COMPARISON_REPORT_NAME"
           gradle :test:partiql-tests-runner:run --args="$ARGS"
       # Print conformance report to GitHub actions workflow summary page
       - name: print markdown in run

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -78,7 +78,10 @@ jobs:
         continue-on-error: true
         run: |
           cd ${{ github.event.pull_request.base.sha }}
-          gradle :test:partiql-tests-runner:test --tests "*ConformanceTestsReportRunner" -PconformanceReport --continue
+          gradle :test:partiql-tests-runner:test --tests "*ConformanceTestsReportRunner" -PconformanceReport
+      - name: (If download of target branch conformance report fails) Move conformance test report of target branch to ./artifact directory
+        if: ${{ steps.download-report.outcome == 'failure' }}
+        run: |
           mkdir -p $GITHUB_WORKSPACE/artifact
           cp -r $GITHUB_WORKSPACE/${{ github.event.pull_request.base.sha }}/$PATH_TO_TEST_RUNNER/$CONFORMANCE_REPORT_NAME $GITHUB_WORKSPACE/artifact/$CONFORMANCE_REPORT_NAME
       # Run conformance report comparison. Generates `comparison_report.md`

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -77,7 +77,7 @@ jobs:
         continue-on-error: true
         run: |
           cd ${{ github.event.pull_request.base.sha }}
-          gradle :test:partiql-tests-runner:test --tests "*ConformanceTestsReportRunner" -PconformanceReport
+          gradle :test:partiql-tests-runner:test --tests "*ConformanceTestsReportRunner" -PconformanceReport --continue
           mkdir -p $GITHUB_WORKSPACE/artifact
           cp -r $GITHUB_WORKSPACE/${{ github.event.pull_request.base.sha }}/$PATH_TO_TEST_RUNNER/$CONFORMANCE_REPORT_NAME $GITHUB_WORKSPACE/artifact/$CONFORMANCE_REPORT_NAME
       # Run conformance report comparison. Generates `comparison_report.md`

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -86,6 +86,7 @@ jobs:
           cp -r $GITHUB_WORKSPACE/${{ github.event.pull_request.base.sha }}/$PATH_TO_TEST_RUNNER/$CONFORMANCE_REPORT_NAME $GITHUB_WORKSPACE/artifact/$CONFORMANCE_REPORT_NAME
       # Run conformance report comparison. Generates `comparison_report.md`
       - name: Run conformance report comparison. Generates `comparison_report.md`
+        continue-on-error: true
         run: |
           ARGS="$GITHUB_WORKSPACE/artifact/$CONFORMANCE_REPORT_NAME $CONFORMANCE_REPORT_NAME ${{ github.event.pull_request.base.sha }} $GITHUB_SHA $COMPARISON_REPORT_NAME"
           gradle :test:partiql-tests-runner:run --args="$ARGS"

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -83,7 +83,7 @@ jobs:
       # Run conformance report comparison. Generates `comparison_report.md`
       - name: Run conformance report comparison. Generates `comparison_report.md`
         run: |
-          ARGS="./artifact/$CONFORMANCE_REPORT_NAME $CONFORMANCE_REPORT_NAME ${{ github.event.pull_request.base.sha }} $GITHUB_SHA $COMPARISON_REPORT_NAME"
+          ARGS="$GITHUB_WORKSPACE/artifact/$CONFORMANCE_REPORT_NAME $CONFORMANCE_REPORT_NAME ${{ github.event.pull_request.base.sha }} $GITHUB_SHA $COMPARISON_REPORT_NAME"
           gradle :test:partiql-tests-runner:run --args="$ARGS"
       # Print conformance report to GitHub actions workflow summary page
       - name: print markdown in run


### PR DESCRIPTION
Adds workflow step to download previously created conformance report with backup condition to re-run if download fails.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.