### PR TITLE
Update partiql-tests to the newest; related doc tweaks.

### DIFF
--- a/test/partiql-tests-runner/README.md
+++ b/test/partiql-tests-runner/README.md
@@ -7,9 +7,6 @@ This package enables:
 1. Verifying conformance tests are defined correctly (e.g. verify evaluation environment is not missing a table)
 2. Identifying areas in the Kotlin implementation that diverge from the [PartiQL Specification](https://partiql.org/assets/PartiQL-Specification.pdf)
 
-Eventually, the `partiql-test-runner` module will replace the `partiql-pts` and `partiql-testscript` modules along with some other 
-tests in `lang` that were ported to `partiql-tests` 
-(see [partiql-lang-kotlin#789](https://github.com/partiql/partiql-lang-kotlin/issues/789)).
 
 ## Run Conformance Tests Locally
 
@@ -21,3 +18,18 @@ tests in `lang` that were ported to `partiql-tests`
 PARTIQL_TESTS_DATA=/path/to/partiql-tests/data \
 ./gradlew :test:partiql-tests-runner:test --tests "*ConformanceTestsReportRunner" -PconformanceReport
 ```
+The report is written into file `test/partiql-tests-runner/conformance_test_results.ion`.
+
+## Run Conformance Tests in IntelliJ
+
+The above project property `-PconformanceReport` is checked in `test/partiql-tests-runner/build.gradle.kts`,
+to prevent the conformance test suite from executing during a normal project-build test run. 
+Unfortunately, this also disables running `ConformanceTestsReportRunner` via IntelliJ UI for unit tests. 
+To make that possible locally, temporarily comment out the check in `test/partiql-tests-runner/build.gradle.kts`.
+
+## Compare Conformance Reports locally
+
+```shell
+./gradlew :test:partiql-tests-runner:run --args="pathToFirstConformanceTestResults pathToSecondConformanceTestResults firstCommitId secondCommitId pathToComparisonReport"
+```
+The last argument, `pathToComparisonReport` is for the `.md` file into which to write the comparison report.

--- a/test/partiql-tests-runner/README.md
+++ b/test/partiql-tests-runner/README.md
@@ -20,11 +20,11 @@ PARTIQL_TESTS_DATA=/path/to/partiql-tests/data \
 ```
 The report is written into file `test/partiql-tests-runner/conformance_test_results.ion`.
 
-## Run Conformance Tests in IntelliJ
+## Run Conformance Tests in UI
 
 The above project property `-PconformanceReport` is checked in `test/partiql-tests-runner/build.gradle.kts`,
-to prevent the conformance test suite from executing during a normal project-build test run. 
-Unfortunately, this also disables running `ConformanceTestsReportRunner` via IntelliJ UI for unit tests. 
+to exclude the conformance test suite from executing during a normal project-build test run. 
+Unfortunately, this also disables running `ConformanceTestsReportRunner` in a UI runner. 
 To make that possible locally, temporarily comment out the check in `test/partiql-tests-runner/build.gradle.kts`.
 
 ## Compare Conformance Reports locally

--- a/test/partiql-tests-runner/build.gradle.kts
+++ b/test/partiql-tests-runner/build.gradle.kts
@@ -40,7 +40,7 @@ tasks.test {
     environment(Env.PARTIQL_EVAL, file("$tests/eval/").absolutePath)
     environment(Env.PARTIQL_EQUIV, file("$tests/eval-equiv/").absolutePath)
 
-    // To make it possible to run ConformanceTestsReportRunner in IntelliJ unit test UI, comment out this check:
+    // To make it possible to run ConformanceTestsReportRunner in unit test UI runner, comment out this check:
     if (!project.hasProperty("conformanceReport")) {
         exclude("org/partiql/runner/TestRunner\$ConformanceTestsReportRunner.class")
     }

--- a/test/partiql-tests-runner/build.gradle.kts
+++ b/test/partiql-tests-runner/build.gradle.kts
@@ -44,4 +44,7 @@ tasks.test {
     if (!project.hasProperty("conformanceReport")) {
         exclude("org/partiql/runner/TestRunner\$ConformanceTestsReportRunner.class")
     }
+
+    // May 2023: Disabled conformance testing during regular project build, because fail lists are out of date.
+    exclude("org/partiql/runner/TestRunner\$DefaultConformanceTestRunner.class")
 }

--- a/test/partiql-tests-runner/build.gradle.kts
+++ b/test/partiql-tests-runner/build.gradle.kts
@@ -40,6 +40,7 @@ tasks.test {
     environment(Env.PARTIQL_EVAL, file("$tests/eval/").absolutePath)
     environment(Env.PARTIQL_EQUIV, file("$tests/eval-equiv/").absolutePath)
 
+    // To make it possible to run ConformanceTestsReportRunner in IntelliJ unit test UI, comment out this check:
     if (!project.hasProperty("conformanceReport")) {
         exclude("org/partiql/runner/TestRunner\$ConformanceTestsReportRunner.class")
     }

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/TestRunner.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/TestRunner.kt
@@ -456,7 +456,8 @@ class TestRunner {
      * succeed with the expected result. Ensures that tests included in the failing list fail.
      *
      * These tests are included in the normal test/building.
-     * Update May 2023: Now excluded from the normal build, because fail lists are out of date.
+     * Update May 2023: Now excluded from the normal build, because the fail lists are out of date.
+     * TODO: Come up with a low-burden method of maintaining fail / exclusion lists. 
      */
     class DefaultConformanceTestRunner {
         // Tests the eval tests with the Kotlin implementation

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/TestRunner.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/TestRunner.kt
@@ -456,6 +456,7 @@ class TestRunner {
      * succeed with the expected result. Ensures that tests included in the failing list fail.
      *
      * These tests are included in the normal test/building.
+     * Update May 2023: Now excluded from the normal build, because fail lists are out of date.
      */
     class DefaultConformanceTestRunner {
         // Tests the eval tests with the Kotlin implementation

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/TestRunner.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/TestRunner.kt
@@ -457,7 +457,7 @@ class TestRunner {
      *
      * These tests are included in the normal test/building.
      * Update May 2023: Now excluded from the normal build, because the fail lists are out of date.
-     * TODO: Come up with a low-burden method of maintaining fail / exclusion lists. 
+     * TODO: Come up with a low-burden method of maintaining fail / exclusion lists.
      */
     class DefaultConformanceTestRunner {
         // Tests the eval tests with the Kotlin implementation


### PR DESCRIPTION
This checks out the git submodule for the most recent version of partiql-tests conformance suite.  
According to a manually-run comparison report, all new failures (and successes) are due to the the new tests that got added to the conformance suite since last refresh.

Also, some documentation tweaks -- see specific comments. 

In addition to the needed improvement with enabling/disabling the conformance suite runs, it would be helpful to get a mechanism for running smaller subsets of the suite (at least being able to limit to a directory), especially when running with IntelliJ UI.

A yet another issue is `DefaultConformanceTestRunner` that runs conformance tests during regular builds, w.r.t. a list of known failures.  After partiql-tests refresh this list became significantly out-of-date. 
This PR disables DefaultConformanceTestRunner for the time being.  The issue might be more significant than deferred maintenance in updating the fail list -- we need to figure out more comfortable / useful workflow with conformance tests overall. 


## Other Information
- Updated Unreleased Section in CHANGELOG: NO
  - internal
- Any backward-incompatible changes? NO
- Any new external dependencies? NO

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.