### PR TITLE
Change minimum arity of struct parts to 0 in logical & later plans.

### DIFF
--- a/partiql-lang/src/main/pig/partiql.ion
+++ b/partiql-lang/src/main/pig/partiql.ion
@@ -648,7 +648,7 @@ may then be further optimized by selecting better implementations of each operat
                 //
                 // TODO:  in the future, when the legacy AST compiler has been removed and the AST is no longer
                 // part of the public API, we should consider moving this definition to the partiql_ast domain.
-                (struct parts::(* struct_part 1))
+                (struct parts::(* struct_part 0))
 
                 // The PIVOT clause produces a single tuple whose attributes are the key and value expression evaluated
                 //   for all input tuples. The tuple is a value, not a bindings expr, hence why this isn't an operator.


### PR DESCRIPTION
To be honest, I do not know why I made this 1 initially, but it's actually totally legit to construct an empty struct.

## Description

See title.

## Other Information
- Updated Unreleased Section in CHANGELOG: No.
  - This is a tiny change with very low impact.

- Any backward-incompatible changes? No.

- Any new external dependencies? NO
- 
## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.