### PR TITLE
From HTTP to SSH URL for the test/partiql-tests git submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/partiql-tests"]
 	path = test/partiql-tests
-	url = https://github.com/partiql/partiql-tests.git
+	url = git@github.com:partiql/partiql-tests.git


### PR DESCRIPTION
In future fresh check-outs of partiql-lang-kotlin, this should help avoid hiccups with git credentials in the submodule. See https://stackoverflow.com/questions/6031494/git-submodules-and-ssh-access/6031607#6031607

## Other Information
- Updated Unreleased Section in CHANGELOG: NO
- Any backward-incompatible changes? NO
- Any new external dependencies? NO

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.