### PR TITLE
Adds support for DML INSERT's WHERE/ALIAS in Parser, AST, and Plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds support for SQL's CURRENT_USER in the AST, EvaluatingCompiler, experimental planner implementation, and Schema Inferencer.
   - Adds the AST node `session_attribute`.
   - Adds the function `EvaluationSession.Builder::user()` to add the CURRENT_USER to the EvaluationSession
+- Adds support for parsing and planning of `INSERT INTO .. AS <alias> ... ON CONFLICT DO [UPDATE|REPLACE] EXCLUDED WHERE <expr>`
 
 ### Changed
+
+- **Breaking**: Adds a new property `as_alias` to the `insert` AST node.
+- **Breaking**: Adds new property `condition` to the AST nodes of `do_replace` and `do_update`
+- **Breaking**: Adds `target_alias` property to the `dml_insert`, `dml_replace`, and `dml_update` nodes within the
+  Logical and Logical Resolved plans
+- **Breaking**: Adds `condition` property to the `dml_replace` and `dml_update` nodes within the
+  Logical and Logical Resolved plans
 
 ### Deprecated
 
 ### Fixed
+
+- Parsing INSERT statements with aliases no longer loses the original table name. Closes #1043.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Adds the AST node `session_attribute`.
   - Adds the function `EvaluationSession.Builder::user()` to add the CURRENT_USER to the EvaluationSession
 - Adds support for parsing and planning of `INSERT INTO .. AS <alias> ... ON CONFLICT DO [UPDATE|REPLACE] EXCLUDED WHERE <expr>`
+- Adds the `statement.dml` and `dml_operation` node to the experimental PartiQL Physical Plan.
 
 ### Changed
 
@@ -46,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing INSERT statements with aliases no longer loses the original table name. Closes #1043.
 
 ### Removed
+
+- **Breaking**: Removes node `statement.dml_query` from the experimental PartiQL Physical Plan. Please see the added
+  `statement.dml` and `dml_operation` nodes.
 
 ### Security
 

--- a/partiql-lang/src/main/antlr/PartiQL.g4
+++ b/partiql-lang/src/main/antlr/PartiQL.g4
@@ -197,7 +197,7 @@ conflictAction
    [ WHERE <condition> ]
 */
 doReplace
-    : EXCLUDED;
+    : EXCLUDED ( WHERE condition=expr )?;
     // :TODO add the rest of the grammar
 
 /*
@@ -207,7 +207,7 @@ doReplace
    [ WHERE <condition> ]
 */
 doUpdate
-    : EXCLUDED;
+    : EXCLUDED ( WHERE condition=expr )?;
     // :TODO add the rest of the grammar
 
 updateClause

--- a/partiql-lang/src/main/antlr/PartiQL.g4
+++ b/partiql-lang/src/main/antlr/PartiQL.g4
@@ -161,6 +161,8 @@ removeCommand
 insertCommandReturning
     : INSERT INTO pathSimple VALUE value=expr ( AT pos=expr )? onConflictClause? returningClause?;
 
