### PR TITLE
Fixes parsing of INSERT and its legacy counterparts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Parsing INSERT statements with aliases no longer loses the original table name. Closes #1043.
+- Parsing INSERT statements with the legacy ON CONFLICT clause is no longer valid. Similarly, parsing the legacy INSERT
+  statement with the up-to-date ON CONFLICT clause is no longer valid. Closes #1063.
 
 ### Removed
 

--- a/partiql-lang/src/main/antlr/PartiQL.g4
+++ b/partiql-lang/src/main/antlr/PartiQL.g4
@@ -123,7 +123,8 @@ dml
     ;
 
 dmlBaseCommand
-    : insertCommand
+    : insertStatement
+    | insertStatementLegacy
     | setCommand
     | replaceCommand
     | removeCommand
@@ -159,19 +160,23 @@ removeCommand
 //  We essentially use the returning clause, because we currently support this with the SqlParser.
 //  See https://github.com/partiql/partiql-lang-kotlin/issues/708
 insertCommandReturning
-    : INSERT INTO pathSimple VALUE value=expr ( AT pos=expr )? onConflictClause? returningClause?;
+    : INSERT INTO pathSimple VALUE value=expr ( AT pos=expr )? onConflictLegacy? returningClause?;
 
-// TODO: Update grammar to disallow the mixing and matching of `insert`, `insertLegacy`, `onConflict`, and `onConflictLegacy`
-//  See https://github.com/partiql/partiql-lang-kotlin/issues/1063 for more details.
-insertCommand
-    : INSERT INTO pathSimple VALUE value=expr ( AT pos=expr )? onConflictClause?  # InsertLegacy
-    // See the Grammar at https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md#2-proposed-grammar-and-semantics
-    | INSERT INTO symbolPrimitive asIdent? value=expr onConflictClause?           # Insert
+// See the Grammar at https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md#2-proposed-grammar-and-semantics
+insertStatement
+    : INSERT INTO symbolPrimitive asIdent? value=expr onConflict?
     ;
 
-onConflictClause
-    : ON CONFLICT WHERE expr DO NOTHING                                           # OnConflictLegacy
-    | ON CONFLICT conflictTarget? conflictAction                                  # OnConflict
+onConflict
+    : ON CONFLICT conflictTarget? conflictAction
+    ;
+
+insertStatementLegacy
+    : INSERT INTO pathSimple VALUE value=expr ( AT pos=expr )? onConflictLegacy?
+    ;
+
+onConflictLegacy
+    : ON CONFLICT WHERE expr DO NOTHING
     ;
 
 /**

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -2565,6 +2565,30 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     )
 
     @Test
+    fun mixAndMatchInsertWithLegacy() = checkInputThrowingParserException(
+        "INSERT INTO foo <<{'id': 1, 'name':'bob'}>> ON CONFLICT WHERE TRUE DO NOTHING",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        expectErrorContextValues = mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 57L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.WHERE.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ION.newSymbol("where")
+        )
+    )
+
+    @Test
+    fun mixAndMatchInsertLegacyWithCurrent() = checkInputThrowingParserException(
+        "INSERT INTO foo VALUE {'id': 1, 'name':'bob'} ON CONFLICT DO UPDATE EXCLUDED",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        expectErrorContextValues = mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 59L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.DO.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ION.newSymbol("do")
+        )
+    )
+
+    @Test
     fun insertWithOnConflictDoNothingWithLiteralValueWithAlias() = assertExpression(
         source = "INSERT into foo AS f <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO NOTHING",
         expectedPigAst = """


### PR DESCRIPTION
## Relevant Issues
- Closes #1063 

## Description
- Prior to this PR, our grammar expressed that users can parse INSERT statements with the *legacy* ON CONFLICT clause. Similarly, they were able to parse *legacy* INSERT statements with the *up-to-date* ON CONFLICT clause.
- This PR updates the ANTLR grammar to disallow this. It also updates the PartiQLVisitor accordingly.

## Testing
- Tests have been added to assert that mixing-and-matching of the *legacy* and *up-to-date* grammar rules is not allowed.

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.