### PR TITLE
Try migrating from JUnit4 to JUnit5.

### DIFF
--- a/lang/src/test/kotlin/org/partiql/lang/ast/passes/StatementRedactorTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/ast/passes/StatementRedactorTest.kt
@@ -1,12 +1,16 @@
 package org.partiql.lang.ast.passes
 
 import com.amazon.ionelement.api.StringElement
-import junitparams.Parameters
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.partiql.lang.domains.PartiqlAst
-import org.partiql.lang.syntax.PartiQLParserTestBase
+import org.partiql.lang.syntax.PartiQLParserTestBase_J5
 
-class StatementRedactorTest : PartiQLParserTestBase() {
+class StatementRedactorTest : PartiQLParserTestBase_J5() {
     private val testSafeFieldNames = setOf("hk", "rk")
 
     data class RedactionTestCase(val originalStatement: String, val redactedStatement: String)
@@ -46,8 +50,8 @@ class StatementRedactorTest : PartiQLParserTestBase() {
         return parser.parseAstStatement(statement) == ast
     }
 
-    @Test
-    @Parameters
+    @ParameterizedTest
+    @MethodSource("parametersForTestRedactOnPositiveCases")
     fun testRedactOnPositiveCases(tc: RedactionTestCase) {
         val testConfig = mapOf("contains" to ::validateFuncContainsAndBeginsWith, "begins_with" to ::validateFuncContainsAndBeginsWith)
         val redactedStatement = redact(tc.originalStatement, testSafeFieldNames, testConfig)
@@ -55,353 +59,356 @@ class StatementRedactorTest : PartiQLParserTestBase() {
         assertEquals(tc.redactedStatement, redactedStatement)
     }
 
-    fun parametersForTestRedactOnPositiveCases() = listOf(
-        // Typed
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk IS MISSING AND attr IS MISSING",
-            "SELECT * FROM tb WHERE hk IS MISSING AND attr IS ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk IS NOT MISSING AND attr IS NOT MISSING",
-            "SELECT * FROM tb WHERE hk IS NOT MISSING AND attr IS NOT ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS MISSING",
-            "SELECT * FROM tb WHERE attr IS ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS NUMERIC",
-            "SELECT * FROM tb WHERE attr IS ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS NOT NUMERIC",
-            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS STRING",
-            "SELECT * FROM tb WHERE attr IS ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS NOT STRING",
-            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS TUPLE",
-            "SELECT * FROM tb WHERE attr IS ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS NOT TUPLE",
-            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS STRUCT",
-            "SELECT * FROM tb WHERE attr IS ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS NOT STRUCT",
-            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS BOOLEAN",
-            "SELECT * FROM tb WHERE attr IS ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS NOT BOOLEAN",
-            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS LIST",
-            "SELECT * FROM tb WHERE attr IS ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS NOT LIST",
-            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS BLOB",
-            "SELECT * FROM tb WHERE attr IS ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS NOT BLOB",
-            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS NULL",
-            "SELECT * FROM tb WHERE attr IS ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE attr IS NOT NULL",
-            "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
-        ),
-        // Call and Nested Call
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 1 AND begins_with(Attr, 'foo') AND begins_with(hk, 'foo')",
-            "SELECT * FROM tb WHERE hk = 1 AND begins_with(Attr, ***(Redacted)) AND begins_with(hk, 'foo')"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 1 AND contains(Attr, 'foo') AND contains(hk, 'foo')",
-            "SELECT * FROM tb WHERE hk = 1 AND contains(Attr, ***(Redacted)) AND contains(hk, 'foo')"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 1 AND arbitrary_udf(Attr, 'foo', arbitrary_udf(hk, 'foo'))",
-            "SELECT * FROM tb WHERE hk = 1 AND arbitrary_udf(Attr, ***(Redacted), arbitrary_udf(hk, ***(Redacted)))"
-        ),
-        // Unary operator
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk IS MISSING AND attr = - 'literal'",
-            "SELECT * FROM tb WHERE hk IS MISSING AND attr = - ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk IS MISSING AND attr = -+ -+ -+ non_literal",
-            "SELECT * FROM tb WHERE hk IS MISSING AND attr = -+ -+ -+ non_literal"
-        ),
-        // Arithmetic operators are not redacted
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = 012-34-5678",
-            "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = ***(Redacted)-***(Redacted)-***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = 012*34*5678",
-            "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = ***(Redacted)****(Redacted)****(Redacted)"
-        ),
-        // Concat operator
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 'abc' || '123' AND ssn = 'abc' || '123' || 'xyz'",
-            "SELECT * FROM tb WHERE hk = 'abc' || '123' AND ssn = ***(Redacted) || ***(Redacted) || ***(Redacted)"
-        ),
-        // In operator
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk IN (1, 3, 5) AND attr IN (2, 4, 6)",
-            "SELECT * FROM tb WHERE hk IN (1, 3, 5) AND attr IN (***(Redacted), ***(Redacted), ***(Redacted))"
-        ),
-        // Between operator
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk BETWEEN 1 AND 2 AND attr BETWEEN 1 AND 2",
-            "SELECT * FROM tb WHERE hk BETWEEN 1 AND 2 AND attr BETWEEN ***(Redacted) AND ***(Redacted)"
-        ),
-        // Comparison operators
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE (hk <> 1 or hk < 1 or hk <= 1 or hk > 1 or hk >=1 )",
-            "SELECT * FROM tb WHERE (hk <> 1 or hk < 1 or hk <= 1 or hk > 1 or hk >=1 )"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 'a' and (attr1 <> 1 or attr2 < 1 or attr3 <= 1 or attr4 > 1 or attr5 >=1 )",
-            "SELECT * FROM tb WHERE hk = 'a' and (attr1 <> ***(Redacted) or attr2 < ***(Redacted) or attr3 <= ***(Redacted) or attr4 > ***(Redacted) or attr5 >=***(Redacted) )"
-        ),
-        // String
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 'a' and attr = 'a'",
-            "SELECT * FROM tb WHERE hk = 'a' and attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = '2016-02-15' and attr = '2016-02-15'",
-            "SELECT * FROM tb WHERE hk = '2016-02-15' and attr = ***(Redacted)"
-        ),
-        // TODO: Fix metadata length for unicode
+    companion object {
+        @JvmStatic
+        fun parametersForTestRedactOnPositiveCases() = listOf(
+            // Typed
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk IS MISSING AND attr IS MISSING",
+                "SELECT * FROM tb WHERE hk IS MISSING AND attr IS ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk IS NOT MISSING AND attr IS NOT MISSING",
+                "SELECT * FROM tb WHERE hk IS NOT MISSING AND attr IS NOT ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS MISSING",
+                "SELECT * FROM tb WHERE attr IS ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS NUMERIC",
+                "SELECT * FROM tb WHERE attr IS ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS NOT NUMERIC",
+                "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS STRING",
+                "SELECT * FROM tb WHERE attr IS ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS NOT STRING",
+                "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS TUPLE",
+                "SELECT * FROM tb WHERE attr IS ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS NOT TUPLE",
+                "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS STRUCT",
+                "SELECT * FROM tb WHERE attr IS ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS NOT STRUCT",
+                "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS BOOLEAN",
+                "SELECT * FROM tb WHERE attr IS ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS NOT BOOLEAN",
+                "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS LIST",
+                "SELECT * FROM tb WHERE attr IS ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS NOT LIST",
+                "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS BLOB",
+                "SELECT * FROM tb WHERE attr IS ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS NOT BLOB",
+                "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS NULL",
+                "SELECT * FROM tb WHERE attr IS ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE attr IS NOT NULL",
+                "SELECT * FROM tb WHERE attr IS NOT ***(Redacted)"
+            ),
+            // Call and Nested Call
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 1 AND begins_with(Attr, 'foo') AND begins_with(hk, 'foo')",
+                "SELECT * FROM tb WHERE hk = 1 AND begins_with(Attr, ***(Redacted)) AND begins_with(hk, 'foo')"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 1 AND contains(Attr, 'foo') AND contains(hk, 'foo')",
+                "SELECT * FROM tb WHERE hk = 1 AND contains(Attr, ***(Redacted)) AND contains(hk, 'foo')"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 1 AND arbitrary_udf(Attr, 'foo', arbitrary_udf(hk, 'foo'))",
+                "SELECT * FROM tb WHERE hk = 1 AND arbitrary_udf(Attr, ***(Redacted), arbitrary_udf(hk, ***(Redacted)))"
+            ),
+            // Unary operator
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk IS MISSING AND attr = - 'literal'",
+                "SELECT * FROM tb WHERE hk IS MISSING AND attr = - ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk IS MISSING AND attr = -+ -+ -+ non_literal",
+                "SELECT * FROM tb WHERE hk IS MISSING AND attr = -+ -+ -+ non_literal"
+            ),
+            // Arithmetic operators are not redacted
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = 012-34-5678",
+                "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = ***(Redacted)-***(Redacted)-***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = 012*34*5678",
+                "SELECT * FROM tb WHERE hk = 012-34-5678 AND ssn = ***(Redacted)****(Redacted)****(Redacted)"
+            ),
+            // Concat operator
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 'abc' || '123' AND ssn = 'abc' || '123' || 'xyz'",
+                "SELECT * FROM tb WHERE hk = 'abc' || '123' AND ssn = ***(Redacted) || ***(Redacted) || ***(Redacted)"
+            ),
+            // In operator
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk IN (1, 3, 5) AND attr IN (2, 4, 6)",
+                "SELECT * FROM tb WHERE hk IN (1, 3, 5) AND attr IN (***(Redacted), ***(Redacted), ***(Redacted))"
+            ),
+            // Between operator
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk BETWEEN 1 AND 2 AND attr BETWEEN 1 AND 2",
+                "SELECT * FROM tb WHERE hk BETWEEN 1 AND 2 AND attr BETWEEN ***(Redacted) AND ***(Redacted)"
+            ),
+            // Comparison operators
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE (hk <> 1 or hk < 1 or hk <= 1 or hk > 1 or hk >=1 )",
+                "SELECT * FROM tb WHERE (hk <> 1 or hk < 1 or hk <= 1 or hk > 1 or hk >=1 )"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 'a' and (attr1 <> 1 or attr2 < 1 or attr3 <= 1 or attr4 > 1 or attr5 >=1 )",
+                "SELECT * FROM tb WHERE hk = 'a' and (attr1 <> ***(Redacted) or attr2 < ***(Redacted) or attr3 <= ***(Redacted) or attr4 > ***(Redacted) or attr5 >=***(Redacted) )"
+            ),
+            // String
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 'a' and attr = 'a'",
+                "SELECT * FROM tb WHERE hk = 'a' and attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = '2016-02-15' and attr = '2016-02-15'",
+                "SELECT * FROM tb WHERE hk = '2016-02-15' and attr = ***(Redacted)"
+            ),
+            // TODO: Fix metadata length for unicode
 //            RedactionTestCase(
 //                    "SELECT * FROM tb WHERE hk = '\uD83D\uDE01\uD83D\uDE1E\uD83D\uDE38\uD83D\uDE38' and attr = '\uD83D\uDE01\uD83D\uDE1E\uD83D\uDE38\uD83D\uDE38'",
 //                    "SELECT * FROM tb WHERE hk = '\uD83D\uDE01\uD83D\uDE1E\uD83D\uDE38\uD83D\uDE38' and attr = ***(Redacted)"),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = '話家身圧費谷料村能計税金' and attr = '話家身圧費谷料村能計税金'",
