### PR TITLE
Updates PIG to 0.6.2; removes some workarounds

### DIFF
--- a/buildSrc/src/main/kotlin/partiql.versions.kt
+++ b/buildSrc/src/main/kotlin/partiql.versions.kt
@@ -41,7 +41,7 @@ object Versions {
     const val picoCli = "4.7.0"
     const val kasechange = "1.3.0"
     const val ktlint = "10.2.1"
-    const val pig = "0.6.1"
+    const val pig = "0.6.2"
 
     // Testing
     const val assertj = "3.11.0"

--- a/lib/isl/src/main/kotlin/org/partiql/pig/runtime/workarounds.kt
+++ b/lib/isl/src/main/kotlin/org/partiql/pig/runtime/workarounds.kt
@@ -1,3 +1,0 @@
-package org.partiql.pig.runtime
-
-fun kotlin.collections.List<com.amazon.ionelement.api.IonElement>.asAnyElement() = map { it.asAnyElement() }

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/poems/KotlinBuilderPoem.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/poems/KotlinBuilderPoem.kt
@@ -1,5 +1,6 @@
 package org.partiql.sprout.generator.target.kotlin.poems
 
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
@@ -40,6 +41,12 @@ class KotlinBuilderPoem(symbols: KotlinSymbols) : KotlinPoem(symbols) {
     // Java style builders, used by the DSL
     private val buildersName = "${symbols.rootId}Builders"
     private val buildersFile = FileSpec.builder(builderPackageName, buildersName)
+
+    // @file:Suppress("UNUSED_PARAMETER")
+    private val suppressUnused = AnnotationSpec.builder(Suppress::class)
+        .useSiteTarget(AnnotationSpec.UseSiteTarget.FILE)
+        .addMember("%S", "UNUSED_PARAMETER")
+        .build()
 
     // Top-Level DSL holder, so that was close on the factory
     private val dslName = "${symbols.rootId}Builder"
@@ -102,6 +109,7 @@ class KotlinBuilderPoem(symbols: KotlinSymbols) : KotlinPoem(symbols) {
                     buildersFile.build(),
                     // DSL
                     FileSpec.builder(builderPackageName, dslName)
+                        .addAnnotation(suppressUnused)
                         .addFunction(dslFunc)
                         .addType(dslSpec.build())
                         .build(),

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/domains/util.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/domains/util.kt
@@ -1,6 +1,5 @@
 package org.partiql.lang.domains
 
-import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
 import com.amazon.ionelement.api.metaContainerOf
@@ -22,11 +21,6 @@ fun PartiqlLogical.Builder.id(name: String) =
 // TODO:  once https://github.com/partiql/partiql-ir-generator/issues/6 has been completed, we can delete this.
 fun PartiqlLogical.Builder.pathExpr(exp: PartiqlLogical.Expr) =
     pathExpr(exp, caseInsensitive())
-
-// Workaround for a bug in PIG that is fixed in its next release:
-// https://github.com/partiql/partiql-ir-generator/issues/41
-fun List<IonElement>.asAnyElement() =
-    this.map { it.asAnyElement() }
 
 val MetaContainer.staticType: StaticTypeMeta? get() = this[StaticTypeMeta.TAG] as StaticTypeMeta?
 


### PR DESCRIPTION
## Relevant Issues
https://github.com/partiql/partiql-ir-generator/issues/41

## Description

The Kotlin target generates code that fails to compile with the error message:` Unresolved reference: asAnyElement`. The workaround is to add this to the consuming project:

```
package org.partiql.pig.runtime

fun kotlin.collections.List<com.amazon.ionelement.api.IonElement>.asAnyElement() = map { it.asAnyElement() }
```

This function has been added to the runtime library and released.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.