### PR TITLE
Publishes PartiQL Types

### DIFF
--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -32,11 +32,11 @@ dependencies {
     antlr(Deps.antlr)
     api(project(":lib:isl"))
     api(project(":partiql-spi"))
+    api(project(":partiql-types"))
     api(Deps.ionElement)
     api(Deps.ionJava)
     api(Deps.pigRuntime)
     // libs are included in partiql-lang-kotlin JAR
-    libs(project(":partiql-types"))
     libs(project(":partiql-plan"))
     implementation(Deps.antlrRuntime)
     implementation(Deps.csv)

--- a/partiql-spi/build.gradle.kts
+++ b/partiql-spi/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 dependencies {
     api(Deps.ionElement)
-    implementation(project(":partiql-types"))
+    api(project(":partiql-types"))
 }
 
 publish {

--- a/partiql-types/build.gradle.kts
+++ b/partiql-types/build.gradle.kts
@@ -15,8 +15,15 @@
 
 plugins {
     id(Plugins.conventions)
+    id(Plugins.publish)
 }
 
 dependencies {
     implementation(Deps.ionElement)
+}
+
+publish {
+    artifactId = "partiql-types"
+    name = "PartiQL Types"
+    description = "The core PartiQL types."
 }


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Publishes PartiQL Types
- Removes `libs` usage under `partiql-lang` and replaces with `api` as `:partiql-types` will be published

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
  - These haven't been released
- Any backward-incompatible changes? **NO**

- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.