### PR TITLE
Put ANTLR and PIG sources back into the jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ANTLR (PartiQL.g4, PartiQLTokens.g4) and PIG (org/partiql/type-domains/partiql.ion) sources 
+  are back to being distributed with the jar.
+
 ### Removed
 - The deprecated `IonValue` property in `ExprValue` interface is now removed.
 

--- a/lang/build.gradle.kts
+++ b/lang/build.gradle.kts
@@ -78,7 +78,11 @@ tasks.dokkaHtml {
 }
 
 tasks.processResources {
-    from("antlr") {
+    from("src/main/antlr") {
         include("**/*.g4")
+    }
+    from("src/main/pig") {
+        include("partiql.ion")
+        into("org/partiql/type-domains/")
     }
 }


### PR DESCRIPTION
Putting the files back to the same jar locations where they used to be before 0.9.0: 
org/partiql/type-domains/partiql.ion and PartiQL.g4, PartiQLTokens.g4 on the top level. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - Will follow-up shortly.
- Any backward-incompatible changes? **[NO]**
- Any new external dependencies? **[NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.