### PR TITLE
Fixes JOIN Predicate and Allows Duplicates in StructType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     externally-defined graphs into the evaluation environment. 
   - Evaluation of straight-path patterns with simple label matching and 
     all directed/undirected edge patterns.
-- Adds new attribute, `isOrdered`, to StructType. See the KDoc for more information.
+- Adds new `TupleConstraint` variant, `IsOrdered`, to represent ordering in `StructType`. See the KDoc for more information.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     externally-defined graphs into the evaluation environment. 
   - Evaluation of straight-path patterns with simple label matching and 
     all directed/undirected edge patterns.
+- Adds new attribute, `isOrdered`, to StructType. See the KDoc for more information.
 
 ### Changed
 
@@ -46,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixes the ability for JOIN predicates to access the FROM source aliases and columns.
+- Fixes the ability for JOIN predicates to access the FROM source aliases and corresponding attributes.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     externally-defined graphs into the evaluation environment. 
   - Evaluation of straight-path patterns with simple label matching and 
     all directed/undirected edge patterns.
-- Adds new `TupleConstraint` variant, `IsOrdered`, to represent ordering in `StructType`. See the KDoc for more information.
+- Adds new `TupleConstraint` variant, `Ordered`, to represent ordering in `StructType`. See the KDoc for more information.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking**: The `fields` attribute of `org.partiql.types.StructType` is no longer a `Map<String, StaticType>`. It is
+  now a `List<org.partiql.types.StructType.Field>`, where `Field` contains a `key (String)` and `value (StaticType)`. This
+  is to allow duplicates within the `StructType`.
+
 ### Deprecated
 
 ### Fixed
+
+- Fixes the ability for JOIN predicates to access the FROM source aliases and columns.
 
 ### Removed
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/mappers/IonSchemaMapper.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/mappers/IonSchemaMapper.kt
@@ -378,12 +378,12 @@ class IonSchemaMapper(private val staticType: StaticType) {
         return IonSchemaModel.build { inlineType(toTypeDefinition(topLevelTypeName), ionBool(nullable)) }.flatten()
     }
 
-    private fun Map<String, StaticType>.toFieldList(topLevelTypeName: String): List<IonSchemaModel.Field> =
+    private fun List<StructType.Field>.toFieldList(topLevelTypeName: String): List<IonSchemaModel.Field> =
         mapNotNull {
             it.toFieldOrNull(topLevelTypeName)
         }
 
-    private fun Map.Entry<String, StaticType>.toFieldOrNull(topLevelTypeName: String): IonSchemaModel.Field? =
+    private fun StructType.Field.toFieldOrNull(topLevelTypeName: String): IonSchemaModel.Field? =
         if (value is MissingType || (value is AnyOfType && (value as AnyOfType).flatten() is MissingType)) {
             // Skip field altogether
             null
@@ -502,7 +502,7 @@ private fun StaticType.visit(accumulator: TypeDefMap): TypeDefMap {
             current = this.elementType.visit(current)
         }
         is StructType -> {
-            this.fields.mapValues { current = it.value.visit(current) } // visit fields
+            this.fields.map { it.value }.map { current = it.visit(current) } // visit fields
         }
         is AnyOfType -> {
             when (val flattenedType = flatten()) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/PlannerSession.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/PlannerSession.kt
@@ -26,6 +26,13 @@ import java.time.Instant
  * @param currentCatalog the current catalog of the session
  * @param currentDirectory the current "namespace" within the Catalog. This will aid in building
  * [org.partiql.spi.connector.ConnectorObjectPath]'s for unresolved variables.
+ * @param catalogConfig a map where each key represents a catalog's name, and each value represents the configuration
+ *  ([StructElement]) for the corresponding [org.partiql.spi.connector.Connector]. The [StructElement] has a single mandatory
+ *  key-value pair, with the key being [org.partiql.spi.connector.Constants.CONFIG_KEY_CONNECTOR_NAME] and the value
+ *  being the [com.amazon.ionelement.api.StringElement] representing the name of the corresponding [org.partiql.spi.connector.Connector].
+ *  The [StructElement] *may* include other key-value pairs that are required/optional by the [org.partiql.spi.connector.Connector].
+ *  This [StructElement] will be passed to [org.partiql.spi.connector.Connector.Factory.create] to create the
+ *  [org.partiql.spi.connector.Connector].
  * @param instant the instant evaluation begins
  */
 public class PlannerSession(

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/PlanTyper.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/PlanTyper.kt
@@ -435,8 +435,7 @@ internal object PlanTyper : PlanRewriter<PlanTyper.Context>() {
                                 StructType.Field(attribute.name, attribute.type)
                             },
                             contentClosed = true,
-                            isOrdered = true,
-                            constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                            constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                         )
                     )
                 )

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/PlanTyper.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/PlanTyper.kt
@@ -435,7 +435,7 @@ internal object PlanTyper : PlanRewriter<PlanTyper.Context>() {
                                 StructType.Field(attribute.name, attribute.type)
                             },
                             contentClosed = true,
-                            constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                            constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                         )
                     )
                 )

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/ReferenceResolver.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/ReferenceResolver.kt
@@ -21,6 +21,7 @@ import org.partiql.spi.BindingPath
 import org.partiql.spi.connector.ConnectorObjectPath
 import org.partiql.types.StaticType
 import org.partiql.types.StructType
