### PR TITLE
CREATE TABLE initial experimental syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Adds ability to pipe queries to the CLI.
 - Adds ability to run PartiQL files as executables by adding support for shebangs.
-- Adds initial syntax for CREATE TABLE.
+- Adds experimental syntax for CREATE TABLE, towards addressing 
+  [#36](https://github.com/partiql/partiql-docs/issues/36) of specifying PartiQL DDL.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.2] - 2023-01-20
 
 ### Added
-- Adds ability to pipe queries to the CLI
-- Adds ability to run PartiQL files as executables by adding support for shebangs
+- Adds ability to pipe queries to the CLI.
+- Adds ability to run PartiQL files as executables by adding support for shebangs.
+- Adds initial syntax for CREATE TABLE.
 
 ### Changed
 

--- a/lang/src/main/antlr/PartiQL.g4
+++ b/lang/src/main/antlr/PartiQL.g4
@@ -95,16 +95,8 @@ tableDef
     ;
 
 tableDefPart
-    : columnDecl                        # TableDefColumn
-    | tableConstraint                   # TableDefConstr
-    ;
-
-columnDecl
-    : columnName columnDef
-    ;
-
-columnDef
-    : type columnConstraint*
+    : columnName type columnConstraint*                             # ColumnDeclaration
+    | ( CONSTRAINT tableConstraintName )?  tableConstraintDef       # TableConstraint
     ;
 
 columnConstraint
@@ -115,10 +107,6 @@ columnConstraintDef
     : NOT NULL                                  # ColConstrNotNull
     | NULL                                      # ColConstrNull
     | CHECK PAREN_LEFT expr PAREN_RIGHT         # ColConstrCheck
-    ;
-
-tableConstraint
-    : ( CONSTRAINT tableConstraintName )?  tableConstraintDef
     ;
 
 tableConstraintDef

--- a/lang/src/main/antlr/PartiQL.g4
+++ b/lang/src/main/antlr/PartiQL.g4
@@ -43,6 +43,11 @@ symbolPrimitive
     : ident=( IDENTIFIER | IDENTIFIER_QUOTED )
     ;
 
+tableName : symbolPrimitive;
+tableConstraintName : symbolPrimitive;
+columnName : symbolPrimitive;
+columnConstraintName : symbolPrimitive;
+
 /**
  *
  * DATA QUERY LANGUAGE (DQL)
@@ -76,13 +81,48 @@ ddl
     ;
 
 createCommand
-    : CREATE TABLE symbolPrimitive                                                              # CreateTable
+    : CREATE TABLE tableName PAREN_LEFT tableDef PAREN_RIGHT                                    # CreateTable
     | CREATE INDEX ON symbolPrimitive PAREN_LEFT pathSimple ( COMMA pathSimple )* PAREN_RIGHT   # CreateIndex
     ;
 
 dropCommand
-    : DROP TABLE target=symbolPrimitive                         # DropTable
+    : DROP TABLE target=tableName                               # DropTable
     | DROP INDEX target=symbolPrimitive ON on=symbolPrimitive   # DropIndex
+    ;
+
+tableDef
+    : tableDefPart ( COMMA tableDefPart )*
+    ;
+
+tableDefPart
+    : columnDecl                        # TableDefColumn
+    | tableConstraint                   # TableDefConstr
+    ;
+
+columnDecl
+    : columnName columnDef
+    ;
+
+columnDef
+    : type columnConstraint*
+    ;
+
+columnConstraint
+    : ( CONSTRAINT columnConstraintName )?  columnConstraintDef
+    ;
+
+columnConstraintDef
+    : NOT NULL                                  # ColConstrNotNull
+    | NULL                                      # ColConstrNull
+    | CHECK PAREN_LEFT expr PAREN_RIGHT         # ColConstrCheck
+    ;
+
+tableConstraint
+    : ( CONSTRAINT tableConstraintName )?  tableConstraintDef
+    ;
+
+tableConstraintDef
+    : CHECK PAREN_LEFT expr PAREN_RIGHT         # TblConstrCheck
     ;
 
 /**

--- a/lang/src/main/antlr/PartiQL.g4
+++ b/lang/src/main/antlr/PartiQL.g4
@@ -81,7 +81,7 @@ ddl
     ;
 
 createCommand
-    : CREATE TABLE tableName PAREN_LEFT tableDef PAREN_RIGHT                                    # CreateTable
+    : CREATE TABLE tableName ( PAREN_LEFT tableDef PAREN_RIGHT )?                               # CreateTable
     | CREATE INDEX ON symbolPrimitive PAREN_LEFT pathSimple ( COMMA pathSimple )* PAREN_RIGHT   # CreateIndex
     ;
 

--- a/lang/src/main/antlr/PartiQL.g4
+++ b/lang/src/main/antlr/PartiQL.g4
@@ -96,7 +96,6 @@ tableDef
 
 tableDefPart
     : columnName type columnConstraint*                             # ColumnDeclaration
-    | ( CONSTRAINT tableConstraintName )?  tableConstraintDef       # TableConstraint
     ;
 
 columnConstraint
@@ -106,11 +105,6 @@ columnConstraint
 columnConstraintDef
     : NOT NULL                                  # ColConstrNotNull
     | NULL                                      # ColConstrNull
-    | CHECK PAREN_LEFT expr PAREN_RIGHT         # ColConstrCheck
-    ;
-
-tableConstraintDef
-    : CHECK PAREN_LEFT expr PAREN_RIGHT         # TblConstrCheck
     ;
 
 /**

--- a/lang/src/main/antlr/PartiQL.g4
+++ b/lang/src/main/antlr/PartiQL.g4
@@ -43,11 +43,6 @@ symbolPrimitive
     : ident=( IDENTIFIER | IDENTIFIER_QUOTED )
     ;
 
-tableName : symbolPrimitive;
-tableConstraintName : symbolPrimitive;
-columnName : symbolPrimitive;
-columnConstraintName : symbolPrimitive;
-
 /**
  *
  * DATA QUERY LANGUAGE (DQL)
@@ -72,8 +67,14 @@ execCommand
 /**
  *
  * DATA DEFINITION LANGUAGE (DDL)
- *
+ * Experimental, towards #36 https://github.com/partiql/partiql-docs/issues/36
+ * Currently, this is a small subset of SQL DDL that is likely to make sense for PartiQL as well.
  */
+
+tableName : symbolPrimitive;
+tableConstraintName : symbolPrimitive;
+columnName : symbolPrimitive;
+columnConstraintName : symbolPrimitive;
 
 ddl
     : createCommand

--- a/lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
@@ -84,7 +84,7 @@ class QueryPrettyPrinter {
     // *******
     private fun writeAstNode(node: PartiqlAst.Statement.Ddl, sb: StringBuilder) {
         when (node.op) {
-            is PartiqlAst.DdlOp.CreateTable -> sb.append("CREATE TABLE ${node.op.tableName.text}")
+            is PartiqlAst.DdlOp.CreateTable -> writeAstNode(node.op, sb)
             is PartiqlAst.DdlOp.DropTable -> {
                 sb.append("DROP TABLE ")
                 writeAstNode(node.op.tableName, sb)
@@ -114,6 +114,14 @@ class QueryPrettyPrinter {
             is PartiqlAst.CaseSensitivity.CaseSensitive -> sb.append("\"${node.name.text}\"")
             is PartiqlAst.CaseSensitivity.CaseInsensitive -> sb.append(node.name.text)
         }
+    }
+
+    private fun writeAstNode(node: PartiqlAst.DdlOp.CreateTable, sb: StringBuilder) {
+        sb.append("CREATE TABLE ${node.tableName.text}")
+        for (x in node.def.parts) {
+            // TODO
+        }
+        sb.append(")")
     }
 
     // *******

--- a/lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
@@ -117,17 +117,20 @@ class QueryPrettyPrinter {
     }
 
     private fun writeAstNode(node: PartiqlAst.DdlOp.CreateTable, sb: StringBuilder) {
-        var separator = "\n\t"
-        sb.append("CREATE TABLE ${node.tableName.text} (")
-        for (n in node.def.parts) {
-            sb.append(separator)
-            when (n) {
-                is PartiqlAst.TableDefPart.ColumnDeclaration -> writeAstNode(n, sb)
-                is PartiqlAst.TableDefPart.TableConstraint -> writeAstNode(n, sb)
+        sb.append("CREATE TABLE ${node.tableName.text}")
+        node.def?.let {
+            var separator = "\n\t"
+            sb.append(" (")
+            for (n in it.parts) {
+                sb.append(separator)
+                when (n) {
+                    is PartiqlAst.TableDefPart.ColumnDeclaration -> writeAstNode(n, sb)
+                    is PartiqlAst.TableDefPart.TableConstraint -> writeAstNode(n, sb)
+                }
+                separator = ",\n\t"
             }
-            separator = ",\n\t"
+            sb.append("\n)")
         }
-        sb.append("\n)")
     }
 
     private fun writeAstNode(node: PartiqlAst.TableDefPart.ColumnDeclaration, sb: StringBuilder) {

--- a/lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
@@ -125,7 +125,6 @@ class QueryPrettyPrinter {
                 sb.append(separator)
                 when (n) {
                     is PartiqlAst.TableDefPart.ColumnDeclaration -> writeAstNode(n, sb)
-                    is PartiqlAst.TableDefPart.TableConstraint -> writeAstNode(n, sb)
                 }
                 separator = ",\n\t"
             }
@@ -142,22 +141,6 @@ class QueryPrettyPrinter {
             when (c.def) {
                 is PartiqlAst.ColumnConstraintDef.ColumnNull -> sb.append("NULL")
                 is PartiqlAst.ColumnConstraintDef.ColumnNotnull -> sb.append("NOT NULL")
-                is PartiqlAst.ColumnConstraintDef.ColumnCheck -> {
-                    sb.append("CHECK (")
-                    writeAstNode(c.def.expr, sb, -1)
-                    sb.append(")")
-                }
-            }
-        }
-    }
-
-    private fun writeAstNode(node: PartiqlAst.TableDefPart.TableConstraint, sb: StringBuilder) {
-        node.name?.let { sb.append("CONSTRAINT ${it.text} ") }
-        when (node.def) {
-            is PartiqlAst.TableConstraintDef.TableCheck -> {
-                sb.append("CHECK (")
-                writeAstNode(node.def.expr, sb, -1)
-                sb.append(")")
             }
         }
     }

--- a/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -211,23 +211,6 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
         columnNull()
     }
 
-    override fun visitColConstrCheck(ctx: PartiQLParser.ColConstrCheckContext) = PartiqlAst.build {
-        val expr = visitExpr(ctx.expr())
-        columnCheck(expr, ctx.CHECK().getSourceMetaContainer())
-    }
-
-    override fun visitTableConstraint(ctx: PartiQLParser.TableConstraintContext) = PartiqlAst.build {
-        val name = ctx.tableConstraintName()?.let { visitSymbolPrimitive(it.symbolPrimitive()).name.text }
-        val def = visit(ctx.tableConstraintDef(), PartiqlAst.TableConstraintDef::class)
-        tableConstraint(name, def)
-    }
-
-    override fun visitTblConstrCheck(ctx: PartiQLParser.TblConstrCheckContext) = PartiqlAst.build {
-        val expr = visitExpr(ctx.expr())
-        ctx.sourceInterval
-        tableCheck(expr, ctx.CHECK().getSourceMetaContainer())
-    }
-
     /**
      *
      * EXECUTE

--- a/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -175,7 +175,7 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
 
     override fun visitCreateTable(ctx: PartiQLParser.CreateTableContext) = PartiqlAst.build {
         val name = visitSymbolPrimitive(ctx.tableName().symbolPrimitive()).name
-        val def = visitTableDef(ctx.tableDef())
+        val def = ctx.tableDef()?.let { visitTableDef(it) }
         createTable_(name, def, ctx.CREATE().getSourceMetaContainer())
     }
 

--- a/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -190,22 +190,11 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
         tableDef(parts)
     }
 
-    override fun visitTableDefColumn(ctx: PartiQLParser.TableDefColumnContext) = PartiqlAst.build {
-        val col = visitColumnDecl(ctx.columnDecl())
-        tdpartColumn(col)
-    }
-
-    override fun visitColumnDecl(ctx: PartiQLParser.ColumnDeclContext) = PartiqlAst.build {
+    override fun visitColumnDeclaration(ctx: PartiQLParser.ColumnDeclarationContext) = PartiqlAst.build {
         val name = visitSymbolPrimitive(ctx.columnName().symbolPrimitive()).name.text
-        val def = visitColumnDef(ctx.columnDef())
-        columnDecl(name, def)
-    }
-
-    override fun visitColumnDef(ctx: PartiQLParser.ColumnDefContext) = PartiqlAst.build {
         val type = visit(ctx.type(), PartiqlAst.Type::class)
         val constrs = ctx.columnConstraint().map { visitColumnConstraint(it) }
-        // process constraints as well
-        columnDef(type, constrs)
+        columnDeclaration(name, type, constrs)
     }
 
     override fun visitColumnConstraint(ctx: PartiQLParser.ColumnConstraintContext) = PartiqlAst.build {
@@ -225,11 +214,6 @@ internal class PartiQLVisitor(val ion: IonSystem, val customTypes: List<CustomTy
     override fun visitColConstrCheck(ctx: PartiQLParser.ColConstrCheckContext) = PartiqlAst.build {
         val expr = visitExpr(ctx.expr())
         columnCheck(expr, ctx.CHECK().getSourceMetaContainer())
-    }
-
-    override fun visitTableDefConstr(ctx: PartiQLParser.TableDefConstrContext) = PartiqlAst.build {
-        val constr = visitTableConstraint(ctx.tableConstraint())
-        tdpartConstr(constr)
     }
 
     override fun visitTableConstraint(ctx: PartiQLParser.TableConstraintContext) = PartiqlAst.build {

--- a/lang/src/main/pig/partiql.ion
+++ b/lang/src/main/pig/partiql.ion
@@ -450,9 +450,7 @@ may then be further optimized by selecting better implementations of each operat
 
         (sum table_def_part
             // `<column_name> <type> <column_constraint>*`
-            (column_declaration name::symbol type::type constraints::(* column_constraint 0))
-            // `CONSTRAINT <name>? <table_constraint_def>`
-            (table_constraint name::(? symbol) def::table_constraint_def))
+            (column_declaration name::symbol type::type constraints::(* column_constraint 0)))
 
         // `( CONSTRAINT <column_constraint_name> )?  <column_constraint_def>`
         (product column_constraint name::(? symbol) def::column_constraint_def)
@@ -460,12 +458,7 @@ may then be further optimized by selecting better implementations of each operat
         //  `NULL | NOT NULL | CHECK ( <expr> )`
         (sum column_constraint_def
             (column_notnull)
-            (column_null)
-            (column_check expr::expr))
-
-        (sum table_constraint_def
-            // `CHECK ( <expr> )`
-            (table_check expr::expr))
+            (column_null))
 
         // `RETURNING (<returning_elem> [, <returning_elem>]...)`
         (product returning_expr elems::(* returning_elem 1))

--- a/lang/src/main/pig/partiql.ion
+++ b/lang/src/main/pig/partiql.ion
@@ -430,8 +430,8 @@ may then be further optimized by selecting better implementations of each operat
 
         // A data definition operation.
         (sum ddl_op
-            // `CREATE TABLE <symbol>`
-            (create_table table_name::symbol)
+            // `CREATE TABLE <symbol> ( <table_def> )`
+            (create_table table_name::symbol def::table_def)
 
             // `DROP TABLE <identifier>`
             (drop_table table_name::identifier)
@@ -440,12 +440,37 @@ may then be further optimized by selecting better implementations of each operat
             // TODO: add optional table name
             (create_index index_name::identifier fields::(* expr 1))
 
-
             // DROP INDEX <identifier> ON <identifier>
             // In Statement, first <identifier> represents keys, second represents table
             (drop_index
                 (table identifier)
                 (keys identifier)))
+
+        // This would be natural for table_def AST:
+        // (product table_def columns::(* column_decl 1) constraints::(* table_constraint 0))
+        // but PIG does not support more than one "variadic" component.
+
+        (product table_def parts::(* table_def_part 1))
+
+        (sum table_def_part
+            (tdpart_column column::column_decl)
+            (tdpart_constr constr::table_constraint))
+
+        (product column_decl name::symbol def::column_def)
+
+        (product column_def type::type constraints::(* column_constraint 0))
+
+        (product column_constraint name::(? symbol) def::column_constraint_def)
+
+        (sum column_constraint_def
+            (column_notnull)
+            (column_null)
+            (column_check expr::expr))
+
+        (product table_constraint name::(? symbol) def::table_constraint_def)
+
+        (sum table_constraint_def
+            (table_check expr::expr))
 
         // `RETURNING (<returning_elem> [, <returning_elem>]...)`
         (product returning_expr elems::(* returning_elem 1))

--- a/lang/src/main/pig/partiql.ion
+++ b/lang/src/main/pig/partiql.ion
@@ -430,8 +430,8 @@ may then be further optimized by selecting better implementations of each operat
 
         // A data definition operation.
         (sum ddl_op
-            // `CREATE TABLE <symbol> ( <table_def> )`
-            (create_table table_name::symbol def::table_def)
+            // `CREATE TABLE <symbol> ( <table_def> )?`
+            (create_table table_name::symbol def::(? table_def))
 
             // `DROP TABLE <identifier>`
             (drop_table table_name::identifier)

--- a/lang/src/main/pig/partiql.ion
+++ b/lang/src/main/pig/partiql.ion
@@ -446,30 +446,25 @@ may then be further optimized by selecting better implementations of each operat
                 (table identifier)
                 (keys identifier)))
 
-        // This would be natural for table_def AST:
-        // (product table_def columns::(* column_decl 1) constraints::(* table_constraint 0))
-        // but PIG does not support more than one "variadic" component.
-
         (product table_def parts::(* table_def_part 1))
 
         (sum table_def_part
-            (tdpart_column column::column_decl)
-            (tdpart_constr constr::table_constraint))
+            // `<column_name> <type> <column_constraint>*`
+            (column_declaration name::symbol type::type constraints::(* column_constraint 0))
+            // `CONSTRAINT <name>? <table_constraint_def>`
+            (table_constraint name::(? symbol) def::table_constraint_def))
 
-        (product column_decl name::symbol def::column_def)
-
-        (product column_def type::type constraints::(* column_constraint 0))
-
+        // `( CONSTRAINT <column_constraint_name> )?  <column_constraint_def>`
         (product column_constraint name::(? symbol) def::column_constraint_def)
 
+        //  `NULL | NOT NULL | CHECK ( <expr> )`
         (sum column_constraint_def
             (column_notnull)
             (column_null)
             (column_check expr::expr))
 
-        (product table_constraint name::(? symbol) def::table_constraint_def)
-
         (sum table_constraint_def
+            // `CHECK ( <expr> )`
             (table_check expr::expr))
 
         // `RETURNING (<returning_elem> [, <returning_elem>]...)`

--- a/lang/src/test/kotlin/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -2609,6 +2609,71 @@ class ParserErrorsTest : PartiQLParserTestBase() {
     )
 
     @Test
+    fun createTableWithoutColumns() = checkInputThrowingParserException(
+        "CREATE TABLE Customer ()",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 24L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.PAREN_RIGHT.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ion.newSymbol(")")
+        )
+    )
+
+    @Test
+    fun createTableNoCONSTRAINT() = checkInputThrowingParserException(
+        "CREATE TABLE Customer (name string name_is_present NOT NULL)",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 36L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ion.newSymbol("name_is_present")
+        )
+    )
+
+    @Test
+    fun createTableNoConstraintName() = checkInputThrowingParserException(
+        "CREATE TABLE Customer (name string CONSTRAINT NOT NULL)",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 47L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.NOT.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ion.newSymbol("not")
+        )
+    )
+
+    @Test
+    fun createTableNoComma() = checkInputThrowingParserException(
+        """
+            CREATE TABLE Customer (
+               age int
+               city string NULL       
+            )
+        """.trimMargin(),
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        mapOf(
+            Property.LINE_NUMBER to 3L,
+            Property.COLUMN_NUMBER to 16L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ion.newSymbol("city")
+        )
+    )
+
+    @Test
+    fun createTableNoColumnType() = checkInputThrowingParserException(
+        "CREATE TABLE Customer (name NOT NULL)",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 29L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.NOT.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ion.newSymbol("not")
+        )
+    )
+
+    @Test
     fun dropTableWithOperatorAfterIdentifier() = checkInputThrowingParserException(
         "DROP TABLE foo+bar",
         ErrorCode.PARSE_UNEXPECTED_TOKEN,

--- a/lang/src/test/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinterTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinterTest.kt
@@ -59,7 +59,7 @@ class ASTPrettyPrinterTest {
     @Test
     fun createTable() {
         checkPrettyPrintAst(
-            "CREATE TABLE foo (boo string)",
+            "CREATE TABLE foo",
             """
                 Ddl
                     op: CreateTable

--- a/lang/src/test/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinterTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinterTest.kt
@@ -59,7 +59,7 @@ class ASTPrettyPrinterTest {
     @Test
     fun createTable() {
         checkPrettyPrintAst(
-            "CREATE TABLE foo",
+            "CREATE TABLE foo (boo string)",
             """
                 Ddl
                     op: CreateTable

--- a/lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
@@ -54,21 +54,17 @@ class QueryPrettyPrinterTest {
         checkPrettyPrintQuery(
             """
                 create table Customer (
-                   name string NOT NULL, 
-                   age int CONSTRAINT 
-                        is_adult check (age >= 21),
+                   name string CONSTRAINT name_is_present NOT NULL, 
+                   age int, 
                    city string null,
-                   state string NULL,
-                   CHECK ((state IS NOT NULL) 
-                          OR (city IS NULL)))                
+                   state string NULL)
             """.trimIndent(),
             """
                 CREATE TABLE Customer (
-                    name STRING NOT NULL,
-                    age INT CONSTRAINT is_adult CHECK (age >= 21),
+                    name STRING CONSTRAINT name_is_present NOT NULL,
+                    age INT,
                     city STRING NULL,
-                    state STRING NULL,
-                    CHECK ((NOT (state IS NULL)) OR (city IS NULL))
+                    state STRING NULL
                 )
             """.trimIndent()
         )

--- a/lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
@@ -33,7 +33,37 @@ class QueryPrettyPrinterTest {
     @Test
     fun createTable() {
         checkPrettyPrintQuery(
-            "CREATE TABLE foo (boo string)", "CREATE TABLE foo (boo string)"
+            "CREATE TABLE foo (boo string)",
+            """
+                CREATE TABLE foo (
+                    boo STRING
+                )
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun createTableWithConstraints() {
+        checkPrettyPrintQuery(
+            """
+                create table Customer (
+                   name string NOT NULL, 
+                   age int CONSTRAINT 
+                        is_adult check (age >= 21),
+                   city string null,
+                   state string NULL,
+                   CHECK ((state IS NOT NULL) 
+                          OR (city IS NULL)))                
+            """.trimIndent(),
+            """
+                CREATE TABLE Customer (
+                    name STRING NOT NULL,
+                    age INT CONSTRAINT is_adult CHECK (age >= 21),
+                    city STRING NULL,
+                    state STRING NULL,
+                    CHECK ((NOT (state IS NULL)) OR (city IS NULL))
+                )
+            """.trimIndent()
         )
     }
 

--- a/lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
@@ -33,7 +33,7 @@ class QueryPrettyPrinterTest {
     @Test
     fun createTable() {
         checkPrettyPrintQuery(
-            "CREATE TABLE foo", "CREATE TABLE foo"
+            "CREATE TABLE foo (boo string)", "CREATE TABLE foo (boo string)"
         )
     }
 

--- a/lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
@@ -33,6 +33,13 @@ class QueryPrettyPrinterTest {
     @Test
     fun createTable() {
         checkPrettyPrintQuery(
+            "CREATE TABLE foo", "CREATE TABLE foo"
+        )
+    }
+
+    @Test
+    fun createTableWithColumn() {
+        checkPrettyPrintQuery(
             "CREATE TABLE foo (boo string)",
             """
                 CREATE TABLE foo (

--- a/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -3569,11 +3569,10 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     fun createTableWithConstraints() = assertExpression(
         """
             CREATE TABLE Customer (
-               name string NOT NULL, 
-               age int CONSTRAINT is_adult CHECK (age >= 21),
+               name string CONSTRAINT name_is_present NOT NULL, 
+               age int,
                city string NULL,
-               state string NULL,
-               CHECK ((state IS NOT NULL) OR (city IS NULL))
+               state string NULL
             )
         """.trimIndent(),
         """
@@ -3581,25 +3580,12 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (create_table
                     Customer (table_def
                         (column_declaration name (string_type)
-                            (column_constraint null (column_notnull)))
-                        (column_declaration age (integer_type)
-                            (column_constraint is_adult (column_check
-                                    (gte
-                                        (id age (case_insensitive) (unqualified))
-                                        (lit 21)))))
+                            (column_constraint name_is_present (column_notnull)))
+                        (column_declaration age (integer_type))
                         (column_declaration city (string_type)
                             (column_constraint null (column_null)))
                         (column_declaration state (string_type)
-                            (column_constraint null (column_null)))
-                        (table_constraint null (table_check
-                                (or
-                                    (not
-                                        (is_type
-                                            (id state (case_insensitive) (unqualified))
-                                            (null_type)))
-                                    (is_type
-                                        (id city (case_insensitive) (unqualified))
-                                        (null_type))))))))                                        
+                            (column_constraint null (column_null))))))
         """.trimIndent()
     )
 

--- a/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -3543,6 +3543,12 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     // ****************************************
     @Test
     fun createTable() = assertExpression(
+        "CREATE TABLE foo",
+        "(ddl (create_table foo null))"
+    )
+
+    @Test
+    fun createTableWithColumn() = assertExpression(
         "CREATE TABLE foo (boo string)",
         """
             (ddl (create_table foo  (table_def

--- a/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -3543,13 +3543,13 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     // ****************************************
     @Test
     fun createTable() = assertExpression(
-        "CREATE TABLE foo",
+        "CREATE TABLE foo (boo string)",
         "(ddl (create_table foo))"
     )
 
     @Test
     fun createTableWithQuotedIdentifier() = assertExpression(
-        "CREATE TABLE \"user\"",
+        "CREATE TABLE \"user\" (\"lastname\" string)",
         "(ddl (create_table user))"
     )
 


### PR DESCRIPTION
An initial portion of experimental CREATE TABLE syntax, with basics of column declarations, with data types and NULL / NOT NULL constraints. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**
- Any backward-incompatible changes? **[NO]**
  - Except that the previous plug-the-hole CREATE TABLE syntax would no longer work.
- Any new external dependencies? **[NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.