### PR TITLE
Fixes javadoc jar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,46 +22,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+
       - name: Use Java ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
           distribution: 'corretto'
           java-version: ${{ matrix.java }}
-          cache: gradle
-      - name: Build and test
-        run: ./gradlew build
 
-  randomized-test:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        java: [ 11, 17 ]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Use Java ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'corretto'
-          java-version: ${{ matrix.java }}
-          cache: gradle
-      - name: Build and test
-        run: ./gradlew :test:partiql-randomized-tests:test -PrandomTests
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
 
-  report-generation:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Use Java 17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'corretto'
-          java-version: 17
-          cache: gradle
-      - name: Generate test coverage report
+      - name: Test and Report
         run: ./gradlew build jacocoTestReport
 
       # Upload coverage for CLI, LANG, PTS, TEST_SCRIPT, and EXAMPLES
@@ -100,3 +71,21 @@ jobs:
         with:
           file: extensions/build/reports/jacoco/test/jacocoTestReport.xml
           flags: EXTENSIONS
+
+  randomized-test:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        java: [ 11, 17 ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Use Java ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: ${{ matrix.java }}
+          cache: gradle
+      - name: Build and test
+        run: ./gradlew :test:partiql-randomized-tests:test -PrandomTests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         java: [11, 17]
@@ -32,7 +32,7 @@ jobs:
         run: ./gradlew build
 
   randomized-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         java: [ 11, 17 ]
@@ -50,7 +50,7 @@ jobs:
         run: ./gradlew :test:partiql-randomized-tests:test -PrandomTests
 
   report-generation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
         java: [11, 17]
     steps:
       - uses: actions/checkout@v2
+        env:
+          DOKKA: false
         with:
           submodules: recursive
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
         java: [11, 17]
     steps:
       - uses: actions/checkout@v2
-        env:
-          DOKKA: false
         with:
           submodules: recursive
 
@@ -35,6 +33,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Test and Report
+        env:
+          DOKKA: false
         run: ./gradlew build jacocoTestReport
 
       # Upload coverage for CLI, LANG, PTS, TEST_SCRIPT, and EXAMPLES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ExprValueFactory` interface marked as deprecated. Equivalent `ExprValue` construction methods are implemented in the `ExprValue` interface as static methods. 
 
 ### Fixed
+- Javadoc jar now contains dokka docs (was broken by gradle commit from 0.9.0)
 
 ### Removed
 - The deprecated `IonValue` property in `ExprValue` interface is now removed.

--- a/buildSrc/src/main/kotlin/org/partiql/gradle/plugin/publish/PublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/partiql/gradle/plugin/publish/PublishPlugin.kt
@@ -23,6 +23,7 @@ import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getByName
@@ -65,12 +66,21 @@ abstract class PublishPlugin : Plugin<Project> {
             withJavadocJar()
         }
 
+        // Add dokkaHtml output to the javadocJar
+        tasks.getByName<Jar>("javadocJar") {
+            dependsOn(JavaPlugin.CLASSES_TASK_NAME)
+            archiveClassifier.set("javadoc")
+            from(tasks.named("dokkaHtml"))
+        }
+
         // Setup Maven Central Publishing
         val publishing = extensions.getByType(PublishingExtension::class.java).apply {
             publications {
                 create<MavenPublication>("maven") {
                     artifactId = ext.artifactId
                     from(components["java"])
+                    artifact(tasks["sourcesJar"])
+                    artifact(tasks["javadocJar"])
                     pom {
                         packaging = "jar"
                         name.set(ext.name)

--- a/lang/build.gradle.kts
+++ b/lang/build.gradle.kts
@@ -73,7 +73,7 @@ tasks.compileKotlin {
     dependsOn(tasks.generateGrammarSource)
 }
 
-tasks.dokkaHtml {
+tasks.dokkaHtml.configure {
     dependsOn(tasks.withType(org.partiql.pig.gradle.PigTask::class))
 }
 

--- a/lang/build.gradle.kts
+++ b/lang/build.gradle.kts
@@ -73,6 +73,10 @@ tasks.compileKotlin {
     dependsOn(tasks.generateGrammarSource)
 }
 
+tasks.findByName("sourcesJar")?.apply {
+    dependsOn(tasks.generateGrammarSource)
+}
+
 tasks.dokkaHtml.configure {
     dependsOn(tasks.withType(org.partiql.pig.gradle.PigTask::class))
 }


### PR DESCRIPTION
## Description

Dokka generated docs weren't getting added to the Javadoc JAR since I moved publishing to plugin. Now each module that uses the publishing plugin will appropriately create sources and javadoc jars as before.

**Workflow Changes**
## Workflow Changes

**Before - failing (cancelled, or fails after ~40mins)**

Before we had six workflows (three jobs, each run twice for java 11 and 17)

- Build and Test
  - tasks: build, test
- Randomized Tests
  - tasks: run randomized tests
- Report Generation
  - tasks: build, test, generate report, upload report

**After - success ~12mins**

- Randomized Tests
  - tasks: run randomized tests
- Report Generation
  - tasks: build, test, generate report, upload report

I removed the double build + test between jobs 1 and 2. Now we have four workflows (2 jobs, 2 java versions)

I also used the gradle action which tunes gradle (I don't know the exact details) to cache its setup between jobs and shouldn't use the gradle daemon. This fixed the workflow which was overwhelmed by building, testing, and generating docs four times.

**Skip Dokka**
You can disable running dokka to save several minutes on the build. Gradle performance is hard to measure because of caching, but it's generally faster to not do a task rather than doing said task. I have dokka skipped on CI
```
             `./gradlew clean build --no-build-cache` BUILD SUCCESSFUL in 8m 22s
 `DOKKA=false ./gradlew clean build --no-build-cache` BUILD SUCCESSFUL in 5m 14s
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
 No

- Any new external dependencies? **[YES/NO]**
No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.