-            "SELECT * FROM tb WHERE hk = '話家身圧費谷料村能計税金' and attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 'abcde\\u0832fgh' and attr = 'abcde\\u0832fgh'",
-            "SELECT * FROM tb WHERE hk = 'abcde\\u0832fgh' and attr = ***(Redacted)"
-        ),
-        // Int
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE NOT hk = 1 AND NOT attr = 1",
-            "SELECT * FROM tb WHERE NOT hk = 1 AND NOT attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE NOT hk = 0 AND NOT attr = 0",
-            "SELECT * FROM tb WHERE NOT hk = 0 AND NOT attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = -0 AND attr = -0",
-            "SELECT * FROM tb WHERE hk = -0 AND attr = -***(Redacted)"
-        ),
-        // Decimal
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 0.123 AND attr = 0.123",
-            "SELECT * FROM tb WHERE hk = 0.123 AND attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = -0.123 AND attr = -0.123",
-            "SELECT * FROM tb WHERE hk = -0.123 AND attr = -***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 0.000 AND attr = 0.000",
-            "SELECT * FROM tb WHERE hk = 0.000 AND attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = -0.000 AND attr = -0.000",
-            "SELECT * FROM tb WHERE hk = -0.000 AND attr = -***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 0.12e-4 AND attr = 0.12e-4",
-            "SELECT * FROM tb WHERE hk = 0.12e-4 AND attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = -0.01200e5 AND attr = -0.01200e5",
-            "SELECT * FROM tb WHERE hk = -0.01200e5 AND attr = -***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 0. AND attr = 0.",
-            "SELECT * FROM tb WHERE hk = 0. AND attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 0E0 AND attr = 0E0",
-            "SELECT * FROM tb WHERE hk = 0E0 AND attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 0E-0 AND attr = 0E-0",
-            "SELECT * FROM tb WHERE hk = 0E-0 AND attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 0.0E1 AND attr = 0.0E1",
-            "SELECT * FROM tb WHERE hk = 0.0E1 AND attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = -0E0 AND attr = -0E0",
-            "SELECT * FROM tb WHERE hk = -0E0 AND attr = -***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = -0. AND attr = -0.",
-            "SELECT * FROM tb WHERE hk = -0. AND attr = -***(Redacted)"
-        ),
-        // Boolean on non-key attr
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = TRUE AND attr = TRUE",
-            "SELECT * FROM tb WHERE hk = TRUE AND attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = FALSE AND attr = FALSE",
-            "SELECT * FROM tb WHERE hk = FALSE AND attr = ***(Redacted)"
-        ),
-        // NULL on non-key attr
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = NULL AND attr = NULL",
-            "SELECT * FROM tb WHERE hk = NULL AND attr = ***(Redacted)"
-        ),
-        // Map on non-key attr
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 'a' AND attr = { 'hk' : 'value' }",
-            "SELECT * FROM tb WHERE hk = 'a' AND attr = { ***(Redacted) : ***(Redacted) }"
-        ),
-        // List
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 'a' AND attr = [ 'value1', 'value2' ]",
-            "SELECT * FROM tb WHERE hk = 'a' AND attr = [ ***(Redacted), ***(Redacted) ]"
-        ),
-        // Set
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 'a' AND attr = << 'value1', 'value2' >>",
-            "SELECT * FROM tb WHERE hk = 'a' AND attr = << ***(Redacted), ***(Redacted) >>"
-        ),
-        // Space and new line preserved
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk =1    \n    AND attr =1",
-            "SELECT * FROM tb WHERE hk =1    \n" +
-                "    AND attr =***(Redacted)"
-        ),
-        RedactionTestCase(
-            "SELECT * \n FROM tb \n WHERE hk =1 \n\r AND attr = 'asdfas \n\r df \n\r sa' AND hk = 2",
-            "SELECT * \n FROM tb \n WHERE hk =1 \n\r AND attr = ***(Redacted) AND hk = 2"
-        ),
-        // Multiple Args cases
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 1 and rk = '1'",
-            "SELECT * FROM tb WHERE hk = 1 and rk = '1'"
-        ),
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 'a' and (rk = 1 or (rk = 2 and attr = '1'))",
-            "SELECT * FROM tb WHERE hk = 'a' and (rk = 1 or (rk = 2 and attr = ***(Redacted)))"
-        ),
-        // Nested Map
-        RedactionTestCase(
-            "SELECT * FROM tb WHERE hk = 'a' AND attr = { 'name' : { 'name' : 'value' } }",
-            "SELECT * FROM tb WHERE hk = 'a' AND attr = { ***(Redacted) : { ***(Redacted) : ***(Redacted) } }"
-        ),
-        // Insert Into
-        RedactionTestCase(
-            "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': 'b' }",
-            "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': ***(Redacted) }"
-        ),
-        RedactionTestCase(
-            "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}",
-            "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': { ***(Redacted): ***(Redacted) }}"
-        ),
-        RedactionTestCase(
-            "INSERT INTO tb VALUE `{ 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}`",
-            "INSERT INTO tb VALUE ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "INSERT INTO tb VALUE HK",
-            "INSERT INTO tb VALUE HK"
-        ),
-        RedactionTestCase(
-            "INSERT INTO tb VALUE hk",
-            "INSERT INTO tb VALUE hk"
-        ),
-        RedactionTestCase(
-            "INSERT INTO tb VALUE hk = 'a' and attr = 'a'",
-            "INSERT INTO tb VALUE hk = 'a' and attr = ***(Redacted)"
-        ),
-        RedactionTestCase(
-            "INSERT INTO tb VALUE MISSING",
-            "INSERT INTO tb VALUE MISSING"
-        ),
-        RedactionTestCase(
-            "INSERT INTO tb VALUE << 'value1', 'value2' >>",
-            "INSERT INTO tb VALUE << ***(Redacted), ***(Redacted) >>"
-        ),
-        RedactionTestCase(
-            "INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': 'b' }>>",
-            "INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': ***(Redacted) }>>"
-        ),
-        RedactionTestCase(
-            "INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}>>",
-            "INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': { ***(Redacted): ***(Redacted) }}>>"
-        ),
-        RedactionTestCase(
-            "UPSERT INTO testTable2 << { 'dummy1' : 'hashKey', 'dummy2' : 'rangeKey', 'dummyTestAttribute' : '123' } >>",
-            "UPSERT INTO testTable2 << { 'dummy1' : ***(Redacted), 'dummy2' : ***(Redacted), 'dummyTestAttribute' : ***(Redacted) } >>"
-        ),
-        RedactionTestCase(
-            "REPLACE INTO testTable2 << { 'dummy1' : 'hashKey', 'dummy2' : 'rangeKey', 'dummyTestAttribute' : '123' } >>",
-            "REPLACE INTO testTable2 << { 'dummy1' : ***(Redacted), 'dummy2' : ***(Redacted), 'dummyTestAttribute' : ***(Redacted) } >>"
-        ),
-        RedactionTestCase(
-            "INSERT INTO testTable2 <<[2, 'some-name']>>",
-            "INSERT INTO testTable2 <<[***(Redacted), ***(Redacted)]>>"
-        ),
-        // Update Assignment
-        RedactionTestCase(
-            "update nonExistentTable set foo = 'bar' where attr1='testValue'",
-            "update nonExistentTable set foo = ***(Redacted) where attr1=***(Redacted)"
-        ),
-        RedactionTestCase(
-            "UPDATE tb SET hk = 'b', rk = 2, attr = 2 WHERE hk = 'a' and rk = 1 and attr = 1",
-            "UPDATE tb SET hk = 'b', rk = 2, attr = ***(Redacted) WHERE hk = 'a' and rk = 1 and attr = ***(Redacted)"
-        ),
-        // Delete
-        RedactionTestCase(
-            "DELETE FROM tb WHERE hk = 'a' AND attr = 'b'",
-            "DELETE FROM tb WHERE hk = 'a' AND attr = ***(Redacted)"
-        ),
-        // Path
-        RedactionTestCase(
-            "SELECT ?, tb.a from tb where tb.hk = ? and tb.rk = 'eggs' and tb[*].bar = ? or tb[*].rk = 'foo'",
-            "SELECT ?, tb.a from tb where tb.hk = ? and tb.rk = 'eggs' and tb[*].bar = ? or tb[*].rk = 'foo'"
-        ),
-        // Parameter
-        RedactionTestCase(
-            "SELECT ?, tb.a from tb where ? = 'foo' and ? = ? and ?.rk = 'eggs' and ?[*].bar = ? or ?[*].rk = 'foo'",
-            "SELECT ?, tb.a from tb where ? = 'foo' and ? = ? and ?.rk = 'eggs' and ?[*].bar = ? or ?[*].rk = 'foo'"
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = '話家身圧費谷料村能計税金' and attr = '話家身圧費谷料村能計税金'",
+                "SELECT * FROM tb WHERE hk = '話家身圧費谷料村能計税金' and attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 'abcde\\u0832fgh' and attr = 'abcde\\u0832fgh'",
+                "SELECT * FROM tb WHERE hk = 'abcde\\u0832fgh' and attr = ***(Redacted)"
+            ),
+            // Int
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE NOT hk = 1 AND NOT attr = 1",
+                "SELECT * FROM tb WHERE NOT hk = 1 AND NOT attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE NOT hk = 0 AND NOT attr = 0",
+                "SELECT * FROM tb WHERE NOT hk = 0 AND NOT attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = -0 AND attr = -0",
+                "SELECT * FROM tb WHERE hk = -0 AND attr = -***(Redacted)"
+            ),
+            // Decimal
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 0.123 AND attr = 0.123",
+                "SELECT * FROM tb WHERE hk = 0.123 AND attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = -0.123 AND attr = -0.123",
+                "SELECT * FROM tb WHERE hk = -0.123 AND attr = -***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 0.000 AND attr = 0.000",
+                "SELECT * FROM tb WHERE hk = 0.000 AND attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = -0.000 AND attr = -0.000",
+                "SELECT * FROM tb WHERE hk = -0.000 AND attr = -***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 0.12e-4 AND attr = 0.12e-4",
+                "SELECT * FROM tb WHERE hk = 0.12e-4 AND attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = -0.01200e5 AND attr = -0.01200e5",
+                "SELECT * FROM tb WHERE hk = -0.01200e5 AND attr = -***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 0. AND attr = 0.",
+                "SELECT * FROM tb WHERE hk = 0. AND attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 0E0 AND attr = 0E0",
+                "SELECT * FROM tb WHERE hk = 0E0 AND attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 0E-0 AND attr = 0E-0",
+                "SELECT * FROM tb WHERE hk = 0E-0 AND attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 0.0E1 AND attr = 0.0E1",
+                "SELECT * FROM tb WHERE hk = 0.0E1 AND attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = -0E0 AND attr = -0E0",
+                "SELECT * FROM tb WHERE hk = -0E0 AND attr = -***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = -0. AND attr = -0.",
+                "SELECT * FROM tb WHERE hk = -0. AND attr = -***(Redacted)"
+            ),
+            // Boolean on non-key attr
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = TRUE AND attr = TRUE",
+                "SELECT * FROM tb WHERE hk = TRUE AND attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = FALSE AND attr = FALSE",
+                "SELECT * FROM tb WHERE hk = FALSE AND attr = ***(Redacted)"
+            ),
+            // NULL on non-key attr
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = NULL AND attr = NULL",
+                "SELECT * FROM tb WHERE hk = NULL AND attr = ***(Redacted)"
+            ),
+            // Map on non-key attr
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 'a' AND attr = { 'hk' : 'value' }",
+                "SELECT * FROM tb WHERE hk = 'a' AND attr = { ***(Redacted) : ***(Redacted) }"
+            ),
+            // List
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 'a' AND attr = [ 'value1', 'value2' ]",
+                "SELECT * FROM tb WHERE hk = 'a' AND attr = [ ***(Redacted), ***(Redacted) ]"
+            ),
+            // Set
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 'a' AND attr = << 'value1', 'value2' >>",
+                "SELECT * FROM tb WHERE hk = 'a' AND attr = << ***(Redacted), ***(Redacted) >>"
+            ),
+            // Space and new line preserved
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk =1    \n    AND attr =1",
+                "SELECT * FROM tb WHERE hk =1    \n" +
+                    "    AND attr =***(Redacted)"
+            ),
+            RedactionTestCase(
+                "SELECT * \n FROM tb \n WHERE hk =1 \n\r AND attr = 'asdfas \n\r df \n\r sa' AND hk = 2",
+                "SELECT * \n FROM tb \n WHERE hk =1 \n\r AND attr = ***(Redacted) AND hk = 2"
+            ),
+            // Multiple Args cases
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 1 and rk = '1'",
+                "SELECT * FROM tb WHERE hk = 1 and rk = '1'"
+            ),
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 'a' and (rk = 1 or (rk = 2 and attr = '1'))",
+                "SELECT * FROM tb WHERE hk = 'a' and (rk = 1 or (rk = 2 and attr = ***(Redacted)))"
+            ),
+            // Nested Map
+            RedactionTestCase(
+                "SELECT * FROM tb WHERE hk = 'a' AND attr = { 'name' : { 'name' : 'value' } }",
+                "SELECT * FROM tb WHERE hk = 'a' AND attr = { ***(Redacted) : { ***(Redacted) : ***(Redacted) } }"
+            ),
+            // Insert Into
+            RedactionTestCase(
+                "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': 'b' }",
+                "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': ***(Redacted) }"
+            ),
+            RedactionTestCase(
+                "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}",
+                "INSERT INTO tb VALUE { 'hk': 'a', 'rk': 1, 'attr': { ***(Redacted): ***(Redacted) }}"
+            ),
+            RedactionTestCase(
+                "INSERT INTO tb VALUE `{ 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}`",
+                "INSERT INTO tb VALUE ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "INSERT INTO tb VALUE HK",
+                "INSERT INTO tb VALUE HK"
+            ),
+            RedactionTestCase(
+                "INSERT INTO tb VALUE hk",
+                "INSERT INTO tb VALUE hk"
+            ),
+            RedactionTestCase(
+                "INSERT INTO tb VALUE hk = 'a' and attr = 'a'",
+                "INSERT INTO tb VALUE hk = 'a' and attr = ***(Redacted)"
+            ),
+            RedactionTestCase(
+                "INSERT INTO tb VALUE MISSING",
+                "INSERT INTO tb VALUE MISSING"
+            ),
+            RedactionTestCase(
+                "INSERT INTO tb VALUE << 'value1', 'value2' >>",
+                "INSERT INTO tb VALUE << ***(Redacted), ***(Redacted) >>"
+            ),
+            RedactionTestCase(
+                "INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': 'b' }>>",
+                "INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': ***(Redacted) }>>"
+            ),
+            RedactionTestCase(
+                "INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': { 'hk': 'a' }}>>",
+                "INSERT INTO tb <<{ 'hk': 'a', 'rk': 1, 'attr': { ***(Redacted): ***(Redacted) }}>>"
+            ),
+            RedactionTestCase(
+                "UPSERT INTO testTable2 << { 'dummy1' : 'hashKey', 'dummy2' : 'rangeKey', 'dummyTestAttribute' : '123' } >>",
+                "UPSERT INTO testTable2 << { 'dummy1' : ***(Redacted), 'dummy2' : ***(Redacted), 'dummyTestAttribute' : ***(Redacted) } >>"
+            ),
+            RedactionTestCase(
+                "REPLACE INTO testTable2 << { 'dummy1' : 'hashKey', 'dummy2' : 'rangeKey', 'dummyTestAttribute' : '123' } >>",
+                "REPLACE INTO testTable2 << { 'dummy1' : ***(Redacted), 'dummy2' : ***(Redacted), 'dummyTestAttribute' : ***(Redacted) } >>"
+            ),
+            RedactionTestCase(
+                "INSERT INTO testTable2 <<[2, 'some-name']>>",
+                "INSERT INTO testTable2 <<[***(Redacted), ***(Redacted)]>>"
+            ),
+            // Update Assignment
+            RedactionTestCase(
+                "update nonExistentTable set foo = 'bar' where attr1='testValue'",
+                "update nonExistentTable set foo = ***(Redacted) where attr1=***(Redacted)"
+            ),
+            RedactionTestCase(
+                "UPDATE tb SET hk = 'b', rk = 2, attr = 2 WHERE hk = 'a' and rk = 1 and attr = 1",
+                "UPDATE tb SET hk = 'b', rk = 2, attr = ***(Redacted) WHERE hk = 'a' and rk = 1 and attr = ***(Redacted)"
+            ),
+            // Delete
+            RedactionTestCase(
+                "DELETE FROM tb WHERE hk = 'a' AND attr = 'b'",
+                "DELETE FROM tb WHERE hk = 'a' AND attr = ***(Redacted)"
+            ),
+            // Path
+            RedactionTestCase(
+                "SELECT ?, tb.a from tb where tb.hk = ? and tb.rk = 'eggs' and tb[*].bar = ? or tb[*].rk = 'foo'",
+                "SELECT ?, tb.a from tb where tb.hk = ? and tb.rk = 'eggs' and tb[*].bar = ? or tb[*].rk = 'foo'"
+            ),
+            // Parameter
+            RedactionTestCase(
+                "SELECT ?, tb.a from tb where ? = 'foo' and ? = ? and ?.rk = 'eggs' and ?[*].bar = ? or ?[*].rk = 'foo'",
+                "SELECT ?, tb.a from tb where ? = 'foo' and ? = ? and ?.rk = 'eggs' and ?[*].bar = ? or ?[*].rk = 'foo'"
+            )
         )