+// TODO: Update grammar to disallow the mixing and matching of `insert`, `insertLegacy`, `onConflict`, and `onConflictLegacy`
+//  See https://github.com/partiql/partiql-lang-kotlin/issues/1063 for more details.
 insertCommand
     : INSERT INTO pathSimple VALUE value=expr ( AT pos=expr )? onConflictClause?  # InsertLegacy
     // See the Grammar at https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md#2-proposed-grammar-and-semantics

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/QueryPlan.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/QueryPlan.kt
@@ -5,7 +5,6 @@ import org.partiql.lang.eval.BindingName
 import org.partiql.lang.eval.Bindings
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
-import org.partiql.lang.eval.ExprValueType
 
 /** A query plan that has been compiled and is ready to be evaluated. */
 fun interface QueryPlan {
@@ -29,7 +28,7 @@ sealed class QueryResult {
      *
      * The primary benefit of this class is that it ensures that the [rows] property is evaluated lazily.  It also
      * provides a cleaner API that is easier to work with for PartiQL embedders.  Without this, the user would have to
-     * consume the [ExprValue] directly and use code similar to that in [toDmlCommand] or convert it to Ion.  Neither
+     * consume the [ExprValue] directly and convert it to Ion.  Neither
      * option is particularly developer friendly, efficient or maintainable.
      *
      * This is currently only factored to support `INSERT INTO` and `DELETE FROM` as `UPDATE` and `FROM ... UPDATE` is
@@ -67,60 +66,5 @@ enum class DmlAction {
     }
 }
 
-internal const val DML_COMMAND_FIELD_ACTION = "action"
-internal const val DML_COMMAND_FIELD_TARGET_UNIQUE_ID = "target_unique_id"
-internal const val DML_COMMAND_FIELD_ROWS = "rows"
-
-// Refers to the condition of conflict actions such as `INSERT .. ON CONFLICT DO REPLACE EXCLUDED WHERE <condition>`
-internal const val DML_CONFLICT_ACTION_CONDITION = "conflict_condition"
-
-// Refers to the index of the target's alias within the state registers
-internal const val DML_COMMAND_FIELD_TARGET_ALIAS_INDEX = "target_alias_index"
-
 private operator fun Bindings<ExprValue>.get(fieldName: String): ExprValue? =
     this[BindingName(fieldName, BindingCase.SENSITIVE)]
-
-private fun errMissing(fieldName: String): Nothing =
-    error("'$fieldName' missing from DML command struct or has incorrect Ion type")
-
-/**
- * Converts an [ExprValue] which is the result of a DML query to an instance of [DmlCommand].
- *
- * Format of a such an [ExprValue]:
- *
- * ```
- * {
- *     'action': <action>,
- *     'target_unique_id': <unique_id>
- *     'rows': <rows>
- * }
- * ```
- *
- * Where:
- *  - `<action>` is either `insert` or `delete`
- *  - `<target_unique_id>` is a string or symbol containing the unique identifier of the table to be effected
- *  by the DML statement.
- *  - `<rows>` is a bag or list containing the rows (structs) effected by the DML statement.
- *      - When `<action>` is `insert` this is the rows to be inserted.
- *      - When `<action>` is `delete` this is the rows to be deleted.  Non-primary key fields may be elided, but the
- *      default behavior is to include all fields because PartiQL does not yet know about primary keys.
- */
-internal fun ExprValue.toDmlCommand(): QueryResult.DmlCommand {
-    require(this.type == ExprValueType.STRUCT) { "'row' must be a struct" }
-
-    val actionString = this.bindings[DML_COMMAND_FIELD_ACTION]?.scalar?.stringValue()?.toUpperCase()
-        ?: errMissing(DML_COMMAND_FIELD_ACTION)
-
-    val dmlAction = DmlAction.safeValueOf(actionString)
-        ?: error("Unknown DmlAction in DML command struct: '$actionString'")
-
-    val targetUniqueId = this.bindings[DML_COMMAND_FIELD_TARGET_UNIQUE_ID]?.scalar?.stringValue()
-        ?: errMissing(DML_COMMAND_FIELD_TARGET_UNIQUE_ID)
-
-    val rows = this.bindings[DML_COMMAND_FIELD_ROWS] ?: errMissing(DML_COMMAND_FIELD_ROWS)
-    if (!rows.type.isSequence) {
-        error("DML command struct '$DML_COMMAND_FIELD_ROWS' field must be a bag or list")
-    }
-
-    return QueryResult.DmlCommand(dmlAction, targetUniqueId, rows)
-}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/QueryPlan.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/QueryPlan.kt
@@ -71,6 +71,12 @@ internal const val DML_COMMAND_FIELD_ACTION = "action"
 internal const val DML_COMMAND_FIELD_TARGET_UNIQUE_ID = "target_unique_id"
 internal const val DML_COMMAND_FIELD_ROWS = "rows"
 
+// Refers to the condition of conflict actions such as `INSERT .. ON CONFLICT DO REPLACE EXCLUDED WHERE <condition>`
+internal const val DML_CONFLICT_ACTION_CONDITION = "conflict_condition"
+
+// Refers to the index of the target's alias within the state registers
+internal const val DML_COMMAND_FIELD_TARGET_ALIAS_INDEX = "target_alias_index"
+
 private operator fun Bindings<ExprValue>.get(fieldName: String): ExprValue? =
     this[BindingName(fieldName, BindingCase.SENSITIVE)]
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -363,46 +363,34 @@ internal class AstToLogicalVisitorTransform(
                     }
                 }
 