+import org.partiql.types.TupleConstraint
 
 internal object ReferenceResolver {
 
@@ -88,7 +89,7 @@ internal object ReferenceResolver {
     internal fun inferStructLookup(
         struct: StructType,
         key: BindingName,
-    ): StaticType? = when (struct.isOrdered) {
+    ): StaticType? = when (struct.constraints.contains(TupleConstraint.IsOrdered)) {
         true -> struct.fields.firstOrNull { entry ->
             key.isEquivalentTo(entry.key)
         }?.value

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/ReferenceResolver.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/ReferenceResolver.kt
@@ -89,7 +89,7 @@ internal object ReferenceResolver {
     internal fun inferStructLookup(
         struct: StructType,
         key: BindingName,
-    ): StaticType? = when (struct.constraints.contains(TupleConstraint.IsOrdered)) {
+    ): StaticType? = when (struct.constraints.contains(TupleConstraint.Ordered)) {
         true -> struct.fields.firstOrNull { entry ->
             key.isEquivalentTo(entry.key)
         }?.value

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/types/StaticTypeUtils.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/types/StaticTypeUtils.kt
@@ -244,9 +244,9 @@ public object StaticTypeUtils {
     private fun StructType.isInstanceOf(value: ExprValue) = when {
         value.type != ExprValueType.STRUCT -> false
         fields.isEmpty() && !contentClosed -> true
-        this.constraints.contains(TupleConstraint.IsOrdered) && value.asFacet(OrderedBindNames::class.java) == null -> false
+        this.constraints.contains(TupleConstraint.Ordered) && value.asFacet(OrderedBindNames::class.java) == null -> false
         else -> {
-            when (this.constraints.contains(TupleConstraint.IsOrdered)) {
+            when (this.constraints.contains(TupleConstraint.Ordered)) {
                 false -> {
                     // build a multi-map of fields in the struct.
                     val scratchPad = HashMap<String, MutableList<ExprValue>>().also { map ->

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/types/StaticTypeUtils.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/types/StaticTypeUtils.kt
@@ -34,6 +34,7 @@ import org.partiql.types.StructType
 import org.partiql.types.SymbolType
 import org.partiql.types.TimeType
 import org.partiql.types.TimestampType
+import org.partiql.types.TupleConstraint
 import org.partiql.types.UnsupportedTypeCheckException
 import java.math.BigDecimal
 
@@ -243,9 +244,9 @@ public object StaticTypeUtils {
     private fun StructType.isInstanceOf(value: ExprValue) = when {
         value.type != ExprValueType.STRUCT -> false
         fields.isEmpty() && !contentClosed -> true
-        this.isOrdered && value.asFacet(OrderedBindNames::class.java) == null -> false
+        this.constraints.contains(TupleConstraint.IsOrdered) && value.asFacet(OrderedBindNames::class.java) == null -> false
         else -> {
-            when (this.isOrdered) {
+            when (this.constraints.contains(TupleConstraint.IsOrdered)) {
                 false -> {
                     // build a multi-map of fields in the struct.
                     val scratchPad = HashMap<String, MutableList<ExprValue>>().also { map ->

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/types/StaticTypeUtils.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/types/StaticTypeUtils.kt
@@ -6,6 +6,7 @@ import org.partiql.lang.ast.passes.inference.isText
 import org.partiql.lang.ast.passes.inference.isUnknown
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueType
+import org.partiql.lang.eval.OrderedBindNames
 import org.partiql.lang.eval.name
 import org.partiql.lang.eval.numberValue
 import org.partiql.lang.eval.stringValue
@@ -240,57 +241,73 @@ public object StaticTypeUtils {
      * [StructType].  We do not even have the ability to model that with Ion/Ion Schema anyway.
      */
     private fun StructType.isInstanceOf(value: ExprValue) = when {
-        fields.isEmpty() && !contentClosed -> value.type == ExprValueType.STRUCT
+        value.type != ExprValueType.STRUCT -> false
+        fields.isEmpty() && !contentClosed -> true
+        this.isOrdered && value.asFacet(OrderedBindNames::class.java) == null -> false
         else -> {
-            if (value.type != ExprValueType.STRUCT) {
-                false
-            } else {
-                // build a multi-map of fields in the struct.
-                val scratchPad = HashMap<String, MutableList<ExprValue>>().also { map ->
-                    value.forEach { v ->
-                        // return false early if the struct key is not a string or symbol.
-                        val structKey = v.name.takeIf { it?.type?.isText ?: false } ?: return false
-                        map.getOrPut(structKey.stringValue()) { ArrayList() }.add(v)
-                    }
-                }
-
-                // Consolidates fields to check that the ExprValue sufficiently conforms to the StaticType
-                //  defined in the consolidated field
-                val consolidatedFields = fields.groupBy({ it.key }) { it.value }.map {
-                    StructType.Field(
-                        it.key,
-                        StaticType.unionOf(it.value.toSet()).flatten()
-                    )
-                }
-
-                // now go thru each of the [fields] and remove those that are valid
-                consolidatedFields.forEach { (fieldName, fieldType) ->
-                    val fieldValues = scratchPad.remove(fieldName)
-
-                    // Field was *not* present
-                    if (fieldValues == null) {
-                        // if field was required, the struct is not an instance of this [StructType]
-                        if (!fieldType.isOptional()) {
-                            return false
+            when (this.isOrdered) {
+                false -> {
+                    // build a multi-map of fields in the struct.
+                    val scratchPad = HashMap<String, MutableList<ExprValue>>().also { map ->
+                        value.forEach { v ->
+                            // return false early if the struct key is not a string or symbol.
+                            val structKey = v.name.takeIf { it?.type?.isText ?: false } ?: return false
+                            map.getOrPut(structKey.stringValue()) { ArrayList() }.add(v)
                         }
-                        // else there is no violation, keep checking other fields
+                    }
+
+                    // Consolidates fields to check that the ExprValue sufficiently conforms to the StaticType
+                    //  defined in the consolidated field
+                    val consolidatedFields = fields.groupBy({ it.key }) { it.value }.map {
+                        StructType.Field(
+                            it.key,
+                            StaticType.unionOf(it.value.toSet()).flatten()
+                        )
+                    }
+
+                    // now go thru each of the [fields] and remove those that are valid
+                    consolidatedFields.forEach { (fieldName, fieldType) ->
+                        val fieldValues = scratchPad.remove(fieldName)
+
+                        // Field was *not* present
+                        if (fieldValues == null) {
+                            // if field was required, the struct is not an instance of this [StructType]
+                            if (!fieldType.isOptional()) {
+                                return false
+                            }
+                            // else there is no violation, keep checking other fields
+                        } else {
+                            // in the case of multiple fields with the same name, all values must match
+                            if (!fieldValues.all { isInstance(it, fieldType) }) {
+                                return false
+                            }
+                            // else there is no violation, keep checking other fields
+                        }
+                    }
+
+                    // if we reach this point, we didn't find any fields that do not comply with their final types.
+
+                    // If no fields remain [value] is an instance of this [StaticType]
+                    if (scratchPad.none()) {
+                        true
                     } else {
-                        // in the case of multiple fields with the same name, all values must match
-                        if (!fieldValues.all { isInstance(it, fieldType) }) {
-                            return false
-                        }
-                        // else there is no violation, keep checking other fields
+                        // There are some fields left over, so we only need to check if we are closedContent or not.
+                        !contentClosed
                     }
                 }
-
-                // if we reach this point, we didn't find any fields that do not comply with their final types.
-
-                // If no fields remain [value] is an instance of this [StaticType]
-                if (scratchPad.none()) {
+                true -> {
+                    value.asFacet(OrderedBindNames::class.java)?.orderedNames.let { orderedNames ->
+                        if (orderedNames == null) { return false }
+                        val fieldNames = this.fields.map { it.key }
+                        if (fieldNames != orderedNames) { return false }
+                    }
+                    this.fields.forEachIndexed { index, field ->
+                        val attrValue = value.ordinalBindings[index] ?: return false
+                        if (isInstance(attrValue, field.value).not()) {
+                            return false
+                        }
+                    }
                     true
-                } else {
-                    // There are some fields left over, so we only need to check if we are closedContent or not.
-                    !contentClosed
                 }
             }
         }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/types/StaticTypeUtils.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/types/StaticTypeUtils.kt
@@ -254,8 +254,17 @@ public object StaticTypeUtils {
                     }
                 }
 
+                // Consolidates fields to check that the ExprValue sufficiently conforms to the StaticType
+                //  defined in the consolidated field
+                val consolidatedFields = fields.groupBy({ it.key }) { it.value }.map {
+                    StructType.Field(
+                        it.key,
+                        StaticType.unionOf(it.value.toSet()).flatten()
+                    )
+                }
+
                 // now go thru each of the [fields] and remove those that are valid
-                fields.forEach { (fieldName, fieldType) ->
+                consolidatedFields.forEach { (fieldName, fieldType) ->
                     val fieldValues = scratchPad.remove(fieldName)
 
                     // Field was *not* present

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
@@ -63,28 +63,28 @@ class PartiQLSchemaInferencerTests {
                     "breed" to TYPE_AWS_DDB_PETS_BREED
                 ),
                 contentClosed = true,
-                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
             )
         )
         val TABLE_AWS_DDB_B = BagType(
             StructType(
                 fields = mapOf("identifier" to StaticType.STRING),
                 contentClosed = true,
-                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
             )
         )
         val TABLE_AWS_B_B = BagType(
             StructType(
                 fields = mapOf("identifier" to StaticType.INT),
                 contentClosed = true,
-                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
             )
         )
         val TYPE_B_B_B_B_B = StaticType.INT
         private val TYPE_B_B_B_B = StructType(
             mapOf("b" to TYPE_B_B_B_B_B),
             contentClosed = true,
-            constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+            constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
         )
         val TYPE_B_B_B_C = StaticType.INT
         val TYPE_B_B_C = StaticType.INT
@@ -95,7 +95,7 @@ class PartiQLSchemaInferencerTests {
                     "c" to TYPE_B_B_B_C
                 ),
                 contentClosed = true,
-                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
             )
     }
 
@@ -140,7 +140,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("pets" to StaticType.ANY),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 ),
                 problemHandler = assertProblemExists {
@@ -158,7 +158,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("pets" to StaticType.ANY),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 ),
                 problemHandler = assertProblemExists {
@@ -210,7 +210,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("pets" to StaticType.ANY),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 ),
                 problemHandler = assertProblemExists {
@@ -555,7 +555,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("unknown_col" to AnyType()),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 ),
                 problemHandler = assertProblemExists {
@@ -635,7 +635,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("cast_breed" to unionOf(StaticType.INT, StaticType.MISSING)),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -648,7 +648,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("upper_breed" to StaticType.STRING),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -659,7 +659,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("a" to ListType(unionOf(StaticType.INT, StaticType.DECIMAL))),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -692,7 +692,7 @@ class PartiQLSchemaInferencerTests {
                             "b" to StaticType.DECIMAL,
                         ),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -706,7 +706,7 @@ class PartiQLSchemaInferencerTests {
                             "b" to StaticType.DECIMAL,
                         ),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -720,7 +720,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.INT),
                         ),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -734,7 +734,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.DECIMAL),
                         ),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -748,7 +748,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.DECIMAL),
                         ),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -773,7 +773,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.STRING),
                         ),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -791,7 +791,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", unionOf(INT, STRING))
                         ),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -807,7 +807,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("e", INT)
                         ),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -821,7 +821,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.DECIMAL),
                         ),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 ),
                 problemHandler = assertProblemExists {
@@ -845,7 +845,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", unionOf(INT, STRING))
                         ),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -861,7 +861,7 @@ class PartiQLSchemaInferencerTests {
                             "m" to StaticType.INT,
                         ),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),
@@ -877,7 +877,7 @@ class PartiQLSchemaInferencerTests {
                             "m" to StaticType.DECIMAL,
                         ),
                         contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 )
             ),

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
@@ -63,32 +63,28 @@ class PartiQLSchemaInferencerTests {
                     "breed" to TYPE_AWS_DDB_PETS_BREED
                 ),
                 contentClosed = true,
-                isOrdered = true,
-                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
             )
         )
         val TABLE_AWS_DDB_B = BagType(
             StructType(
                 fields = mapOf("identifier" to StaticType.STRING),
                 contentClosed = true,
-                isOrdered = true,
-                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
             )
         )
         val TABLE_AWS_B_B = BagType(
             StructType(
                 fields = mapOf("identifier" to StaticType.INT),
                 contentClosed = true,
-                isOrdered = true,
-                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
             )
         )
         val TYPE_B_B_B_B_B = StaticType.INT
         private val TYPE_B_B_B_B = StructType(
             mapOf("b" to TYPE_B_B_B_B_B),
             contentClosed = true,
-            isOrdered = true,
-            constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+            constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
         )
         val TYPE_B_B_B_C = StaticType.INT
         val TYPE_B_B_C = StaticType.INT
@@ -99,8 +95,7 @@ class PartiQLSchemaInferencerTests {
                     "c" to TYPE_B_B_B_C
                 ),
                 contentClosed = true,
-                isOrdered = true,
-                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
             )
     }
 
@@ -145,8 +140,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("pets" to StaticType.ANY),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 ),
                 problemHandler = assertProblemExists {
@@ -164,8 +158,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("pets" to StaticType.ANY),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 ),
                 problemHandler = assertProblemExists {
@@ -217,8 +210,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("pets" to StaticType.ANY),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 ),
                 problemHandler = assertProblemExists {
@@ -563,8 +555,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("unknown_col" to AnyType()),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 ),
                 problemHandler = assertProblemExists {
@@ -644,8 +635,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("cast_breed" to unionOf(StaticType.INT, StaticType.MISSING)),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -658,8 +648,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("upper_breed" to StaticType.STRING),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -670,8 +659,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("a" to ListType(unionOf(StaticType.INT, StaticType.DECIMAL))),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -704,8 +692,7 @@ class PartiQLSchemaInferencerTests {
                             "b" to StaticType.DECIMAL,
                         ),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -719,8 +706,7 @@ class PartiQLSchemaInferencerTests {
                             "b" to StaticType.DECIMAL,
                         ),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -734,8 +720,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.INT),
                         ),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -749,8 +734,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.DECIMAL),
                         ),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -764,8 +748,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.DECIMAL),
                         ),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -790,8 +773,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.STRING),
                         ),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -809,8 +791,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", unionOf(INT, STRING))
                         ),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -826,8 +807,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("e", INT)
                         ),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -841,8 +821,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.DECIMAL),
                         ),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 ),
                 problemHandler = assertProblemExists {
@@ -866,8 +845,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", unionOf(INT, STRING))
                         ),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -883,8 +861,7 @@ class PartiQLSchemaInferencerTests {
                             "m" to StaticType.INT,
                         ),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),
