### PR TITLE
Touch-ups in SQL desugaring

### DIFF
--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/PartiqlAstExtensions.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/PartiqlAstExtensions.kt
@@ -13,7 +13,7 @@ import org.partiql.lang.domains.PartiqlAst
  *
  * If [this] is a [PartiqlAst.Expr.Path], invokes [PartiqlAst.Expr.Path.extractColumnAlias] to determine the alias.
  *
- * If [this] is a [PartiqlAst.Expr.Cast], the column alias is the name of the [PartiqlAst.Expr.Cast.value] to be `CAST`.
+ * If [this] is a [PartiqlAst.Expr.Cast], the column alias is the same as would be given to the [PartiqlAst.Expr.Cast.value] to be `CAST`.
  *
  * Otherwise, returns the column index prefixed with `_`.
  */

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/FromSourceAliasVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/FromSourceAliasVisitorTransform.kt
@@ -15,27 +15,44 @@ import org.partiql.pig.runtime.SymbolPrimitive
  * If provided with a query that has all of the from source aliases already specified, an exact clone is returned.
  */
 class FromSourceAliasVisitorTransform : VisitorTransformBase() {
+    // When this visitor reaches a top-level FromSource, it transforms it with a fresh instance
+    // of the helper visitor below.
+    // Currently, there are two places where a top-level FromSource can occur: in a SELECT and in a DML statement.
 
+    override fun transformExprSelect_from(node: PartiqlAst.Expr.Select): PartiqlAst.FromSource {
+        val newFrom = super.transformExprSelect_from(node) // this applies the transformation to any eligible subqueries
+        return InnerFromSourceAliasVisitorTransform().transformFromSource(newFrom)
+    }
+
+    override fun transformStatementDml_from(node: PartiqlAst.Statement.Dml): PartiqlAst.FromSource? {
+        val newFrom = super.transformStatementDml_from(node)
+        return newFrom?.let { InnerFromSourceAliasVisitorTransform().transformFromSource(it) }
+    }
+
+    /** The helper visitor is responsible for traversing one top-level FromSource and creating aliases in it.
+     *  Only the [transformFromSource] method is intended to be useful as an entry point.
+     *  The visitor is stateful, maintaining a counter for synthetic aliases,
+     *  so a separate instance is needed for each top level FromSource.
+     */
     private class InnerFromSourceAliasVisitorTransform : VisitorTransformBase() {
         private var fromSourceCounter = 0
 
-        override fun transformFromSourceScan_asAlias(node: PartiqlAst.FromSource.Scan): SymbolPrimitive? {
+        override fun transformFromSourceScan_asAlias(node: PartiqlAst.FromSource.Scan): SymbolPrimitive {
             val thisFromSourceIndex = fromSourceCounter++
             return node.asAlias
                 ?: SymbolPrimitive(node.expr.extractColumnAlias(thisFromSourceIndex), node.extractSourceLocation())
         }
 
-        override fun transformFromSourceUnpivot_asAlias(node: PartiqlAst.FromSource.Unpivot): SymbolPrimitive? {
+        override fun transformFromSourceUnpivot_asAlias(node: PartiqlAst.FromSource.Unpivot): SymbolPrimitive {
             val thisFromSourceIndex = fromSourceCounter++
             return node.asAlias
                 ?: SymbolPrimitive(node.expr.extractColumnAlias(thisFromSourceIndex), node.extractSourceLocation())
         }
 
-        // Need use a different [fromSourceCounter] for sub-queries.
-        override fun transformExprSelect(node: PartiqlAst.Expr.Select): PartiqlAst.Expr =
-            FromSourceAliasVisitorTransform().transformExprSelect(node)
+        // Do not traverse into subexpressions of a [FromSource].
+        // All relevant subqueries are reached by the host [FromSourceAliasVisitorTransform].
+        override fun transformExpr(node: PartiqlAst.Expr): PartiqlAst.Expr {
+            return node
+        }
     }
-
-    override fun transformFromSource(node: PartiqlAst.FromSource): PartiqlAst.FromSource =
-        InnerFromSourceAliasVisitorTransform().transformFromSource(node)
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/FromSourceAliasVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/FromSourceAliasVisitorTransform.kt
@@ -17,6 +17,8 @@ import org.partiql.pig.runtime.SymbolPrimitive
 class FromSourceAliasVisitorTransform : VisitorTransformBase() {
     // When this visitor reaches a top-level FromSource, it transforms it with a fresh instance
     // of the helper visitor below.
+    // (A FromSource is top-level if it does not occur inside another FromSource, which is possible because
+    // FromSource is recursive, to accommodate complex joins in the AST.)
     // Currently, there are two places where a top-level FromSource can occur: in a SELECT and in a DML statement.
 
     override fun transformExprSelect_from(node: PartiqlAst.Expr.Select): PartiqlAst.FromSource {
@@ -29,7 +31,8 @@ class FromSourceAliasVisitorTransform : VisitorTransformBase() {
         return newFrom?.let { InnerFromSourceAliasVisitorTransform().transformFromSource(it) }
     }
 
-    /** The helper visitor is responsible for traversing one top-level FromSource and creating aliases in it.
+    /** The helper visitor is responsible for traversing the recursive structure of one top-level FromSource
+     *  and creating aliases in it.
      *  Only the [transformFromSource] method is intended to be useful as an entry point.
      *  The visitor is stateful, maintaining a counter for synthetic aliases,
      *  so a separate instance is needed for each top level FromSource.

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SelectListItemAliasVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SelectListItemAliasVisitorTransform.kt
@@ -14,8 +14,9 @@ import org.partiql.pig.runtime.SymbolPrimitive
  *  SELECT
  *      foo,
  *      b.bat,
- *      baz + 1
- * FROM bar AS b
+ *      baz + 1,
+ *      zoo.*
+ *  FROM bar AS b
  * ```
  *
  * Into:
@@ -24,8 +25,9 @@ import org.partiql.pig.runtime.SymbolPrimitive
  *  SELECT
  *      foo AS foo,
  *      b.bat AS bat,
- *      baz + 1 AS _3
- * FROM bar AS b
+ *      baz + 1 AS _3,
+ *      zoo.*
+ *  FROM bar AS b
  * ```
  *
  * If provided with a query with all of the select list aliases are already specified, an exact clone is returned.

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SelectStarVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SelectStarVisitorTransform.kt
@@ -22,30 +22,16 @@ import org.partiql.lang.domains.metaContainerOf
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.eval.errNoContext
 
+/** Desugars `SELECT *` by, for example,
+ *  transforming  `SELECT * FROM A as x, B as y at i`
+ *            to  `SELECT x.*, y.*, i FROM A as x, B as y at i`
+ *  and transforming `SELECT * FROM ... GROUP BY E as x, D as y GROUP as g`
+ *                to `SELECT x, y, g FROM ... GROUP BY E as x, D as y GROUP as g`
+ *
+ *  Requires that [FromSourceAliasVisitorTransform] and [GroupByItemAliasVisitorTransform]
+ *  have already been applied.
+ */
 class SelectStarVisitorTransform : VisitorTransformBase() {
-
-    /**
-     * Copies all parts of [PartiqlAst.Expr.Select] except [newProjection] for [PartiqlAst.Projection].
-     */
-    private fun copyProjectionToSelect(node: PartiqlAst.Expr.Select, newProjection: PartiqlAst.Projection): PartiqlAst.Expr {
-        // Once https://github.com/partiql/partiql-ir-generator/issues/52, adding the .copy function is released,
-        // we can remove this code and call .copy instead
-        return PartiqlAst.build {
-            select(
-                setq = node.setq,
-                project = newProjection,
-                from = node.from,
-                fromLet = node.fromLet,
-                where = node.where,
-                group = node.group,
-                having = node.having,
-                order = node.order,
-                limit = node.limit,
-                offset = node.offset,
-                metas = node.metas
-            )
-        }
-    }
 
     override fun transformExprSelect(node: PartiqlAst.Expr.Select): PartiqlAst.Expr {
         val transformedExpr = super.transformExprSelect(node) as PartiqlAst.Expr.Select
@@ -54,8 +40,8 @@ class SelectStarVisitorTransform : VisitorTransformBase() {
 
         // Check if SELECT * is being used.
         if (projection is PartiqlAst.Projection.ProjectStar) {
-            when (transformedExpr.group) { // No group by
-                null -> {
+            when (transformedExpr.group) {
+                null -> { // No group by
                     val fromSourceAliases = extractAliases(transformedExpr.from)
 
                     val newProjection =
@@ -70,7 +56,7 @@ class SelectStarVisitorTransform : VisitorTransformBase() {
                                 transformedExpr.metas
                             )
                         }
-                    return copyProjectionToSelect(transformedExpr, newProjection)
+                    return transformedExpr.copy(project = newProjection)
                 }
                 else -> { // With group by
                     val selectListItemsFromGroupBy = transformedExpr.group.keyList.keys.map {
@@ -99,7 +85,7 @@ class SelectStarVisitorTransform : VisitorTransformBase() {
 
                     val newProjection = PartiqlAst.build { projectList(selectListItemsFromGroupBy + groupNameItem, metas = transformMetas(projection.metas)) }
 
-                    return copyProjectionToSelect(transformedExpr, newProjection)
+                    return transformedExpr.copy(project = newProjection)
                 }
             }
         }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/StaticTypeInferenceVisitorTransform.kt
@@ -1469,15 +1469,10 @@ internal class StaticTypeInferenceVisitorTransform(
                 }
                 pathComponent.withStaticType(currentType)
             }
-            // When [this](https://github.com/partiql/partiql-ir-generator/pull/53) is merged the below
-            // can be simplified.
-            return PartiqlAst.build {
-                path(
-                    root = path.root,
-                    steps = newComponents,
-                    metas = super.transformMetas(node.metas)
-                ).withStaticType(currentType)
-            }
+            return path.copy(
+                steps = newComponents,
+                metas = super.transformMetas(node.metas)
+            ).withStaticType(currentType)
         }
 
         private fun inferPathComponentExprType(

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/VisitorTransforms.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/VisitorTransforms.kt
@@ -16,7 +16,7 @@ fun basicVisitorTransforms() = PipelinedVisitorTransform(
     AggregateSupportVisitorTransform(),
     OrderBySortSpecVisitorTransform(),
 
-    // [GroupByPathExpressionVisitorTransform] requires:
+    // [GroupByPathExpressionVisitorTransform] and [SelectStarVisitorTransform] require:
     //   - the synthetic from source aliases added by [FromSourceAliasVisitorTransform]
     //   - The synthetic group by item aliases added by [GroupByItemAliasVisitorTransform]
     GroupByPathExpressionVisitorTransform(),


### PR DESCRIPTION
Here are a few touch-ups in SQL-to-PartiQL desugaring that came up while I was working on understanding it, as likely needed for #826.  

The commits are self-contained and are as follows: 

* A few old todos that awaited for PIG copy() methods.
* A few comment touch-ups in desugaring.
* Revisit `FromSourceAliasVisitorTransform` implementation.
  * The previous implementation relied on delicate ping-ponging of control between multiple instances of the host (`FromSourceAliasVisitorTransform`) and helper (`InnerFromSourceAliasVisitorTransform`) visitors.
  * In the amended implementation, the host visitor drives the traversal and calls a fresh instance of the helper visitor in each spot where a transformation is needed.
  * Both implementations create the same number of helper visitors (one per a FROM clause).
  * The new implementation needs only one host visitor, as opposed to a host visitor per subquery.
  * Absence of ping-ponging means the "stack" of visitors is at most two, as opposed to growing as the traversal goes deeper into the query, with implications for the lifetime of the involved visitor objects and, therefore, memory usage.


## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - Internal improvements.

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.