-    )
+    }
 
     @Test
     fun testDefaultArguments() {

--- a/lang/src/test/kotlin/org/partiql/lang/eval/ExprValueAdaptersTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/ExprValueAdaptersTest.kt
@@ -14,11 +14,13 @@
 
 package org.partiql.lang.eval
 
-import org.junit.Test
-import org.partiql.lang.TestBase
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
 import org.partiql.lang.util.newFromIonText
 
-class ExprValueAdaptersTest : TestBase() {
+class ExprValueAdaptersTest {
     @Test
     fun asNamed() {
         val value = newFromIonText("5")

--- a/lang/src/test/kotlin/org/partiql/lang/eval/NullIfEvaluationTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/NullIfEvaluationTest.kt
@@ -38,7 +38,6 @@ class NullIfEvaluationTest : EvaluatorTestBase() {
         fun testCase(expr1: String, expr2: String, expected: String) = NullIfTestCase(expr1, expr2, expected)
 
         @JvmStatic
-        @Suppress("unused")
         fun nullifEvaluationTests() = listOf(
             testCase("1", "1", "null"),
             testCase("1", "2", "1"),

--- a/lang/src/test/kotlin/org/partiql/lang/eval/builtins/TimestampTemporalAccessorTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/eval/builtins/TimestampTemporalAccessorTests.kt
@@ -1,19 +1,16 @@
 package org.partiql.lang.eval.builtins
 
 import com.amazon.ion.Timestamp
-import junitparams.JUnitParamsRunner
-import junitparams.Parameters
-import junitparams.naming.TestCaseName
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import java.time.DateTimeException
 import java.time.format.DateTimeFormatter
 import java.time.temporal.UnsupportedTemporalTypeException
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
-@RunWith(JUnitParamsRunner::class)
 class TimestampTemporalAccessorTests {
 
     @Test
@@ -32,9 +29,8 @@ class TimestampTemporalAccessorTests {
         override fun toString(): String = formatSymbol
     }
 
-    @Test
-    @Parameters
-    @TestCaseName("handleUnsupportedFormatSymbols_{0}")
+    @ParameterizedTest(name = "handleUnsupportedFormatSymbols_{0}")
+    @MethodSource("parametersForHandleUnsupportedFormatSymbolsTest")
     fun handleUnsupportedFormatSymbolsTest(testCase: UnsupportedSymbolTestCase) {
         val timestamp = Timestamp.forSecond(1969, 7, 20, 20, 18, 36, 0)
         val temporalAccessor = TimestampTemporalAccessor(timestamp)
@@ -44,27 +40,30 @@ class TimestampTemporalAccessorTests {
             .isInstanceOf(testCase.expectedExceptionType)
     }
 
-    /** Most of these format symbols are unsupported either because Ion's Timestamp doesn't store the information required
-     * (i.e. timezone) or as a risk mitigation strategy that reduces the complexity should we need to completely replace
-     * Java's DateTimeFormatter with something else later.
-     */
-    fun parametersForHandleUnsupportedFormatSymbolsTest(): List<UnsupportedSymbolTestCase> = listOf(
-        UnsupportedSymbolTestCase("G", UnsupportedTemporalTypeException::class.java), // Era, e.g. "AD"
-        UnsupportedSymbolTestCase("u", UnsupportedTemporalTypeException::class.java), // Year of era, e.g. "1978"; "78", (this is always positive, even for BC values)
-        UnsupportedSymbolTestCase("Q", UnsupportedTemporalTypeException::class.java), // Quarter of year (1-4)
-        UnsupportedSymbolTestCase("q", UnsupportedTemporalTypeException::class.java), // Quarter of year e.g. "Q3" "3rd quarter",
-        UnsupportedSymbolTestCase("E", UnsupportedTemporalTypeException::class.java), // Day of week
-        UnsupportedSymbolTestCase("F", UnsupportedTemporalTypeException::class.java), // Week of month
-        UnsupportedSymbolTestCase("K", UnsupportedTemporalTypeException::class.java), // hour of am-pm (0-11)
-        UnsupportedSymbolTestCase("k", UnsupportedTemporalTypeException::class.java), // clock of am-pm (1-24)
-        UnsupportedSymbolTestCase("A", UnsupportedTemporalTypeException::class.java), // Millisecond of day (0-85,499,999)
-        UnsupportedSymbolTestCase("N", UnsupportedTemporalTypeException::class.java), // Nano of day (0-85,499,999,999,999)
-        UnsupportedSymbolTestCase("Y", UnsupportedTemporalTypeException::class.java), // Week based year
-        UnsupportedSymbolTestCase("w", UnsupportedTemporalTypeException::class.java), // Week of week based year
-        UnsupportedSymbolTestCase("W", UnsupportedTemporalTypeException::class.java), // Week of month
-        UnsupportedSymbolTestCase("e", UnsupportedTemporalTypeException::class.java), // Localized day of week (number)
-        UnsupportedSymbolTestCase("c", UnsupportedTemporalTypeException::class.java), // Localized day of week (week name, e.g. "Tue" or "Tuesday")
-        UnsupportedSymbolTestCase("VV", DateTimeException::class.java), // time zone id, e.g "America/Los_Angeles; Z; -08:30" - ion timestamp does not know timezone, only offset
-        UnsupportedSymbolTestCase("z", DateTimeException::class.java) // time zone name, e.g. "Pacific Standard Time" - ion timestamp does not know timezone, only offset
-    )
+    companion object {
+        /** Most of these format symbols are unsupported either because Ion's Timestamp doesn't store the information required
+         * (i.e. timezone) or as a risk mitigation strategy that reduces the complexity should we need to completely replace
+         * Java's DateTimeFormatter with something else later.
+         */
+        @JvmStatic
+        fun parametersForHandleUnsupportedFormatSymbolsTest(): List<UnsupportedSymbolTestCase> = listOf(
+            UnsupportedSymbolTestCase("G", UnsupportedTemporalTypeException::class.java), // Era, e.g. "AD"
+            UnsupportedSymbolTestCase("u", UnsupportedTemporalTypeException::class.java), // Year of era, e.g. "1978"; "78", (this is always positive, even for BC values)
+            UnsupportedSymbolTestCase("Q", UnsupportedTemporalTypeException::class.java), // Quarter of year (1-4)
+            UnsupportedSymbolTestCase("q", UnsupportedTemporalTypeException::class.java), // Quarter of year e.g. "Q3" "3rd quarter",
+            UnsupportedSymbolTestCase("E", UnsupportedTemporalTypeException::class.java), // Day of week
+            UnsupportedSymbolTestCase("F", UnsupportedTemporalTypeException::class.java), // Week of month
+            UnsupportedSymbolTestCase("K", UnsupportedTemporalTypeException::class.java), // hour of am-pm (0-11)
+            UnsupportedSymbolTestCase("k", UnsupportedTemporalTypeException::class.java), // clock of am-pm (1-24)
+            UnsupportedSymbolTestCase("A", UnsupportedTemporalTypeException::class.java), // Millisecond of day (0-85,499,999)
+            UnsupportedSymbolTestCase("N", UnsupportedTemporalTypeException::class.java), // Nano of day (0-85,499,999,999,999)
+            UnsupportedSymbolTestCase("Y", UnsupportedTemporalTypeException::class.java), // Week based year
+            UnsupportedSymbolTestCase("w", UnsupportedTemporalTypeException::class.java), // Week of week based year
+            UnsupportedSymbolTestCase("W", UnsupportedTemporalTypeException::class.java), // Week of month
+            UnsupportedSymbolTestCase("e", UnsupportedTemporalTypeException::class.java), // Localized day of week (number)
+            UnsupportedSymbolTestCase("c", UnsupportedTemporalTypeException::class.java), // Localized day of week (week name, e.g. "Tue" or "Tuesday")
+            UnsupportedSymbolTestCase("VV", DateTimeException::class.java), // time zone id, e.g "America/Los_Angeles; Z; -08:30" - ion timestamp does not know timezone, only offset
+            UnsupportedSymbolTestCase("z", DateTimeException::class.java) // time zone name, e.g. "Pacific Standard Time" - ion timestamp does not know timezone, only offset
+        )
+    }
 }

--- a/lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
@@ -877,21 +877,20 @@ class AstToLogicalVisitorTransformTests {
         )
     }
 
-    data class ProblemTestCase(val id: Int, val sql: String, val expectedProblem: Problem)
+    data class ProblemTestCase(val sql: String, val expectedProblem: Problem)
 
     @ParameterizedTest
     @ArgumentsSource(ArgumentsForProblemTests::class)
     fun `unimplemented features are blocked`(tc: ProblemTestCase) {
-        val id by lazy { "[in test case #${tc.id}]" }
         val problemHandler = ProblemCollector()
-        assertDoesNotThrow("Parsing TestCase.sql should not throw $id") {
+        assertDoesNotThrow("Parsing TestCase.sql should not throw") {
             parseAndTransform(tc.sql, problemHandler)
         }
 
-        assertFalse(problemHandler.hasWarnings, "didn't expect any warnings $id")
-        assertTrue(problemHandler.hasErrors, "at least one error was expected $id")
+        assertFalse(problemHandler.hasWarnings, "didn't expect any warnings")
+        assertTrue(problemHandler.hasErrors, "at least one error was expected")
 
-        assertEquals(tc.expectedProblem, problemHandler.problems.first(), "actual problem is not as expected $id")
+        assertEquals(tc.expectedProblem, problemHandler.problems.first())
     }
 
     /**
@@ -904,27 +903,25 @@ class AstToLogicalVisitorTransformTests {
 
         override fun getParameters() = listOf(
             // DDL is  not implemented
-            ProblemTestCase(100, "CREATE TABLE foo (boo string)", unimplementedProblem("CREATE TABLE", 1, 1)),
-            ProblemTestCase(101, "DROP TABLE foo", unimplementedProblem("DROP TABLE", 1, 1)),
-            ProblemTestCase(102, "CREATE INDEX ON foo (x)", unimplementedProblem("CREATE INDEX", 1, 1)),
-            ProblemTestCase(103, "DROP INDEX bar ON foo", unimplementedProblem("DROP INDEX", 1, 1)),
+            ProblemTestCase("CREATE TABLE foo", unimplementedProblem("CREATE TABLE", 1, 1)),
+            ProblemTestCase("DROP TABLE foo", unimplementedProblem("DROP TABLE", 1, 1)),
+            ProblemTestCase("CREATE INDEX ON foo (x)", unimplementedProblem("CREATE INDEX", 1, 1)),
+            ProblemTestCase("DROP INDEX bar ON foo", unimplementedProblem("DROP INDEX", 1, 1)),
 
             // Unimplemented parts of DML
-            ProblemTestCase(200, "FROM x AS xx INSERT INTO foo VALUES (1, 2)", unimplementedProblem("UPDATE / INSERT", 1, 14)),
-            ProblemTestCase(201, "FROM x AS xx SET k = 5", unimplementedProblem("SET", 1, 14)),
-            ProblemTestCase(202, "UPDATE x SET k = 5", unimplementedProblem("SET", 1, 10)),
-            ProblemTestCase(203, "UPDATE x REMOVE k", unimplementedProblem("REMOVE", 1, 10)),
-            ProblemTestCase(204, "UPDATE x INSERT INTO k << 1 >>", unimplementedProblem("UPDATE / INSERT", 1, 10)),
+            ProblemTestCase("FROM x AS xx INSERT INTO foo VALUES (1, 2)", unimplementedProblem("UPDATE / INSERT", 1, 14)),
+            ProblemTestCase("FROM x AS xx SET k = 5", unimplementedProblem("SET", 1, 14)),
+            ProblemTestCase("UPDATE x SET k = 5", unimplementedProblem("SET", 1, 10)),
+            ProblemTestCase("UPDATE x REMOVE k", unimplementedProblem("REMOVE", 1, 10)),
+            ProblemTestCase("UPDATE x INSERT INTO k << 1 >>", unimplementedProblem("UPDATE / INSERT", 1, 10)),
 
             // INSERT INTO ... VALUE ... is not supported because it is redundant with INSERT INTO ... << <expr> >>
             ProblemTestCase(
-                300,
                 "INSERT INTO x VALUE 1",
                 Problem(SourceLocationMeta(1, 1), PlanningProblemDetails.InsertValueDisallowed)
             ),
             // We need schema to support using INSERT INTO without an explicit list of fields.
             ProblemTestCase(
-                301,
                 "INSERT INTO x VALUES (1, 2, 3)",
                 Problem(SourceLocationMeta(1, 1), PlanningProblemDetails.InsertValuesDisallowed)
             )

--- a/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTestBase_J5.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTestBase_J5.kt
@@ -15,12 +15,15 @@
 package org.partiql.lang.syntax
 
 import com.amazon.ion.IonSexp
+import com.amazon.ion.IonSystem
 import com.amazon.ion.IonValue
 import com.amazon.ionelement.api.SexpElement
 import com.amazon.ionelement.api.toIonElement
 import com.amazon.ionelement.api.toIonValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.fail
 import org.partiql.lang.CUSTOM_TEST_TYPES
-import org.partiql.lang.TestBase
+import org.partiql.lang.ION
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
@@ -30,8 +33,9 @@ import org.partiql.lang.util.checkErrorAndErrorContext
 import org.partiql.lang.util.softAssert
 import org.partiql.pig.runtime.toIonElement
 
-abstract class PartiQLParserTestBase : TestBase() {
+abstract class PartiQLParserTestBase_J5 {
 
+    val ion: IonSystem = ION
     val parser = PartiQLParserBuilder().ionSystem(ion).customTypes(CUSTOM_TEST_TYPES).build()
 
     protected fun parse(source: String): PartiqlAst.Statement = parser.parseAstStatement(source)

--- a/lang/src/test/kotlin/org/partiql/lang/util/NumbersTest.kt
+++ b/lang/src/test/kotlin/org/partiql/lang/util/NumbersTest.kt
@@ -15,11 +15,12 @@
 package org.partiql.lang.util
 
 import com.amazon.ion.Decimal
-import org.junit.Test
-import org.partiql.lang.TestBase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 
-class NumbersTest : TestBase() {
+class NumbersTest {
     fun dec(text: String): BigDecimal = bigDecimalOf(text)
     fun dec(value: Double): BigDecimal = bigDecimalOf(value)
 


### PR DESCRIPTION
We currently have a mix of JUint4(+ JUnitParametrs) and JUnit5 tests (#577) as well as a questionable setup for importing JUnit4 assertions (#576). 

This PR is a peek into what would it take to fully transition to  JUnit5. There is nothing particularly new here: all changes are something that is already in use in other places. But it is worth to have a look at them, as a highlight of what will have to be done. 
My opinion is that the transition is doable, is worth it, -- but it would be somewhat of a mind-numbing  slog.

When there is agreement, I propose merging this PR and then following with the rest of the transition.   

A few specifics to note: 

* I decided to skip switching from `TestBase` to direct JUnit4 imports (as recommended in #576) and got straight to JUnit5 in the affected test suites, but take measures to make it possible to have a gradual transition, suite by suite.  

* In particular, this explains the `PartiQLParserTestBase_J5` duplicate of `PartiQLParserTestBase`, to deal with transitive inheritance from `TestBase`. (We can discuss whether we want to commit this like this in this PR and drop the `_J5` suffix later, or do it differently.)

* Introduction of `companion object`s (because @MethodSource needs a static method) is the most unpleasant thing, for its tab-shift and, sometimes, code relocation.  

See a couple more comments at specific spots. 


## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
- Any backward-incompatible changes? **[YES/NO]**
- Any new external dependencies? **[YES/NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.