@@ -900,8 +877,7 @@ class PartiQLSchemaInferencerTests {
                             "m" to StaticType.DECIMAL,
                         ),
                         contentClosed = true,
-                        isOrdered = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 )
             ),

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
@@ -777,26 +777,6 @@ class PartiQLSchemaInferencerTests {
                     )
                 )
             ),
-            ErrorTestCase(
-                name = "LEFT JOIN Ambiguous Reference in ON",
-                query = "SELECT * FROM <<{ 'a': 1 }>> AS t1 LEFT JOIN <<{ 'a': 2.0 }>> AS t2 ON a = 3",
-                expected = BagType(
-                    StructType(
-                        fields = listOf(
-                            StructType.Field("a", StaticType.INT),
-                            StructType.Field("a", StaticType.DECIMAL),
-                        ),
-                        contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
-                    )
-                ),
-                problemHandler = assertProblemExists {
-                    Problem(
-                        UNKNOWN_SOURCE_LOCATION,
-                        PlanningProblemDetails.UndefinedVariable("a", false)
-                    )
-                }
-            ),
             SuccessTestCase(
                 name = "Duplicate fields in struct",
                 query = """
@@ -832,54 +812,6 @@ class PartiQLSchemaInferencerTests {
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
-            ),
-            ErrorTestCase(
-                name = "Ambiguous reference to bindings environment",
-                query = """
-                    SELECT t.a
-                    FROM <<
-                        { 'a': 1, 'a': 'hello' }
-                    >> AS t, << 0 >> AS t
-                """,
-                expected = BagType(
-                    StructType(
-                        fields = listOf(
-                            StructType.Field("a", StaticType.ANY),
-                        ),
-                        contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
-                    )
-                ),
-                problemHandler = assertProblemExists {
-                    Problem(
-                        UNKNOWN_SOURCE_LOCATION,
-                        PlanningProblemDetails.UndefinedVariable("a", false)
-                    )
-                }
-            ),
-            ErrorTestCase(
-                name = "Ambiguous reference in struct of bindings environment",
-                query = """
-                    SELECT a
-                    FROM <<
-                        { 'a': 1, 'a': 'hello' }
-                    >> AS t, << { 'a': 2.0 } >> AS t
-                """,
-                expected = BagType(
-                    StructType(
-                        fields = listOf(
-                            StructType.Field("a", StaticType.ANY),
-                        ),
-                        contentClosed = true,
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
-                    )
-                ),
-                problemHandler = assertProblemExists {
-                    Problem(
-                        UNKNOWN_SOURCE_LOCATION,
-                        PlanningProblemDetails.UndefinedVariable("a", false)
-                    )
-                }
             ),
             SuccessTestCase(
                 name = "AGGREGATE over INTS",

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
@@ -63,6 +63,7 @@ class PartiQLSchemaInferencerTests {
                     "breed" to TYPE_AWS_DDB_PETS_BREED
                 ),
                 contentClosed = true,
+                isOrdered = true,
                 constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
             )
         )
@@ -70,6 +71,7 @@ class PartiQLSchemaInferencerTests {
             StructType(
                 fields = mapOf("identifier" to StaticType.STRING),
                 contentClosed = true,
+                isOrdered = true,
                 constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
             )
         )
@@ -77,6 +79,7 @@ class PartiQLSchemaInferencerTests {
             StructType(
                 fields = mapOf("identifier" to StaticType.INT),
                 contentClosed = true,
+                isOrdered = true,
                 constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
             )
         )
@@ -84,6 +87,7 @@ class PartiQLSchemaInferencerTests {
         private val TYPE_B_B_B_B = StructType(
             mapOf("b" to TYPE_B_B_B_B_B),
             contentClosed = true,
+            isOrdered = true,
             constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
         )
         val TYPE_B_B_B_C = StaticType.INT
@@ -95,6 +99,7 @@ class PartiQLSchemaInferencerTests {
                     "c" to TYPE_B_B_B_C
                 ),
                 contentClosed = true,
+                isOrdered = true,
                 constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
             )
     }
@@ -140,6 +145,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("pets" to StaticType.ANY),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 ),
@@ -158,6 +164,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("pets" to StaticType.ANY),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 ),
@@ -210,6 +217,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("pets" to StaticType.ANY),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 ),
@@ -555,6 +563,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("unknown_col" to AnyType()),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 ),
@@ -635,6 +644,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("cast_breed" to unionOf(StaticType.INT, StaticType.MISSING)),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
@@ -648,6 +658,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("upper_breed" to StaticType.STRING),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
@@ -659,6 +670,7 @@ class PartiQLSchemaInferencerTests {
                     StructType(
                         fields = mapOf("a" to ListType(unionOf(StaticType.INT, StaticType.DECIMAL))),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
@@ -692,6 +704,7 @@ class PartiQLSchemaInferencerTests {
                             "b" to StaticType.DECIMAL,
                         ),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
@@ -706,6 +719,7 @@ class PartiQLSchemaInferencerTests {
                             "b" to StaticType.DECIMAL,
                         ),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
@@ -720,6 +734,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.INT),
                         ),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
@@ -734,6 +749,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.DECIMAL),
                         ),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
@@ -748,6 +764,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.DECIMAL),
                         ),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
@@ -773,6 +790,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", StaticType.STRING),
                         ),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
@@ -791,12 +809,51 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", unionOf(INT, STRING))
                         ),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
             ),
             SuccessTestCase(
-                name = "Duplicate fields in bindings",
+                name = "Duplicate fields in ordered STRUCT. NOTE: b.b.d is an ordered struct with two attributes (e). First is INT.",
+                query = """
+                    SELECT d.e AS e
+                    FROM << b.b.d >> AS d
+                """,
+                expected = BagType(
+                    StructType(
+                        fields = listOf(
+                            StructType.Field("e", INT)
+                        ),
+                        contentClosed = true,
+                        isOrdered = true,
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                    )
+                )
+            ),
+            ErrorTestCase(
+                name = "LEFT JOIN Ambiguous Reference in ON",
+                query = "SELECT * FROM <<{ 'a': 1 }>> AS t1 LEFT JOIN <<{ 'a': 2.0 }>> AS t2 ON a = 3",
+                expected = BagType(
+                    StructType(
+                        fields = listOf(
+                            StructType.Field("a", StaticType.INT),
+                            StructType.Field("a", StaticType.DECIMAL),
+                        ),
+                        contentClosed = true,
+                        isOrdered = true,
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                    )
+                ),
+                problemHandler = assertProblemExists {
+                    Problem(
+                        UNKNOWN_SOURCE_LOCATION,
+                        PlanningProblemDetails.UndefinedVariable("a", false)
+                    )
+                }
+            ),
+            SuccessTestCase(
+                name = "Duplicate fields in struct",
                 query = """
                     SELECT a AS a
                     FROM <<
@@ -809,6 +866,7 @@ class PartiQLSchemaInferencerTests {
                             StructType.Field("a", unionOf(INT, STRING))
                         ),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
@@ -825,6 +883,7 @@ class PartiQLSchemaInferencerTests {
                             "m" to StaticType.INT,
                         ),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )
