### PR TITLE
A couple fixes to error processing in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ANTLR (PartiQL.g4, PartiQLTokens.g4) and PIG (org/partiql/type-domains/partiql.ion) sources 
   are back to being distributed with the jar.
 
+- CLI no longer terminates on user errors in submitted PartiQL (when printing out the AST with !!)
+  and no longer prints out stack traces upon user errors. 
+
 ### Removed
 - The deprecated `IonValue` property in `ExprValue` interface is now removed.
 


### PR DESCRIPTION
This started by dealing with the issue that the CLI would terminate when one would issue `!!` to see the AST, but the supplied query had a syntax error. 
Another thing was both ERROR! and OK! being printed out on a syntax error. 
(Use something silly like `select +` to reproduce.) 

Besides addressing the above, this also changes which failures are displayed how. 
* When it is an anticipated error from PartiQL (parsing, evaluation, etc), we ought to print the error, but not the stack trace, and continue the repl.  In practice, this means avoiding `catch (ex: Exception)`, instead catching `SqlException`, which is the umbrella for what we ourselves throw on user error.
* OTOH, when it is not an anticipated error, it is likely a bug. Philosophies vary on what to do in this case.  I suggest it is ok to terminate the CLI completely and let the system print out the postmortem -- with the stack trace and such.  

Unless there are immediately-visible shortcomings with this approach, I suggest, let's try how it goes and adjust if needed.


## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**
- Any backward-incompatible changes? **[NO]**
- Any new external dependencies? **[YES/NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.