### PR TITLE
Initial Implementation on Datetime Type (Timestamp/Interval)

### DIFF
--- a/partiql-lang/src/main/antlr/PartiQL.g4
+++ b/partiql-lang/src/main/antlr/PartiQL.g4
@@ -721,28 +721,35 @@ pair
     : lhs=expr COLON rhs=expr;
 
 literal
-    : NULL                                                                                # LiteralNull
-    | MISSING                                                                             # LiteralMissing
-    | TRUE                                                                                # LiteralTrue
-    | FALSE                                                                               # LiteralFalse
-    | LITERAL_STRING                                                                      # LiteralString
-    | LITERAL_INTEGER                                                                     # LiteralInteger
-    | LITERAL_DECIMAL                                                                     # LiteralDecimal
-    | ION_CLOSURE                                                                         # LiteralIon
-    | DATE LITERAL_STRING                                                                 # LiteralDate
-    | TIME ( PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT )? (WITH TIME ZONE)? LITERAL_STRING   # LiteralTime
+    : NULL                                                                                     # LiteralNull
+    | MISSING                                                                                  # LiteralMissing
+    | TRUE                                                                                     # LiteralTrue
+    | FALSE                                                                                    # LiteralFalse
+    | LITERAL_STRING                                                                           # LiteralString
+    | LITERAL_INTEGER                                                                          # LiteralInteger
+    | LITERAL_DECIMAL                                                                          # LiteralDecimal
+    | ION_CLOSURE                                                                              # LiteralIon
+    | DATE LITERAL_STRING                                                                      # LiteralDate
+    | TIME ( PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT )? (WITH TIME ZONE)? LITERAL_STRING        # LiteralTime
+    | TIMESTAMP ( PAREN_LEFT LITERAL_INTEGER PAREN_RIGHT )? (WITH TIME ZONE)? LITERAL_STRING   # LiteralTimestamp
+    | INTERVAL sign=(PLUS | MINUS)? LITERAL_STRING from=intervalField (TO to=intervalField)?   # LiteralInterval
     ;
 
 type
     : datatype=(
         NULL | BOOL | BOOLEAN | SMALLINT | INTEGER2 | INT2 | INTEGER | INT | INTEGER4 | INT4
-        | INTEGER8 | INT8 | BIGINT | REAL | TIMESTAMP | CHAR | CHARACTER | MISSING
+        | INTEGER8 | INT8 | BIGINT | REAL | CHAR | CHARACTER | MISSING
         | STRING | SYMBOL | BLOB | CLOB | DATE | STRUCT | TUPLE | LIST | SEXP | BAG | ANY
       )                                                                                                                # TypeAtomic
     | datatype=DOUBLE PRECISION                                                                                        # TypeAtomic
     | datatype=(CHARACTER|CHAR|FLOAT|VARCHAR) ( PAREN_LEFT arg0=LITERAL_INTEGER PAREN_RIGHT )?                         # TypeArgSingle
     | CHARACTER VARYING ( PAREN_LEFT arg0=LITERAL_INTEGER PAREN_RIGHT )?                                               # TypeVarChar
     | datatype=(DECIMAL|DEC|NUMERIC) ( PAREN_LEFT arg0=LITERAL_INTEGER ( COMMA arg1=LITERAL_INTEGER )? PAREN_RIGHT )?  # TypeArgDouble
-    | TIME ( PAREN_LEFT precision=LITERAL_INTEGER PAREN_RIGHT )? (WITH TIME ZONE)?                                     # TypeTimeZone
+    | datatype=(TIME|TIMESTAMP) ( PAREN_LEFT precision=LITERAL_INTEGER PAREN_RIGHT )? (WITH TIME ZONE)?                # TypeTimeZone
+    | INTERVAL from=intervalField (TO to=intervalField)?                                                               # TypeInterval
     | symbolPrimitive                                                                                                  # TypeCustom
+    ;
+
+intervalField
+    : YEAR | MONTH | DAY | HOUR | MINUTE | SECOND
     ;

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/errors/ErrorCode.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/errors/ErrorCode.kt
@@ -453,6 +453,12 @@ enum class ErrorCode(
         "expected time string to be of the format HH:MM:SS[.dddd...][+|-HH:MM]"
     ),
 