@@ -841,6 +900,7 @@ class PartiQLSchemaInferencerTests {
                             "m" to StaticType.DECIMAL,
                         ),
                         contentClosed = true,
+                        isOrdered = true,
                         constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
                     )
                 )

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/types/StaticTypeTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/types/StaticTypeTests.kt
@@ -215,7 +215,7 @@ class StaticTypeTests {
                                 StructType.Field("bar", staticType),
                             ),
                             contentClosed = true,
-                            constraints = setOf(TupleConstraint.IsOrdered),
+                            constraints = setOf(TupleConstraint.Ordered),
                         )
                         listOf(
                             listOf(

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/types/StaticTypeTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/types/StaticTypeTests.kt
@@ -1,12 +1,14 @@
 package org.partiql.lang.types
 
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.CompilerPipeline
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.StructExprValue
+import org.partiql.lang.eval.StructOrdering
+import org.partiql.lang.eval.namedValue
 import org.partiql.lang.types.StaticTypeUtils.isInstance
 import org.partiql.lang.util.ArgumentsProviderBase
 import org.partiql.types.AnyOfType
@@ -72,28 +74,29 @@ class StaticTypeTests {
             // BLOB
             InputTypes("`{{ SGVsbG8sIHdvcmxkIQ== }}`", listOf(BLOB))
         )
+
+        fun eval(sql: String): ExprValue =
+            CompilerPipeline.standard().compile(sql).eval(EvaluationSession.standard())
     }
 
     data class TestCase(
-        val sqlValue: String,
+        val exprValue: ExprValue,
         val staticType: StaticType,
         val expectedIsInstanceResult: Boolean
-    )
-
-    fun eval(sql: String): ExprValue =
-        CompilerPipeline.standard().compile(sql).eval(EvaluationSession.standard())
+    ) {
+        constructor(
+            sqlValue: String,
+            staticType: StaticType,
+            expectedIsInstanceResult: Boolean
+        ) : this(eval(sqlValue), staticType, expectedIsInstanceResult)
+    }
 
     @ParameterizedTest
     @ArgumentsSource(ScalarIsInstanceArguments::class)
     fun scalarIsInstanceArgumentsTest(tc: TestCase) {
-
-        val exprValue = assertDoesNotThrow("Evaluating the value under test should not throw") {
-            eval(tc.sqlValue)
-        }
-
         assertEquals(
-            tc.expectedIsInstanceResult, isInstance(exprValue, tc.staticType),
-            "The result of StaticType.isInstance() should match the expected value for type ${tc.staticType} and \"${tc.sqlValue}\""
+            tc.expectedIsInstanceResult, isInstance(tc.exprValue, tc.staticType),
+            "The result of StaticType.isInstance() should match the expected value for type ${tc.staticType} and \"${tc.exprValue}\""
         )
     }
 
