### PR TITLE
To-singleton coercion of SQL-style SELECT subqueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added numeric builtins ABS, SQRT, EXP, LN, POW, MOD.
 - Added string builtins POSITION, OVERLAY, BIT_LENGTH, OCTET_LENGTH, CARDINALITY.
-- Added coercion of SQL-style subquery to a single value, as defined in SQL for 
+- **Breaking** Added coercion of SQL-style subquery to a single value, as defined in SQL for 
   subqueries occurring in a single-value context and outlined in Chapter 9 of the PartiQL specification. 
   This is backward incompatible with the prior behavior, but brings it in conformance with the specification.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added string builtins POSITION, OVERLAY, BIT_LENGTH, OCTET_LENGTH, CARDINALITY.
 - Added coercion of SQL-style subquery to a single value, as defined in SQL for 
   subqueries occurring in a single-value context and outlined in Chapter 9 of the PartiQL specification. 
+  This is backward incompatible with the prior behavior, but brings it in conformance with the specification.
 
 ### Changed
 - Deprecates the project level opt-in annotation `PartiQLExperimental` and split it into feature level. `ExperimentalPartiQLCompilerPipeline` and `ExperimentalWindowFunctions`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added numeric builtins ABS, SQRT, EXP, LN, POW, MOD.
-- Added string builtins POSITION, OVERLAY, BIT_LENGTH, OCTET_LENGTH, CARDINALITY
+- Added string builtins POSITION, OVERLAY, BIT_LENGTH, OCTET_LENGTH, CARDINALITY.
+- Added coercion of SQL-style subquery to a single value, as defined in SQL for 
+  subqueries occurring in a single-value context and outlined in Chapter 9 of the PartiQL specification. 
 
 ### Changed
 - Deprecates the project level opt-in annotation `PartiQLExperimental` and split it into feature level. `ExperimentalPartiQLCompilerPipeline` and `ExperimentalWindowFunctions`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added string builtins POSITION, OVERLAY, BIT_LENGTH, OCTET_LENGTH, CARDINALITY.
 - **Breaking** Added coercion of SQL-style subquery to a single value, as defined in SQL for 
   subqueries occurring in a single-value context and outlined in Chapter 9 of the PartiQL specification. 
-  This is backward incompatible with the prior behavior, but brings it in conformance with the specification.
+  This is backward incompatible with the prior behavior (which left the computed collection as is), 
+  but brings it in conformance with the specification.
 
 ### Changed
 - Deprecates the project level opt-in annotation `PartiQLExperimental` and split it into feature level. `ExperimentalPartiQLCompilerPipeline` and `ExperimentalWindowFunctions`.

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/CompilerPipeline.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/CompilerPipeline.kt
@@ -24,6 +24,7 @@ import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.Expression
 import org.partiql.lang.eval.ThunkReturnTypeAssertions
 import org.partiql.lang.eval.builtins.SCALAR_BUILTINS_DEFAULT
+import org.partiql.lang.eval.builtins.definitionalBuiltins
 import org.partiql.lang.eval.builtins.storedprocedure.StoredProcedure
 import org.partiql.lang.eval.visitors.PipelinedVisitorTransform
 import org.partiql.lang.eval.visitors.StaticTypeInferenceVisitorTransform
@@ -253,13 +254,16 @@ interface CompilerPipeline {
                 }
             }
 
+            val definitionalBuiltins = definitionalBuiltins(compileOptionsToUse.typingMode).associateBy {
+                it.signature.name
+            }
             val builtinFunctions = SCALAR_BUILTINS_DEFAULT.associateBy {
                 it.signature.name
             }
 
             // customFunctions must be on the right side of + here to ensure that they overwrite any
             // built-in functions with the same name.
