### PR TITLE
Adds asAlias property to INSERT AST node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking**: Adds a new property `asAlias` to the `insert` AST node.
+
 ### Deprecated
 
 ### Fixed
+
+- Parsing INSERT statements with aliases no longer loses the original table name. Closes #1043.
 
 ### Removed
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/PartiQLVisitor.kt
@@ -280,23 +280,19 @@ internal class PartiQLVisitor(val customTypes: List<CustomType> = listOf(), priv
     }
 
     override fun visitInsert(ctx: PartiQLParser.InsertContext) = PartiqlAst.build {
-        val metas = ctx.INSERT().getSourceMetaContainer()
-        val asIdent = ctx.asIdent()
-        // Based on the RFC, if alias exists the table must be hidden behind the alias, see:
-        // https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md#41-insert-parameters
-        val target = if (asIdent != null) visitAsIdent(asIdent) else visitSymbolPrimitive(ctx.symbolPrimitive())
-        val conflictAction = visitOrNull(ctx.onConflictClause(), PartiqlAst.ConflictAction::class)
-        insert(target, visit(ctx.value, PartiqlAst.Expr::class), conflictAction, metas)
+        insert(
+            target = visitSymbolPrimitive(ctx.symbolPrimitive()),
+            asAlias = visitOrNull(ctx.asIdent(), PartiqlAst.Expr.Id::class)?.name?.text,
+            values = visit(ctx.value, PartiqlAst.Expr::class),
+            conflictAction = visitOrNull(ctx.onConflictClause(), PartiqlAst.ConflictAction::class),
+            metas = ctx.INSERT().getSourceMetaContainer()
+        )
     }
 