@@ -110,14 +113,9 @@ class StaticTypeTests {
     @ParameterizedTest
     @ArgumentsSource(SequenceIsInstanceArguments::class)
     fun sequenceIsInstanceArgumentsTest(tc: TestCase) {
-
-        val exprValue = assertDoesNotThrow("Evaluating the value under test should not throw") {
-            eval(tc.sqlValue)
-        }
-
         assertEquals(
-            tc.expectedIsInstanceResult, isInstance(exprValue, tc.staticType),
-            "The result of StaticType.isInstance() should match the expected value for type ${tc.staticType} and \"${tc.sqlValue}\""
+            tc.expectedIsInstanceResult, isInstance(tc.exprValue, tc.staticType),
+            "The result of StaticType.isInstance() should match the expected value for type ${tc.staticType} and \"${tc.exprValue}\""
         )
     }
 
@@ -194,14 +192,9 @@ class StaticTypeTests {
     @ParameterizedTest
     @ArgumentsSource(StructIsInstanceArguments::class)
     fun structIsInstanceTest(tc: TestCase) {
-
-        val exprValue = assertDoesNotThrow("Evaluating the value under test should not throw") {
-            eval(tc.sqlValue)
-        }
-
         assertEquals(
-            tc.expectedIsInstanceResult, isInstance(exprValue, tc.staticType),
-            "The result of StaticType.isInstance() should match the expected value for type ${tc.staticType} and \"${tc.sqlValue}\""
+            tc.expectedIsInstanceResult, isInstance(tc.exprValue, tc.staticType),
+            "The result of StaticType.isInstance() should match the expected value for type ${tc.staticType} and \"${tc.exprValue}\""
         )
     }
 
@@ -215,6 +208,14 @@ class StaticTypeTests {
                         val closedContentStructType = StructType(mapOf("foo" to staticType), contentClosed = true)
                         val openContentStructType = StructType(mapOf("foo" to staticType), contentClosed = false)
                         val closedContentWithOptionalField = StructType(mapOf("foo" to AnyOfType(setOf(MISSING, staticType))), contentClosed = true)
+                        val orderedStructType = StructType(
+                            listOf(
+                                StructType.Field("foo", AnyOfType(setOf(MISSING, staticType))),
+                                StructType.Field("bar", staticType),
+                            ),
+                            contentClosed = true,
+                            isOrdered = true
+                        )
                         listOf(
                             listOf(
                                 // closed content with matching field
@@ -285,7 +286,56 @@ class StaticTypeTests {
                                     sqlValue = "{'foo': ${scalarInput1.sqlValue}, 'foo': ${scalarInput1.sqlValue} }",
                                     staticType = closedContentStructType,
                                     expectedIsInstanceResult = scalarInput1.expectedTypes.contains(staticType)
-                                )
+                                ),
+
+                                // duplicate struct fields with values of the same type (but value is ordered, while type is unordered)
+                                TestCase(
+                                    exprValue = StructExprValue(
+                                        StructOrdering.ORDERED,
+                                        sequence {
+                                            yield(eval(scalarInput1.sqlValue).namedValue(ExprValue.newString("foo")))
+                                            yield(eval(scalarInput1.sqlValue).namedValue(ExprValue.newString("foo")))
+                                        }
+                                    ),
+                                    staticType = closedContentStructType,
+                                    expectedIsInstanceResult = scalarInput1.expectedTypes.contains(staticType)
+                                ),
+                                // Both present
+                                TestCase(
+                                    exprValue = StructExprValue(
+                                        StructOrdering.ORDERED,
+                                        sequence {
+                                            yield(eval(scalarInput1.sqlValue).namedValue(ExprValue.newString("foo")))
+                                            yield(eval(scalarInput1.sqlValue).namedValue(ExprValue.newString("bar")))
+                                        }
+                                    ),
+                                    staticType = orderedStructType,
+                                    expectedIsInstanceResult = scalarInput1.expectedTypes.contains(staticType)
+                                ),
+                                // One missing
+                                TestCase(
+                                    exprValue = StructExprValue(
+                                        StructOrdering.ORDERED,
+                                        sequence {
+                                            yield(ExprValue.missingValue.namedValue(ExprValue.newString("foo")))
+                                            yield(eval(scalarInput1.sqlValue).namedValue(ExprValue.newString("bar")))
+                                        }
+                                    ),
+                                    staticType = orderedStructType,
+                                    expectedIsInstanceResult = scalarInput1.expectedTypes.contains(staticType)
+                                ),
+                                // Unordered StructExprValue always fails
+                                TestCase(
+                                    exprValue = StructExprValue(
+                                        StructOrdering.UNORDERED,
+                                        sequence {
+                                            yield(ExprValue.missingValue.namedValue(ExprValue.newString("foo")))
+                                            yield(eval(scalarInput1.sqlValue).namedValue(ExprValue.newString("bar")))
+                                        }
+                                    ),
+                                    staticType = orderedStructType,
+                                    expectedIsInstanceResult = false
+                                ),
                             ),
                             // Duplicate struct fields with values of different types.
                             // We generate one test case for every scalar value with every other scalar value and

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/types/StaticTypeTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/types/StaticTypeTests.kt
@@ -31,6 +31,7 @@ import org.partiql.types.StaticType.Companion.STRING
 import org.partiql.types.StaticType.Companion.SYMBOL
 import org.partiql.types.StaticType.Companion.TIMESTAMP
 import org.partiql.types.StructType
+import org.partiql.types.TupleConstraint
 import java.math.BigInteger
 
 /**
@@ -214,7 +215,7 @@ class StaticTypeTests {
                                 StructType.Field("bar", staticType),
                             ),
                             contentClosed = true,
-                            isOrdered = true
+                            constraints = setOf(TupleConstraint.IsOrdered),
                         )
                         listOf(
                             listOf(

--- a/partiql-lang/src/test/resources/catalogs/b/b/d.json
+++ b/partiql-lang/src/test/resources/catalogs/b/b/d.json
@@ -1,0 +1,22 @@
+{
+  "name": "d",
+  "type": "STRUCT",
+  "attributes": [
+    {
+      "name": "e",
+      "type": "INT",
+      "attributes": []
+    },
+    {
+      "name": "e",
+      "type": "STRUCT",
+      "attributes": [
+        {
+          "name": "f",
+          "type": "INT",
+          "attributes": []
+        }
+      ]
+    }
+  ]
+}

--- a/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
@@ -508,7 +508,7 @@ data class StructType(
      * its [StaticType]. Note: multiple [Field]s within a [StructType] may contain the same [key], and therefore,
      * multiple same-named keys may refer to distinct [StaticType]s. To determine the [StaticType]
      * of a reference to a field, especially in the case of duplicates, it depends on the ordering of the [StructType]
-     * (denoted by the presence of [TupleConstraint.IsOrdered] in the [StructType.constraints]).
+     * (denoted by the presence of [TupleConstraint.Ordered] in the [StructType.constraints]).
      * - If ORDERED: the PartiQL specification says to grab the first encountered matching field.
      * - If UNORDERED: it is implementation-defined. However, gather all possible types, merge them using [AnyOfType].
      */
@@ -613,10 +613,10 @@ sealed class TupleConstraint {
     data class Open(val value: Boolean) : TupleConstraint()
 
     /**
-     * The presence of the [IsOrdered] on a [StructType] represents that the [StructType] is ORDERED. The absence of
+     * The presence of the [Ordered] on a [StructType] represents that the [StructType] is ORDERED. The absence of
      * this constrain represents the opposite -- AKA that the [StructType] is UNORDERED
      */
-    object IsOrdered : TupleConstraint()
+    object Ordered : TupleConstraint()
 }
 
 /**

--- a/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
@@ -464,6 +464,16 @@ data class BagType(
     override fun toString(): String = "bag($elementType)"
 }
 
+/**
+ * Describes a PartiQL Struct.
+ *
+ * @param fields the key-value pairs of the struct
+ * @param contentClosed when true, denotes that no other attributes may be present
+ * @param isOrdered when true, denotes that the fields are ordered.
+ * @param primaryKeyFields fields designated as primary keys
+ * @param constraints set of constraints applied to the Struct
+ * @param metas meta-data
+ */
 data class StructType(
     val fields: List<Field> = listOf(),
     // `TupleConstraint` already has `Open` constraint which overlaps with `contentClosed`.
@@ -475,6 +485,7 @@ data class StructType(
     // TODO remove `contentClosed` and `primaryKeyFields` if after finalizing our type specification we're
     // still going with `StructType`.
     val contentClosed: Boolean = false,
+    val isOrdered: Boolean = false,
     val primaryKeyFields: List<String> = listOf(),
     val constraints: Set<TupleConstraint> = setOf(),
     override val metas: Map<String, Any> = mapOf(),
@@ -483,12 +494,14 @@ data class StructType(
     public constructor(
         fields: Map<String, StaticType>,
         contentClosed: Boolean = false,
+        isOrdered: Boolean = false,
         primaryKeyFields: List<String> = listOf(),
         constraints: Set<TupleConstraint> = setOf(),
         metas: Map<String, Any> = mapOf(),
     ) : this(
         fields.map { Field(it.key, it.value) },
         contentClosed,
+        isOrdered,
         primaryKeyFields,
         constraints,
         metas

--- a/plugins/partiql-mockdb/src/main/kotlin/org/partiql/plugins/mockdb/LocalConnectorObject.kt
+++ b/plugins/partiql-mockdb/src/main/kotlin/org/partiql/plugins/mockdb/LocalConnectorObject.kt
@@ -100,6 +100,7 @@ internal class LocalConnectorObject(
                 StructType.Field(it.getName(), it.getValueDesc())
             },
             contentClosed = true,
+            isOrdered = true,
             constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true)),
         )
 
@@ -109,7 +110,8 @@ internal class LocalConnectorObject(
                 fields = this.attributes.map {
                     StructType.Field(it.getName(), it.getValueDesc())
                 },
-                contentClosed = true
+                contentClosed = true,
+                isOrdered = true,
             )
         )
     }

--- a/plugins/partiql-mockdb/src/main/kotlin/org/partiql/plugins/mockdb/LocalConnectorObject.kt
+++ b/plugins/partiql-mockdb/src/main/kotlin/org/partiql/plugins/mockdb/LocalConnectorObject.kt
@@ -96,8 +96,8 @@ internal class LocalConnectorObject(
 
     private fun LocalSchema.ValueSchema.StructSchema.getDesc() =
         StructType(
-            fields = this.attributes.associate {
-                it.getName() to it.getValueDesc()
+            fields = this.attributes.map {
+                StructType.Field(it.getName(), it.getValueDesc())
             },
             contentClosed = true,
             constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true)),
@@ -106,8 +106,8 @@ internal class LocalConnectorObject(
     private fun LocalSchema.TableSchema.getDesc(): StaticType {
         return BagType(
             StructType(
-                fields = this.attributes.associate {
-                    it.getName() to it.getValueDesc()
+                fields = this.attributes.map {
+                    StructType.Field(it.getName(), it.getValueDesc())
                 },
                 contentClosed = true
             )

--- a/plugins/partiql-mockdb/src/main/kotlin/org/partiql/plugins/mockdb/LocalConnectorObject.kt
+++ b/plugins/partiql-mockdb/src/main/kotlin/org/partiql/plugins/mockdb/LocalConnectorObject.kt
@@ -100,8 +100,7 @@ internal class LocalConnectorObject(
                 StructType.Field(it.getName(), it.getValueDesc())
             },
             contentClosed = true,
-            isOrdered = true,
-            constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true)),
+            constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered),
         )
 
     private fun LocalSchema.TableSchema.getDesc(): StaticType {
@@ -111,7 +110,7 @@ internal class LocalConnectorObject(
                     StructType.Field(it.getName(), it.getValueDesc())
                 },
                 contentClosed = true,
-                isOrdered = true,
+                constraints = setOf(TupleConstraint.IsOrdered),
             )
         )
     }

--- a/plugins/partiql-mockdb/src/main/kotlin/org/partiql/plugins/mockdb/LocalConnectorObject.kt
+++ b/plugins/partiql-mockdb/src/main/kotlin/org/partiql/plugins/mockdb/LocalConnectorObject.kt
@@ -100,7 +100,7 @@ internal class LocalConnectorObject(
                 StructType.Field(it.getName(), it.getValueDesc())
             },
             contentClosed = true,
-            constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered),
+            constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered),
         )
 
     private fun LocalSchema.TableSchema.getDesc(): StaticType {
@@ -110,7 +110,7 @@ internal class LocalConnectorObject(
                     StructType.Field(it.getName(), it.getValueDesc())
                 },
                 contentClosed = true,
-                constraints = setOf(TupleConstraint.IsOrdered),
+                constraints = setOf(TupleConstraint.Ordered),
             )
         )
     }

