### PR TITLE
fix maven publish issue

### DIFF
--- a/buildSrc/src/main/kotlin/org/partiql/gradle/plugin/publish/PublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/partiql/gradle/plugin/publish/PublishPlugin.kt
@@ -87,8 +87,6 @@ abstract class PublishPlugin : Plugin<Project> {
                 create<MavenPublication>("maven") {
                     artifactId = ext.artifactId
                     from(components["java"])
-                    artifact(tasks["sourcesJar"])
-                    artifact(tasks["javadocJar"])
                     pom {
                         packaging = "jar"
                         name.set(ext.name)


### PR DESCRIPTION
## Relevant Issues
- N/A

## Description
- When running the publish plugin to publish to maven central or maven local, I have encountered a issue. 

See below:

<img width="961" alt="Screenshot 2023-03-08 at 2 45 21 PM" src="https://user-images.githubusercontent.com/107505258/223868870-a3468d65-9ace-4add-bc29-a7e20f3f239c.png"> 

In the debugger: 

<img width="985" alt="Screenshot 2023-03-08 at 2 44 55 PM" src="https://user-images.githubusercontent.com/107505258/223869297-b255514d-4ff5-40c6-a056-c758ca8f72cf.png">

I was able to pin down the issue to those two lines here: 
https://github.com/partiql/partiql-lang-kotlin/blob/1f102d6e57655234ac7e491c4d55174cb4f218c0/buildSrc/src/main/kotlin/org/partiql/gradle/plugin/publish/PublishPlugin.kt#L90-L91

Based on the commit history, those two lines were added to make sure that source jar and javadoc jar are included. 

However, https://github.com/partiql/partiql-lang-kotlin/blob/1f102d6e57655234ac7e491c4d55174cb4f218c0/buildSrc/src/main/kotlin/org/partiql/gradle/plugin/publish/PublishPlugin.kt#L63-L64 
should be sufficient, with additional fix in the [commit](https://github.com/partiql/partiql-lang-kotlin/commit/d6322903a8d9cbf8975a3a8bf699405b494dc33f) . 

Upon removing the two lines, the publish plugin works fine. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No. Maven publish plugin bug fix. 

- Any backward-incompatible changes? **[YES/NO]**
  - No. 
 
- Any new external dependencies? **[YES/NO]**
  - No.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.