### PR TITLE
Deduplication of path bindings, as in GPML paper Section 6.5

### DIFF
--- a/partiql-lang/src/main/kotlin/org/partiql/lang/graph/GraphEngine.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/graph/GraphEngine.kt
@@ -44,7 +44,8 @@ object GraphEngine {
             is EdgeSpec -> error("Bug: evaluateNodeStride should not be called on an EdgeSpec")
             is NodeSpec -> StrideResult(
                 stride,
-                graph.scanNodes(node.label).map { Stride(listOf(it)) }
+                // toSet contributes to the deduplication step of Section 6.5 in the GPML paper
+                graph.scanNodes(node.label).toSet().map { Stride(listOf(it)) }.toSet()
             )
         }
     }
@@ -112,11 +113,12 @@ object GraphEngine {
                     if (lft.binder != null && rgt.binder != null && lft.binder == rgt.binder) {
                         triple ->
                         triple.first == triple.third
-                    } else { triple -> true }
+                    } else { _ -> true }
                 val prunedTriples = triples.filter { bindCheck(it) }
                 StrideResult(
                     plan.stride,
-                    prunedTriples.map { Stride(listOf(it.first, it.second, it.third)) }
+                    // toSet contributes to the deduplication step of Section 6.5 in the GPML paper
+                    prunedTriples.toSet().map { Stride(listOf(it.first, it.second, it.third)) }.toSet()
                 )
             }
 