--- a/plugins/partiql-mockdb/src/test/kotlin/org/partiql/plugins/mockdb/LocalConnectorMetadataTests.kt
+++ b/plugins/partiql-mockdb/src/test/kotlin/org/partiql/plugins/mockdb/LocalConnectorMetadataTests.kt
@@ -42,7 +42,7 @@ class LocalConnectorMetadataTests {
                     "path" to StaticType.STRING
                 ),
                 contentClosed = true,
-                isOrdered = true
+                constraints = setOf(TupleConstraint.IsOrdered)
             )
         )
 
@@ -69,19 +69,17 @@ class LocalConnectorMetadataTests {
         val expected =
             StructType(
                 contentClosed = true,
-                isOrdered = true,
                 fields = mapOf(
                     "id" to IntType(),
                     "nested" to StructType(
                         contentClosed = true,
-                        isOrdered = true,
                         fields = mapOf(
                             "nested_id" to IntType()
                         ),
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
                     )
                 ),
-                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true))
+                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
             )
 
         // Act

--- a/plugins/partiql-mockdb/src/test/kotlin/org/partiql/plugins/mockdb/LocalConnectorMetadataTests.kt
+++ b/plugins/partiql-mockdb/src/test/kotlin/org/partiql/plugins/mockdb/LocalConnectorMetadataTests.kt
@@ -41,7 +41,8 @@ class LocalConnectorMetadataTests {
                     "id" to StaticType.INT,
                     "path" to StaticType.STRING
                 ),