+    PARSE_INVALID_TIMESTAMP_STRING(
+        ErrorCategory.PARSER,
+        LOC_TOKEN,
+        "expected timestamp string to be of the format YYYY-MM-DD HH:MM:SS[.dddd...][+|-HH:MM]"
+    ),
+
     @Deprecated("This ErrorCode is subject to removal.") // To be removed before 1.0
     @Suppress("UNUSED")
     PARSE_EMPTY_SELECT(

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -411,6 +411,7 @@ internal class EvaluatingCompiler(
             is PartiqlAst.Expr.Parameter -> compileParameter(expr, metas)
             is PartiqlAst.Expr.Date -> compileDate(expr, metas)
             is PartiqlAst.Expr.LitTime -> compileLitTime(expr, metas)
+            is PartiqlAst.Expr.Timestamp -> compileTimestamp(expr, metas)
 
             // arithmetic operations
             is PartiqlAst.Expr.Plus -> compilePlus(expr, metas)
@@ -3044,6 +3045,13 @@ internal class EvaluatingCompiler(
                     expr.value.precision.value.toInt(),
                     if (expr.value.withTimeZone.value && expr.value.tzMinutes == null) compileOptions.defaultTimezoneOffset.totalMinutes else expr.value.tzMinutes?.value?.toInt()
                 )
+            )
+        }
+
+    private fun compileTimestamp(expr: PartiqlAst.Expr.Timestamp, metas: Map<String, Any>): ThunkEnv =
+        thunkFactory.thunkEnv(metas) {
+            ExprValue.newTimestamp(
+                expr.value.ionTimestamp.timestampValue
             )
         }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/ExprValueType.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/ExprValueType.kt