@@ -137,7 +139,7 @@ object GraphEngine {
         val joinedSpec = leftSpec + rightSpec.tail
         val joinCondition = stridesJoinable(left.spec, right.spec)
 
-        val joined = mutableListOf<Stride>()
+        val joined = mutableSetOf<Stride>()
         for (lft in left.result) {
             for (rgt in right.result) {
                 if (joinCondition(lft, rgt)) {
@@ -147,7 +149,7 @@ object GraphEngine {
         }
         return StrideResult(
             StrideSpec(joinedSpec),
-            joined.toList()
+            joined.toSet()
         )
     }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/graph/MatchSpec.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/graph/MatchSpec.kt
@@ -47,7 +47,7 @@ data class StrideSpec(val elems: List<ElemSpec>)
  *  Each [Stride] in [result] is one valid match for [spec].
  *  Keeping [spec] within the result is for maintaining the association between
  *  [Variable]s and graph elements in [result] that the variables matched. */
-data class StrideResult(val spec: StrideSpec, val result: List<Stride>)
+data class StrideResult(val spec: StrideSpec, val result: Set<Stride>)
 
 /** Translation of a graph match pattern -- a collection of path patterns --
  *  into a "plan" for [GraphEngine]. */

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerGraphMatchTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerGraphMatchTests.kt
@@ -165,11 +165,10 @@ class EvaluatingCompilerGraphMatchTests : EvaluatorTestBase() {
             "(N1D1 MATCH (x1)-[y1]->(x2)-[y2]->(x3) )" to "<< {'x1':1, 'y1':1.1, 'x2':1, 'y2':1.1, 'x3':1} >>",
 
             "(N1U1 MATCH (x))" to "<< {'x':1} >>",
-//  Results are not yet correct: need the deduplication of Section 6.5
-//            "(N1U1 MATCH ~[y]~ )" to "<< {'y':1.1} >>",
-//            "(N1U1 MATCH (x)~[y]~(z) )" to "<< {'x':1, 'y':1.1, 'z':1} >>",
-//            "(N1U1 MATCH (x)~[y]~(x) )" to "<< {'x':1, 'y':1.1} >>",
-//            "(N1U1 MATCH (x1)~[y1]~(x2)~[y2]~(x3) )" to "<< {'x1':1, 'y1':1.1, 'x2':1, 'y2':1.1, 'x3':1} >>",
+            "(N1U1 MATCH ~[y]~ )" to "<< {'y':1.1} >>",
+            "(N1U1 MATCH (x)~[y]~(z) )" to "<< {'x':1, 'y':1.1, 'z':1} >>",
+            "(N1U1 MATCH (x)~[y]~(x) )" to "<< {'x':1, 'y':1.1} >>",
+            "(N1U1 MATCH (x1)~[y1]~(x2)~[y2]~(x3) )" to "<< {'x1':1, 'y1':1.1, 'x2':1, 'y2':1.1, 'x3':1} >>",
 
             "(N1D2 MATCH (x))" to "<< {'x':1} >>",
             "(N1D2 MATCH -[y]-> )" to "<< {'y':1.1}, {'y':11.11} >>",
@@ -197,9 +196,8 @@ class EvaluatingCompilerGraphMatchTests : EvaluatorTestBase() {
                 """<< {'x1':1, 'y1':1.2, 'x2':2, 'y2':1.2, 'x3':1},
                     | {'x1':2, 'y1':1.2, 'x2':1, 'y2':1.2, 'x3':2} >>""".trimMargin(),
 
-            // Two tests for N2U1 need the deduplication pass of Section 6.5
             "(N2U1 MATCH (x))" to "<< {'x':1}, {'x':2} >>",
-            // "(N2U1 MATCH ~[y]~ )" to "<< {'y':1.2} >>",
+            "(N2U1 MATCH ~[y]~ )" to "<< {'y':1.2}, {'y':1.2} >>", // duplicated! -- erasure of the next test
             "(N2U1 MATCH (x)~[y]~(z) )" to "<< {'x':1, 'y':1.2, 'z':2}, {'x':2, 'y':1.2, 'z':1} >>",
             "(N2U1 MATCH (x)~[y]~(x) )" to "<< >>",
             "(N2U1 MATCH (x1)~[y1]~(x2)~[y2]~(x3) )" to
@@ -271,7 +269,7 @@ class EvaluatingCompilerGraphMatchTests : EvaluatorTestBase() {
                         | {'x1':2, 'y1':2.1, 'x2':1, 'y2':2.1, 'x3':2} >>""".trimMargin(),
 
             "(N2U2 MATCH (x))" to "<< {'x':1}, {'x':2} >>",
-            // "(N2U2 MATCH ~[y]~ )" to "<< {'y':1.2}, {'y':2.1} >>",  // needs deduplication of Section 6.5
+            "(N2U2 MATCH ~[y]~ )" to "<< {'y':1.2}, {'y':2.1}, {'y':1.2}, {'y':2.1} >>", // duplicated, being an erasure of the next test
             "(N2U2 MATCH (x)~[y]~(z) )" to
                 """<< {'x':1, 'y':1.2, 'z':2}, {'x':2, 'y':2.1, 'z':1}, 
                     | {'x':2, 'y':1.2, 'z':1}, {'x':1, 'y':2.1, 'z':2} >>""".trimMargin(),

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/InvalidArgTypeChecker.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/InvalidArgTypeChecker.kt
@@ -57,7 +57,6 @@ private fun SingleType.getExample() = when (this) {
     is SexpType -> "sexp()"
     is StructType -> "{}"
     is BagType -> "<<>>"
-    is GraphType -> "graph{}" // TODO: something better after we have concrete syntax for graphs
     is MissingType,
     is NullType -> throw Exception("NULL or MISSING should be the problem of permissive mode, not type checking.")
     is GraphType -> throw Exception("Without concrete graph syntax, can't have an example for a graph.")


### PR DESCRIPTION
This makes it possible to re-enable 6 tests that were commented out in #1104, because the deduplication of path bindings was not happening. 
Interestingly, 2 of those tests initially had wrong outcomes specified, now corrected. 

Note that the PR includes changes in the `partiql-tests` git submodule. Is there  chance that merging this PR will induce a merge in the submodule, without a separate PR being opened there?

## Other Information
- Updated Unreleased Section in CHANGELOG: NO
- Any backward-incompatible changes? NO
- Any new external dependencies? NO

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.