### PR TITLE
Removed unused IonSystem from PartiQLCompilerBuilder (trivial)

### DIFF
--- a/examples/src/main/java/org/partiql/examples/PartiQLCompilerPipelineJavaExample.java
+++ b/examples/src/main/java/org/partiql/examples/PartiQLCompilerPipelineJavaExample.java
@@ -71,7 +71,7 @@ public class PartiQLCompilerPipelineJavaExample extends Example {
         final PartiQLPlanner planner = PartiQLPlannerBuilder.standard().globalVariableResolver(globalVariableResolver).build();
 
         @OptIn(markerClass = ExperimentalPartiQLCompilerPipeline.class)
-        final PartiQLCompiler compiler = PartiQLCompilerBuilder.standard().ionSystem(ion).options(evaluatorOptions).build();
+        final PartiQLCompiler compiler = PartiQLCompilerBuilder.standard().options(evaluatorOptions).build();
 
         @OptIn(markerClass = ExperimentalPartiQLCompilerPipeline.class)
         final PartiQLCompilerPipeline pipeline = new PartiQLCompilerPipeline(

--- a/examples/src/main/kotlin/org/partiql/examples/PartiQLCompilerPipelineExample.kt
+++ b/examples/src/main/kotlin/org/partiql/examples/PartiQLCompilerPipelineExample.kt
@@ -65,7 +65,6 @@ class PartiQLCompilerPipelineExample(out: PrintStream) : Example(out) {
         planner
             .globalVariableResolver(globalVariableResolver)
         compiler
-            .ionSystem(myIonSystem)
             .options(evaluatorOptions)
     }
 

--- a/lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
@@ -15,7 +15,6 @@
 package org.partiql.lang.compiler
 
 import com.amazon.ion.IonSystem
-import com.amazon.ion.system.IonSystemBuilder
 import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
 import org.partiql.annotations.ExperimentalWindowFunctions
 import org.partiql.lang.eval.ExprFunction
@@ -48,7 +47,6 @@ import org.partiql.lang.types.CustomType
  *
  * // Fluent builder
  * val compiler = PartiQLCompilerBuilder.standard()
- *                                      .ionSystem(myIonSystem)
  *                                      .customFunctions(myCustomFunctionList)
  *                                      .build()
  * ```
@@ -57,7 +55,6 @@ import org.partiql.lang.types.CustomType
 @ExperimentalPartiQLCompilerPipeline
 class PartiQLCompilerBuilder private constructor() {
 
-    private var ion: IonSystem = DEFAULT_ION
     private var options: EvaluatorOptions = EvaluatorOptions.standard()
     private var customTypes: List<CustomType> = emptyList()
     private var customFunctions: List<ExprFunction> = emptyList()
@@ -65,8 +62,6 @@ class PartiQLCompilerBuilder private constructor() {
     private var customOperatorFactories: List<RelationalOperatorFactory> = emptyList()
 
     companion object {
-
-        private val DEFAULT_ION = IonSystemBuilder.standard().build()
 
         /**
          * A collection of all the default relational operator implementations provided by PartiQL.
@@ -116,8 +111,9 @@ class PartiQLCompilerBuilder private constructor() {
         )
     }
 
+    @Deprecated("An IonSystem is no longer needed to construct a PartiQLCompiler. Do not use this setter.")
+    @Suppress("UNUSED_PARAMETER")
     fun ionSystem(ion: IonSystem): PartiQLCompilerBuilder = this.apply {
-        this.ion = ion
     }
 
     fun options(options: EvaluatorOptions) = this.apply {

--- a/lang/src/test/kotlin/org/partiql/lang/compiler/PartiQLCompilerPipelineSmokeTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/compiler/PartiQLCompilerPipelineSmokeTests.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
-import org.partiql.lang.ION
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.errors.PartiQLException
@@ -34,8 +33,6 @@ class PartiQLCompilerPipelineSmokeTests {
         plannerEventCallback: PlannerEventCallback?,
         block: PartiQLCompilerPipeline.Builder.() -> Unit = { }
     ) = PartiQLCompilerPipeline.build {
-        compiler
-            .ionSystem(ION)
         planner.options(
             PartiQLPlanner.Options(
                 allowedUndefinedVariables = allowUndefinedVariables,

--- a/lang/src/test/kotlin/org/partiql/lang/compiler/memorydb/QueryEngine.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/compiler/memorydb/QueryEngine.kt
@@ -162,7 +162,6 @@ class QueryEngine(val db: MemoryDatabase) {
                 )
             )
         compiler
-            .ionSystem(ION)
             .customOperatorFactories(
                 listOf(
                     GetByKeyProjectRelationalOperatorFactory()

--- a/lang/src/test/kotlin/org/partiql/lang/compiler/operators/CustomOperatorFactoryTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/compiler/operators/CustomOperatorFactoryTests.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
-import org.partiql.lang.ION
 import org.partiql.lang.compiler.PartiQLCompilerPipeline
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.eval.physical.EvaluatorState
@@ -102,7 +101,6 @@ class CustomOperatorFactoryTests {
     fun `make sure custom operator implementations are called`(tc: CustomOperatorCases.TestCase) {
         val pipeline = PartiQLCompilerPipeline.build {
             compiler
-                .ionSystem(ION)
                 .customOperatorFactories(
                     fakeOperatorFactories.map {
                         it

--- a/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactory.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactory.kt
@@ -80,7 +80,6 @@ internal class PartiQLCompilerPipelineFactory() : PipelineFactory {
                 .globalVariableResolver(globalVariableResolver)
                 .build(),
             compiler = PartiQLCompilerBuilder.standard()
-                .ionSystem(ION)
                 .options(evaluatorOptions)
                 .customTypes(legacyPipeline.customDataTypes)
                 .customFunctions(legacyPipeline.functions.values.toList())

--- a/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pipeline/AbstractPipeline.kt
+++ b/partiql-app/partiql-cli/src/main/kotlin/org/partiql/cli/pipeline/AbstractPipeline.kt
@@ -156,7 +156,6 @@ internal sealed class AbstractPipeline(open val options: PipelineOptions) {
                     .globalVariableResolver(globalVariableResolver)
                     .build(),
                 compiler = PartiQLCompilerBuilder.standard()
-                    .ionSystem(options.ion)
                     .options(evaluatorOptions)
                     .build(),
             )


### PR DESCRIPTION
Includes the @Deprecated ceremony where this was exposed through a user-visible method, but I'd be glad not to bother about that if people agree.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - Internal, except for the deprecation. 
- Any backward-incompatible changes? **[NO]**
- Any new external dependencies? **[NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.