@@ -125,7 +125,8 @@ enum class ExprValueType(
             is PartiqlAst.Type.DoublePrecisionType -> FLOAT
             is PartiqlAst.Type.DecimalType -> DECIMAL
             is PartiqlAst.Type.NumericType -> DECIMAL
-            is PartiqlAst.Type.TimestampType -> TIMESTAMP
+            is PartiqlAst.Type.TimestampType,
+            is PartiqlAst.Type.TimestampWithTimeZoneType -> TIMESTAMP
             is PartiqlAst.Type.CharacterType -> STRING
             is PartiqlAst.Type.CharacterVaryingType -> STRING
             is PartiqlAst.Type.StringType -> STRING

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/ScalarBuiltinsExt.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/ScalarBuiltinsExt.kt
@@ -25,10 +25,10 @@ import org.partiql.lang.eval.ExprFunction
 import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueType
 import org.partiql.lang.eval.bigDecimalValue
-import org.partiql.lang.eval.builtins.internal.TimestampParser
-import org.partiql.lang.eval.builtins.internal.adjustPrecisionTo
-import org.partiql.lang.eval.builtins.internal.toOffsetDateTime
+import org.partiql.lang.eval.builtins.timestamp.TimestampParser
 import org.partiql.lang.eval.builtins.timestamp.TimestampTemporalAccessor
+import org.partiql.lang.eval.builtins.timestamp.adjustPrecisionTo
+import org.partiql.lang.eval.builtins.timestamp.toOffsetDateTime
 import org.partiql.lang.eval.err
 import org.partiql.lang.eval.errNoContext
 import org.partiql.lang.eval.intValue

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/ScalarBuiltinsSql.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/ScalarBuiltinsSql.kt
@@ -27,8 +27,8 @@ import org.partiql.lang.eval.builtins.internal.codepointOverlay
 import org.partiql.lang.eval.builtins.internal.codepointPosition
 import org.partiql.lang.eval.builtins.internal.codepointTrailingTrim
 import org.partiql.lang.eval.builtins.internal.codepointTrim
-import org.partiql.lang.eval.builtins.internal.extractedValue
 import org.partiql.lang.eval.builtins.internal.transformIntType
+import org.partiql.lang.eval.builtins.timestamp.extractedValue
 import org.partiql.lang.eval.bytesValue
 import org.partiql.lang.eval.dateTimePartValue
 import org.partiql.lang.eval.dateValue

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/timestamp/TimestampExtensions.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/timestamp/TimestampExtensions.kt
@@ -1,4 +1,4 @@
-package org.partiql.lang.eval.builtins.internal
+package org.partiql.lang.eval.builtins.timestamp
 
 import com.amazon.ion.Timestamp
 import org.partiql.lang.errors.ErrorCode

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/timestamp/TimestampParser.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/timestamp/TimestampParser.kt
@@ -1,11 +1,9 @@
-package org.partiql.lang.eval.builtins.internal
+package org.partiql.lang.eval.builtins.timestamp
 
 import com.amazon.ion.Timestamp
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.eval.EvaluationException
-import org.partiql.lang.eval.builtins.timestamp.FormatPattern
-import org.partiql.lang.eval.builtins.timestamp.TimestampField
 import org.partiql.lang.eval.errNoContext
 import org.partiql.lang.util.propertyValueMapOf
 import java.math.BigDecimal
@@ -27,7 +25,7 @@ import java.time.temporal.TemporalAccessor
  *    recognize this and there's no reliable workaround that we've yet been able to determine.  Unfortunately, this
  *    means that unknown offsets specified are parsed as if they were explicitly UTC (i.e. "+00:00" or "Z").
  *  - DateTimeFormatter is capable of parsing UTC offsets to the precision of seconds, but Ion Timestamp's precision
- *    for offsets is 1 minute.  [TimestampParser] currently handles this by throwing an exception when an attempt
+ *    for offsets is 1 minute.  [IonTimestampParser] currently handles this by throwing an exception when an attempt
  *    is made to parse a timestamp with an offset that does does not land on a minute boundary.
  *  - Ion Java's Timestamp allows specification of offsets up to +/- 24h, while an exception is thrown by
  *    DateTimeFormatter for any attempt to parse an offset greater than +/- 18h.  The Ion specification does not seem

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
@@ -229,6 +229,7 @@ internal class PhysicalPlanCompilerImpl(
             is PartiqlPhysical.Expr.Parameter -> compileParameter(expr, metas)
             is PartiqlPhysical.Expr.Date -> compileDate(expr, metas)
             is PartiqlPhysical.Expr.LitTime -> compileLitTime(expr, metas)
+            is PartiqlPhysical.Expr.Timestamp -> TODO("not yet supported")
 
             // arithmetic operations
             is PartiqlPhysical.Expr.Plus -> compilePlus(expr, metas)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransform.kt
@@ -59,6 +59,7 @@ class SubqueryCoercionVisitorTransform : VisitorTransformBase() {
 
             is PartiqlAst.Expr.Date -> n
             is PartiqlAst.Expr.LitTime -> n
+            is PartiqlAst.Expr.Timestamp -> n
 
             is PartiqlAst.Expr.GraphMatch -> n.copy(expr = coerceToSingle(n.expr))
 
@@ -101,6 +102,7 @@ class SubqueryCoercionVisitorTransform : VisitorTransformBase() {
             is PartiqlAst.Expr.CanLosslessCast -> n
             is PartiqlAst.Expr.NullIf -> n
             is PartiqlAst.Expr.Coalesce -> n
+            is PartiqlAst.Expr.Interval -> n
         }
     }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
@@ -319,6 +319,11 @@ class ASTPrettyPrinter {
                     ", 'tzminute': " + node.value.tzMinutes.toString(),
                 attrOfParent = attrOfParent,
             )
+            is PartiqlAst.Expr.Timestamp -> RecursionTree(
+                astType = "Timestamp",
+                value = node.value.ionTimestamp.timestampValue.toString(),
+                attrOfParent = attrOfParent,
+            )
             is PartiqlAst.Expr.Not -> RecursionTree(
                 astType = "Not",
                 attrOfParent = attrOfParent,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
@@ -277,6 +277,7 @@ class QueryPrettyPrinter {
             is PartiqlAst.Expr.Missing -> writeAstNode(node, sb)
             is PartiqlAst.Expr.Lit -> writeAstNode(node, sb)
             is PartiqlAst.Expr.LitTime -> writeAstNode(node, sb)
+            is PartiqlAst.Expr.Timestamp -> writeAstNode(node, sb)
             is PartiqlAst.Expr.Date -> writeAstNode(node, sb)
             is PartiqlAst.Expr.Id -> writeAstNode(node, sb)
             is PartiqlAst.Expr.Bag -> writeAstNode(node, sb, level)
@@ -402,6 +403,13 @@ class QueryPrettyPrinter {
         when (withTimeZone.value) {
             true -> sb.append("TIME ($precision) WITH TIME ZONE '$localTime$tzTime'")
             false -> sb.append("TIME ($precision) '$localTime'")
+        }
+    }
+
+    private fun writeAstNode(node: PartiqlAst.Expr.Timestamp, sb: StringBuilder) {
+        when (node.value.ionTimestamp.timestampValue.localOffset) {
+            null -> sb.append("TIMESTAMP (${node.value.precision}) '${node.value.ionTimestamp.timestampValue}'")
+            else -> sb.append("TIMESTAMP WITH TIME ZONE (${node.value.precision}) '${node.value.ionTimestamp.timestampValue}'")
         }
     }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/types/PartiqlPhysicalTypeExtensions.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/types/PartiqlPhysicalTypeExtensions.kt
@@ -7,6 +7,7 @@ import org.partiql.types.NumberConstraint
 import org.partiql.types.StaticType
 import org.partiql.types.StringType
 import org.partiql.types.TimeType
+import org.partiql.types.TimestampType
 
 /**
  * Helper to convert [PartiqlPhysical.Type] in AST to a [TypedOpParameter].
@@ -34,7 +35,12 @@ internal fun PartiqlPhysical.Type.toTypedOpParameter(customTypedOpParameters: Ma
             DecimalType(DecimalType.PrecisionScaleConstraint.Constrained(this.precision!!.value.toInt(), this.scale!!.value.toInt()))
         )
     }
-    is PartiqlPhysical.Type.TimestampType -> TypedOpParameter(StaticType.TIMESTAMP)
+    is PartiqlPhysical.Type.TimestampType -> TypedOpParameter(
+        TimestampType(this.precision?.value?.toInt(), withTimeZone = false)
+    )
+    is PartiqlPhysical.Type.TimestampWithTimeZoneType -> TypedOpParameter(
+        TimestampType(this.precision?.value?.toInt(), withTimeZone = true)
+    )
     is PartiqlPhysical.Type.CharacterType -> when {
         this.length == null -> TypedOpParameter(
             StringType(

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/util/DateTimeUtil.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/util/DateTimeUtil.kt
@@ -1,0 +1,152 @@
+package org.partiql.lang.util
+
+import org.partiql.lang.errors.ErrorCode
+import java.math.RoundingMode
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+import com.amazon.ion.Timestamp as IonTimestamp
+
+internal object DateTimeUtil {
+
+    // -------------------------------
+    // |           COMMON            |
+    // -------------------------------
+    internal val DATETIME_PATTERN = Pattern.compile(
+        "(?<year>[-+]?\\d{4,})-(?<month>\\d{1,2})-(?<day>\\d{1,2})" +
+            "(?: (?<hour>\\d{1,2}):(?<minute>\\d{1,2})(?::(?<second>\\d{1,2})(?:\\.(?<fraction>\\d+))?)?)?" +
+            "\\s*(?<timezone>[+-]\\d\\d:\\d\\d)?"
+    )
+
+    internal const val MILLIS_IN_SECOND: Long = 1000
+    internal const val MILLIS_IN_MINUTE = 60 * MILLIS_IN_SECOND
+    internal const val MILLIS_IN_HOUR = 60 * MILLIS_IN_MINUTE
+    internal const val MILLIS_IN_DAY = 24 * MILLIS_IN_HOUR
+
+    // -------------------------------
+    // |         TIMESTAMP           |
+    // -------------------------------
+    internal data class Timestamp(
+        val ionTimestamp: IonTimestamp,
+        val precision: Int?
+    ) {
+        companion object {
+            internal fun parseTimestamp(value: String, precision: Int?): Timestamp {
+                val matcher: Matcher = DATETIME_PATTERN.matcher(value)
+                // TODO : CHANGE where we throw the error
+                if (!matcher.matches()) ErrorCode.PARSE_INVALID_TIMESTAMP_STRING
+                val year = matcher.group("year")
+                val month = matcher.group("month")
+                val day = matcher.group("day")
+                val hour = matcher.group("hour")
+                val minute = matcher.group("minute")
+                val second = matcher.group("second")
+                val fraction = matcher.group("fraction")
+
+                val ionTimestamp = IonTimestamp.valueOf(
+                    "$year-$month-${day}T$hour:$minute:$second.$fraction-00:00"
+                )
+
+                println(
+                    """
+                    Timestamp (no timezone)
+                    year: $year, month: $month, day: $day, 
+                    hour: $hour, minute: $minute, second: $second, nano: $fraction, 
+                    precision: $precision
+                    ionTimestamp: $ionTimestamp
+                    """.trimIndent()
+                )
+
+                return when (precision) {
+                    fraction.length, null -> Timestamp(ionTimestamp, precision)
+                    else -> Timestamp(rescale(ionTimestamp, precision), precision)
+                }
+            }
+
+            internal fun parseTimestampWithTimeZone(value: String, precision: Int?): Timestamp {
+                val matcher: Matcher = DATETIME_PATTERN.matcher(value)
+                if (!matcher.matches()) ErrorCode.PARSE_INVALID_TIMESTAMP_STRING
+                try {
+                    matcher.group("timezone")
+                } catch (e: IllegalStateException) {
+                    ErrorCode.PARSE_INVALID_TIMESTAMP_STRING
+                }
+                val year = matcher.group("year")
+                val month = matcher.group("month")
+                val day = matcher.group("day")
+                val hour = matcher.group("hour")
+                val minute = matcher.group("minute")
+                val second = matcher.group("second")
+                val fraction = matcher.group("fraction")
+                val timezone = matcher.group("timezone")
+                val ionTimestamp = IonTimestamp.valueOf(
+                    "$year-$month-${day}T$hour:$minute:$second.$fraction$timezone"
+                )
+
+                println(
+                    """
+                    Timestamp With TimeZone
+                    year: $year, month: $month, day: $day, 
+                    hour: $hour, minute: $minute, second: $second, nano: $fraction, 
+                    precision: $precision
+                    ionTimestamp: $ionTimestamp
+                    """.trimIndent()
+                )
+                return when (precision) {
+                    fraction.length, null -> Timestamp(ionTimestamp, precision)
+                    else -> Timestamp(rescale(ionTimestamp, precision), precision)
+                }
+            }
+
+            /**
+             * Rescale the timestamp object to desired precision
+             */
+            private fun rescale(ionTimestamp: IonTimestamp, precision: Int): IonTimestamp =
+                IonTimestamp.forMillis(
+                    ionTimestamp.decimalMillis.movePointLeft(3).setScale(precision, RoundingMode.HALF_UP).movePointRight(3),
+                    ionTimestamp.localOffset
+                )
+        }
+    }
+
+    // -------------------------------
+    // |     INTERVAL( DAY TIME)     |
+    // -------------------------------
+    internal data class IntervalDayTime(val milliSeconds: Long) {
+
+        companion object {
+            fun of(day: Long, hour: Long, minute: Long, second: Long, millis: Long): IntervalDayTime {
+                val millis = toMillis(day, hour, minute, second, millis)
+                return IntervalDayTime(millis)
+            }
+
+            private fun toMillis(day: Long, hour: Long, minute: Long, second: Long, millis: Long): Long =
+                try {
+                    var value = millis
+                    value = Math.addExact(value, Math.multiplyExact(day, MILLIS_IN_DAY))
+                    value = Math.addExact(value, Math.multiplyExact(hour, MILLIS_IN_HOUR))
+                    value = Math.addExact(value, Math.multiplyExact(minute, MILLIS_IN_MINUTE))
+                    value = Math.addExact(value, Math.multiplyExact(second, MILLIS_IN_SECOND))
+                    value
+                } catch (e: ArithmeticException) {
+                    throw IllegalArgumentException(e)
+                }
+        }
+    }
+
+    // -------------------------------
+    // |    INTERVAL( YEAR MONTH)    |
+    // -------------------------------
+    internal data class IntervalYearMonth(val months: Long) {
+        companion object {
+            fun of(year: Long, months: Long) {
+                IntervalYearMonth(toMonth(year, months))
+            }
+
+            fun toMonth(year: Long, months: Long) = try {
+                Math.addExact(months, Math.multiplyExact(year, months))
+            } catch (e: ArithmeticException) {
+                throw IllegalArgumentException(e)
+            }
+        }
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/util/ExprValueFormatter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/util/ExprValueFormatter.kt
@@ -7,6 +7,7 @@ import org.partiql.lang.eval.ExprValueType
 import org.partiql.lang.eval.dateValue
 import org.partiql.lang.eval.name
 import org.partiql.lang.eval.timeValue
+import org.partiql.lang.eval.timestampValue
 import org.partiql.lang.eval.toIonValue
 import java.math.BigDecimal
 
@@ -63,9 +64,14 @@ class ConfigurableExprValueFormatter(private val config: Configuration) : ExprVa
                     val prefix = if (time.offsetTime == null) "TIME" else "TIME WITH TIME ZONE"
                     out.append("$prefix '$time'")
                 }
+                ExprValueType.TIMESTAMP -> {
+                    val timestamp = value.timestampValue()
+                    val prefix = if (timestamp.localOffset == null) "TIMESTAMP" else "TIMESTAMP WITH TIME ZONE"
+                    out.append("$prefix '$timestamp'")
+                }
 
                 // fallback to an Ion literal for all types that don't have a native PartiQL representation
-                ExprValueType.FLOAT, ExprValueType.TIMESTAMP, ExprValueType.SYMBOL,
+                ExprValueType.FLOAT, ExprValueType.SYMBOL,
                 ExprValueType.CLOB, ExprValueType.BLOB, ExprValueType.SEXP -> prettyPrintIonLiteral(value)
 
                 ExprValueType.LIST -> prettyPrintContainer(value, "[", "]")

--- a/partiql-lang/src/main/pig/partiql.ion
+++ b/partiql-lang/src/main/pig/partiql.ion
@@ -140,6 +140,8 @@ may then be further optimized by selecting better implementations of each operat
             // Constructors for DateTime types
             (date year::int month::int day::int)
             (lit_time value::time_value)
+            (timestamp value::timestamp_value)
+            (interval value::interval_value)
 
             // Bag operators
             (bag_op op::bag_op_type quantifier::set_quantifier operands::(* expr 2))
@@ -177,6 +179,20 @@ may then be further optimized by selecting better implementations of each operat
 
         // Time
         (product time_value hour::int minute::int second::int nano::int precision::int with_time_zone::bool tz_minutes::(? int))
+
+        // Timestamp
+        // We use a ion_timestamp directly here because we don't have a better way to support unlimited second fraction.
+        // TODO : Check if we have a better way to model this
+        (product timestamp_value precision::int ion_timestamp::ion)
+
+        // Interval
+        // According to the SQL spec, there are two kinds of interval, Year-month interval and day-time interval
+        (sum interval_value
+             // year month interval
+             (year_month_interval year::int month::int)
+             // date time interval
+             (date_time_interval day::int hour::int minute::int second::int millis::int)
+        )
 
         // A "step" within a path expression; that is the components of the expression following the root.
         (sum path_step
@@ -535,9 +551,6 @@ may then be further optimized by selecting better implementations of each operat
             // `NUMERIC[(<int> [, int])]`.  Elements are precision then scale.
             (numeric_type precision::(? int) scale::(? int))
 
-            // `TIMESTAMP`
-            (timestamp_type)
-
             // `CHAR(<int>)`
             (character_type length::(? int))
 
@@ -552,9 +565,11 @@ may then be further optimized by selecting better implementations of each operat
             (clob_type)
             (date_type)
 
-            // TIME : timezoneSpecified is 1 if time zone is specified else 0
+            // TIME / Timestamp : timezoneSpecified is 1 if time zone is specified else 0
             //        precision is defaulted to the length of the mantissa of the second's value if the precision is not specified.
             // Note: This logic is implemented in SqlParser.
+            (timestamp_type precision::(? int))
+            (timestamp_with_time_zone_type precision::(? int))
             (time_type precision::(? int))
             (time_with_time_zone_type precision::(? int))
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerDateTimeTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerDateTimeTests.kt
@@ -20,6 +20,14 @@ import kotlin.math.absoluteValue
 class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
 
     @Test
+    fun testTimestampLiteral() {
+        runEvaluatorTestCase(
+            query = "TIMESTAMP '2000-01-02 11:12:13'",
+            expectedResult = "'2000-01-02 11:12:13'"
+        )
+    }
+
+    @Test
     fun testDateLiteral() {
         runEvaluatorTestCase(
             query = "DATE '2000-01-02'",

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/ExprValueTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/ExprValueTest.kt
@@ -74,7 +74,7 @@ class ExprValueTest {
             TestCase(ExprValueType.CLOB, someTestBytes, ion.newClob(someTestBytes), ExprValue.newClob(someTestBytes)),
             TestCase(ExprValueType.BLOB, someTestBytes, ion.newBlob(someTestBytes), ExprValue.newBlob(someTestBytes)),
             TestCase(ExprValueType.DATE, localDate, ion.singleValue("$DATE_ANNOTATION::2022-01-01"), ExprValue.newDate(localDate)),
-            TestCase(ExprValueType.TIME, time, ion.singleValue("$TIME_ANNOTATION::{hour:17,minute:40,second:1.123456789,timezone_hour:1,timezone_minute:5}"), ExprValue.newTime(time))
+            TestCase(ExprValueType.TIME, time, ion.singleValue("$TIME_ANNOTATION::{hour:17,minute:40,second:1.123456789,timezone_hour:1,timezone_minute:5}"), ExprValue.newTime(time)),
         )
     }
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/TimestampParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/TimestampParserTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.eval.EvaluationException
-import org.partiql.lang.eval.builtins.internal.TimestampParser
+import org.partiql.lang.eval.builtins.timestamp.TimestampParser
 import java.lang.reflect.Type
 import java.time.format.DateTimeParseException
 import kotlin.test.assertEquals
@@ -423,7 +423,7 @@ class TimestampParserTest {
         // Note: exception message differs in JDK versions later than 1.8
         // "Text '1969 07 20 20 01 -2400' could not be parsed: Zone offset not in valid range: -18:00 to +18:00"),
 
-        // Offset not ending on a minute boundary (error condition detected by TimestampParser)
+        // Offset not ending on a minute boundary (error condition detected by IonTimestampParser)
         ParseFailureTestCase(
             "yyyy M d H m xxxxx",
             "1969 07 20 20 01 +01:00:01",

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/timestamp/TimestampFormatPatternParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/timestamp/TimestampFormatPatternParserTest.kt
@@ -110,7 +110,7 @@ internal class TimestampFormatPatternParserTest {
 
     @Test
     fun mostPreciseField() {
-        // NOTE: we can't parameterize this unless we want to expose TimestampParser.FormatPatternPrecision as public.
+        // NOTE: we can't parameterize this unless we want to expose IonTimestampParser.FormatPatternPrecision as public.
         softAssert {
             for ((pattern, expectedResult, expectedHas2DigitYear) in parametersForExaminePatternTest) {
                 val result = FormatPattern.fromString(pattern)

--- a/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
@@ -360,11 +360,18 @@ public data class TimeType(
     }
 }
 
-public data class TimestampType(override val metas: Map<String, Any> = mapOf()) : SingleType() {
+public data class TimestampType(
+    val precision: Int? = null,
+    val withTimeZone: Boolean = false,
+    override val metas: Map<String, Any> = mapOf()
+) : SingleType() {
     override val allTypes: List<StaticType>
         get() = listOf(this)
 
-    override fun toString(): String = "timestamp"
+    override fun toString(): String = when (withTimeZone) {
+        true -> "time with time zone"
+        false -> "time"
+    }
 }
 
 public data class SymbolType(override val metas: Map<String, Any> = mapOf()) : SingleType() {


### PR DESCRIPTION
## Relevant Issues
- #1057

## Description
Supporting Timestamp and Interval. 
### Timestamp
- [x] SQL Timestamp Literal syntax
- [x] Second-Fraction Rounding
- [ ] Basic Arithmetic Operation with Timestamp
- [ ] Casting behavior from/to Timestamp
- [ ] Functions (working with both Ion Literal and SQL timestamp) 

### Interval 
- [ ] SQL Interval Literal
- [ ] Arithmetic Operation with Interval and Timestamp.

### Documentation
- [ ] Document Spec related work in PartiQL-Doc. 
- [ ] Document implementation related work in Wiki. 

### Conformance Test
- [ ] Add timestamp / interval related tests to Conformance Test Suite. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - Not Yet.

- Any backward-incompatible changes? **[YES/NO]**
  - Not so far. 

- Any new external dependencies? **[YES/NO]**
 - No. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.