### PR TITLE
Prepare v0.9.4 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.9.4] - 2023-04-20
+
+### Added
+- Adds ability to pipe queries to the CLI
+- Adds ability to run PartiQL files as executables by adding support for shebangs
+
+### Changed
+
+### Deprecated
+
+### Fixed
+- Fixes list/bag ExprValue creation in plan evaluator
+- Fixes gradle build issues.
+
+### Removed
+- Revert changes in 0.9.3 (the previous version) as they include breaking changes 
+
+### Security
+
+## [0.9.3] - 2023-04-12
+
+### Added
+- Added numeric builtins ABS, SQRT, EXP, LN, POW, MOD.
+- Added standard SQL built-in functions POSITION, OVERLAY, LENGTH, BIT_LENGTH, OCTET_LENGTH, CARDINALITY,
+  an additional builtin TEXT_REPLACE, and standard SQL aggregations on booleans EVERY, ANY, SOME.
+- **Breaking** Added coercion of SQL-style subquery to a single value, as defined in SQL for
+  subqueries occurring in a single-value context and outlined in Chapter 9 of the PartiQL specification.
+  This is backward incompatible with the prior behavior (which left the computed collection as is),
+  but brings it in conformance with the specification.
+- Added `partiql-plan` package which contains experimental PartiQL Plan data structures.
+- Initializes SPI Framework under `partiql-spi`.
+- Models experimental `Schema` with constraints.
+  With this change, we're introducing `Tuple` and `Collection` constraints to be able to model the shape of data as
+  constraints.
+- Introduces the PartiQLSchemaInferencer and PlannerSession
+  - The PlannerSession describes the current session and is used by the PartiQLSchemaInferencer.
+  - The PartiQLSchemaInferencer provides a function, `infer`, to aid in inferring the output `StaticType` of a
+    PartiQL Query. See the KDoc for more information and examples.
+
+### Changed
+- Deprecates the project level opt-in annotation `PartiQLExperimental` and split it into feature level. `ExperimentalPartiQLCompilerPipeline` and `ExperimentalWindowFunctions`.
+- **Breaking**: Moves StaticType to `partiql-types`.
+  - All references to static types need to modify their imports accordingly. For example,
+    `org.partiql.lang.types.IntType` is now `org.partiql.types.IntType`.
+  - Please modify existing dependencies accordingly. You may need to add dependency `org.partiql:partiql-types:0.10.0`.
+  - Also, several methods within StaticType have been moved to a utility class within `partiql-lang-kotln`. See the below list:
+    1. `org.partiql.lang.types.StaticType.fromExprValueType` -> `org.partiql.lang.types.StaticTypeUtils.staticTypeFromExprValueType`
+    2. `org.partiql.lang.types.StaticType.fromExprValue` -> `org.partiql.lang.types.StaticTypeUtils.staticTypeFromExprValue`
+    3. `org.partiql.lang.types.StaticType.isInstance` -> `org.partiql.lang.types.StaticTypeUtils.isInstance`
+    4. `org.partiql.lang.types.StaticType.isComparableTo` -> `org.partiql.lang.types.StaticTypeUtils.areStaticTypesComparable`
+    5. `org.partiql.lang.types.StaticType.isSubTypeOf` -> `org.partiql.lang.types.StaticTypeUtils.isSubTypeOf`
+    5. `org.partiql.lang.types.StaticType.typeDomain` -> `org.partiql.lang.types.StaticTypeUtils.getTypeDomain`
+    6. `org.partiql.lang.types.SingleType.getRuntimeType` -> `org.partiql.lang.types.StaticTypeUtils.getRuntimeType`
+    7. `org.partiql.lang.types.StringType.StringLengthConstraint.matches` -> `org.partiql.lang.types.StaticTypeUtils.stringLengthConstraintMatches`
+- **Breaking**: Removes deprecated `ionSystem()` function from PartiQLCompilerBuilder and PartiQLParserBuilder
+
+
 ## [0.9.2] - 2023-01-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID      | Artifact ID           | Recommended Version |
 |---------------|-----------------------|---------------------|
-| `org.partiql` | `partiql-lang-kotlin` | `0.9.1`             | 
+| `org.partiql` | `partiql-lang-kotlin` | `0.9.4`             | 
 
 
 For Maven builds, add the following to your `pom.xml`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=0.9.2
+version=0.9.4
 
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY


### PR DESCRIPTION
Base branch is `v0.9.4`, which uses `v0.9.2`.

## Description
This commit reverts changes in v0.9.3 as there are breaking changes in the previous release that need to get released as a new major version.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Yes.

- Any backward-incompatible changes? **[YES/NO]**
No. 

- Any new external dependencies? **[YES/NO]**
No.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.