### PR TITLE
debug github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Test and Report
         env:
           DOKKA: false
+          GRADLE_OPTS: -Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=1g"
         run: ./gradlew build jacocoTestReport
 
       # Upload coverage for CLI, LANG, PTS, TEST_SCRIPT, and EXAMPLES

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,4 @@ ossrhPassword=EMPTY
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx4096M
+


### PR DESCRIPTION
## Relevant Issues
- N/A

## Description
- [PR#1041](https://github.com/partiql/partiql-lang-kotlin/pull/1041) contains three changed files, two of which are markdown changes and the other one is to change the version attribute in `gradle.properties`. However, it caused github action to fail. See the error [here](https://github.com/partiql/partiql-lang-kotlin/actions/runs/4684254058/jobs/8300209279?pr=1041). 
```
* What went wrong:
Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)
```
- The root cause for that issue is OOM. Github only providers workers with 7g of Ram. 
- Setting a value of org.gradle.jvmargs in `gradle.properties` overwrites these Gradle's default jvm args, and those values get fall back to JVM default. 
- In particular, the `MaxMetaspaceSize` value is set to `256m` by Gradle, and seemingly is unbounded by JVM default. 
- This caused a OOM issue. 

Reference: 
1. https://github.com/gradle/gradle-build-action/issues/122
2. https://github.com/gradle/gradle/issues/19648
3. https://docs.oracle.com/en/java/javase/17/gctuning/other-considerations.html#GUID-B29C9153-3530-4C15-9154-E74F44E3DAD9 

Further investigation: 
I am not sure as of why changing the version from `xxx-snapshot` to `xxx` trigger the OOM issue mentioned above. I don't find any information regarding whether Gradle will handle things differently if the `-snapshot` is presented. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No. Change in github workflow.

- Any backward-incompatible changes? **[YES/NO]**
  - No.

- Any new external dependencies? **[YES/NO]**
  - No.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.