### PR TITLE
Adds Explicit API Mode to Publishing Plugin, Plan, and SPI

### DIFF
--- a/buildSrc/src/main/kotlin/org/partiql/gradle/plugin/publish/PublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/partiql/gradle/plugin/publish/PublishPlugin.kt
@@ -24,6 +24,7 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.KotlinClosure0
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getByName
@@ -32,6 +33,8 @@ import org.gradle.plugins.signing.SigningExtension
 import org.gradle.plugins.signing.SigningPlugin
 import org.jetbrains.dokka.gradle.DokkaPlugin
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import java.io.File
 
 /**
@@ -40,6 +43,7 @@ import java.io.File
  * - Signing
  * - SourcesJar
  * - Dokka + JavadocJar
+ * - Kotlin Explicit API Mode
  */
 abstract class PublishPlugin : Plugin<Project> {
 
@@ -48,6 +52,7 @@ abstract class PublishPlugin : Plugin<Project> {
         pluginManager.apply(MavenPublishPlugin::class.java)
         pluginManager.apply(SigningPlugin::class.java)
         pluginManager.apply(DokkaPlugin::class.java)
+        extensions.getByType(KotlinJvmProjectExtension::class.java).explicitApi = ExplicitApiMode.Strict
         val ext = extensions.create("publish", PublishExtension::class.java)
         target.afterEvaluate { publish(ext) }
     }

--- a/lib/isl/build.gradle.kts
+++ b/lib/isl/build.gradle.kts
@@ -28,6 +28,11 @@ dependencies {
     api(Deps.pigRuntime)
 }
 
+// Disabled for ISL project
+kotlin {
+    explicitApi = null
+}
+
 publish {
     artifactId = "partiql-isl-kotlin"
     name = "PartiQL ISL Kotlin"

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -28,6 +28,11 @@ configurations {
     api.get().extendsFrom(libs)
 }
 
+// Disabled for partiql-lang project.
+kotlin {
+    explicitApi = null
+}
+
 dependencies {
     antlr(Deps.antlr)
     api(project(":lib:isl"))

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/BindingCase.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/BindingCase.kt
@@ -15,7 +15,7 @@
 package org.partiql.spi
 
 /** Indicates if the lookup of a particular binding should be case-sensitive or not. */
-enum class BindingCase {
+public enum class BindingCase {
     SENSITIVE,
     INSENSITIVE;
 }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/BindingName.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/BindingName.kt
@@ -17,13 +17,13 @@ package org.partiql.spi
 /**
  * Encapsulates the data necessary to perform a binding lookup.
  */
-data class BindingName(val name: String, val bindingCase: BindingCase) {
+public data class BindingName(val name: String, val bindingCase: BindingCase) {
     val loweredName: String by lazy(LazyThreadSafetyMode.PUBLICATION) { name.toLowerCase() }
 
     /**
      * Compares [name] to [otherName] using the rules specified by [bindingCase].
      */
-    fun isEquivalentTo(otherName: String?) = otherName != null && name.isBindingNameEquivalent(otherName, bindingCase)
+    public fun isEquivalentTo(otherName: String?): Boolean = otherName != null && name.isBindingNameEquivalent(otherName, bindingCase)
 
     /**
      * Compares this string to [other] using the rules specified by [case].

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/BindingPath.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/BindingPath.kt
@@ -14,6 +14,6 @@
 
 package org.partiql.spi
 
-data class BindingPath(
+public data class BindingPath(
     val steps: List<BindingName>
 )

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/ConnectorObject.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/ConnectorObject.kt
@@ -20,4 +20,4 @@ package org.partiql.spi.connector
  * the serialized [org.partiql.types.StaticType], so that the [ConnectorMetadata] may be able
  * to grab the descriptor using [ConnectorMetadata.getObjectType].
  */
-interface ConnectorObject
+public interface ConnectorObject

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/ConnectorObjectHandle.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/ConnectorObjectHandle.kt
@@ -17,7 +17,7 @@ package org.partiql.spi.connector
 /**
  * Holds a PartiQL Value's representation within a Catalog and its location within the Catalog.
  */
-class ConnectorObjectHandle(
-    val absolutePath: ConnectorObjectPath,
-    val value: ConnectorObject
+public class ConnectorObjectHandle(
+    public val absolutePath: ConnectorObjectPath,
+    public val value: ConnectorObject
 )

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/Constants.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/Constants.kt
@@ -15,5 +15,5 @@
 package org.partiql.spi.connector
 
 public object Constants {
-    public const val CONFIG_KEY_CONNECTOR_NAME = "connector_name"
+    public const val CONFIG_KEY_CONNECTOR_NAME: String = "connector_name"
 }

--- a/partiql-types/build.gradle.kts
+++ b/partiql-types/build.gradle.kts
@@ -22,6 +22,11 @@ dependencies {
     implementation(Deps.ionElement)
 }
 
+// TODO: Make this STRICT. See https://github.com/partiql/partiql-lang-kotlin/issues/1078
+kotlin {
+    explicitApi = null
+}
+
 publish {
     artifactId = "partiql-types"
     name = "PartiQL Types"

--- a/partiql-types/build.gradle.kts
+++ b/partiql-types/build.gradle.kts
@@ -22,11 +22,6 @@ dependencies {
     implementation(Deps.ionElement)
 }
 
-// TODO: Make this STRICT. See https://github.com/partiql/partiql-lang-kotlin/issues/1078
-kotlin {
-    explicitApi = null
-}
-
 publish {
     artifactId = "partiql-types"
     name = "PartiQL Types"

--- a/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
@@ -512,7 +512,7 @@ public data class StructType(
      * - If ORDERED: the PartiQL specification says to grab the first encountered matching field.
      * - If UNORDERED: it is implementation-defined. However, gather all possible types, merge them using [AnyOfType].
      */
-    data class Field(
+    public data class Field(
         val key: String,
         val value: StaticType
     )

--- a/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
@@ -10,15 +10,15 @@ import java.math.RoundingMode
 /**
  * Represents static types available in the language and ways to extends them to create new types.
  */
-sealed class StaticType {
-    companion object {
+public sealed class StaticType {
+    public companion object {
 
         /**
          * varargs variant, folds [types] into a [Set]
          * The usage of LinkedHashSet is to preserve the order of `types` to ensure behavior is consistent in our tests
          */
         @JvmStatic
-        fun unionOf(vararg types: StaticType, metas: Map<String, Any> = mapOf()) =
+        public fun unionOf(vararg types: StaticType, metas: Map<String, Any> = mapOf()): StaticType =
             unionOf(types.toSet(), metas)
 
         /**
@@ -29,40 +29,40 @@ sealed class StaticType {
          * @return [StaticType] representing the union of [types]
          */
         @JvmStatic
-        fun unionOf(types: Set<StaticType>, metas: Map<String, Any> = mapOf()): StaticType = AnyOfType(types, metas)
+        public fun unionOf(types: Set<StaticType>, metas: Map<String, Any> = mapOf()): StaticType = AnyOfType(types, metas)
 
         // TODO consider making these into an enumeration...
 
         // Convenient enums to create a bare bones instance of StaticType
-        @JvmField val MISSING: MissingType = MissingType
-        @JvmField val NULL: NullType = NullType()
-        @JvmField val ANY: AnyType = AnyType()
-        @JvmField val NULL_OR_MISSING: StaticType = unionOf(NULL, MISSING)
-        @JvmField val BOOL: BoolType = BoolType()
-        @JvmField val INT2: IntType = IntType(IntType.IntRangeConstraint.SHORT)
-        @JvmField val INT4: IntType = IntType(IntType.IntRangeConstraint.INT4)
-        @JvmField val INT8: IntType = IntType(IntType.IntRangeConstraint.LONG)
-        @JvmField val INT: IntType = IntType(IntType.IntRangeConstraint.UNCONSTRAINED)
-        @JvmField val FLOAT: FloatType = FloatType()
-        @JvmField val DECIMAL: DecimalType = DecimalType()
-        @JvmField val NUMERIC: StaticType = unionOf(INT2, INT4, INT8, INT, FLOAT, DECIMAL)
-        @JvmField val DATE: DateType = DateType()
-        @JvmField val TIME: TimeType = TimeType()
-        @JvmField val TIMESTAMP: TimestampType = TimestampType()
-        @JvmField val SYMBOL: SymbolType = SymbolType()
-        @JvmField val STRING: StringType = StringType()
-        @JvmField val TEXT: StaticType = unionOf(SYMBOL, STRING)
-        @JvmField val CLOB: ClobType = ClobType()
-        @JvmField val BLOB: BlobType = BlobType()
-        @JvmField val LIST: ListType = ListType()
-        @JvmField val SEXP: SexpType = SexpType()
-        @JvmField val STRUCT: StructType = StructType()
-        @JvmField val BAG: BagType = BagType()
-        @JvmField val GRAPH: GraphType = GraphType()
+        @JvmField public val MISSING: MissingType = MissingType
+        @JvmField public val NULL: NullType = NullType()
+        @JvmField public val ANY: AnyType = AnyType()
+        @JvmField public val NULL_OR_MISSING: StaticType = unionOf(NULL, MISSING)
+        @JvmField public val BOOL: BoolType = BoolType()
+        @JvmField public val INT2: IntType = IntType(IntType.IntRangeConstraint.SHORT)
+        @JvmField public val INT4: IntType = IntType(IntType.IntRangeConstraint.INT4)
+        @JvmField public val INT8: IntType = IntType(IntType.IntRangeConstraint.LONG)
+        @JvmField public val INT: IntType = IntType(IntType.IntRangeConstraint.UNCONSTRAINED)
+        @JvmField public val FLOAT: FloatType = FloatType()
+        @JvmField public val DECIMAL: DecimalType = DecimalType()
+        @JvmField public val NUMERIC: StaticType = unionOf(INT2, INT4, INT8, INT, FLOAT, DECIMAL)
+        @JvmField public val DATE: DateType = DateType()
+        @JvmField public val TIME: TimeType = TimeType()
+        @JvmField public val TIMESTAMP: TimestampType = TimestampType()
+        @JvmField public val SYMBOL: SymbolType = SymbolType()
+        @JvmField public val STRING: StringType = StringType()
+        @JvmField public val TEXT: StaticType = unionOf(SYMBOL, STRING)
+        @JvmField public val CLOB: ClobType = ClobType()
+        @JvmField public val BLOB: BlobType = BlobType()
+        @JvmField public val LIST: ListType = ListType()
+        @JvmField public val SEXP: SexpType = SexpType()
+        @JvmField public val STRUCT: StructType = StructType()
+        @JvmField public val BAG: BagType = BagType()
+        @JvmField public val GRAPH: GraphType = GraphType()
 
         /** All the StaticTypes, except for `ANY`. */
         @JvmStatic
-        val ALL_TYPES = listOf(
+        public val ALL_TYPES: List<SingleType> = listOf(
             MISSING,
             NULL,
             BOOL,
@@ -92,7 +92,7 @@ sealed class StaticType {
      *
      *  If it already nullable, returns the original type.
      */
-    fun asNullable() =
+    public fun asNullable(): StaticType =
         when {
             this.isNullable() -> this
             else -> unionOf(this, NULL).flatten()
@@ -103,20 +103,20 @@ sealed class StaticType {
      *
      *  If it already optional, returns the original type.
      */
-    fun asOptional() =
+    public fun asOptional(): StaticType =
         when {
             this.isOptional() -> this
             else -> unionOf(this, MISSING).flatten()
         }
 
-    abstract val metas: Map<String, Any>
+    public abstract val metas: Map<String, Any>
 
     /**
      * Convenience method to copy over StaticType to a new instance with given `metas`
      * MissingType is a singleton and there can only be one representation for it
      * i.e. you cannot have two instances of MissingType with different metas.
      */
-    fun withMetas(metas: Map<String, Any>): StaticType =
+    public fun withMetas(metas: Map<String, Any>): StaticType =
         when (this) {
             is AnyType -> copy(metas = metas)
             is ListType -> copy(metas = metas)
@@ -143,7 +143,7 @@ sealed class StaticType {
     /**
      * Type is nullable if it is of Null type or is an AnyOfType that contains a Null type
      */
-    fun isNullable(): Boolean =
+    public fun isNullable(): Boolean =
         when (this) {
             is AnyOfType -> types.any { it.isNullable() }
             is AnyType, is NullType -> true
@@ -153,7 +153,7 @@ sealed class StaticType {
     /**
      * Type is optional if it is Any, or Missing, or an AnyOfType that contains Any or Missing type
      */
-    internal fun isOptional(): Boolean =
+    private fun isOptional(): Boolean =
         when (this) {
             is AnyType, MissingType -> true // Any includes Missing type
             is AnyOfType -> types.any { it.isOptional() }
@@ -168,7 +168,7 @@ sealed class StaticType {
      */
     public abstract val allTypes: List<StaticType>
 
-    abstract fun flatten(): StaticType
+    public abstract fun flatten(): StaticType
 }
 
 /**
@@ -176,12 +176,12 @@ sealed class StaticType {
  */
 // TODO: Remove `NULL` from here. This affects inference as operations (especially NAry) can produce
 //  `NULL` or `MISSING` depending on a null propagation or an incorrect argument.
-data class AnyType(override val metas: Map<String, Any> = mapOf()) : StaticType() {
+public data class AnyType(override val metas: Map<String, Any> = mapOf()) : StaticType() {
     /**
      * Converts this into an [AnyOfType] representation. This method is helpful in inference when
      * it wants to iterate over all possible types of an expression.
      */
-    fun toAnyOfType() = AnyOfType(ALL_TYPES.toSet())
+    public fun toAnyOfType(): AnyOfType = AnyOfType(ALL_TYPES.toSet())
 
     override fun flatten(): StaticType = this
 
@@ -192,27 +192,27 @@ data class AnyType(override val metas: Map<String, Any> = mapOf()) : StaticType(
 }
 
 /**
- * Represents a [StaticType] that is type of a single [ExprValueType].
+ * Represents a [StaticType] that is type of a single [StaticType].
  */
-sealed class SingleType : StaticType() {
+public sealed class SingleType : StaticType() {
     override fun flatten(): StaticType = this
 }
 
 /**
- * Exception thrown when [StaticType.isInstance] cannot perform a type check because of a temporarily unimplemented
- * code path.
+ * Exception thrown when [StaticTypeUtils.isInstance](https://javadoc.io/doc/org.partiql/partiql-lang-kotlin/latest/partiql-lang/org.partiql.lang.types/-static-type-utils/is-instance.html)
+ * cannot perform a type check because of a temporarily unimplemented code path.
  *
  * This exception type needs to exist so that the callers can catch it explicitly and disambiguate from the more
  * generic [NotImplementedError].
  */
-class UnsupportedTypeCheckException(message: String) : RuntimeException(message)
+public class UnsupportedTypeCheckException(message: String) : RuntimeException(message)
 
 /**
  * Represents collection types i.e list, bag and sexp.
  */
-sealed class CollectionType : SingleType() {
-    abstract val elementType: StaticType
-    abstract val constraints: Set<CollectionConstraint>
+public sealed class CollectionType : SingleType() {
+    public abstract val elementType: StaticType
+    public abstract val constraints: Set<CollectionConstraint>
 
     internal fun validateCollectionConstraints() {
         if (elementType !is StructType && constraints.any { it is TupleCollectionConstraint }) {
@@ -224,7 +224,7 @@ sealed class CollectionType : SingleType() {
 /**
  * Exception thrown when a [StaticType] is initialized with an unsupported type constraint.
  */
-class UnsupportedTypeConstraint(message: String) : Exception(message)
+public class UnsupportedTypeConstraint(message: String) : Exception(message)
 
 // Single types from ExprValueType.
 
@@ -233,7 +233,7 @@ class UnsupportedTypeConstraint(message: String) : Exception(message)
  *
  * This is not a singleton since there may be more that one representation of a Null type (each with different metas)
  */
-data class NullType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
+public data class NullType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
     override val allTypes: List<StaticType>
         get() = listOf(this)
 
@@ -246,7 +246,7 @@ data class NullType(override val metas: Map<String, Any> = mapOf()) : SingleType
  * This is a singleton unlike the rest of the types as there cannot be
  * more that one representations of a missing type.
  */
-object MissingType : SingleType() {
+public object MissingType : SingleType() {
     override val metas: Map<String, Any> = mapOf()
 
     override val allTypes: List<StaticType>
@@ -255,19 +255,19 @@ object MissingType : SingleType() {
     override fun toString(): String = "missing"
 }
 
-data class BoolType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
+public data class BoolType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
     override val allTypes: List<StaticType>
         get() = listOf(this)
 
     override fun toString(): String = "bool"
 }
 
-data class IntType(
+public data class IntType(
     val rangeConstraint: IntRangeConstraint = IntRangeConstraint.UNCONSTRAINED,
     override val metas: Map<String, Any> = mapOf()
 ) : SingleType() {
 
-    enum class IntRangeConstraint(val numBytes: Int, val validRange: LongRange) {
+    public enum class IntRangeConstraint(public val numBytes: Int, public val validRange: LongRange) {
         /** SQL's SMALLINT (2 Bytes) */
         SHORT(2, Short.MIN_VALUE.toLong()..Short.MAX_VALUE.toLong()),
 
@@ -294,27 +294,27 @@ data class IntType(
         }
 }
 
-data class FloatType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
+public data class FloatType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
     override val allTypes: List<StaticType>
         get() = listOf(this)
 
     override fun toString(): String = "float"
 }
 
-data class DecimalType(
+public data class DecimalType(
     val precisionScaleConstraint: PrecisionScaleConstraint = PrecisionScaleConstraint.Unconstrained,
     override val metas: Map<String, Any> = mapOf()
 ) : SingleType() {
 
-    sealed class PrecisionScaleConstraint {
-        abstract fun matches(d: BigDecimal): Boolean
+    public sealed class PrecisionScaleConstraint {
+        public abstract fun matches(d: BigDecimal): Boolean
 
         // TODO: Do we need unconstrained precision and scale? What's our limit?
-        object Unconstrained : PrecisionScaleConstraint() {
+        public object Unconstrained : PrecisionScaleConstraint() {
             override fun matches(d: BigDecimal): Boolean = true
         }
 
-        data class Constrained(val precision: Int, val scale: Int = 0) : PrecisionScaleConstraint() {
+        public data class Constrained(val precision: Int, val scale: Int = 0) : PrecisionScaleConstraint() {
             override fun matches(d: BigDecimal): Boolean {
                 // check scale
                 val decimalPoint = if (d.scale() >= 0) d.scale() else 0
@@ -339,14 +339,14 @@ data class DecimalType(
     override fun toString(): String = "decimal"
 }
 
-data class DateType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
+public data class DateType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
     override val allTypes: List<StaticType>
         get() = listOf(this)
 
     override fun toString(): String = "date"
 }
 
-data class TimeType(
+public data class TimeType(
     val precision: Int? = null,
     val withTimeZone: Boolean = false,
     override val metas: Map<String, Any> = mapOf()
@@ -360,28 +360,28 @@ data class TimeType(
     }
 }
 
-data class TimestampType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
+public data class TimestampType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
     override val allTypes: List<StaticType>
         get() = listOf(this)
 
     override fun toString(): String = "timestamp"
 }
 
-data class SymbolType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
+public data class SymbolType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
     override val allTypes: List<StaticType>
         get() = listOf(this)
 
     override fun toString(): String = "symbol"
 }
 
-data class StringType(
+public data class StringType(
     val lengthConstraint: StringLengthConstraint = StringLengthConstraint.Unconstrained,
     override val metas: Map<String, Any> = mapOf()
 ) : SingleType() {
 
-    sealed class StringLengthConstraint {
-        object Unconstrained : StringLengthConstraint()
-        data class Constrained(val length: NumberConstraint) : StringLengthConstraint()
+    public sealed class StringLengthConstraint {
+        public object Unconstrained : StringLengthConstraint()
+        public data class Constrained(val length: NumberConstraint) : StringLengthConstraint()
     }
 
     override val allTypes: List<StaticType>
@@ -389,17 +389,17 @@ data class StringType(
 
     override fun toString(): String = "string"
 
-    constructor(numberConstraint: NumberConstraint) : this(StringLengthConstraint.Constrained(numberConstraint))
+    public constructor(numberConstraint: NumberConstraint) : this(StringLengthConstraint.Constrained(numberConstraint))
 }
 
-data class BlobType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
+public data class BlobType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
     override val allTypes: List<StaticType>
         get() = listOf(this)
 
     override fun toString(): String = "blob"
 }
 
-data class ClobType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
+public data class ClobType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
     override val allTypes: List<StaticType>
         get() = listOf(this)
 
@@ -409,7 +409,7 @@ data class ClobType(override val metas: Map<String, Any> = mapOf()) : SingleType
 /**
  * @param [elementType] type of element within the list.
  */
-data class ListType(
+public data class ListType(
     override val elementType: StaticType = ANY,
     override val metas: Map<String, Any> = mapOf(),
     override val constraints: Set<CollectionConstraint> = setOf()
@@ -429,7 +429,7 @@ data class ListType(
 /**
  * @param [elementType] type of element within the s-exp.
  */
-data class SexpType(
+public data class SexpType(
     override val elementType: StaticType = ANY,
     override val metas: Map<String, Any> = mapOf(),
     override val constraints: Set<CollectionConstraint> = setOf(),
@@ -448,7 +448,7 @@ data class SexpType(
 /**
  * @param [elementType] type of element within the bag.
  */
-data class BagType(
+public data class BagType(
     override val elementType: StaticType = ANY,
     override val metas: Map<String, Any> = mapOf(),
     override val constraints: Set<CollectionConstraint> = setOf(),
@@ -464,7 +464,7 @@ data class BagType(
     override fun toString(): String = "bag($elementType)"
 }
 
-data class StructType(
+public data class StructType(
     val fields: Map<String, StaticType> = mapOf(),
     // `TupleConstraint` already has `Open` constraint which overlaps with `contentClosed`.
     // In addition, `primaryKeyFields` must not exist on the `StructType` as `PrimaryKey`
@@ -494,7 +494,7 @@ data class StructType(
     }
 }
 
-data class GraphType(
+public data class GraphType(
     override val metas: Map<String, Any> = mapOf()
 ) : SingleType() {
 
@@ -507,7 +507,7 @@ data class GraphType(
 /**
  * Represents a [StaticType] that's defined by the union of multiple [StaticType]s.
  */
-data class AnyOfType(val types: Set<StaticType>, override val metas: Map<String, Any> = mapOf()) : StaticType() {
+public data class AnyOfType(val types: Set<StaticType>, override val metas: Map<String, Any> = mapOf()) : StaticType() {
     /**
      * Flattens a union type by traversing the types and recursively bubbling up the underlying union types.
      *
@@ -549,18 +549,18 @@ data class AnyOfType(val types: Set<StaticType>, override val metas: Map<String,
         get() = this.types.map { it.flatten() }
 }
 
-sealed class NumberConstraint {
+public sealed class NumberConstraint {
 
     /** Returns true of [num] matches the constraint. */
-    abstract fun matches(num: Int): Boolean
+    public abstract fun matches(num: Int): Boolean
 
-    abstract val value: Int
+    public abstract val value: Int
 
-    data class Equals(override val value: Int) : NumberConstraint() {
+    public data class Equals(override val value: Int) : NumberConstraint() {
         override fun matches(num: Int): Boolean = value == num
     }
 
-    data class UpTo(override val value: Int) : NumberConstraint() {
+    public data class UpTo(override val value: Int) : NumberConstraint() {
         override fun matches(num: Int): Boolean = value >= num
     }
 }
@@ -571,15 +571,15 @@ sealed class NumberConstraint {
  * - https://github.com/partiql/partiql-spec/issues/49
  * - https://github.com/partiql/partiql-docs/issues/37
  */
-sealed class TupleConstraint {
-    data class UniqueAttrs(val value: Boolean) : TupleConstraint()
-    data class Open(val value: Boolean) : TupleConstraint()
+public sealed class TupleConstraint {
+    public data class UniqueAttrs(val value: Boolean) : TupleConstraint()
+    public data class Open(val value: Boolean) : TupleConstraint()
 }
 
 /**
  * An Interface for constraints that are only applicable to collection of tuples, e.g. `PrimaryKey`.
  */
-interface TupleCollectionConstraint
+public interface TupleCollectionConstraint
 
 /**
  * Represents Collection constraints; this is still experimental.
@@ -587,13 +587,12 @@ interface TupleCollectionConstraint
  * - https://github.com/partiql/partiql-spec/issues/49
  * - https://github.com/partiql/partiql-docs/issues/37
  */
-sealed class CollectionConstraint {
-    data class PrimaryKey(val keys: Set<String>) : TupleCollectionConstraint, CollectionConstraint()
-    data class PartitionKey(val keys: Set<String>) : TupleCollectionConstraint, CollectionConstraint()
+public sealed class CollectionConstraint {
+    public data class PrimaryKey(val keys: Set<String>) : TupleCollectionConstraint, CollectionConstraint()
+    public data class PartitionKey(val keys: Set<String>) : TupleCollectionConstraint, CollectionConstraint()
 }
 
 internal fun StaticType.isNullOrMissing(): Boolean = (this is NullType || this is MissingType)
 internal fun StaticType.isNumeric(): Boolean = (this is IntType || this is FloatType || this is DecimalType)
 internal fun StaticType.isText(): Boolean = (this is SymbolType || this is StringType)
-internal fun StaticType.isLob(): Boolean = (this is BlobType || this is ClobType)
 internal fun StaticType.isUnknown(): Boolean = (this.isNullOrMissing() || this == StaticType.NULL_OR_MISSING)


### PR DESCRIPTION
## Relevant Issues
- Closes #1079
- Closes #1080
- Closes #1077
- Closes #1078 

## Description
- Adds Explicit API Mode to the Publishing Plugin (so that all projects intending to publish will have STRICT Explicit API Mode enabled)
- Allows `partiql-lang` and `isl` to be excluded.
  - `lang` will eventually be deprecated/removed
  - `isl` may eventually be deprecated/removed

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
  - No. No changes facing the end user.
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.