### PR TITLE
Enables overriding partiql-tests-data for conformance report

### DIFF
--- a/test/partiql-tests-runner/README.md
+++ b/test/partiql-tests-runner/README.md
@@ -10,3 +10,14 @@ This package enables:
 Eventually, the `partiql-test-runner` module will replace the `partiql-pts` and `partiql-testscript` modules along with some other 
 tests in `lang` that were ported to `partiql-tests` 
 (see [partiql-lang-kotlin#789](https://github.com/partiql/partiql-lang-kotlin/issues/789)).
+
+## Run Conformance Tests Locally
+
+```shell
+# default, test data from partiql-tests submodule will be used
+./gradlew :test:partiql-tests-runner:test --tests "*ConformanceTestsReportRunner" -PconformanceReport
+
+# override test data location
+PARTIQL_TESTS_DATA=/path/to/partiql-tests/data \
+./gradlew :test:partiql-tests-runner:test --tests "*ConformanceTestsReportRunner" -PconformanceReport
+```

--- a/test/partiql-tests-runner/build.gradle.kts
+++ b/test/partiql-tests-runner/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     testImplementation(project(":lang"))
 }
 
-val tests = "../partiql-tests/partiql-tests-data"
+val tests = System.getenv()["PARTIQL_TESTS_DATA"] ?: "../partiql-tests/partiql-tests-data"
 
 object Env {
     const val PARTIQL_EVAL = "PARTIQL_EVAL_TESTS_DATA"


### PR DESCRIPTION
Enables overriding partiql-tests-data for conformance report

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.