### PR TITLE
Preserves list variant in QueryPrettyPrinter

### DIFF
--- a/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
@@ -1,5 +1,6 @@
 package org.partiql.lang.prettyprint
 
+import org.partiql.lang.ast.IsListParenthesizedMeta
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.PartiQLParserBuilder
 import org.partiql.pig.runtime.toIonElement
@@ -435,7 +436,11 @@ class QueryPrettyPrinter {
 
     @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.List, sb: StringBuilder, level: Int) {
-        sb.append("[ ")
+        val (open, close) = when (node.metas.containsKey(IsListParenthesizedMeta.tag)) {
+            true -> "( " to " )"
+            else -> "[ " to " ]"
+        }
+        sb.append(open)
         node.values.forEach {
             // Print anything as one line inside a list
             writeAstNodeCheckSubQuery(it, sb, -1)
@@ -444,7 +449,7 @@ class QueryPrettyPrinter {
         if (node.values.isNotEmpty()) {
             sb.removeLast(2)
         }
-        sb.append(" ]")
+        sb.append(close)
     }
 
     @Suppress("UNUSED_PARAMETER")

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
@@ -96,7 +96,7 @@ class QueryPrettyPrinterTest {
     @Test
     fun insertValue() {
         checkPrettyPrintQuery(
-            "INSERT INTO foo VALUE (1, 2)", "INSERT INTO foo VALUE [ 1, 2 ]"
+            "INSERT INTO foo VALUE (1, 2)", "INSERT INTO foo VALUE ( 1, 2 )"
         )
     }
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
@@ -454,8 +454,13 @@ class QueryPrettyPrinterTest {
     }
 
     @Test
-    fun inCollection() {
+    fun inCollectionBrackets() {
         checkPrettyPrintQuery("1 IN [1, 2, 3]", "1 IN [ 1, 2, 3 ]")
+    }
+
+    @Test
+    fun inCollectionParens() {
+        checkPrettyPrintQuery("1 IN (1, 2, 3)", "1 IN ( 1, 2, 3 )")
     }
 
     @Test


### PR DESCRIPTION
## Relevant Issues
#1089 

## Description

We use the `IsListParenthesizedMeta` to indicate if a list was parenthesized rather than bracketed as our AST does not model these variants. This is a tiny fix to the QueryPrettyPrinter to ensure the list variant is preserved round-trip.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Nop

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.