### PR TITLE
Fix conformance GH Actions workflow by using a fixed gradle version

### DIFF
--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -61,7 +61,11 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: 17
-          cache: gradle
+      # Fix gradle version to what's used in gradle-wrapper
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.5.1
       - name: Download `conformance_test_results.ion` from target branch
         uses: dawidd6/action-download-artifact@v2
         id: download-report

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -19,7 +19,11 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: 17
-          cache: gradle
+      # Fix gradle version to what's used in gradle-wrapper
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.5.1
       # Run the conformance tests and save to an Ion file.
       - name: gradle test of the conformance tests (can fail) and save to Ion file
         continue-on-error: true


### PR DESCRIPTION
Noticed that the GH Actions workflow for conformance started failing. Example failed run: https://github.com/partiql/partiql-lang-kotlin/actions/runs/4506051931/jobs/7932435216#step:4:38. I think this is due to the GH Actions workflow running with Gradle 8.0. This PR fixes the conformance gradle version to what's in the `gradle-wrapper`, `7.5.1`.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.