### PR TITLE
Replace DSL containers with Java style builders; invoke default Jacks…

### DIFF
--- a/partiql-lib/partiql-sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/spec/KotlinNodeSpec.kt
+++ b/partiql-lib/partiql-sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/spec/KotlinNodeSpec.kt
@@ -29,6 +29,7 @@ import org.partiql.sprout.model.TypeDef
  * @property clazz          Type ClassName
  * @property builder        Type builder
  * @property constructor    Implementation constructor
+ * @property companion      A place for static methods on nodes
  * @property types          Non-node types defined within this node
  */
 sealed class KotlinNodeSpec(
@@ -36,6 +37,7 @@ sealed class KotlinNodeSpec(
     val clazz: ClassName,
     val builder: TypeSpec.Builder,
     val constructor: FunSpec.Builder,
+    val companion: TypeSpec.Builder,
     val types: MutableList<TypeSpec> = mutableListOf(),
 ) {
 
@@ -48,6 +50,9 @@ sealed class KotlinNodeSpec(
         primaryConstructor(constructor.build())
         types.forEach { addType(it) }
         children.forEach { addType(it.build()) }
+        if (companion.propertySpecs.isNotEmpty() || companion.funSpecs.isNotEmpty()) {
+            addType(companion.build())
+        }
         build()
     }
 
@@ -65,6 +70,7 @@ sealed class KotlinNodeSpec(
         clazz = clazz,
         builder = TypeSpec.classBuilder(clazz),
         constructor = FunSpec.constructorBuilder(),
+        companion = TypeSpec.companionObjectBuilder(),
         types = types.toMutableList()
     )
 
@@ -80,6 +86,7 @@ sealed class KotlinNodeSpec(
         clazz = clazz,
         builder = TypeSpec.classBuilder(clazz).addModifiers(KModifier.SEALED),
         constructor = FunSpec.constructorBuilder(),
+        companion = TypeSpec.companionObjectBuilder(),
     ) {
         override val children: List<KotlinNodeSpec> = variants
     }

--- a/partiql-lib/partiql-sprout/src/test/java/org/partiql/sprout/example/JavaBuildersTest.java
+++ b/partiql-lib/partiql-sprout/src/test/java/org/partiql/sprout/example/JavaBuildersTest.java
@@ -1,0 +1,27 @@
+package org.partiql.sprout.example;
+
+
+import com.amazon.ionelement.api.Ion;
+import org.junit.jupiter.api.Test;
+import org.partiql.sprout.test.generated.Inlines;
+import org.partiql.sprout.test.generated.Node;
+
+class JavaBuildersTest {
+
+    @Test
+    void example() {
+        // basic example
+        Node node = Node.builder()
+                .a(false)
+                .b(1)
+                .c("C Value")
+                .e(Ion.ionTimestamp("2009-01-01T00:00Z"))
+                .build();
+
+        // nested example
+        Inlines.Foo foo = Inlines.Foo.builder()
+                .x(-1)
+                .y(Inlines.Bar.A)
+                .build();
+    }
+}

--- a/partiql-lib/partiql-sprout/src/test/kotlin/org/partiql/sprout/example/KotlinBuildersTest.kt
+++ b/partiql-lib/partiql-sprout/src/test/kotlin/org/partiql/sprout/example/KotlinBuildersTest.kt
@@ -1,0 +1,39 @@
+package org.partiql.sprout.example
+
+import com.amazon.ionelement.api.ionTimestamp
+import org.junit.jupiter.api.Test
+import org.partiql.sprout.test.generated.Inlines
+import org.partiql.sprout.test.generated.Node
+import org.partiql.sprout.test.generated.builder.sproutTest
+import kotlin.test.assertEquals
+
+class KotlinBuildersTest {
+
+    @Test
+    internal fun example() {
+
+        val node: Node = sproutTest {
+            node {
+                a = false
+                b = 1
+                c = "C Value"
+                e = ionTimestamp("2009-01-01T00:00Z")
+            }
+        }
+
+        assertEquals(false, node.a)
+        assertEquals(1, node.b)
+        assertEquals("C Value", node.c)
+        assertEquals(ionTimestamp("2009-01-01T00:00Z"), node.e)
+
+        val foo = sproutTest {
+            inlinesFoo {
+                x = -1
+                y = Inlines.Bar.A
+            }
+        }
+
+        assertEquals(-1, foo.x)
+        assertEquals(Inlines.Bar.A, foo.y)
+    }
+}

--- a/partiql-lib/partiql-sprout/src/test/kotlin/org/partiql/sprout/test/generated/Types.kt
+++ b/partiql-lib/partiql-sprout/src/test/kotlin/org/partiql/sprout/test/generated/Types.kt
@@ -1,14 +1,15 @@
 package org.partiql.sprout.test.generated
 
 import com.amazon.ionelement.api.TimestampElement
+import org.partiql.sprout.test.generated.builder.CollectionMyListBuilder
+import org.partiql.sprout.test.generated.builder.CollectionMyMapBuilder
+import org.partiql.sprout.test.generated.builder.CollectionMySetBuilder
+import org.partiql.sprout.test.generated.builder.InlinesBuilder
+import org.partiql.sprout.test.generated.builder.InlinesFooBuilder
+import org.partiql.sprout.test.generated.builder.InlinesSumUBuilder
+import org.partiql.sprout.test.generated.builder.InlinesSumVBuilder
+import org.partiql.sprout.test.generated.builder.NodeBuilder
 import org.partiql.sprout.test.generated.visitor.SproutTestVisitor
-import kotlin.Boolean
-import kotlin.Float
-import kotlin.Int
-import kotlin.String
-import kotlin.collections.List
-import kotlin.collections.Map
-import kotlin.collections.Set
 
 public abstract class SproutTestNode {
     public open val children: List<SproutTestNode> = emptyList()
@@ -25,6 +26,11 @@ public data class Node(
 ) : SproutTestNode() {
     public override fun <R, C> accept(visitor: SproutTestVisitor<R, C>, ctx: C): R =
         visitor.visitNode(this, ctx)
+
+    public companion object {
+        @JvmStatic
+        public fun builder(): NodeBuilder = NodeBuilder()
+    }
 }
 
 public sealed class Collection : SproutTestNode() {
@@ -39,6 +45,11 @@ public sealed class Collection : SproutTestNode() {
     ) : Collection() {
         public override fun <R, C> accept(visitor: SproutTestVisitor<R, C>, ctx: C): R =
             visitor.visitCollectionMySet(this, ctx)
+
+        public companion object {
+            @JvmStatic
+            public fun builder(): CollectionMySetBuilder = CollectionMySetBuilder()
+        }
     }
 
     public data class MyList(
@@ -46,6 +57,11 @@ public sealed class Collection : SproutTestNode() {
     ) : Collection() {
         public override fun <R, C> accept(visitor: SproutTestVisitor<R, C>, ctx: C): R =
             visitor.visitCollectionMyList(this, ctx)
+
+        public companion object {
+            @JvmStatic
+            public fun builder(): CollectionMyListBuilder = CollectionMyListBuilder()
+        }
     }
 
     public data class MyMap(
@@ -53,6 +69,11 @@ public sealed class Collection : SproutTestNode() {
     ) : Collection() {
         public override fun <R, C> accept(visitor: SproutTestVisitor<R, C>, ctx: C): R =
             visitor.visitCollectionMyMap(this, ctx)
+
+        public companion object {
+            @JvmStatic
+            public fun builder(): CollectionMyMapBuilder = CollectionMyMapBuilder()
+        }
     }
 }
 
@@ -83,6 +104,11 @@ public data class Inlines(
     ) : SproutTestNode() {
         public override fun <R, C> accept(visitor: SproutTestVisitor<R, C>, ctx: C): R =
             visitor.visitInlinesFoo(this, ctx)
+
+        public companion object {
+            @JvmStatic
+            public fun builder(): InlinesFooBuilder = InlinesFooBuilder()
+        }
     }
 
     public sealed class Sum : SproutTestNode() {
@@ -96,6 +122,11 @@ public data class Inlines(
         ) : Sum() {
             public override fun <R, C> accept(visitor: SproutTestVisitor<R, C>, ctx: C): R =
                 visitor.visitInlinesSumU(this, ctx)
+
+            public companion object {
+                @JvmStatic
+                public fun builder(): InlinesSumUBuilder = InlinesSumUBuilder()
+            }
         }
 
         public data class V(
@@ -103,6 +134,16 @@ public data class Inlines(
         ) : Sum() {
             public override fun <R, C> accept(visitor: SproutTestVisitor<R, C>, ctx: C): R =
                 visitor.visitInlinesSumV(this, ctx)
+
+            public companion object {
+                @JvmStatic
+                public fun builder(): InlinesSumVBuilder = InlinesSumVBuilder()
+            }
         }
+    }
+
+    public companion object {
+        @JvmStatic
+        public fun builder(): InlinesBuilder = InlinesBuilder()
     }
 }

--- a/partiql-lib/partiql-sprout/src/test/kotlin/org/partiql/sprout/test/generated/builder/SproutTestBuilder.kt
+++ b/partiql-lib/partiql-sprout/src/test/kotlin/org/partiql/sprout/test/generated/builder/SproutTestBuilder.kt
@@ -1,0 +1,91 @@
+package org.partiql.sprout.test.generated.builder
+
+import com.amazon.ionelement.api.TimestampElement
+import org.partiql.sprout.test.generated.Collection
+import org.partiql.sprout.test.generated.Inlines
+import org.partiql.sprout.test.generated.Node
+import org.partiql.sprout.test.generated.SproutTestNode
+
+public fun <T : SproutTestNode> sproutTest(
+    factory: SproutTestFactory = SproutTestFactory.DEFAULT,
+    block: SproutTestBuilder.() -> T
+) = SproutTestBuilder(factory).block()
+
+public class SproutTestBuilder(
+    private val factory: SproutTestFactory = SproutTestFactory.DEFAULT
+) {
+    public fun node(
+        a: Boolean? = null,
+        b: Int? = null,
+        c: String? = null,
+        d: Float? = null,
+        e: TimestampElement? = null,
+        block: NodeBuilder.() -> Unit = {}
+    ): Node {
+        val builder = NodeBuilder()
+        builder.block()
+        return builder.build(factory)
+    }
+
+    public fun collectionMySet(
+        values: MutableSet<Int> = mutableSetOf(),
+        block: CollectionMySetBuilder.() -> Unit = {}
+    ): Collection.MySet {
+        val builder = CollectionMySetBuilder()
+        builder.block()
+        return builder.build(factory)
+    }
+
+    public fun collectionMyList(
+        values: MutableList<Int> = mutableListOf(),
+        block: CollectionMyListBuilder.() -> Unit = {}
+    ): Collection.MyList {
+        val builder = CollectionMyListBuilder()
+        builder.block()
+        return builder.build(factory)
+    }
+
+    public fun collectionMyMap(
+        values: MutableMap<String, Int> = mutableMapOf(),
+        block: CollectionMyMapBuilder.() -> Unit = {}
+    ): Collection.MyMap {
+        val builder = CollectionMyMapBuilder()
+        builder.block()
+        return builder.build(factory)
+    }
+
+    public fun inlines(
+        `enum`: Inlines.Bar? = null,
+        product: Inlines.Foo? = null,
+        sum: Inlines.Sum? = null,
+        block: InlinesBuilder.() -> Unit = {}
+    ): Inlines {
+        val builder = InlinesBuilder()
+        builder.block()
+        return builder.build(factory)
+    }
+
+    public fun inlinesFoo(
+        x: Int? = null,
+        y: Inlines.Bar? = null,
+        block: InlinesFooBuilder.() -> Unit = {}
+    ): Inlines.Foo {
+        val builder = InlinesFooBuilder()
+        builder.block()
+        return builder.build(factory)
+    }
+
+    public fun inlinesSumU(foo: String? = null, block: InlinesSumUBuilder.() -> Unit = {}):
+        Inlines.Sum.U {
+        val builder = InlinesSumUBuilder()
+        builder.block()
+        return builder.build(factory)
+    }
+
+    public fun inlinesSumV(bar: String? = null, block: InlinesSumVBuilder.() -> Unit = {}):
+        Inlines.Sum.V {
+        val builder = InlinesSumVBuilder()
+        builder.block()
+        return builder.build(factory)
+    }
+}

--- a/partiql-lib/partiql-sprout/src/test/kotlin/org/partiql/sprout/test/generated/builder/SproutTestBuilders.kt
+++ b/partiql-lib/partiql-sprout/src/test/kotlin/org/partiql/sprout/test/generated/builder/SproutTestBuilders.kt
@@ -1,6 +1,9 @@
 package org.partiql.sprout.test.generated.builder
 
 import com.amazon.ionelement.api.TimestampElement
+import org.partiql.sprout.test.generated.Collection
+import org.partiql.sprout.test.generated.Inlines
+import org.partiql.sprout.test.generated.Node
 import kotlin.Boolean
 import kotlin.Float
 import kotlin.Int
@@ -8,9 +11,6 @@ import kotlin.String
 import kotlin.collections.MutableList
 import kotlin.collections.MutableMap
 import kotlin.collections.MutableSet
-import org.partiql.sprout.test.generated.Collection
-import org.partiql.sprout.test.generated.Inlines
-import org.partiql.sprout.test.generated.Node
 
 public class NodeBuilder {
     public var a: Boolean? = null
@@ -45,8 +45,11 @@ public class NodeBuilder {
 
     public fun build(): Node = build(SproutTestFactory.DEFAULT)
 
-    public fun build(factory: SproutTestFactory = SproutTestFactory.DEFAULT): Node = factory.node(a =
-    a!!, b = b!!, c = c!!, d = d, e = e!!)
+    public fun build(factory: SproutTestFactory = SproutTestFactory.DEFAULT): Node = factory.node(
+        a =
+        a!!,
+        b = b!!, c = c!!, d = d, e = e!!
+    )
 }
 
 public class CollectionMySetBuilder {

--- a/partiql-lib/partiql-sprout/src/test/kotlin/org/partiql/sprout/test/generated/builder/SproutTestBuilders.kt
+++ b/partiql-lib/partiql-sprout/src/test/kotlin/org/partiql/sprout/test/generated/builder/SproutTestBuilders.kt
@@ -1,0 +1,159 @@
+package org.partiql.sprout.test.generated.builder
+
+import com.amazon.ionelement.api.TimestampElement
+import kotlin.Boolean
+import kotlin.Float
+import kotlin.Int
+import kotlin.String
+import kotlin.collections.MutableList
+import kotlin.collections.MutableMap
+import kotlin.collections.MutableSet
+import org.partiql.sprout.test.generated.Collection
+import org.partiql.sprout.test.generated.Inlines
+import org.partiql.sprout.test.generated.Node
+
+public class NodeBuilder {
+    public var a: Boolean? = null
+
+    public var b: Int? = null
+
+    public var c: String? = null
+
+    public var d: Float? = null
+
+    public var e: TimestampElement? = null
+
+    public fun a(a: Boolean?): NodeBuilder = this.apply {
+        this.a = a
+    }
+
+    public fun b(b: Int?): NodeBuilder = this.apply {
+        this.b = b
+    }
+
+    public fun c(c: String?): NodeBuilder = this.apply {
+        this.c = c
+    }
+
+    public fun d(d: Float?): NodeBuilder = this.apply {
+        this.d = d
+    }
+
+    public fun e(e: TimestampElement?): NodeBuilder = this.apply {
+        this.e = e
+    }
+
+    public fun build(): Node = build(SproutTestFactory.DEFAULT)
+
+    public fun build(factory: SproutTestFactory = SproutTestFactory.DEFAULT): Node = factory.node(a =
+    a!!, b = b!!, c = c!!, d = d, e = e!!)
+}
+
+public class CollectionMySetBuilder {
+    public var values: MutableSet<Int> = mutableSetOf()
+
+    public fun values(values: MutableSet<Int>): CollectionMySetBuilder = this.apply {
+        this.values = values
+    }
+
+    public fun build(): Collection.MySet = build(SproutTestFactory.DEFAULT)
+
+    public fun build(factory: SproutTestFactory = SproutTestFactory.DEFAULT): Collection.MySet =
+        factory.collectionMySet(values = values)
+}
+
+public class CollectionMyListBuilder {
+    public var values: MutableList<Int> = mutableListOf()
+
+    public fun values(values: MutableList<Int>): CollectionMyListBuilder = this.apply {
+        this.values = values
+    }
+
+    public fun build(): Collection.MyList = build(SproutTestFactory.DEFAULT)
+
+    public fun build(factory: SproutTestFactory = SproutTestFactory.DEFAULT): Collection.MyList =
+        factory.collectionMyList(values = values)
+}
+
+public class CollectionMyMapBuilder {
+    public var values: MutableMap<String, Int> = mutableMapOf()
+
+    public fun values(values: MutableMap<String, Int>): CollectionMyMapBuilder = this.apply {
+        this.values = values
+    }
+
+    public fun build(): Collection.MyMap = build(SproutTestFactory.DEFAULT)
+
+    public fun build(factory: SproutTestFactory = SproutTestFactory.DEFAULT): Collection.MyMap =
+        factory.collectionMyMap(values = values)
+}
+
+public class InlinesBuilder {
+    public var `enum`: Inlines.Bar? = null
+
+    public var product: Inlines.Foo? = null
+
+    public var sum: Inlines.Sum? = null
+
+    public fun `enum`(`enum`: Inlines.Bar?): InlinesBuilder = this.apply {
+        this.`enum` = `enum`
+    }
+
+    public fun product(product: Inlines.Foo?): InlinesBuilder = this.apply {
+        this.product = product
+    }
+
+    public fun sum(sum: Inlines.Sum?): InlinesBuilder = this.apply {
+        this.sum = sum
+    }
+
+    public fun build(): Inlines = build(SproutTestFactory.DEFAULT)
+
+    public fun build(factory: SproutTestFactory = SproutTestFactory.DEFAULT): Inlines =
+        factory.inlines(enum = enum, product = product!!, sum = sum!!)
+}
+
+public class InlinesFooBuilder {
+    public var x: Int? = null
+
+    public var y: Inlines.Bar? = null
+
+    public fun x(x: Int?): InlinesFooBuilder = this.apply {
+        this.x = x
+    }
+
+    public fun y(y: Inlines.Bar?): InlinesFooBuilder = this.apply {
+        this.y = y
+    }
+
+    public fun build(): Inlines.Foo = build(SproutTestFactory.DEFAULT)
+
+    public fun build(factory: SproutTestFactory = SproutTestFactory.DEFAULT): Inlines.Foo =
+        factory.inlinesFoo(x = x!!, y = y!!)
+}
+
+public class InlinesSumUBuilder {
+    public var foo: String? = null
+
+    public fun foo(foo: String?): InlinesSumUBuilder = this.apply {
+        this.foo = foo
+    }
+
+    public fun build(): Inlines.Sum.U = build(SproutTestFactory.DEFAULT)
+
+    public fun build(factory: SproutTestFactory = SproutTestFactory.DEFAULT): Inlines.Sum.U =
+        factory.inlinesSumU(foo = foo!!)
+}
+
+public class InlinesSumVBuilder {
+    public var bar: String? = null
+
+    public fun bar(bar: String?): InlinesSumVBuilder = this.apply {
+        this.bar = bar
+    }
+
+    public fun build(): Inlines.Sum.V = build(SproutTestFactory.DEFAULT)
+
+    public fun build(factory: SproutTestFactory = SproutTestFactory.DEFAULT): Inlines.Sum.V =
+        factory.inlinesSumV(bar = bar!!)
+}

--- a/partiql-lib/partiql-sprout/src/test/kotlin/org/partiql/sprout/test/generated/builder/SproutTestFactory.kt
+++ b/partiql-lib/partiql-sprout/src/test/kotlin/org/partiql/sprout/test/generated/builder/SproutTestFactory.kt
@@ -1,0 +1,43 @@
+package org.partiql.sprout.test.generated.builder
+
+import com.amazon.ionelement.api.TimestampElement
+import org.partiql.sprout.test.generated.Collection
+import org.partiql.sprout.test.generated.Inlines
+import org.partiql.sprout.test.generated.Node
+import org.partiql.sprout.test.generated.SproutTestNode
+
+public abstract class SproutTestFactory {
+    public open fun node(
+        a: Boolean,
+        b: Int,
+        c: String,
+        d: Float?,
+        e: TimestampElement
+    ) = Node(a, b, c, d, e)
+
+    public open fun collectionMySet(values: Set<Int>) = Collection.MySet(values)
+
+    public open fun collectionMyList(values: List<Int>) = Collection.MyList(values)
+
+    public open fun collectionMyMap(values: Map<String, Int>) = Collection.MyMap(values)
+
+    public open fun inlines(
+        `enum`: Inlines.Bar?,
+        product: Inlines.Foo,
+        sum: Inlines.Sum
+    ) = Inlines(enum, product, sum)
+
+    public open fun inlinesFoo(x: Int, y: Inlines.Bar) = Inlines.Foo(x, y)
+
+    public open fun inlinesSumU(foo: String) = Inlines.Sum.U(foo)
+
+    public open fun inlinesSumV(bar: String) = Inlines.Sum.V(bar)
+
+    public companion object {
+        public val DEFAULT: SproutTestFactory = object : SproutTestFactory() {}
+
+        @JvmStatic
+        public fun <T : SproutTestNode> create(block: SproutTestFactory.() -> T) =
+            SproutTestFactory.DEFAULT.block()
+    }
+}


### PR DESCRIPTION
## Description

> The generated `builder` package is included, hence the +550 — so a reviewer can see the output.

This PR replaces the DSL container classes with Java style builders. This improves Java interop ergonomics (example test added) while the DSL functionality remains the same.

*Java*
```java
Node node = Node.builder()
                .a(false)
                .b(1)
                .c("C Value")
                .e(Ion.ionTimestamp("2009-01-01T00:00Z"))
                .build();
```

*Kotlin*
```kotlin
val node: Node = sproutTest {
            node {
                a = false
                b = 1
                c = "C Value"
                e = ionTimestamp("2009-01-01T00:00Z")
            }
        }
```

You have the options of invoking constructors directly, using a Java fluent/lombok style builder, or using the Kotlin DSL. All of these enable passing a factory.

Also, this PR adds serde for `Map<String, T>` and invokes the current Jackson module's deserializers for imported types. This means you can perform serde on imported types if the object mapper's module has the appropriates serializers/deserializers registered.

## Relevant Issues
N/A


## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
no

- Any backward-incompatible changes? **[YES/NO]**
no

- Any new external dependencies? **[YES/NO]**
no

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.