-                contentClosed = true
+                contentClosed = true,
+                isOrdered = true
             )
         )
 
@@ -68,10 +69,12 @@ class LocalConnectorMetadataTests {
         val expected =
             StructType(
                 contentClosed = true,
+                isOrdered = true,
                 fields = mapOf(
                     "id" to IntType(),
                     "nested" to StructType(
                         contentClosed = true,
+                        isOrdered = true,
                         fields = mapOf(
                             "nested_id" to IntType()
                         ),

--- a/plugins/partiql-mockdb/src/test/kotlin/org/partiql/plugins/mockdb/LocalConnectorMetadataTests.kt
+++ b/plugins/partiql-mockdb/src/test/kotlin/org/partiql/plugins/mockdb/LocalConnectorMetadataTests.kt
@@ -42,7 +42,7 @@ class LocalConnectorMetadataTests {
                     "path" to StaticType.STRING
                 ),
                 contentClosed = true,
-                constraints = setOf(TupleConstraint.IsOrdered)
+                constraints = setOf(TupleConstraint.Ordered)
             )
         )
 
@@ -76,10 +76,10 @@ class LocalConnectorMetadataTests {
                         fields = mapOf(
                             "nested_id" to IntType()
                         ),
-                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                        constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
                     )
                 ),
-                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.IsOrdered)
+                constraints = setOf(TupleConstraint.Open(false), TupleConstraint.UniqueAttrs(true), TupleConstraint.Ordered)
             )
 
         // Act


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Fixes JOIN predicate by adding the correct bindings to the input to the predicate for typing
- Modifies StructType attribute `fields` to be a List<Field>. This allows for ordering of the Struct as well as duplicate keys.
- Adds attribute, `isOrdered`, to StructType. As the PartiQL Spec allows for ordered tuples in the presence of schema, I opted to add it directly to StructType.
  - For referencing attributes of an ORDERED StructType, the behavior is well-defined in grabbing the first attribute:
    - > When the tuple t has multiple attributes a, the tuple path navigation t.a will return the first instance of a. Note that for tuples whose order is defined by schema, this is well-defined. For unordered tuples, it is implementation defined which attribute is returned in permissive mode or an error in type checking mode, which is described in Section 4.1.
    --- PartiQL Spec Page 13
  - For referencing attributes of an UNORDERED StructType, it is implementation-defined.
- Removed the ambiguity with referencing `a` in the following:
  ```
  SELECT * FROM << { 'a': 0 } >> AS t JOIN << { 'a': true } >> ON a = false
  ```

## Testing

- Made sure all tests pass in StaticTypeTests which tests `isInstance` for Structs. Added tests relevant to ordering.
- Added tests for the additions in the PartiQLSchemaInferencer
- Modified the LocalPlugin to return all structs to be ORDERED. Reflected those changes in the tests.

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **YES**
  - See CHANGELOG.
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.