### PR TITLE
Removes IonSystem from PartiQLParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     5. `org.partiql.lang.types.StaticType.typeDomain` -> `org.partiql.lang.types.StaticTypeUtils.getTypeDomain`
     6. `org.partiql.lang.types.SingleType.getRuntimeType` -> `org.partiql.lang.types.StaticTypeUtils.getRuntimeType`
     7. `org.partiql.lang.types.StringType.StringLengthConstraint.matches` -> `org.partiql.lang.types.StaticTypeUtils.stringLengthConstraintMatches`
+- **Breaking**: Removes deprecated `ionSystem()` function from PartiQLParserBuilder
 
 ### Deprecated
 - `ExprValueFactory` interface marked as deprecated. Equivalent `ExprValue` construction methods are implemented in the `ExprValue` interface as static methods. 
@@ -63,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - The deprecated `IonValue` property in `ExprValue` interface is now removed.
 - Removed partiql-extensions to partiql-cli `org.partiql.cli.functions`
+- Removed IonSystem from PartiQLParserBuilder
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     5. `org.partiql.lang.types.StaticType.typeDomain` -> `org.partiql.lang.types.StaticTypeUtils.getTypeDomain`
     6. `org.partiql.lang.types.SingleType.getRuntimeType` -> `org.partiql.lang.types.StaticTypeUtils.getRuntimeType`
     7. `org.partiql.lang.types.StringType.StringLengthConstraint.matches` -> `org.partiql.lang.types.StaticTypeUtils.stringLengthConstraintMatches`
-- **Breaking**: Removes deprecated `ionSystem()` function from PartiQLParserBuilder
+- **Breaking**: Removes deprecated `ionSystem()` function from PartiQLCompilerBuilder and PartiQLParserBuilder
 
 ### Deprecated
 - `ExprValueFactory` interface marked as deprecated. Equivalent `ExprValue` construction methods are implemented in the `ExprValue` interface as static methods. 

