### PR TITLE
Renames Rel.Common.Schema to Rel.Common.TypeEnv

### DIFF
--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencer.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencer.kt
@@ -175,7 +175,7 @@ public object PartiQLSchemaInferencer {
         is Rex.Path -> ValueDescriptor.TypeDescriptor(rex.type!!)
         is Rex.Query.Collection -> when (rex.constructor) {
             null -> {
-                val attrs = PlanUtils.getSchema(rex.rel).map { attr -> ColumnMetadata(attr.name, attr.type) }
+                val attrs = PlanUtils.getTypeEnv(rex.rel).map { attr -> ColumnMetadata(attr.name, attr.type) }
                 TableDescriptor(
                     name = DEFAULT_TABLE_NAME,
                     attributes = attrs

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/PlanUtils.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/PlanUtils.kt
@@ -20,16 +20,16 @@ import org.partiql.plan.Rex
 import org.partiql.types.StaticType
 
 internal object PlanUtils {
-    internal fun getSchema(input: Rel): List<Attribute> = when (input) {
-        is Rel.Project -> input.common.schema
-        is Rel.Aggregate -> input.common.schema
-        is Rel.Bag -> input.common.schema
-        is Rel.Fetch -> input.common.schema
-        is Rel.Filter -> input.common.schema
-        is Rel.Join -> input.common.schema
-        is Rel.Scan -> input.common.schema
-        is Rel.Sort -> input.common.schema
-        is Rel.Unpivot -> input.common.schema
+    internal fun getTypeEnv(input: Rel): List<Attribute> = when (input) {
+        is Rel.Project -> input.common.typeEnv
+        is Rel.Aggregate -> input.common.typeEnv
+        is Rel.Bag -> input.common.typeEnv
+        is Rel.Fetch -> input.common.typeEnv
+        is Rel.Filter -> input.common.typeEnv
+        is Rel.Join -> input.common.typeEnv
+        is Rel.Scan -> input.common.typeEnv
+        is Rel.Sort -> input.common.typeEnv
+        is Rel.Unpivot -> input.common.typeEnv
     }
 
     internal fun Rex.addType(type: StaticType): Rex = when (this) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/RelConverter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/RelConverter.kt
@@ -22,7 +22,7 @@ internal class RelConverter {
      * As of now, the COMMON property of relation operators is under development, so just use empty for now
      */
     private val empty = Common(
-        schema = emptyList(),
+        typeEnv = emptyList(),
         properties = emptySet(),
         metas = emptyMap()
     )

--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -16,7 +16,7 @@ parti_q_l_plan::{
 
 // Grouping of common fields without implications of interfaces or inheritance
 common::{
-  schema: list::[attribute],
+  type_env: list::[attribute],
   properties: set::[property],
   metas: map::[string,any],
 }


### PR DESCRIPTION
## Relevant Issues
- Closes #1032 

## Description
- Renames the unreleased Rel.Common.Schema to Rel.Common.TypeEnv

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
  - No, because Rel.Common.Schema is unreleased
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.