### PR TITLE
Change minimum number of function call arguments from 1 to 0.

### DIFF
--- a/partiql-lang/src/main/pig/partiql.ion
+++ b/partiql-lang/src/main/pig/partiql.ion
@@ -149,7 +149,7 @@ may then be further optimized by selecting better implementations of each operat
 
             // Other expression types
             (path root::expr steps::(* path_step 1))
-            (call func_name::symbol args::(* expr 1))
+            (call func_name::symbol args::(* expr 0))
             (call_agg setq::set_quantifier func_name::symbol arg::expr)
             // TODO: In the feature, when we allow use of aggregation function as window function, we need to consider incorporate in setq
             (call_window func_name::symbol over::over args::(* expr 1))


### PR DESCRIPTION
I think this has gone unnoticed until now because PIG does not enforce the minimum arity of variadic elements is not enforced at during deserialization.

## Relevant Issues
Related to #1069

## Description
See title.

## Other Information
- Updated Unreleased Section in CHANGELOG: No.
  - This is a tiny change with very low impact.

- Any backward-incompatible changes? No.

- Any new external dependencies? NO

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.