--- a/examples/src/main/java/org/partiql/examples/ParserJavaExample.java
+++ b/examples/src/main/java/org/partiql/examples/ParserJavaExample.java
@@ -38,11 +38,8 @@ public class ParserJavaExample extends Example {
 
     @Override
     public void run() {
-        // A standard instance of [IonSystem], which is required by [SqlParser].
-        final IonSystem ion = IonSystemBuilder.standard().build();
-
         // An instance of [SqlParser].
-        final Parser parser = new PartiQLParserBuilder().ionSystem(ion).build();
+        final Parser parser = new PartiQLParserBuilder().build();
 
         // A query in string format
         final String query = "SELECT exampleField FROM exampleTable WHERE anotherField > 10";

--- a/examples/src/main/java/org/partiql/examples/PartiQLCompilerPipelineJavaExample.java
+++ b/examples/src/main/java/org/partiql/examples/PartiQLCompilerPipelineJavaExample.java
@@ -65,7 +65,7 @@ public class PartiQLCompilerPipelineJavaExample extends Example {
                 .projectionIteration(ProjectionIterationBehavior.UNFILTERED)
                 .build();
 
-        final Parser parser = PartiQLParserBuilder.standard().ionSystem(ion).build();
+        final Parser parser = PartiQLParserBuilder.standard().build();
 
         @OptIn(markerClass = ExperimentalPartiQLCompilerPipeline.class)
         final PartiQLPlanner planner = PartiQLPlannerBuilder.standard().globalVariableResolver(globalVariableResolver).build();

--- a/examples/src/main/kotlin/org/partiql/examples/ParserErrorExample.kt
+++ b/examples/src/main/kotlin/org/partiql/examples/ParserErrorExample.kt
@@ -1,6 +1,5 @@
 package org.partiql.examples
 
-import com.amazon.ion.system.IonSystemBuilder
 import org.partiql.examples.util.Example
 import org.partiql.lang.errors.Property
 import org.partiql.lang.syntax.Parser
@@ -9,15 +8,12 @@ import org.partiql.lang.syntax.PartiQLParserBuilder
 import java.io.PrintStream
 
 /**
- * Demonstrates the use of [Parser], [AstSerializer] and [AstDeserializer].
+ * Demonstrates the use of [Parser].
  */
 class ParserErrorExample(out: PrintStream) : Example(out) {
 
-    /** A standard instance of [IonSystem], which is required by [Parser].  */
-    internal var ion = IonSystemBuilder.standard().build()
-
     /** An instance of [Parser].  */
-    private var parser: Parser = PartiQLParserBuilder().ionSystem(ion).build()
+    private var parser: Parser = PartiQLParserBuilder().build()
 
     /** Demonstrates handling of syntax errors.  */
     override fun run() = try {

--- a/examples/src/main/kotlin/org/partiql/examples/ParserExample.kt
+++ b/examples/src/main/kotlin/org/partiql/examples/ParserExample.kt
@@ -1,6 +1,5 @@
 package org.partiql.examples
 
-import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ion.system.IonTextWriterBuilder
 import org.partiql.examples.util.Example
 import org.partiql.lang.domains.PartiqlAst
@@ -15,11 +14,8 @@ class ParserExample(out: PrintStream) : Example(out) {
 
     /** Demonstrates query parsing and SerDe.  */
     override fun run() {
-        // / A standard instance of [IonSystem], which is required by [SqlParser].
-        val ion = IonSystemBuilder.standard().build()
-
         // An instance of [Parser].
-        val parser: Parser = PartiQLParserBuilder().ionSystem(ion).build()
+        val parser: Parser = PartiQLParserBuilder().build()
 
         // A query in string format
         val query = "SELECT exampleField FROM exampleTable WHERE anotherField > 10"

--- a/examples/src/main/kotlin/org/partiql/examples/PartiQLCompilerPipelineExample.kt
+++ b/examples/src/main/kotlin/org/partiql/examples/PartiQLCompilerPipelineExample.kt
@@ -60,8 +60,6 @@ class PartiQLCompilerPipelineExample(out: PrintStream) : Example(out) {
 
     @OptIn(ExperimentalPartiQLCompilerPipeline::class)
     private val partiQLCompilerPipeline = PartiQLCompilerPipeline.build {
-        parser
-            .ionSystem(myIonSystem)
         planner
             .globalVariableResolver(globalVariableResolver)
         compiler

--- a/examples/src/main/kotlin/org/partiql/examples/PreventJoinVistor.kt
+++ b/examples/src/main/kotlin/org/partiql/examples/PreventJoinVistor.kt
@@ -1,6 +1,5 @@
 package org.partiql.examples
 
-import com.amazon.ion.system.IonSystemBuilder
 import org.partiql.examples.util.Example
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.PartiQLParserBuilder
@@ -16,8 +15,7 @@ private class InvalidAstException(message: String) : RuntimeException(message)
  */
 
 class PreventJoinVisitorExample(out: PrintStream) : Example(out) {
-    private val ion = IonSystemBuilder.standard().build()
-    private val parser = PartiQLParserBuilder().ionSystem(ion).build()
+    private val parser = PartiQLParserBuilder().build()
 
     private fun hasJoins(sql: String): Boolean = try {
         val ast = parser.parseAstStatement(sql)

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/pipeline/AbstractPipeline.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/pipeline/AbstractPipeline.kt
@@ -78,7 +78,7 @@ internal sealed class AbstractPipeline(open val options: PipelineOptions) {
                 WriteFile(ion),
                 QueryDDB(ion)
             )
-            val parser = PartiQLParserBuilder().ionSystem(ion).build()
+            val parser = PartiQLParserBuilder().build()
             return PipelineOptions(
                 pipeline,
                 ion,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/CompilerPipeline.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/CompilerPipeline.kt
@@ -264,7 +264,7 @@ interface CompilerPipeline {
 
             return CompilerPipelineImpl(
                 ion = ion,
-                parser = parser ?: PartiQLParserBuilder().ionSystem(ion).customTypes(customDataTypes).build(),
+                parser = parser ?: PartiQLParserBuilder().customTypes(customDataTypes).build(),
                 compileOptions = compileOptionsToUse,
                 functions = allFunctions,
                 customDataTypes = customDataTypes,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/ast/passes/StatementRedactor.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/ast/passes/StatementRedactor.kt
@@ -1,6 +1,5 @@
 package org.partiql.lang.ast.passes
 
-import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionelement.api.StringElement
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.ast.sourceLocation
@@ -19,8 +18,7 @@ import org.partiql.lang.syntax.PartiQLParserBuilder
  */
 typealias UserDefinedFunctionRedactionLambda = (List<PartiqlAst.Expr>) -> List<PartiqlAst.Expr>
 
-private val ion = IonSystemBuilder.standard().build()
-private val parser = PartiQLParserBuilder().ionSystem(ion).build()
+private val parser = PartiQLParserBuilder().build()
 private const val maskPattern = "***(Redacted)"
 
 const val INVALID_NUM_ARGS = "Invalid number of args in node"

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
@@ -14,7 +14,6 @@
 
 package org.partiql.lang.compiler
 
-import com.amazon.ion.IonSystem
 import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
 import org.partiql.annotations.ExperimentalWindowFunctions
 import org.partiql.lang.eval.ExprFunction
@@ -111,11 +110,6 @@ class PartiQLCompilerBuilder private constructor() {
             ),
             operatorFactories = allOperatorFactories()
         )
-    }
-
-    @Deprecated("An IonSystem is no longer needed to construct a PartiQLCompiler. Do not use this setter.")
-    @Suppress("UNUSED_PARAMETER")
-    fun ionSystem(ion: IonSystem): PartiQLCompilerBuilder = this.apply {
     }
 
     fun options(options: EvaluatorOptions) = this.apply {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
@@ -1,6 +1,5 @@
 package org.partiql.lang.prettyprint
 
-import com.amazon.ion.system.IonSystemBuilder
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.PartiQLParserBuilder
 import org.partiql.pig.runtime.SymbolPrimitive
@@ -37,9 +36,7 @@ class ASTPrettyPrinter {
      * @return formatted string corresponding to the input AST.
      */
     fun prettyPrintAST(query: String): String {
-        val ion = IonSystemBuilder.standard().build()
-        val ast = PartiQLParserBuilder().ionSystem(ion).build().parseAstStatement(query)
-
+        val ast = PartiQLParserBuilder().build().parseAstStatement(query)
         return prettyPrintAST(ast)
     }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLParserBuilder.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLParserBuilder.kt
@@ -14,8 +14,6 @@
 
 package org.partiql.lang.syntax
 
-import com.amazon.ion.IonSystem
-import com.amazon.ion.system.IonSystemBuilder
 import org.partiql.lang.types.CustomType
 
 /**
@@ -26,32 +24,25 @@ import org.partiql.lang.types.CustomType
  * ```
  * val parser = PartiQLParserBuilder.standard().build()
  * val parser = PartiQLParserBuilder.standard().customTypes(types).build()
- * val parser = PartiQLParserBuilder().ionSystem(ion).customTypes().build()
  * ```
  */
 class PartiQLParserBuilder {
 
     companion object {
-        private val DEFAULT_ION = IonSystemBuilder.standard().build()
 
         @JvmStatic
         fun standard(): PartiQLParserBuilder {
-            return PartiQLParserBuilder().ionSystem(DEFAULT_ION)
+            return PartiQLParserBuilder()
         }
     }
 
-    private var ion: IonSystem = DEFAULT_ION
     private var customTypes: List<CustomType> = emptyList()
-
-    fun ionSystem(ion: IonSystem): PartiQLParserBuilder = this.apply {
-        this.ion = ion
-    }
 
     fun customTypes(types: List<CustomType>): PartiQLParserBuilder = this.apply {
         this.customTypes = types
     }
 
     fun build(): Parser {
-        return PartiQLParser(this.ion, this.customTypes)
+        return PartiQLParser(this.customTypes)
     }
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/util/AntlrUtilities.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/util/AntlrUtilities.kt
@@ -14,9 +14,18 @@
 
 package org.partiql.lang.util
 
-import com.amazon.ion.IonSystem
+import com.amazon.ion.Decimal
 import com.amazon.ion.IonValue
 import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.ionBool
+import com.amazon.ionelement.api.ionDecimal
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.ionNull
+import com.amazon.ionelement.api.ionString
+import com.amazon.ionelement.api.ionSymbol
+import com.amazon.ionelement.api.loadSingleElement
+import com.amazon.ionelement.api.toIonValue
 import org.antlr.v4.runtime.Token
 import org.antlr.v4.runtime.tree.TerminalNode
 import org.partiql.lang.errors.ErrorCode
@@ -30,15 +39,17 @@ import org.partiql.lang.syntax.TYPE_ALIASES
 import org.partiql.lang.syntax.antlr.PartiQLParser
 import java.math.BigInteger
 
+// workaround until ErrorAndErrorContexts no longer uses IonSystem
+private val ion = IonSystemBuilder.standard().build()
+
 internal fun TerminalNode?.error(
     message: String,
     errorCode: ErrorCode,
     errorContext: PropertyValueMap = PropertyValueMap(),
     cause: Throwable? = null,
-    ion: IonSystem = IonSystemBuilder.standard().build()
 ) = when (this) {
     null -> ParserException(errorCode = errorCode, errorContext = errorContext, cause = cause)
-    else -> this.symbol.error(message, errorCode, errorContext, cause, ion)
+    else -> this.symbol.error(message, errorCode, errorContext, cause)
 }
 
 internal fun Token?.error(
@@ -46,47 +57,50 @@ internal fun Token?.error(
     errorCode: ErrorCode,
     errorContext: PropertyValueMap = PropertyValueMap(),
     cause: Throwable? = null,
-    ion: IonSystem = IonSystemBuilder.standard().build()
 ) = when (this) {
     null -> ParserException(errorCode = errorCode, errorContext = errorContext, cause = cause)
     else -> {
         errorContext[Property.LINE_NUMBER] = this.line.toLong()
         errorContext[Property.COLUMN_NUMBER] = this.charPositionInLine.toLong() + 1
         errorContext[Property.TOKEN_DESCRIPTION] = this.type.getAntlrDisplayString()
-        errorContext[Property.TOKEN_VALUE] = getIonValue(ion, this)
+        errorContext[Property.TOKEN_VALUE] = getIonValue(this)
         ParserException(message, errorCode, errorContext, cause)
     }
 }
 
+internal fun getIonValue(token: Token): IonValue {
+    return getIonElement(token).toIonValue(ion)
+}
+
 /**
- * Returns the corresponding [IonValue] for a particular ANTLR Token
+ * Returns the corresponding [IonElement] for a particular ANTLR Token
  */
-internal fun getIonValue(ion: IonSystem, token: Token): IonValue {
+internal fun getIonElement(token: Token): IonElement {
     val type = token.type
     val text = token.text
     return when {
-        type == PartiQLParser.EOF -> ion.newSymbol("EOF")
-        ALL_OPERATORS.contains(text.toLowerCase()) -> ion.newSymbol(text.toLowerCase())
-        type == PartiQLParser.ION_CLOSURE -> ion.singleValue(text.trimStart('`').trimEnd('`'))
-        type == PartiQLParser.TRUE -> ion.newBool(true)
-        type == PartiQLParser.FALSE -> ion.newBool(false)
-        type == PartiQLParser.NULL -> ion.newNull()
-        type == PartiQLParser.NULLS -> ion.newSymbol("nulls")
-        type == PartiQLParser.MISSING -> ion.newNull()
-        type == PartiQLParser.LITERAL_STRING -> ion.newString(text.trim('\'').replace("''", "'"))
-        type == PartiQLParser.LITERAL_INTEGER -> ion.newInt(BigInteger(text, 10))
+        type == PartiQLParser.EOF -> ionSymbol("EOF")
+        ALL_OPERATORS.contains(text.toLowerCase()) -> ionSymbol(text.toLowerCase())
+        type == PartiQLParser.ION_CLOSURE -> loadSingleElement(text.trimStart('`').trimEnd('`'))
+        type == PartiQLParser.TRUE -> ionBool(true)
+        type == PartiQLParser.FALSE -> ionBool(false)
+        type == PartiQLParser.NULL -> ionNull()
+        type == PartiQLParser.NULLS -> ionSymbol("nulls")
+        type == PartiQLParser.MISSING -> ionNull()
+        type == PartiQLParser.LITERAL_STRING -> ionString(text.trim('\'').replace("''", "'"))
+        type == PartiQLParser.LITERAL_INTEGER -> ionInt(BigInteger(text, 10))
         type == PartiQLParser.LITERAL_DECIMAL -> try {
-            ion.newDecimal(bigDecimalOf(text))
+            ionDecimal(Decimal.valueOf(text))
         } catch (e: NumberFormatException) {
-            throw token.error(e.localizedMessage, ErrorCode.PARSE_EXPECTED_NUMBER, cause = e, ion = ion)
+            throw token.error(e.localizedMessage, ErrorCode.PARSE_EXPECTED_NUMBER, cause = e)
         }
-        type == PartiQLParser.IDENTIFIER_QUOTED -> ion.newSymbol(text.trim('\"').replace("\"\"", "\""))
+        type == PartiQLParser.IDENTIFIER_QUOTED -> ionSymbol(text.trim('\"').replace("\"\"", "\""))
         MULTI_LEXEME_TOKEN_MAP.containsKey(text.toLowerCase().split("\\s+".toRegex())) -> {
             val pair = MULTI_LEXEME_TOKEN_MAP[text.toLowerCase().split("\\s+".toRegex())]!!
-            ion.newSymbol(pair.first)
+            ionSymbol(pair.first)
         }
-        KEYWORDS.contains(text.toLowerCase()) -> ion.newSymbol(TYPE_ALIASES[text.toLowerCase()] ?: text.toLowerCase())
-        else -> ion.newSymbol(text)
+        KEYWORDS.contains(text.toLowerCase()) -> ionSymbol(TYPE_ALIASES[text.toLowerCase()] ?: text.toLowerCase())
+        else -> ionSymbol(text)
     }
 }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/util/NumberExtensions.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/util/NumberExtensions.kt
@@ -126,6 +126,11 @@ internal fun Number.exprValue(): ExprValue = when (this) {
     )
 }
 
+operator fun Decimal.unaryMinus(): Decimal = when {
+    isZero() -> Decimal.negativeZero(this.scale())
+    else -> Decimal.valueOf(negate())
+}
+
 operator fun Number.unaryMinus(): Number {
     return when (this) {
         // - LONG.MIN_VALUE will result in LONG.MIN_VALUE in JVM because LONG is a signed two's-complement integers
@@ -259,20 +264,23 @@ operator fun Number.compareTo(other: Number): Int {
     }
 }
 
-val Number.isNaN get() = when (this) {
-    is Double -> isNaN()
-    else -> false
-}
+val Number.isNaN
+    get() = when (this) {
+        is Double -> isNaN()
+        else -> false
+    }
 
-val Number.isNegInf get() = when (this) {
-    is Double -> isInfinite() && this < 0
-    else -> false
-}
+val Number.isNegInf
+    get() = when (this) {
+        is Double -> isInfinite() && this < 0
+        else -> false
+    }
 
-val Number.isPosInf get() = when (this) {
-    is Double -> isInfinite() && this > 0
-    else -> false
-}
+val Number.isPosInf
+    get() = when (this) {
+        is Double -> isInfinite() && this > 0
+        else -> false
+    }
 
 /**
  * Returns the given BigDecimal with precision equals to mathContext.precision.

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/ast/IsIonLiteralMetaTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/ast/IsIonLiteralMetaTest.kt
@@ -14,7 +14,6 @@ package org.partiql.lang.ast
  *  language governing permissions and limitations under the License.
  */
 
-import com.amazon.ion.system.IonSystemBuilder
 import org.junit.Assert
 import org.junit.Test
 import org.partiql.lang.syntax.PartiQLParser
@@ -23,8 +22,7 @@ class IsIonLiteralMetaTest {
 
     @Test
     fun testIonLiteralMetaPreserved() {
-        val ion = IonSystemBuilder.standard().build()
-        val ionLiteral = PartiQLParser(ion).parseAstStatement("`1.0`")
+        val ionLiteral = PartiQLParser().parseAstStatement("`1.0`")
         Assert.assertTrue(ionLiteral.metas.hasMeta(IsIonLiteralMeta.TAG))
     }
 }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/PartiqlAstExtensionsTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/PartiqlAstExtensionsTests.kt
@@ -1,6 +1,5 @@
 package org.partiql.lang.eval
 
-import com.amazon.ion.system.IonSystemBuilder
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.ast.SourceLocationMeta
@@ -9,7 +8,7 @@ import org.partiql.lang.syntax.PartiQLParser
 import org.partiql.lang.util.ArgumentsProviderBase
 
 class PartiqlAstExtensionsTests : EvaluatorTestBase() {
-    private val parser = PartiQLParser(IonSystemBuilder.standard().build())
+    private val parser = PartiQLParser()
 
     data class StartingSourceLocationTestCase(val query: String, val expectedSourceLocationMeta: SourceLocationMeta)
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactory.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactory.kt
@@ -1,7 +1,6 @@
 package org.partiql.lang.eval.evaluatortestframework
 
 import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
-import org.partiql.lang.ION
 import org.partiql.lang.compiler.PartiQLCompilerBuilder
 import org.partiql.lang.compiler.PartiQLCompilerPipeline
 import org.partiql.lang.eval.EvaluationSession
@@ -74,7 +73,7 @@ internal class PartiQLCompilerPipelineFactory() : PipelineFactory {
         )
 
         val pipeline = PartiQLCompilerPipeline(
-            parser = PartiQLParserBuilder().ionSystem(ION).customTypes(legacyPipeline.customDataTypes).build(),
+            parser = PartiQLParserBuilder().customTypes(legacyPipeline.customDataTypes).build(),
             planner = PartiQLPlannerBuilder.standard()
                 .options(plannerOptions)
                 .globalVariableResolver(globalVariableResolver)

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/VisitorTransformBaseTestAdapter.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/VisitorTransformBaseTestAdapter.kt
@@ -1,7 +1,6 @@
 package org.partiql.lang.eval.evaluatortestframework
 
 import org.partiql.lang.CUSTOM_TEST_TYPES
-import org.partiql.lang.ION
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.visitors.VisitorTransformBase
 import org.partiql.lang.syntax.PartiQLParser
@@ -20,7 +19,7 @@ class VisitorTransformBaseTestAdapter : EvaluatorTestAdapter {
     }
 
     private fun testVistorTransformBase(tc: EvaluatorTestDefinition) {
-        val parser = PartiQLParser(ION, CUSTOM_TEST_TYPES)
+        val parser = PartiQLParser(CUSTOM_TEST_TYPES)
         val ast = parser.parseAstStatement(tc.query)
 
         val clonedAst = defaultTransformer.transformStatement(ast)

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
@@ -1,6 +1,5 @@
 package org.partiql.lang.planner.transforms
 
-import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionelement.api.ionBool
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.ionString
@@ -30,8 +29,7 @@ import org.partiql.lang.util.ArgumentsProviderBase
  * heavily exercised during many other integration tests.  These should be considered "smoke tests".
  */
 class AstToLogicalVisitorTransformTests {
-    private val ion = IonSystemBuilder.standard().build()
-    internal val parser = PartiQLParser(ion)
+    internal val parser = PartiQLParser()
 
     private fun parseAndTransform(sql: String, problemHandler: ProblemHandler): PartiqlLogical.Statement {
         val parseAstStatement = parser.parseAstStatement(sql)

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransformTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransformTests.kt
@@ -1,6 +1,5 @@
 package org.partiql.lang.planner.transforms
 
-import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionelement.api.ionSymbol
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -106,8 +105,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
         }.toTypedArray()
     )
 
-    private val ion = IonSystemBuilder.standard().build()
-    private val parser = PartiQLParser(ion)
+    private val parser = PartiQLParser()
 
     private fun runTestCase(tc: TestCase) {
         val problemHandler = ProblemCollector()

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
@@ -1,13 +1,12 @@
 package org.partiql.lang.prettyprint
 
-import com.amazon.ion.system.IonSystemBuilder
 import org.junit.Assert
 import org.junit.Test
 import org.partiql.lang.syntax.PartiQLParser
 
 class QueryPrettyPrinterTest {
     private val prettyPrinter = QueryPrettyPrinter()
-    private val sqlParser = PartiQLParser(IonSystemBuilder.standard().build())
+    private val sqlParser = PartiQLParser()
 
     private fun checkPrettyPrintQuery(query: String, expected: String) {
         // In triples quotes, a tab consists of 4 whitespaces. We need to transform them into a tab.

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserCastTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserCastTests.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.CUSTOM_TEST_TYPES
 import org.partiql.lang.domains.PartiqlAst
-import org.partiql.lang.eval.CastTestBase.Companion.ion
 import org.partiql.lang.util.ArgumentsProviderBase
 
 class PartiQLParserCastTests : PartiQLParserTestBase() {
@@ -163,7 +162,7 @@ class PartiQLParserCastTests : PartiQLParserTestBase() {
 
     data class ConfiguredCastParseTest(val source: String, val expectedAst: PartiqlAst.PartiqlAstNode) {
 
-        val parser = PartiQLParserBuilder().ionSystem(ion).customTypes(CUSTOM_TEST_TYPES).build()
+        val parser = PartiQLParserBuilder().customTypes(CUSTOM_TEST_TYPES).build()
 
         fun assertCase() {
             // Convert the query to ast

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTestBase.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTestBase.kt
@@ -34,7 +34,7 @@ import org.partiql.pig.runtime.toIonElement
 
 abstract class PartiQLParserTestBase : TestBase() {
 
-    val parser = PartiQLParserBuilder().ionSystem(ion).customTypes(CUSTOM_TEST_TYPES).build()
+    val parser = PartiQLParserBuilder().customTypes(CUSTOM_TEST_TYPES).build()
 
     protected fun parse(source: String): PartiqlAst.Statement = parser.parseAstStatement(source)
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/util/ConfigurableExprValueFormatterTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/util/ConfigurableExprValueFormatterTest.kt
@@ -1,6 +1,5 @@
 package org.partiql.lang.util
 
-import com.amazon.ion.system.IonSystemBuilder
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Test
@@ -15,8 +14,7 @@ import kotlin.test.assertTrue
 @RunWith(JUnitParamsRunner::class)
 class ConfigurableExprValueFormatterTest {
 
-    private val ion = IonSystemBuilder.standard().build()
-    private val parser = PartiQLParser(ion)
+    private val parser = PartiQLParser()
     private val compiler = CompilerPipeline.builder().sqlParser(parser).build()
 
     private val pretty = ConfigurableExprValueFormatter.pretty

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/util/testdsl/IonResultTestCase.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/util/testdsl/IonResultTestCase.kt
@@ -64,7 +64,7 @@ data class IonResultTestCase(
 
     fun toStatementTestCase(): StatementTestCase =
         assertDoesNotThrow("IonResultTestCase ${toString()} should not throw when parsing") {
-            StatementTestCase(name, PartiQLParser(ION).parseAstStatement(sqlUnderTest))
+            StatementTestCase(name, PartiQLParser().parseAstStatement(sqlUnderTest))
         }
 }
 


### PR DESCRIPTION
## Relevant Issues

Follow up to https://github.com/partiql/partiql-lang-kotlin/pull/949

## Description

Removes IonSystem and deprecated parameters for the PartiQLParser

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Yes

- Any backward-incompatible changes? **[YES/NO]**
Yes. We've removed the IonSystem.

- Any new external dependencies? **[YES/NO]**
No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.