-                when (val conflictAction = dmlOp.conflictAction) {
-                    null -> {
-                        PartiqlLogical.build {
-                            dml(
-                                target = dmlOp.target.toDmlTargetId(),
-                                operation = dmlInsert(),
-                                rows = transformExpr(dmlOp.values),
-                                metas = node.metas
-                            )
-                        }
+                val target = dmlOp.target.toDmlTargetId()
+                val alias = dmlOp.asAlias?.let {
+                    PartiqlLogical.VarDecl(it)
+                } ?: PartiqlLogical.VarDecl(target.name)
+
+                val operation = when (val conflictAction = dmlOp.conflictAction) {
+                    null -> PartiqlLogical.DmlOperation.DmlInsert(targetAlias = alias)
+                    is PartiqlAst.ConflictAction.DoReplace -> when (conflictAction.value) {
+                        is PartiqlAst.OnConflictValue.Excluded -> PartiqlLogical.DmlOperation.DmlReplace(
+                            targetAlias = alias,
+                            condition = conflictAction.condition?.let { transformExpr(conflictAction.condition) }
+                        )
                     }
-                    is PartiqlAst.ConflictAction.DoReplace -> {
-                        when (conflictAction.value) {
-                            PartiqlAst.OnConflictValue.Excluded() -> PartiqlLogical.build {
-                                dml(
-                                    target = dmlOp.target.toDmlTargetId(),
-                                    operation = dmlReplace(),
-                                    rows = transformExpr(dmlOp.values),
-                                    metas = node.metas
-                                )
-                            } else -> TODO("Only `DO REPLACE EXCLUDED` is supported in logical plan at the moment.")
-                        }
+                    is PartiqlAst.ConflictAction.DoUpdate -> when (conflictAction.value) {
+                        is PartiqlAst.OnConflictValue.Excluded -> PartiqlLogical.DmlOperation.DmlUpdate(
+                            targetAlias = alias,
+                            condition = conflictAction.condition?.let { transformExpr(conflictAction.condition) }
+                        )
                     }
-                    is PartiqlAst.ConflictAction.DoUpdate -> {
-                        when (conflictAction.value) {
-                            PartiqlAst.OnConflictValue.Excluded() -> PartiqlLogical.build {
-                                dml(
-                                    target = dmlOp.target.toDmlTargetId(),
-                                    operation = dmlUpdate(),
-                                    rows = transformExpr(dmlOp.values),
-                                    metas = node.metas
-                                )
-                            }
-                            else -> TODO("Only `DO UPDATE EXCLUDED` is supported in logical plan at the moment.")
-                        }
-                    }
-                    is PartiqlAst.ConflictAction.DoNothing -> TODO(
-                        "`ON CONFLICT DO NOTHING` is not supported in logical plan yet."
-                    )
+                    is PartiqlAst.ConflictAction.DoNothing -> TODO("`ON CONFLICT DO NOTHING` is not supported in logical plan yet.")
                 }
+
+                PartiqlLogical.Statement.Dml(
+                    target = target,
+                    operation = operation,
+                    rows = transformExpr(dmlOp.values),
+                    metas = node.metas
+                )
             }
             // INSERT single row with VALUE is disallowed. (This variation of INSERT might be removed in a future
             // release of PartiQL.)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
@@ -378,6 +378,24 @@ internal data class LogicalToLogicalResolvedVisitorTransform(
         }
     }
 
+    override fun transformDmlOperationDmlInsert(node: PartiqlLogical.DmlOperation.DmlInsert): PartiqlLogicalResolved.DmlOperation {
+        return withInputScope(this.inputScope.concatenate(node.targetAlias)) {
+            super.transformDmlOperationDmlInsert(node)
+        }
+    }
+
+    override fun transformDmlOperationDmlReplace(node: PartiqlLogical.DmlOperation.DmlReplace): PartiqlLogicalResolved.DmlOperation {
+        return withInputScope(this.inputScope.concatenate(node.targetAlias)) {
+            super.transformDmlOperationDmlReplace(node)
+        }
+    }
+
+    override fun transformDmlOperationDmlUpdate(node: PartiqlLogical.DmlOperation.DmlUpdate): PartiqlLogicalResolved.DmlOperation {
+        return withInputScope(this.inputScope.concatenate(node.targetAlias)) {
+            super.transformDmlOperationDmlUpdate(node)
+        }
+    }
+
     /**
      * Returns a list of variables accessible from the current scope which contain variables that may contain
      * an unqualified variable, in the order that they should be searched.

--- a/partiql-lang/src/main/pig/partiql.ion
+++ b/partiql-lang/src/main/pig/partiql.ion
@@ -404,7 +404,7 @@ may then be further optimized by selecting better implementations of each operat
         (sum dml_op
             // See the following RFC for more details:
             // https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md
-            (insert target::expr values::expr conflict_action::(? conflict_action))
+            (insert target::expr as_alias::(? symbol) values::expr conflict_action::(? conflict_action))
 
             // `INSERT INTO <expr> VALUE <expr> [AT <expr>]` [ON CONFLICT WHERE <expr> DO NOTHING]`
             (insert_value target::expr value::expr index::(? expr) on_conflict::(? on_conflict))
@@ -424,8 +424,8 @@ may then be further optimized by selecting better implementations of each operat
 
         // `CONFLICT_ACTION <action>`
         (sum conflict_action
-            (do_replace value::on_conflict_value)
-            (do_update value::on_conflict_value)
+            (do_replace value::on_conflict_value condition::(? expr))
+            (do_update value::on_conflict_value condition::(? expr))
             (do_nothing))
 
         (sum on_conflict_value
@@ -764,10 +764,10 @@ may then be further optimized by selecting better implementations of each operat
         (include
             // Indicates kind of DML operation.
             (sum dml_operation
-                (dml_insert)
+                (dml_insert target_alias::var_decl)
                 (dml_delete)
-                (dml_replace)
-                (dml_update)
+                (dml_replace target_alias::var_decl condition::(? expr))
+                (dml_update target_alias::var_decl condition::(? expr))
             )
         )
 

--- a/partiql-lang/src/main/pig/partiql.ion
+++ b/partiql-lang/src/main/pig/partiql.ion
@@ -903,15 +903,6 @@ may then be further optimized by selecting better implementations of each operat
             (product impl name::symbol static_args::(* ion 0))
         )
 
-        // drop DML stuff added in partiql_logical (these should be rewritten into queries).
-        (exclude dml_operation)
-        (with statement
-            (exclude dml)
-            (include
-                // Include the dml_query variant, so that we know how to interpret the results of the query.
-                (dml_query expr::expr))
-        )
-
         // Every variant of bexpr changes by adding an `impl` element in the physical algebra, so let's replace it
         // entirely.
         (exclude bexpr)

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
@@ -733,7 +733,7 @@ class AstToLogicalVisitorTransformTests {
                 PartiqlLogical.build {
                     dml(
                         identifier("foo", caseInsensitive()),
-                        dmlInsert(),
+                        dmlInsert(varDecl("foo")),
                         bag(lit(ionInt(1)))
                     )
                 }
@@ -744,7 +744,7 @@ class AstToLogicalVisitorTransformTests {
                 PartiqlLogical.build {
                     dml(
                         identifier("foo", caseInsensitive()),
-                        dmlInsert(),
+                        dmlInsert(varDecl("foo")),
                         bindingsToValues(
                             struct(structFields(id("x", caseInsensitive(), unqualified()))),
                             scan(lit(ionInt(1)), varDecl("x"))
@@ -757,7 +757,31 @@ class AstToLogicalVisitorTransformTests {
                 PartiqlLogical.build {
                     dml(
                         identifier("foo", caseInsensitive()),
-                        dmlReplace(),
+                        dmlReplace(varDecl("foo")),
+                        bindingsToValues(
+                            struct(structFields(id("x", caseInsensitive(), unqualified()))),
+                            scan(lit(ionInt(1)), varDecl("x"))
+                        )
+                    )
+                }
+            ),
+            TestCase(
+                "INSERT INTO foo SELECT x.* FROM 1 AS x ON CONFLICT DO REPLACE EXCLUDED WHERE foo.id > 2",
+                PartiqlLogical.build {
+                    dml(
+                        identifier("foo", caseInsensitive()),
+                        dmlReplace(
+                            targetAlias = varDecl("foo"),
+                            condition = gt(
+                                listOf(
+                                    path(
+                                        id("foo", caseInsensitive(), unqualified()),
+                                        listOf(pathExpr(lit(ionString("id")), caseInsensitive()))
+                                    ),
+                                    lit(ionInt(2))
+                                )
+                            )
+                        ),
                         bindingsToValues(
                             struct(structFields(id("x", caseInsensitive(), unqualified()))),
                             scan(lit(ionInt(1)), varDecl("x"))
@@ -770,8 +794,36 @@ class AstToLogicalVisitorTransformTests {
                 PartiqlLogical.build {
                     PartiqlLogical.build {
                         dml(
-                            identifier("f", caseInsensitive()),
-                            dmlReplace(),
+                            identifier("foo", caseInsensitive()),
+                            dmlReplace(varDecl("f")),
+                            bag(
+                                struct(
+                                    structField(lit(ionString("id")), lit(ionInt(1))),
+                                    structField(lit(ionString("name")), lit(ionString("bob")))
+                                )
+                            )
+                        )
+                    }
+                }
+            ),
+            TestCase(
+                "INSERT INTO foo AS f <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO REPLACE EXCLUDED WHERE f.id > 2",
+                PartiqlLogical.build {
+                    PartiqlLogical.build {
+                        dml(
+                            identifier("foo", caseInsensitive()),
+                            dmlReplace(
+                                varDecl("f"),
+                                condition = gt(
+                                    listOf(
+                                        path(
+                                            id("f", caseInsensitive(), unqualified()),
+                                            listOf(pathExpr(lit(ionString("id")), caseInsensitive()))
+                                        ),
+                                        lit(ionInt(2))
+                                    )
+                                )
+                            ),
                             bag(
                                 struct(
                                     structField(lit(ionString("id")), lit(ionInt(1))),
@@ -787,7 +839,7 @@ class AstToLogicalVisitorTransformTests {
                 PartiqlLogical.build {
                     dml(
                         identifier("foo", caseInsensitive()),
-                        dmlUpdate(),
+                        dmlUpdate(varDecl("foo")),
                         bindingsToValues(
                             struct(structFields(id("x", caseInsensitive(), unqualified()))),
                             scan(lit(ionInt(1)), varDecl("x"))
@@ -800,8 +852,36 @@ class AstToLogicalVisitorTransformTests {
                 PartiqlLogical.build {
                     PartiqlLogical.build {
                         dml(
-                            identifier("f", caseInsensitive()),
-                            dmlUpdate(),
+                            identifier("foo", caseInsensitive()),
+                            dmlUpdate(varDecl("f")),
+                            bag(
+                                struct(
+                                    structField(lit(ionString("id")), lit(ionInt(1))),
+                                    structField(lit(ionString("name")), lit(ionString("bob")))
+                                )
+                            )
+                        )
+                    }
+                }
+            ),
+            TestCase(
+                "INSERT INTO foo AS f <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO UPDATE EXCLUDED WHERE f.id > 2",
+                PartiqlLogical.build {
+                    PartiqlLogical.build {
+                        dml(
+                            identifier("foo", caseInsensitive()),
+                            dmlUpdate(
+                                varDecl("f"),
+                                condition = gt(
+                                    listOf(
+                                        path(
+                                            id("f", caseInsensitive(), unqualified()),
+                                            listOf(pathExpr(lit(ionString("id")), caseInsensitive()))
+                                        ),
+                                        lit(ionInt(2))
+                                    )
+                                )
+                            ),
                             bag(
                                 struct(
                                     structField(lit(ionString("id")), lit(ionInt(1))),
@@ -817,8 +897,8 @@ class AstToLogicalVisitorTransformTests {
                 PartiqlLogical.build {
                     PartiqlLogical.build {
                         dml(
-                            identifier("f", caseInsensitive()),
-                            dmlReplace(),
+                            identifier("foo", caseInsensitive()),
+                            dmlReplace(varDecl("f")),
                             bag(
                                 struct(
                                     structField(lit(ionString("id")), lit(ionInt(1))),
@@ -834,8 +914,8 @@ class AstToLogicalVisitorTransformTests {
                 PartiqlLogical.build {
                     PartiqlLogical.build {
                         dml(
-                            identifier("f", caseInsensitive()),
-                            dmlUpdate(),
+                            identifier("foo", caseInsensitive()),
+                            dmlUpdate(varDecl("f")),
                             bindingsToValues(
                                 struct(structFields(id("x", caseInsensitive(), unqualified()))),
                                 scan(lit(ionInt(1)), varDecl("x"))

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass.kt
@@ -11,11 +11,6 @@ import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.domains.PartiqlLogicalResolved
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.errors.ProblemCollector
-import org.partiql.lang.planner.DML_COMMAND_FIELD_ACTION
-import org.partiql.lang.planner.DML_COMMAND_FIELD_ROWS
-import org.partiql.lang.planner.DML_COMMAND_FIELD_TARGET_ALIAS_INDEX
-import org.partiql.lang.planner.DML_COMMAND_FIELD_TARGET_UNIQUE_ID
-import org.partiql.lang.planner.DML_CONFLICT_ACTION_CONDITION
 import org.partiql.lang.util.ArgumentsProviderBase
 import kotlin.test.fail
 
@@ -240,13 +235,10 @@ class LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass {
                     )
                 },
                 PartiqlPhysical.build {
-                    dmlQuery(
-                        struct(
-                            structField(DML_COMMAND_FIELD_ACTION, "insert"),
-                            structField(DML_COMMAND_FIELD_TARGET_UNIQUE_ID, lit(ionSymbol("foo"))),
-                            structField(DML_COMMAND_FIELD_ROWS, bag(lit(ionInt(1)))),
-                            structField(DML_COMMAND_FIELD_TARGET_ALIAS_INDEX, lit(ionInt(0)))
-                        )
+                    dml(
+                        uniqueId = "foo",
+                        operation = dmlInsert(varDecl(0)),
+                        rows = bag(lit(ionInt(1)))
                     )
                 }
             ),
@@ -263,22 +255,12 @@ class LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass {
                     )
                 },
                 PartiqlPhysical.build {
-                    dmlQuery(
-                        struct(
-                            structField(DML_COMMAND_FIELD_ACTION, "insert"),
-                            structField(DML_COMMAND_FIELD_TARGET_UNIQUE_ID, lit(ionSymbol("foo"))),
-                            structField(
-                                DML_COMMAND_FIELD_ROWS,
-                                bindingsToValues(
-                                    struct(structFields(localId(0))),
-                                    scan(
-                                        i = DEFAULT_IMPL,
-                                        expr = lit(ionInt(1)),
-                                        asDecl = varDecl(0)
-                                    )
-                                )
-                            ),
-                            structField(DML_COMMAND_FIELD_TARGET_ALIAS_INDEX, lit(ionInt(0)))
+                    dml(
+                        uniqueId = "foo",
+                        operation = dmlInsert(varDecl(0)),
+                        rows = bindingsToValues(
+                            struct(structFields(localId(0))),
+                            scan(DEFAULT_IMPL, lit(ionInt(1)), varDecl(0))
                         )
                     )
                 }
@@ -296,22 +278,12 @@ class LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass {
                     )
                 },
                 PartiqlPhysical.build {
-                    dmlQuery(
-                        struct(
-                            structField(DML_COMMAND_FIELD_ACTION, "replace"),
-                            structField(DML_COMMAND_FIELD_TARGET_UNIQUE_ID, lit(ionSymbol("foo"))),
-                            structField(
-                                DML_COMMAND_FIELD_ROWS,
-                                bindingsToValues(
-                                    struct(structFields(localId(0))),
-                                    scan(
-                                        i = DEFAULT_IMPL,
-                                        expr = lit(ionInt(1)),
-                                        asDecl = varDecl(0)
-                                    )
-                                )
-                            ),
-                            structField(DML_COMMAND_FIELD_TARGET_ALIAS_INDEX, lit(ionInt(0)))
+                    dml(
+                        uniqueId = "foo",
+                        operation = dmlReplace(varDecl(0)),
+                        rows = bindingsToValues(
+                            struct(structFields(localId(0))),
+                            scan(DEFAULT_IMPL, lit(ionInt(1)), varDecl(0))
                         )
                     )
                 }
@@ -340,34 +312,23 @@ class LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass {
                     )
                 },
                 PartiqlPhysical.build {
-                    dmlQuery(
-                        struct(
-                            structField(DML_COMMAND_FIELD_ACTION, "replace"),
-                            structField(DML_COMMAND_FIELD_TARGET_UNIQUE_ID, lit(ionSymbol("foo"))),
-                            structField(
-                                DML_COMMAND_FIELD_ROWS,
-                                bindingsToValues(
-                                    struct(structFields(localId(0))),
-                                    scan(
-                                        i = DEFAULT_IMPL,
-                                        expr = lit(ionInt(1)),
-                                        asDecl = varDecl(0)
-                                    )
-                                )
-                            ),
-                            structField(DML_COMMAND_FIELD_TARGET_ALIAS_INDEX, lit(ionInt(0))),
-                            structField(
-                                DML_CONFLICT_ACTION_CONDITION,
-                                gt(
-                                    listOf(
-                                        path(
-                                            localId(0),
-                                            listOf(pathExpr(lit(ionString("id")), caseInsensitive()))
-                                        ),
-                                        lit(ionInt(1))
-                                    )
+                    dml(
+                        uniqueId = "foo",
+                        operation = dmlReplace(
+                            targetAlias = varDecl(0),
+                            condition = gt(
+                                listOf(
+                                    path(
+                                        localId(0),
+                                        listOf(pathExpr(lit(ionString("id")), caseInsensitive()))
+                                    ),
+                                    lit(ionInt(1))
                                 )
                             )
+                        ),
+                        rows = bindingsToValues(
+                            struct(structFields(localId(0))),
+                            scan(DEFAULT_IMPL, lit(ionInt(1)), varDecl(0))
                         )
                     )
                 }
@@ -385,21 +346,12 @@ class LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass {
                     )
                 },
                 PartiqlPhysical.build {
-                    dmlQuery(
-                        struct(
-                            structField(DML_COMMAND_FIELD_ACTION, "delete"),
-                            structField(DML_COMMAND_FIELD_TARGET_UNIQUE_ID, lit(ionSymbol("foo"))),
-                            structField(
-                                DML_COMMAND_FIELD_ROWS,
-                                bindingsToValues(
-                                    localId(0),
-                                    scan(
-                                        i = DEFAULT_IMPL,
-                                        expr = globalId("y"),
-                                        asDecl = varDecl(0)
-                                    )
-                                )
-                            )
+                    dml(
+                        uniqueId = "foo",
+                        operation = dmlDelete(),
+                        rows = bindingsToValues(
+                            localId(0),
+                            scan(DEFAULT_IMPL, globalId("y"), varDecl(0))
                         )
                     )
                 }
@@ -421,25 +373,16 @@ class LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass {
                     )
                 },
                 PartiqlPhysical.build {
-                    dmlQuery(
-                        struct(
-                            structField(DML_COMMAND_FIELD_ACTION, "delete"),
-                            structField(DML_COMMAND_FIELD_TARGET_UNIQUE_ID, lit(ionSymbol("y"))),
-                            structField(
-                                DML_COMMAND_FIELD_ROWS,
-                                bindingsToValues(
-                                    localId(0),
-                                    // this logical plan is same as previous but includes this filter
-                                    filter(
-                                        i = DEFAULT_IMPL,
-                                        eq(lit(ionInt(1)), lit(ionInt(1))),
-                                        scan(
-                                            i = DEFAULT_IMPL,
-                                            expr = globalId("y"),
-                                            asDecl = varDecl(0)
-                                        )
-                                    )
-                                )
+                    dml(
+                        uniqueId = "y",
+                        operation = dmlDelete(),
+                        rows = bindingsToValues(
+                            localId(0),
+                            // this logical plan is same as previous but includes this filter
+                            filter(
+                                DEFAULT_IMPL,
+                                eq(lit(ionInt(1)), lit(ionInt(1))),
+                                scan(DEFAULT_IMPL, globalId("y"), varDecl(0))
                             )
                         )
                     )


### PR DESCRIPTION
## Relevant Issues
- Closes #1038
- Closes #1043 
- Closes #1052 
  - By adding support for the alias and condition in the physical plan, there is no longer a need to rewrite the DML statement into a projection operator -- as requested in 1052.

## Description
- Adds support for DML INSERT's WHERE/ALIAS in Parser, AST, and Plans

## Changes
- Adds support for ALIAS syntax
  - Adds a new property `as_alias` to the `insert` AST node.
  - Adds `target_alias` property to the `dml_insert`, `dml_replace`, and `dml_update` nodes within the
  Logical and Logical Resolved plans
  - Adds new physical plan field representing the register allocated to the index.
- Adds support for CONDITION in `ON CONFLICT DO [REPLACE|UPDATE] EXCLUDED WHERE <condition>`
  - Adds new property `condition` to the AST nodes of `do_replace` and `do_update`
  - Adds `condition` property to the `dml_replace` and `dml_update` nodes within the
  Logical and Logical Resolved plans
  - Adds new physical plan field representing the conflict condition.
- Removes `dml_query` from the physical plan and adds the `statement.dml` and `dml_operation` to the physical plan.
  - This allows users to rewrite the physical plan without using the "loose" contract that used to be `dml_query` -- which was effectively just a struct with key-value pairs.

**Note**: The pipeline currently doesn't support the physical plan for `ON CONFLICT DO UPDATE EXCLUDED`. This PR still provides the changes for this clause, but it does not complete the required physical plan changes to support full planning of this statement.

## Testing
- Added tests for the PartiQLParser, the AstToLogicalVisitorTransform, the LogicalToLogicalResolvedVisitorTransform, and the LogicalResolvedToDefaultPhysicalVisitorTransform
- Compilation of DML has changed from extracting the key-value pairs from the evaluated physical plan to immediately evaluating the `table_unique_id` and `rows` expressions. These cases are covered by the integration tests under `IntegrationTests.kt`.

## To Check
For the PR reviewer, you can use these features by starting up the experimental planner in the CLI and adding an empty table to the global environment:

<img width="1039" alt="Screenshot 2023-05-01 at 2 14 08 PM" src="https://user-images.githubusercontent.com/40360967/235532502-8ff50684-a333-469c-8315-28dca3b4b99a.png">

Then, explain the `ast`, `logical`, `logical_resolved`, and `physical` plans for example queries. For example, here is the `logical_resolved`:

<img width="1324" alt="Screenshot 2023-05-01 at 2 15 47 PM" src="https://user-images.githubusercontent.com/40360967/235532757-903e4f50-1212-4cbc-b7b6-a4cb9df6b21c.png">


## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **YES**
  - `partiql.ion` has modifications. See the CHANGELOG.
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.