-    // TODO move from experimental; pending: https://github.com/partiql/partiql-docs/issues/27
     override fun visitReplaceCommand(ctx: PartiQLParser.ReplaceCommandContext) = PartiqlAst.build {
-        val asIdent = ctx.asIdent()
-        // Based on the RFC, if alias exists the table must be hidden behind the alias, see:
-        // https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md#41-insert-parameters
-        val target = if (asIdent != null) visitAsIdent(asIdent) else visitSymbolPrimitive(ctx.symbolPrimitive())
         insert(
-            target = target,
+            target = visitSymbolPrimitive(ctx.symbolPrimitive()),
+            asAlias = visitOrNull(ctx.asIdent(), PartiqlAst.Expr.Id::class)?.name?.text,
             values = visit(ctx.value, PartiqlAst.Expr::class),
             conflictAction = doReplace(excluded()),
             metas = ctx.REPLACE().getSourceMetaContainer()
@@ -305,12 +301,9 @@ internal class PartiQLVisitor(val customTypes: List<CustomType> = listOf(), priv
 
     // Based on https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md
     override fun visitUpsertCommand(ctx: PartiQLParser.UpsertCommandContext) = PartiqlAst.build {
-        val asIdent = ctx.asIdent()
-        // Based on the RFC, if alias exists the table must be hidden behind the alias, see:
-        // https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md#41-insert-parameters
-        val target = if (asIdent != null) visitAsIdent(asIdent) else visitSymbolPrimitive(ctx.symbolPrimitive())
         insert(
-            target = target,
+            target = visitSymbolPrimitive(ctx.symbolPrimitive()),
+            asAlias = visitOrNull(ctx.asIdent(), PartiqlAst.Expr.Id::class)?.name?.text,
             values = visit(ctx.value, PartiqlAst.Expr::class),
             conflictAction = doUpdate(excluded()),
             metas = ctx.UPSERT().getSourceMetaContainer()

--- a/partiql-lang/src/main/pig/partiql.ion
+++ b/partiql-lang/src/main/pig/partiql.ion
@@ -401,7 +401,7 @@ may then be further optimized by selecting better implementations of each operat
         (sum dml_op
             // See the following RFC for more details:
             // https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md
-            (insert target::expr values::expr conflict_action::(? conflict_action))
+            (insert target::expr as_alias::(? symbol) values::expr conflict_action::(? conflict_action))
 
             // `INSERT INTO <expr> VALUE <expr> [AT <expr>]` [ON CONFLICT WHERE <expr> DO NOTHING]`
             (insert_value target::expr value::expr index::(? expr) on_conflict::(? on_conflict))

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
@@ -740,7 +740,7 @@ class AstToLogicalVisitorTransformTests {
                 PartiqlLogical.build {
                     PartiqlLogical.build {
                         dml(
-                            identifier("f", caseInsensitive()),
+                            identifier("foo", caseInsensitive()),
                             dmlReplace(),
                             bag(
                                 struct(
@@ -770,7 +770,7 @@ class AstToLogicalVisitorTransformTests {
                 PartiqlLogical.build {
                     PartiqlLogical.build {
                         dml(
-                            identifier("f", caseInsensitive()),
+                            identifier("foo", caseInsensitive()),
                             dmlUpdate(),
                             bag(
                                 struct(
@@ -787,7 +787,7 @@ class AstToLogicalVisitorTransformTests {
                 PartiqlLogical.build {
                     PartiqlLogical.build {
                         dml(
-                            identifier("f", caseInsensitive()),
+                            identifier("foo", caseInsensitive()),
                             dmlReplace(),
                             bag(
                                 struct(
@@ -804,7 +804,7 @@ class AstToLogicalVisitorTransformTests {
                 PartiqlLogical.build {
                     PartiqlLogical.build {
                         dml(
-                            identifier("f", caseInsensitive()),
+                            identifier("foo", caseInsensitive()),
                             dmlUpdate(),
                             bindingsToValues(
                                 struct(structFields(id("x", caseInsensitive(), unqualified()))),

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -1720,6 +1720,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (dml_op_list
                     (insert
                         (id foo (case_insensitive) (unqualified))
+                        null
                         (bag
                             (list
                                 (lit 1)
@@ -1818,6 +1819,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (dml_op_list
                     (insert
                         (id foo (case_insensitive) (unqualified))
+                        null
                         (select
                             (project
                                 (project_list
@@ -1897,6 +1899,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (dml_op_list
                     (insert
                         (id foo (case_insensitive) (unqualified))
+                        null
                         (bag
                             (list
                                 (lit 1)
@@ -2171,6 +2174,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (dml_op_list
                     (insert
                         (id foo (case_insensitive) (unqualified))
+                        null
                         (select
                             (project
                                 (project_list
@@ -2196,6 +2200,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (dml_op_list
                     (insert
                         (id foo (case_insensitive) (unqualified))
+                        null
                         (bag
                             (list
                                 (lit 1)
@@ -2216,7 +2221,8 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (operations
                     (dml_op_list
                         (insert
-                            (id f (case_insensitive) (unqualified))
+                            (id foo (case_insensitive) (unqualified))
+                            f
                             (bag
                                 (struct
                                     (expr_pair
@@ -2239,6 +2245,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
+                            null
                             (select
                                 (project
                                     (project_list
@@ -2276,6 +2283,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (dml_op_list
                     (insert
                         (id foo (case_insensitive) (unqualified))
+                        null
                         (bag
                             (list
                                 (lit 1)
@@ -2296,7 +2304,8 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (operations
                     (dml_op_list
                         (insert
-                            (id f (case_insensitive) (unqualified))
+                            (id foo (case_insensitive) (unqualified))
+                            f
                             (bag
                                 (struct
                                     (expr_pair
@@ -2319,6 +2328,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
+                            null
                             (select
                                 (project
                                     (project_list
@@ -2356,6 +2366,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
+                            null
                             (bag
                                 (struct
                                     (expr_pair
@@ -2376,7 +2387,8 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (operations
                     (dml_op_list
                         (insert
-                            (id f (case_insensitive) (unqualified))
+                            (id foo (case_insensitive) (unqualified))
+                            f
                             (bag
                                 (struct
                                     (expr_pair
@@ -2398,6 +2410,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
+                            null
                             (select
                                 (project
                                     (project_list
@@ -2434,6 +2447,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
+                            null
                             (bag
                                 (struct
                                     (expr_pair
@@ -2455,7 +2469,8 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (operations
                     (dml_op_list
                         (insert
-                            (id f (case_insensitive) (unqualified))
+                            (id foo (case_insensitive) (unqualified))
+                            f
                             (bag
                                 (struct
                                     (expr_pair
@@ -2478,6 +2493,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
+                            null
                             (bag
                                 (struct
                                     (expr_pair
@@ -2499,7 +2515,8 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (operations
                     (dml_op_list
                         (insert
-                            (id f (case_insensitive) (unqualified))
+                            (id foo (case_insensitive) (unqualified))
+                            f
                             (bag
                                 (struct
                                     (expr_pair
@@ -2522,6 +2539,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
+                            null
                             (select
                                 (project
                                     (project_list
@@ -2559,6 +2577,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (dml_op_list
                     (insert
                         (id foo (case_insensitive) (unqualified))
+                        null
                         (select
                             (project
                                 (project_list
@@ -3129,6 +3148,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (dml_op_list
                     (insert
                         (id k (case_insensitive) (unqualified))
+                        null
                         (bag
                             (lit 1))
                         null)))
@@ -3154,6 +3174,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (dml_op_list
                     (insert
                         (id k (case_insensitive) (unqualified))
+                        null
                         (bag
                             (lit 1))
                         null)))


### PR DESCRIPTION
## Relevant Issues
- Closes #1043 

## Description
- **Breaking**: Adds `asAlias` nullable property to the `insert` AST node.
- Modifies tests corresponding to the change
- This PR does NOT add the alias to the DML Conflict Action -- as the current planner does NOT support any action besides EXCLUDED -- which does not reference the alias. This will need to be addressed once we extend support to the conflict action value to include SET/VALUE according to the [RFC](https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md).

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **YES**
  - Yes, the public AST node `insert` now contains another property called `asAlias`
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.