### PR TITLE
Fix conformance comparison report for passing row

### DIFF
--- a/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
+++ b/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
@@ -56,7 +56,7 @@ fun main(args: Array<String>) {
 | | Base ($origCommitId) | $newCommitId | +/- |
 | --- | ---: | ---: | ---: |
 | % Passing | ${"%.2f".format(origPassingPercent)}% | ${"%.2f".format(newPassingPercent)}% | ${"%.2f".format(newPassingPercent - origPassingPercent)}% |
-| :white_check_mark: Passing | $numOrigPassing | $numNewPassing | ${numNewPassing - numOrigFailing} |
+| :white_check_mark: Passing | $numOrigPassing | $numNewPassing | ${numNewPassing - numOrigPassing} |
 | :x: Failing | $numOrigFailing | $numNewFailing | ${numNewFailing - numOrigFailing} |
 | :large_orange_diamond: Ignored | $numOrigIgnored | $numNewIgnored | ${numNewIgnored - numOrigIgnored} |
 | Total Tests | $totalOrig | $totalNew | ${totalNew - totalOrig} |


### PR DESCRIPTION
Conformance comparison report comment had the wrong variable in the difference of passing tests. Should be `${numNewPassing - numOrigPassing}` rather than `${numNewPassing - numOrigFailing}`.

## Other Information
- Updated Unreleased Section in CHANGELOG: No
  - No changes to released code
- Any backward-incompatible changes? No
- Any new external dependencies? No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.