-            val allFunctions = builtinFunctions + customFunctions
+            val allFunctions = definitionalBuiltins + builtinFunctions + customFunctions
 
             return CompilerPipelineImpl(
                 ion = ion,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/SqlException.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/SqlException.kt
@@ -100,7 +100,7 @@ open class SqlException(
     }
 
     private fun errorCategory(errorCode: ErrorCode?): String =
-        errorCode?.errorCategory() ?: UNKNOWN
+        errorCode?.category?.message ?: UNKNOWN
 
     override fun toString(): String =
         when (this.message.isNotBlank()) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
@@ -19,8 +19,10 @@ import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
 import org.partiql.annotations.ExperimentalWindowFunctions
 import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ThunkReturnTypeAssertions
+import org.partiql.lang.eval.TypingMode
 import org.partiql.lang.eval.builtins.DynamicLookupExprFunction
 import org.partiql.lang.eval.builtins.SCALAR_BUILTINS_DEFAULT
+import org.partiql.lang.eval.builtins.definitionalBuiltins
 import org.partiql.lang.eval.builtins.storedprocedure.StoredProcedure
 import org.partiql.lang.eval.physical.operators.AggregateOperatorFactoryDefault
 import org.partiql.lang.eval.physical.operators.FilterRelationalOperatorFactoryDefault
@@ -102,7 +104,7 @@ class PartiQLCompilerBuilder private constructor() {
                 keySelector = { it.name },
                 valueTransform = { it.typedOpParameter }
             ),
-            functions = allFunctions(),
+            functions = allFunctions(options.typingMode),
             procedures = customProcedures.associateBy(
                 keySelector = { it.signature.name },
                 valueTransform = { it }
@@ -138,9 +140,10 @@ class PartiQLCompilerBuilder private constructor() {
 
     // --- Internal ----------------------------------
 
-    private fun allFunctions(): Map<String, ExprFunction> {
+    private fun allFunctions(typingMode: TypingMode): Map<String, ExprFunction> {
+        val definitionalBuiltins = definitionalBuiltins(typingMode)
         val builtins = SCALAR_BUILTINS_DEFAULT
-        val allFunctions = builtins + customFunctions + DynamicLookupExprFunction()
+        val allFunctions = definitionalBuiltins + builtins + customFunctions + DynamicLookupExprFunction()
         return allFunctions.associateBy { it.signature.name }
     }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/errors/ErrorAndErrorContexts.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/errors/ErrorAndErrorContexts.kt
@@ -30,8 +30,6 @@ enum class ErrorCategory(val message: String) {
     PARSER("Parser Error"),
     SEMANTIC("Semantic Error"),
     EVALUATOR("Evaluator Error");
-
-    override fun toString() = message
 }
 
 /** Each possible value that can be reported as part of an error has a

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/errors/ErrorCode.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/errors/ErrorCode.kt
@@ -1372,8 +1372,6 @@ enum class ErrorCode(
     open fun getErrorMessage(errorContext: PropertyValueMap?): String =
         "${detailMessagePrefix()}, ${detailMessageSuffix(errorContext)}"
 
-    fun errorCategory(): String = category.toString()
-
     fun getProperties(): Set<Property> = properties
 }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/errors/ErrorCode.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/errors/ErrorCode.kt
@@ -1218,6 +1218,13 @@ enum class ErrorCode(
         ErrorBehaviorInPermissiveMode.RETURN_MISSING
     ),
 
+    EVALUATOR_NON_SINGLETON_COLLECTION(
+        ErrorCategory.EVALUATOR,
+        LOCATION,
+        "Expected collection cannot be coerced to a single value",
+        ErrorBehaviorInPermissiveMode.RETURN_MISSING
+    ),
+
     SEMANTIC_NON_TEXT_STRUCT_FIELD_KEY(
         ErrorCategory.SEMANTIC,
         LOCATION + setOf(Property.ACTUAL_TYPE),

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/ErrorSignaler.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/ErrorSignaler.kt
@@ -54,7 +54,7 @@ internal class ErrorDetails(
 internal fun TypingMode.createErrorSignaler() =
     when (this) {
         TypingMode.LEGACY -> LegacyErrorSignaler()
-        TypingMode.PERMISSIVE -> PermissiveErrorSignaler(ExprValue.missingValue)
+        TypingMode.PERMISSIVE -> PermissiveErrorSignaler()
     }
 
 /** Defines legacy error signaling. */
@@ -65,13 +65,13 @@ private class LegacyErrorSignaler : ErrorSignaler {
 }
 
 /** Defines permissive error signaling. */
-private class PermissiveErrorSignaler(private val theMissingValue: ExprValue) : ErrorSignaler {
+private class PermissiveErrorSignaler() : ErrorSignaler {
 
-    /** Ignores [createErrorDetails] and simply returns [theMissingValue]. */
+    /** Ignores [createErrorDetails] and simply returns MISSING. */
     override fun error(errorCode: ErrorCode, createErrorDetails: () -> ErrorDetails): ExprValue =
         when (errorCode.errorBehaviorInPermissiveMode) {
             ErrorBehaviorInPermissiveMode.THROW_EXCEPTION -> throwEE(errorCode, createErrorDetails)
-            ErrorBehaviorInPermissiveMode.RETURN_MISSING -> theMissingValue
+            ErrorBehaviorInPermissiveMode.RETURN_MISSING -> ExprValue.missingValue
         }
 }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/DefinitionalBuiltins.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/DefinitionalBuiltins.kt
@@ -1,0 +1,88 @@
+package org.partiql.lang.eval.builtins
+
+import org.partiql.lang.errors.ErrorCode
+import org.partiql.lang.eval.ErrorDetails
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprFunction
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueType
+import org.partiql.lang.eval.TypingMode
+import org.partiql.lang.eval.createErrorSignaler
+import org.partiql.lang.types.FunctionSignature
+import org.partiql.types.StaticType
+
+/** Built-in functions specific to the PartiQL language definition.
+ *
+ *  These functions are defined in the language specification in order to explain some of the PartiQL semantics,
+ *  but are also made available to the user.
+ *  Implementations of these built-ins can depend on compilation options and specific compilation options
+ *  must be chosen in order to obtain an [ExprFunction] instance of these built-ins.
+ *  It is intended that the compilation options used for instantiating a compiler are the same ones
+ *  as used for instantiating these built-ins when adding them as functions to the compiler's environment.
+ *
+ */
+// TODO: Currently, the only compilation option in use is [TypingMode], so it is passed here by itself.
+// Ideally, something like [CompileOptions] would be the argument instead, but [CompileOptions] is only used
+// by the "evaluating compiler" and not by the "planning compiler", while this parameterization
+// of the built-ins needs to be applicable in both.
+internal fun definitionalBuiltins(typingMode: TypingMode): List<ExprFunction> =
+    listOf(
+        ExprFunctionCollToScalar(typingMode),
+    )
+
+/** `coll_to_scalar` extracts the scalar value contained in a "singleton table",
+ *   as performed in most cases of subquery coercion.
+ *   If the input is a collection consisting of a single element,
+ *   which in turn is a struct with exactly one attribute,
+ *   `coll_to_scalar` returns the value of the attribute.
+ *   For all other inputs, the result is either `MISSING` or an error,
+ *   depending on the typing mode.
+ */
+internal class ExprFunctionCollToScalar(typingMode: TypingMode) : ExprFunction {
+    override val signature = FunctionSignature(
+        name = "coll_to_scalar",
+        requiredParameters = listOf(StaticType.ANY),
+        returnType = StaticType.ANY
+    )
+
+    // TODO: Is ErrorSignaler most appropriate to use here?
+    // By its external structure, ErrorSignaler is exactly what is needed:
+    // based on TypingMode, it either produces MISSING or an error.
+    // However, it is not used much, the existing usage is for a different setting
+    // (defined on top of the basic setting needed here),
+    // and the final error message is not best formatted.
+    // The latter appears to be a symptom of general accumulated cruft in error-handling.
+    private val signaler = typingMode.createErrorSignaler()
+
+    /** Handler for situations when extraction cannot succeed.
+     *  Produces either the MISSING or an error.  */
+    private fun hiccup(reason: String): ExprValue {
+        return signaler.error(
+            ErrorCode.EVALUATOR_NON_SINGLETON_COLLECTION
+        ) { ErrorDetails(metas = emptyMap(), message = reason) }
+    }
+
+    override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
+        val coll = required[0]
+        if (!coll.type.isSequence) {
+            return hiccup("because it is not a collection.")
+        } else { // coll is a LIST, BAG, or SEXP
+            val seq = coll.asSequence()
+            if (seq.count() != 1) {
+                return hiccup("because the collection does not contain exactly one member.")
+            } else { // we have a singleton collection
+                val struct = seq.first()
+                if (struct.type != ExprValueType.STRUCT) {
+                    return hiccup("because the only member of the collection is not a struct.")
+                } else { // the single element is a struct
+                    val vals = struct.asSequence()
+                    if (vals.count() != 1) {
+                        return hiccup("because the only struct member of the collection does not contain exactly one attribute.")
+                    } else { // the single struct has exactly one attribute
+                        return vals.first()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransform.kt
@@ -5,16 +5,16 @@ import org.partiql.lang.domains.PartiqlAst
 /** Coerce each SQL-style SELECT subquery to single value, if it occurs in a context that expects a single value -- as
  *  prescribed in SQL for scalar-expecting contexts and as outlined in Chapter 9 of the PartiQL specification.
  *  The coercion is done by wrapping each eligible SELECT in a call to the COLL_TO_SCALAR built-in.
- *
- *  The coercion task is context-dependent, in the sense that not every SELECT needs to be coerced,
- *  but only a SELECT subquery in an appropriate context, while its coercion specifics depend on the context as well.
- *  The implementation deals with this by using the visitor to find possible _contexts_ of possible SELECT subqueries
- *  (rather than the subqueries themselves) and then inspecting each context to find the subquery
+ *  The coercion is context-dependent, in the sense that not every SELECT is coerced,
+ *  but only a SELECT subquery in an appropriate context, while its coercion specifics depend on the context as well. */
+/*
+ *  The implementation deals with context-dependency by using the visitor to find possible _contexts_ of possible SELECT
+ *  subqueries (rather than the subqueries themselves) and then inspecting each context to find the subquery
  *  and coerce it, if eligible. (In this problem, a "context" is an AST node that can contain an eligible subquery.)
  */
 class SubqueryCoercionVisitorTransform : VisitorTransformBase() {
 
-    /** When an Expr E is reached during the visitor's traversal,
+    /*  When an Expr E is reached during the visitor's traversal,
      * - First, perform the visitor's transformation recursively on E's components.
      *   This will coerce eligible SELECTs deep in each E's subexpression,
      *   but won't coerce any E's direct subexpression itself, even if it is a SELECT.

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransform.kt
@@ -1,0 +1,153 @@
+package org.partiql.lang.eval.visitors
+
+import org.partiql.lang.domains.PartiqlAst
+
+/** Coerce each SQL-style SELECT subquery to single value, if it occurs in a context that expects a single value -- as
+ *  prescribed in SQL for scalar-expecting contexts and as outlined in Chapter 9 of the PartiQL specification.
+ *  The coercion is done by wrapping each eligible SELECT in a call to the COLL_TO_SCALAR built-in.
+ *
+ *  The implementation is somewhat clever, dealing with the problem that not every SELECT needs to be coerced,
+ *  but only a SELECT subquery in an appropriate context, while its coercion details are context-dependent.
+ */
+class SubqueryCoercionVisitorTransform : VisitorTransformBase() {
+
+    /** When an Expr E is reached during the visitor's traversal,
+     * - First, perform the visitor's transformation recursively on E's components.
+     *   This will coerce eligible SELECTs deep in each E's subexpression,
+     *   but won't coerce any E's direct subexpression itself, even if it is a SELECT.
+     * - Then, treat E as a context for a possible SELECT subquery.
+     *   That is, detect each possible subexpression of E and, when the context is right
+     *   and the subexpression is an SQL-style SELECT, coerce it.
+     * With this, a top-level expression is never coerced, whether it is a SELECT or not.
+     */
+    override fun transformExpr(node: PartiqlAst.Expr): PartiqlAst.Expr {
+        val n = super.transformExpr(node)
+        return when (n) {
+            is PartiqlAst.Expr.Missing -> n
+            is PartiqlAst.Expr.Lit -> n
+            is PartiqlAst.Expr.Id -> n
+            is PartiqlAst.Expr.Parameter -> n
+
+            is PartiqlAst.Expr.Not -> n.copy(expr = coerceToSingle(n.expr))
+            is PartiqlAst.Expr.Pos -> n.copy(expr = coerceToSingle(n.expr))
+            is PartiqlAst.Expr.Neg -> n.copy(expr = coerceToSingle(n.expr))
+
+            is PartiqlAst.Expr.Plus -> n.copy(operands = n.operands.map { coerceToSingle(it) })
+            is PartiqlAst.Expr.Minus -> n.copy(operands = n.operands.map { coerceToSingle(it) })
+            is PartiqlAst.Expr.Times -> n.copy(operands = n.operands.map { coerceToSingle(it) })
+            is PartiqlAst.Expr.Divide -> n.copy(operands = n.operands.map { coerceToSingle(it) })
+            is PartiqlAst.Expr.Modulo -> n.copy(operands = n.operands.map { coerceToSingle(it) })
+            is PartiqlAst.Expr.Concat -> n.copy(operands = n.operands.map { coerceToSingle(it) })
+            is PartiqlAst.Expr.And -> n.copy(operands = n.operands.map { coerceToSingle(it) })
+            is PartiqlAst.Expr.Or -> n.copy(operands = n.operands.map { coerceToSingle(it) })
+
+            is PartiqlAst.Expr.Eq -> n.copy(operands = coerceInComparisonOps(n.operands))
+            is PartiqlAst.Expr.Ne -> n.copy(operands = coerceInComparisonOps(n.operands))
+            is PartiqlAst.Expr.Gt -> n.copy(operands = coerceInComparisonOps(n.operands))
+            is PartiqlAst.Expr.Gte -> n.copy(operands = coerceInComparisonOps(n.operands))
+            is PartiqlAst.Expr.Lt -> n.copy(operands = coerceInComparisonOps(n.operands))
+            is PartiqlAst.Expr.Lte -> n.copy(operands = coerceInComparisonOps(n.operands))
+
+            is PartiqlAst.Expr.Like -> n.copy(value = coerceToSingle(n.value), pattern = coerceToSingle(n.pattern))
+            is PartiqlAst.Expr.Between -> n.copy(value = coerceToSingle(n.value), from = coerceToSingle(n.from), to = coerceToSingle(n.to))
+
+            is PartiqlAst.Expr.InCollection -> toSingleInInCollection(n)
+
+            // TODO Revisit the following expression forms, where this implementation does not coerce most potential SELECT subqueries,
+            // being at odds with the literal letter of the Ch 9 of the PartiQL specification.
+            // Some of these are clear-cut cases, others need to be considered and decided upon.
+            is PartiqlAst.Expr.IsType -> n
+            is PartiqlAst.Expr.SimpleCase -> n
+            is PartiqlAst.Expr.SearchedCase -> n
+            is PartiqlAst.Expr.Struct -> n
+            is PartiqlAst.Expr.Bag -> n
+            is PartiqlAst.Expr.List -> n
+            is PartiqlAst.Expr.Sexp -> n
+            is PartiqlAst.Expr.Date -> n
+            is PartiqlAst.Expr.LitTime -> n
+            is PartiqlAst.Expr.BagOp -> n
+
+            is PartiqlAst.Expr.GraphMatch -> n.copy(expr = coerceToSingle(n.expr))
+
+            // ... continuing the expressions with so far un-coerced subqueries
+            is PartiqlAst.Expr.Path -> n
+            is PartiqlAst.Expr.Call -> n
+            is PartiqlAst.Expr.CallAgg -> n
+            is PartiqlAst.Expr.CallWindow -> n
+            is PartiqlAst.Expr.Cast -> n
+            is PartiqlAst.Expr.CanCast -> n
+            is PartiqlAst.Expr.CanLosslessCast -> n
+            is PartiqlAst.Expr.NullIf -> n
+            is PartiqlAst.Expr.Coalesce -> n
+
+            is PartiqlAst.Expr.Select ->
+                n.copy(
+                    setq = n.setq,
+                    project = toSingleInProject(n.project),
+                    from = n.from, // per SQL, don't coerce subqueries that are data sources in FROM
+                    fromLet = n.fromLet, // LET is PartiQL-specific, so allow binding to a non-scalar
+                    where = n.where?.let { coerceToSingle(it) },
+                    group = n.group?.let { toSingleInGroup(it) },
+                    having = n.having?.let { coerceToSingle(it) },
+                    order = n.order?.let { toSingleInOrderby(it) },
+                    limit = n.limit?.let { coerceToSingle(it) },
+                    offset = n.offset?.let { coerceToSingle(it) }
+                )
+        }
+    }
+
+    /**  Whenever the expression is an SQL-style select, wrap it with a singleton coercion. */
+    private fun coerceToSingle(e: PartiqlAst.Expr): PartiqlAst.Expr =
+        when (e) {
+            is PartiqlAst.Expr.Select ->
+                if ((e.project is PartiqlAst.Projection.ProjectStar) || (e.project is PartiqlAst.Projection.ProjectList)) {
+                    PartiqlAst.build { call("coll_to_scalar", e) }
+                } else e
+            else -> e
+        }
+
+    private fun coerceToArray(e: PartiqlAst.Expr): PartiqlAst.Expr =
+        e // TODO: actual to-array coercion, like toSingle above
+
+    /** Coerce the two operands of a comparison operation (<, =, ...),
+     *  considering each as part of the context for the other, as prescribed in SQL. */
+    private fun coerceInComparisonOps(operands: List<PartiqlAst.Expr>): List<PartiqlAst.Expr> {
+        fun isArrayLiteral(x: PartiqlAst.Expr): Boolean = x is PartiqlAst.Expr.List
+        val lhs = operands[0]
+        val rhs = operands[1]
+        val rest = operands.takeLast(operands.size - 2) // these are useless operands, but the AST carries them, so here we go
+        return when {
+            isArrayLiteral(lhs) && isArrayLiteral(rhs) -> operands
+            isArrayLiteral(lhs) -> listOf(lhs, coerceToArray(rhs)) + rest
+            isArrayLiteral(rhs) -> listOf(coerceToArray(lhs), rhs) + rest
+            else -> listOf(coerceToSingle(lhs), coerceToSingle(rhs)) + rest
+        }
+    }
+
+    /** Only coerce the element(lhs) side of `<lhs> IN <rhs>` */
+    private fun toSingleInInCollection(n: PartiqlAst.Expr.InCollection): PartiqlAst.Expr.InCollection {
+        val ops = n.operands
+        // only the first two operands are meaningful for IN, but the AST supports multiple, so here we go
+        return n.copy(operands = listOf(coerceToSingle(ops[0]), ops[1]) + ops.takeLast(ops.size - 2))
+    }
+
+    private fun toSingleInProject(p: PartiqlAst.Projection): PartiqlAst.Projection =
+        when (p) {
+            is PartiqlAst.Projection.ProjectList ->
+                p.copy(
+                    projectItems = p.projectItems.map { i ->
+                        when (i) {
+                            is PartiqlAst.ProjectItem.ProjectExpr -> i.copy(expr = coerceToSingle(i.expr))
+                            else -> i
+                        }
+                    }
+                )
+            else -> p
+        }
+
+    private fun toSingleInGroup(g: PartiqlAst.GroupBy): PartiqlAst.GroupBy =
+        g.copy(keyList = g.keyList.copy(keys = g.keyList.keys.map { k -> k.copy(expr = coerceToSingle(k.expr)) }))
+
+    private fun toSingleInOrderby(b: PartiqlAst.OrderBy): PartiqlAst.OrderBy =
+        b.copy(sortSpecs = b.sortSpecs.map { s -> s.copy(expr = coerceToSingle(s.expr)) })
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/VisitorTransforms.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/VisitorTransforms.kt
@@ -20,7 +20,9 @@ fun basicVisitorTransforms() = PipelinedVisitorTransform(
     //   - the synthetic from source aliases added by [FromSourceAliasVisitorTransform]
     //   - The synthetic group by item aliases added by [GroupByItemAliasVisitorTransform]
     GroupByPathExpressionVisitorTransform(),
-    SelectStarVisitorTransform()
+    SelectStarVisitorTransform(),
+
+    SubqueryCoercionVisitorTransform(),
 )
 
 /** A stateless visitor transform that returns the input. */

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/VisitorTransforms.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/VisitorTransforms.kt
@@ -2,7 +2,8 @@ package org.partiql.lang.eval.visitors
 
 import org.partiql.lang.domains.PartiqlAst
 
-/**
+/** AST Normalization Passes.
+ *
  * Returns a [PartiqlAst.VisitorTransform] requiring no external state for the basic functionality of compiling
  * PartiQL queries.
  *

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/PartiQLPlannerDefault.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/PartiQLPlannerDefault.kt
@@ -116,9 +116,6 @@ internal class PartiQLPlannerDefault(
 
     /**
      * AST Normalization Passes
-     *  1. Synthesizes unspecified `SELECT <expr> AS ...` aliases
-     *  2. Synthesizes unspecified `FROM <expr> AS ...` aliases
-     *  3. Changes `SELECT * FROM a, b` to SELECT a.*, b.* FROM a, b`
      */
     @Suppress("UNUSED_PARAMETER") // future work?
     private fun PartiqlAst.Statement.normalize(problems: ProblemCollector): PartiqlAst.Statement {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/PartiQLPlannerDefault.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/PartiQLPlannerDefault.kt
@@ -29,6 +29,7 @@ import org.partiql.lang.eval.visitors.PartiqlAstSanityValidator
 import org.partiql.lang.eval.visitors.PipelinedVisitorTransform
 import org.partiql.lang.eval.visitors.SelectListItemAliasVisitorTransform
 import org.partiql.lang.eval.visitors.SelectStarVisitorTransform
+import org.partiql.lang.eval.visitors.SubqueryCoercionVisitorTransform
 import org.partiql.lang.planner.transforms.AstToLogicalVisitorTransform
 import org.partiql.lang.planner.transforms.LogicalResolvedToDefaultPhysicalVisitorTransform
 import org.partiql.lang.planner.transforms.LogicalToLogicalResolvedVisitorTransform
@@ -126,7 +127,8 @@ internal class PartiQLPlannerDefault(
             FromSourceAliasVisitorTransform(),
             OrderBySortSpecVisitorTransform(),
             AggregationVisitorTransform(),
-            SelectStarVisitorTransform()
+            SelectStarVisitorTransform(),
+            SubqueryCoercionVisitorTransform(),
         )
         return transform.transformStatement(this)
     }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerCollectionAggregationsTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerCollectionAggregationsTest.kt
@@ -200,9 +200,10 @@ internal class EvaluatingCompilerCollectionAggregationsTest : EvaluatorTestBase(
                         COLL_SUM('all', k) AS coll_sum_a,
                         SUM(t.b) AS sum_b,
                         (
-                            SELECT COLL_AVG('all', k2) AS coll_avg_inner_k, AVG(t.b) AS avg_inner_b
+                            SELECT VALUE { 'coll_avg_inner_k': COLL_AVG('all', k2), 
+                                           'avg_inner_b': COLL_AVG('all', SELECT VALUE x.t.b FROM g AS x) }
                             FROM table_06 AS t
-                            GROUP BY t.a AS k2
+                            GROUP BY t.a AS k2 GROUP AS g
                             ORDER BY COLL_AVG('all', k2)
                         ) AS coll_sum_inner
                     FROM table_05 AS t

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerGroupByTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerGroupByTest.kt
@@ -1209,7 +1209,7 @@ class EvaluatingCompilerGroupByTest : EvaluatorTestBase() {
             FROM widgets_a AS a
             GROUP BY a.categoryId
             """,
-            "<< { 'categoryId': 1, 'from_widgets_b': <<{ 'name': 'Thingy' }>> }>>"
+            "<< { 'categoryId': 1, 'from_widgets_b': 'Thingy' }>>"
         ) +
             createGroupByTestCases(
                 """
@@ -1223,7 +1223,7 @@ class EvaluatingCompilerGroupByTest : EvaluatorTestBase() {
             FROM widgets_a AS a
             GROUP BY a.categoryId
             """,
-                "<< { 'categoryId': 1, 'from_widgets_b': <<{ 'name': 'Thingy' }>> }>>"
+                "<< { 'categoryId': 1, 'from_widgets_b': 'Thingy' }>>"
             )
 
     @Test

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerOrderByTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerOrderByTests.kt
@@ -289,23 +289,43 @@ class EvaluatingCompilerOrderByTests : EvaluatorTestBase() {
             ),
             // Empty Projection item (ordered) -- Output (unordered)
             EvaluatorTestCase(
-                "SELECT (SELECT * FROM <<>> ORDER BY true) AS ordered FROM <<0>>",
+                "SELECT ([]) AS ordered FROM <<0>>",
                 "<< { 'ordered': [] } >>"
             ),
             // Empty Projection item (unordered) -- Output (ordered)
             EvaluatorTestCase(
-                "SELECT (SELECT * FROM <<>>) AS ordered FROM <<0>> ORDER BY true",
+                "SELECT (<<>>) AS ordered FROM <<0>> ORDER BY true",
                 "[ { 'ordered': <<>> } ]"
             ),
             // Empty Projection item (ordered) -- Output (ordered)
             EvaluatorTestCase(
-                "SELECT (SELECT * FROM <<>> ORDER BY true) AS ordered FROM <<0>> ORDER BY true",
+                "SELECT ([]) AS ordered FROM <<0>> ORDER BY true",
                 "[ { 'ordered': [] } ]"
             ),
             // Empty Projection item (unordered) -- Output (unordered)
             EvaluatorTestCase(
-                "SELECT (SELECT * FROM <<>>) AS ordered FROM <<0>>",
+                "SELECT (<<>>) AS ordered FROM <<0>>",
                 "<< { 'ordered': <<>> } >>"
+            ),
+            // Subquery projection item (ordered) -- Output (unordered)
+            EvaluatorTestCase(
+                "SELECT (SELECT * FROM <<1>> ORDER BY true) AS ordered FROM <<0>>",
+                "<< { 'ordered': 1 } >>"
+            ),
+            // Subquery projection item (unordered) -- Output (ordered)
+            EvaluatorTestCase(
+                "SELECT (SELECT * FROM <<1>>) AS ordered FROM <<0>> ORDER BY true",
+                "[ { 'ordered': 1 } ]"
+            ),
+            // Subquery projection item (ordered) -- Output (ordered)
+            EvaluatorTestCase(
+                "SELECT (SELECT * FROM <<1>> ORDER BY true) AS ordered FROM <<0>> ORDER BY true",
+                "[ { 'ordered': 1 } ]"
+            ),
+            // Subquery projection item (unordered) -- Output (unordered)
+            EvaluatorTestCase(
+                "SELECT (SELECT * FROM <<1>>) AS ordered FROM <<0>>",
+                "<< { 'ordered': 1 } >>"
             ),
         )
     }
@@ -331,7 +351,7 @@ class EvaluatingCompilerOrderByTests : EvaluatorTestBase() {
                     FROM products_sparse
                     GROUP BY supplierId_nulls
                     ORDER BY
-                        (SELECT supplierId_nulls FROM << 0, 1 >>)
+                        (SELECT supplierId_nulls FROM << 1 >>)
                     DESC NULLS FIRST
                 """,
                 "[{'supplierId_nulls': NULL}, {'supplierId_nulls': 11}, {'supplierId_nulls': 10}]"
@@ -343,7 +363,7 @@ class EvaluatingCompilerOrderByTests : EvaluatorTestBase() {
                     FROM products_sparse
                     GROUP BY supplierId_nulls
                     ORDER BY
-                        (SELECT supplierId_nulls FROM << 0, 1 >>)
+                        (SELECT supplierId_nulls FROM << 1 >>)
                     ASC NULLS FIRST
                 """,
                 "[{'supplierId_nulls': NULL}, {'supplierId_nulls': 10}, {'supplierId_nulls': 11}]"
@@ -358,7 +378,7 @@ class EvaluatingCompilerOrderByTests : EvaluatorTestBase() {
                     FROM products_sparse
                     GROUP BY supplierId_nulls
                     ORDER BY
-                        (SELECT 1 FROM products_sparse GROUP BY supplierId_nulls ORDER BY supplierId_nulls ASC NULLS FIRST)
+                        (SELECT VALUE { '_1': 1 } FROM products_sparse GROUP BY supplierId_nulls ORDER BY supplierId_nulls ASC NULLS FIRST)
                     DESC NULLS FIRST
                 """,
                 "[{'supplierId_nulls': NULL}, {'supplierId_nulls': 10}, {'supplierId_nulls': 11}]"

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/DefinitionalBuiltinsTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/DefinitionalBuiltinsTest.kt
@@ -1,0 +1,56 @@
+package org.partiql.lang.eval.builtins.functions
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.partiql.lang.errors.ErrorCode
+import org.partiql.lang.eval.EvaluatorTestBase
+import org.partiql.lang.eval.builtins.ExprFunctionTestCase
+import org.partiql.lang.eval.evaluatortestframework.EvaluatorErrorTestCase
+import org.partiql.lang.util.ArgumentsProviderBase
+
+class DefinitionalBuiltinsTest : EvaluatorTestBase() {
+
+    @ParameterizedTest
+    @ArgumentsSource(PassCases::class)
+    fun runPassTests(tc: ExprFunctionTestCase) = runEvaluatorTestCase(
+        tc.source,
+        expectedResult = tc.expectedLegacyModeResult
+    )
+
+    class PassCases : ArgumentsProviderBase() {
+        override fun getParameters(): List<Any> = listOf(
+            ExprFunctionTestCase("coll_to_scalar( << {'a': 1} >> )", "1"),
+            ExprFunctionTestCase("coll_to_scalar( [ {'a': 1} ] )", "1"),
+            ExprFunctionTestCase("coll_to_scalar(<< {'a': {'aa': 11, 'bb': 22}} >> )", "{'aa': 11, 'bb': 22}"),
+            ExprFunctionTestCase("coll_to_scalar( << {'a': []} >> )", "[]"),
+        )
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ErrorCases::class)
+    fun runErrorTests(tc: EvaluatorErrorTestCase) = runEvaluatorErrorTestCase(
+        tc.query,
+        expectedErrorCode = tc.expectedErrorCode,
+        expectedPermissiveModeResult = tc.expectedPermissiveModeResult
+    )
+
+    class ErrorCases : ArgumentsProviderBase() {
+        fun errorcase(query: String) =
+            EvaluatorErrorTestCase(
+                query = query,
+                expectedErrorCode = ErrorCode.EVALUATOR_NON_SINGLETON_COLLECTION,
+                expectedPermissiveModeResult = "MISSING",
+            )
+        override fun getParameters(): List<Any> = listOf(
+            errorcase("coll_to_scalar( 1 )"),
+            errorcase("coll_to_scalar( {'a': 1} )"),
+            errorcase("coll_to_scalar( << >> )"),
+            errorcase("coll_to_scalar( << {'a': 1}, {'a': 2} >> )"),
+            errorcase("coll_to_scalar( [ {'a': 1}, 2 ] )"),
+            errorcase("coll_to_scalar( [ 1 ] )"),
+            errorcase("coll_to_scalar( [ <<>> ] )"),
+            errorcase("coll_to_scalar( [ {'a': 1, 'b': 2} ] )"),
+            errorcase("coll_to_scalar(  << {} >> )"),
+        )
+    }
+}

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/windowFunctions/WindowFunctionTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/windowFunctions/WindowFunctionTests.kt
@@ -134,12 +134,12 @@ class WindowFunctionTests : EvaluatorTestBase() {
                     FROM stock_price as sp
                 """,
                 expectedResult = """<<
-                    {'_1': <<{'previous_price': NULL}>>},
-                    {'_1': <<{'previous_price': NULL}>>},
-                    {'_1': <<{'previous_price': NULL}>>},
-                    {'_1': <<{'previous_price': NULL}>>},
-                    {'_1': <<{'previous_price': NULL}>>},
-                    {'_1': <<{'previous_price': NULL}>>}
+                    {'_1': NULL},
+                    {'_1': NULL},
+                    {'_1': NULL},
+                    {'_1': NULL},
+                    {'_1': NULL},
+                    {'_1': NULL}
                 >>"""
             ),
 
@@ -153,12 +153,12 @@ class WindowFunctionTests : EvaluatorTestBase() {
                     FROM stock_price as sp
                 """,
                 expectedResult = """<<
-                    {'previous_price': NULL, '_2': <<{'Inner_lag': NULL}>>},
-                    {'previous_price': 113.00, '_2': <<{'Inner_lag': NULL}>>},
-                    {'previous_price': 115.88, '_2': <<{'Inner_lag': NULL}>>},
-                    {'previous_price': NULL, '_2': <<{'Inner_lag': NULL}>>},
-                    {'previous_price': 96.15, '_2': <<{'Inner_lag': NULL}>>},
-                    {'previous_price': 99.30, '_2': <<{'Inner_lag': NULL}>>}
+                    {'previous_price': NULL, '_2': NULL},
+                    {'previous_price': 113.00, '_2': NULL},
+                    {'previous_price': 115.88, '_2': NULL},
+                    {'previous_price': NULL, '_2': NULL},
+                    {'previous_price': 96.15, '_2': NULL},
+                    {'previous_price': 99.30, '_2': NULL}
                 >>"""
             ),
 
@@ -308,12 +308,12 @@ class WindowFunctionTests : EvaluatorTestBase() {
                     FROM stock_price as sp
                 """,
                 expectedResult = """<<
-                    {'_1': <<{'next_price': NULL}>>},
-                    {'_1': <<{'next_price': NULL}>>},
-                    {'_1': <<{'next_price': NULL}>>},
-                    {'_1': <<{'next_price': NULL}>>},
-                    {'_1': <<{'next_price': NULL}>>},
-                    {'_1': <<{'next_price': NULL}>>}
+                    {'_1': NULL},
+                    {'_1': NULL},
+                    {'_1': NULL},
+                    {'_1': NULL},
+                    {'_1': NULL},
+                    {'_1': NULL}
                 >>"""
             ),
 
@@ -327,12 +327,12 @@ class WindowFunctionTests : EvaluatorTestBase() {
                     FROM stock_price as sp
                 """,
                 expectedResult = """<<
-                    {'next_price': 115.88, '_2': <<{'Inner_lead': NULL}>>},
-                    {'next_price': 121.09, '_2': <<{'Inner_lead': NULL}>>},
-                    {'next_price': NULL, '_2': <<{'Inner_lead': NULL}>>},
-                    {'next_price': 99.30, '_2': <<{'Inner_lead': NULL}>>},
-                    {'next_price': 101.04, '_2': <<{'Inner_lead': NULL}>>},
-                    {'next_price': NULL, '_2': <<{'Inner_lead': NULL}>>}
+                    {'next_price': 115.88, '_2': NULL},
+                    {'next_price': 121.09, '_2': NULL},
+                    {'next_price': NULL, '_2': NULL},
+                    {'next_price': 99.30, '_2': NULL},
+                    {'next_price': 101.04, '_2': NULL},
+                    {'next_price': NULL, '_2': NULL}
                 >>"""
             ),
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransformTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransformTests.kt
@@ -62,12 +62,12 @@ class SubqueryCoercionVisitorTransformTests : VisitorTransformTestBase() {
                 original = """
                     SELECT x.b
                     FROM << {'a': 1, 'b': 10}, {'a': 3, 'b': 30} >>  AS x
-                    where (SELECT max(n) = x.a FROM [1,2,3] AS n) 
+                    WHERE (SELECT max(n) = x.a FROM [1,2,3] AS n) 
                 """.trimIndent(),
                 expected = """
                     SELECT x.b
                     FROM << {'a': 1, 'b': 10}, {'a': 3, 'b': 30} >>  AS x
-                    where coll_to_scalar(SELECT max(n) = x.a FROM [1,2,3] AS n) 
+                    WHERE coll_to_scalar(SELECT max(n) = x.a FROM [1,2,3] AS n) 
                 """.trimIndent()
             ),
             TransformTestCase(
@@ -81,7 +81,7 @@ class SubqueryCoercionVisitorTransformTests : VisitorTransformTestBase() {
                      SELECT x.b, 
                             (SELECT y.c
                              FROM << {'a': 1, 'c': 100}, {'a': 3, 'c': 300} >> AS y
-                             where y.a = x.a ) AS c2
+                             WHERE y.a = x.a ) AS c2
                      FROM << {'a': 1, 'b': 10}, {'a': 3, 'b': 30} >>  AS x
                 """.trimIndent(),
                 expected = """
@@ -89,7 +89,7 @@ class SubqueryCoercionVisitorTransformTests : VisitorTransformTestBase() {
                            coll_to_scalar(
                             SELECT y.c
                             FROM << {'a': 1, 'c': 100}, {'a': 3, 'c': 300} >> AS y
-                            where y.a = x.a ) AS c2
+                            WHERE y.a = x.a ) AS c2
                     FROM << {'a': 1, 'b': 10}, {'a': 3, 'b': 30} >>  AS x
                 """.trimIndent()
             ),
@@ -99,13 +99,13 @@ class SubqueryCoercionVisitorTransformTests : VisitorTransformTestBase() {
                     SELECT n2.n1, m2.m
                     FROM (SELECT n1 FROM <<1,2,3>> AS n1) AS n2,
                          (SELECT min(m1) AS m FROM [4,5] AS m1) AS m2
-                    where 2 * n2.n1 = m2.m
+                    WHERE 2 * n2.n1 = m2.m
                 """.trimIndent(),
                 expected = """
                      SELECT n2.n1, m2.m
                      FROM (SELECT n1 FROM <<1,2,3>> AS n1) AS n2,
                           (SELECT min(m1) AS m FROM [4,5] AS m1) AS m2
-                     where 2 * n2.n1 = m2.m
+                     WHERE 2 * n2.n1 = m2.m
                 """.trimIndent()
             ),
         )

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransformTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransformTests.kt
@@ -1,0 +1,113 @@
+package org.partiql.lang.eval.visitors
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.partiql.lang.util.ArgumentsProviderBase
+
+class SubqueryCoercionVisitorTransformTests : VisitorTransformTestBase() {
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgsProvider::class)
+    fun test(tc: TransformTestCase) = runTest(tc, listOf(SubqueryCoercionVisitorTransform()))
+
+    class ArgsProvider : ArgumentsProviderBase() {
+        override fun getParameters(): List<Any> = listOf(
+            TransformTestCase(
+                name = "Bare SELECT is not coerced",
+                original = """ SELECT max(n) FROM [1,2,3] AS n """,
+                expected = """ SELECT max(n) FROM [1,2,3] AS n """
+            ),
+            TransformTestCase(
+                name = "Coerce subquery in an arithmetic rhs",
+                original = """ 5 + (SELECT max(n) FROM <<1,2,3>> AS n) """,
+                expected = """ 5 + coll_to_scalar(SELECT max(n) FROM <<1,2,3>> AS n) """
+            ),
+            TransformTestCase(
+                name = "Coerce subquery in an arithmetic lhs",
+                original = """ (SELECT n FROM <<1, 2, 3>> AS n) * 4 """,
+                expected = """ coll_to_scalar(SELECT n FROM <<1, 2, 3>> AS n) * 4 """
+            ),
+            TransformTestCase(
+                name = "Coerce in scalar comparison lhs",
+                original = """ x < (SELECT avg(n) FROM <<1,2,3>> AS n) """,
+                expected = """ x < coll_to_scalar(SELECT avg(n) FROM <<1,2,3>> AS n)"""
+            ),
+            TransformTestCase(
+                name = "Coerce in scalar comparison rhs",
+                original = """ (SELECT n FROM [1,2,3] AS n) = 2 """,
+                expected = """ coll_to_scalar(SELECT n FROM [1,2,3] AS n) = 2 """
+            ),
+            TransformTestCase(
+                name = "Coerce on both sides of a scalar comparison",
+                original = """ (SELECT n FROM [1,2,3] AS n) <> (SELECT avg(n) FROM <<1,2,3>> AS n) """,
+                expected = """ coll_to_scalar(SELECT n FROM [1,2,3] AS n) <> coll_to_scalar(SELECT avg(n) FROM <<1,2,3>> AS n) """
+            ),
+            TransformTestCase(
+                name = "Do not coerce in lhs of array comparison",
+                original = """ (SELECT n FROM [1,2,3] AS n) = [3, 2, 1] """,
+                expected = """ (SELECT n FROM [1,2,3] AS n) = [3, 2, 1] """
+            ),
+            TransformTestCase(
+                name = "Do not coerce in rhs of array comparison",
+                original = """ (1, 2, 3) < (SELECT n FROM [1,2,3] AS n) """,
+                expected = """ (1, 2, 3) < (SELECT n FROM [1,2,3] AS n)"""
+            ),
+            TransformTestCase(
+                name = "Coerce lhs of IN, but not rhs",
+                original = """ (SELECT max(n) FROM <<1,2,3>> AS n) IN (SELECT n FROM [1,2,3] AS n) """,
+                expected = """ coll_to_scalar(SELECT max(n) FROM <<1,2,3>> AS n) IN (SELECT n FROM [1,2,3] AS n) """
+            ),
+            TransformTestCase(
+                name = "Coerce subquery that is the WHERE expression",
+                original = """
+                    SELECT x.b
+                    FROM << {'a': 1, 'b': 10}, {'a': 3, 'b': 30} >>  AS x
+                    where (SELECT max(n) = x.a FROM [1,2,3] AS n) 
+                """.trimIndent(),
+                expected = """
+                    SELECT x.b
+                    FROM << {'a': 1, 'b': 10}, {'a': 3, 'b': 30} >>  AS x
+                    where coll_to_scalar(SELECT max(n) = x.a FROM [1,2,3] AS n) 
+                """.trimIndent()
+            ),
+            TransformTestCase(
+                name = "Coerce SELECT when the only item in another SELECT",
+                original = """ SELECT (SELECT max(n) FROM [1,2,3] AS n) AS m FROM 0 """,
+                expected = """ SELECT coll_to_scalar(SELECT max(n) FROM [1,2,3] AS n) AS m FROM 0 """
+            ),
+            TransformTestCase(
+                name = "Coerce SELECT when among items in another SELECT",
+                original = """
+                     SELECT x.b, 
+                            (SELECT y.c
+                             FROM << {'a': 1, 'c': 100}, {'a': 3, 'c': 300} >> AS y
+                             where y.a = x.a ) AS c2
+                     FROM << {'a': 1, 'b': 10}, {'a': 3, 'b': 30} >>  AS x
+                """.trimIndent(),
+                expected = """
+                    SELECT x.b, 
+                           coll_to_scalar(
+                            SELECT y.c
+                            FROM << {'a': 1, 'c': 100}, {'a': 3, 'c': 300} >> AS y
+                            where y.a = x.a ) AS c2
+                    FROM << {'a': 1, 'b': 10}, {'a': 3, 'b': 30} >>  AS x
+                """.trimIndent()
+            ),
+            TransformTestCase(
+                name = "Do not coerce data sources in FROM",
+                original = """ 
+                    SELECT n2.n1, m2.m
+                    FROM (SELECT n1 FROM <<1,2,3>> AS n1) AS n2,
+                         (SELECT min(m1) AS m FROM [4,5] AS m1) AS m2
+                    where 2 * n2.n1 = m2.m
+                """.trimIndent(),
+                expected = """
+                     SELECT n2.n1, m2.m
+                     FROM (SELECT n1 FROM <<1,2,3>> AS n1) AS n2,
+                          (SELECT min(m1) AS m FROM [4,5] AS m1) AS m2
+                     where 2 * n2.n1 = m2.m
+                """.trimIndent()
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- Closes Issue #826

## Description

Resolves #826, implementing to-singleton subquery coercion for SQL contexts of SQL-style SELECTs, following what is outlined in Ch 9 of the PartiQL specification.

Natural follow-ups would be #1011 and [#42](https://github.com/partiql/partiql-spec/issues/42). 

The implementation has two parts: 

 - New built-in function COLL_TO_SCALAR (defined in the spec), which is used to wrap SELECTs eligible for the coercion. 
 - New visitor SubqueryCoercionVisitorTransform that detects eligible SELECTs and applies COLL_TO_SCALAR to them. 

Behavior of COLL_TO_SCALAR (returning MISSING vs an error when the coercion cannot be performed) depends on compilation options, particularly on TypingMode. This dependency is new, compared to other built-ins. Unfortunately, the accommodation for supporting this is not yet as generic as it should be, since our two compilers use different sets of options. 

An alternative to COLL_TO_SCALAR would be emitting the code corresponding to its body somewhere during compilation.  This would have avoided the need of making compilation options a parameter to built-ins, but it seems it would require two entirely different implementations in EvaluatingCompiler and the "planning compiler."  Also, the approach with the explicit COLL_TO_SCALAR is closer to the specification -- a worthwhile thing in the reference implementation.  It could be worthwhile considering this for other functions defined in the spec, such as TUPLEUNION. 

The implementation of the visitor covers the contexts explicitly mentioned in the specification, but there are a few more worth considering separately -- [#42](https://github.com/partiql/partiql-spec/issues/42).

There are also a couple unrelated touch-ups of the underlying codebase, in two first commits. 


## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**

- Any backward-incompatible changes? **[YES]**
  - Since subqueries were allowed, but not coersed, their behavior was different. 

- Any new external dependencies? **[NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.