### PR TITLE
Add back ability to convert `IonDatagram` to `ExprValue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Adds back ability to convert an `IonDatagram` to an `ExprValue` using `of(value: IonValue): ExprValue` and `newFromIonValue(value: IonValue): ExprValue`
 
 ### Changed
 

--- a/docs/wiki/upgrades/v0.8-to-v0.9-upgrade.md
+++ b/docs/wiki/upgrades/v0.8-to-v0.9-upgrade.md
@@ -52,3 +52,6 @@ N/A
 * Removes the deprecated SqlParser and SqlLexer
 * Removes the `CallAgg` node from the Logical, LogicalResolved, and Physical plans.
 * Removes the experimental `PlannerPipeline` and replaces it with `PartiQLCompilerPipeline`.
+* Removes the prior ability to convert an `IonDatagram` to an `ExprValue` using `of(value: IonValue): ExprValue`, which is called by `newFromIonValue(value: IonValue): ExprValue`
+  * Workaround could be to use older version of `partiql-lang-kotlin` or convert the `IonDatagram`'s values into an `IonList`
+  * This will capability will be added back in an upcoming release

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/ExprValue.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/ExprValue.kt
@@ -17,6 +17,7 @@ package org.partiql.lang.eval
 import com.amazon.ion.IonBlob
 import com.amazon.ion.IonBool
 import com.amazon.ion.IonClob
+import com.amazon.ion.IonDatagram
 import com.amazon.ion.IonDecimal
 import com.amazon.ion.IonFloat
 import com.amazon.ion.IonInt
@@ -397,6 +398,7 @@ interface ExprValue : Iterable<ExprValue>, Faceted {
                 value is IonList -> newList(value.map { of(it) }) // LIST
                 value is IonSexp -> newSexp(value.map { of(it) }) // SEXP
                 value is IonStruct -> IonStructExprValue(value) // STRUCT
+                value is IonDatagram -> newBag(value.map { of(it) }) // DATAGRAM represented as BAG ExprValue
                 else -> error("Unrecognized IonValue to transform to ExprValue: $value")
             }
         }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/ExprValueTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/ExprValueTest.kt
@@ -502,4 +502,12 @@ class ExprValueTest {
         // Assert
         assertEquals(expected, exprValue.timeValue())
     }
+
+    @Test
+    fun testIonDatagram() {
+        val ionDatagram = ion.newDatagram()
+        ionDatagram.addAll(listOf(ion.singleValue("1"), ion.singleValue("2"), ion.singleValue("3")))
+        val ionDatagramAsExprValue = ExprValue.of(ionDatagram)
+        assertBagValues(ionDatagramAsExprValue)
+    }
 }


### PR DESCRIPTION
Previous versions of PartiQL supported converting an `IonDatagram` to an `ExprValue` (as a bag). This capability seemed to be unintentionally removed in https://github.com/partiql/partiql-lang-kotlin/pull/881, which was part of the v0.9.0 release.

Also updated the migration guide for 0.8.0 -> 0.9.0 to make note of this change.

## Other Information
- Updated Unreleased Section in CHANGELOG: Yes
- Any backward-incompatible changes? No
- Any new external dependencies? No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.