### PR TITLE
Adds syntactic and planning support for EXCLUDED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds support for using EXCLUDED within DML ON-CONFLICT-ACTION conditions. Closes #1111.
+
 ### Changed
 
 - Moves PartiqlAst, PartiqlLogical, PartiqlLogicalResolved, and PartiqlPhysical (along with the transforms)
@@ -34,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The file `partiql.ion` is still published in the `partiql-lang-kotlin` JAR.
 - Moves internal class org.partiql.lang.syntax.PartiQLParser to org.partiql.lang.syntax.impl.PartiQLPigParser as we refactor for explicit API.
 - Moves ANTLR grammar to `partiql-parser` package. The files `PartiQL.g4` and `PartiQLTokens.g4` are still published in the `partiql-lang-kotlin` JAR.
+- **Breaking**: Adds new property, `rowAlias`, to experimental `PartiqlLogical.DmlOperation.DmlUpdate`,
+  `PartiqlLogical.DmlOperation.DmlReplace`, `PartiqlLogicalResolved.DmlOperation.DmlUpdate`,
+  `PartiqlLogicalResolved.DmlOperation.DmlReplace`, `PartiqlPhysical.DmlOperation.DmlUpdate`, and
+  `PartiqlPhysical.DmlOperation.DmlReplace`.
 
 ### Deprecated
 

--- a/partiql-ast/src/main/pig/partiql.ion
+++ b/partiql-ast/src/main/pig/partiql.ion
@@ -767,10 +767,24 @@ may then be further optimized by selecting better implementations of each operat
                 (dml_insert target_alias::var_decl)
                 (dml_delete)
 
-                // row_alias is made optional since dml_replace is currently shared by REPLACE & INSERT ... ON CONFLICT DO REPLACE ...
+                // Represents the REPLACE statement as well as INSERT ... ON CONFLICT DO REPLACE ...
+                // [target-alias]: represents the alias for the table name. See the following syntactical example:
+                //  `INSERT INTO Table1 AS <alias> << { 'id': 1, 'name': 'Arash' } >> ON CONFLICT DO REPLACE ...`
+                // [condition]: represents the condition by which a row should be replaced. See the following syntactical example:
+                //  `INSERT INTO x << {'id': 1, 'name': 'John'}} >> ON CONFLICT DO REPLACE EXCLUDED WHERE <condition>`
+                // [row_alias]: represents the alias given to the rows meant to be inserted/replaced. It is made optional
+                //  since dml_replace is currently shared by REPLACE (which does not allow the aliasing of rows) and
+                //  INSERT ... ON CONFLICT DO REPLACE ... (which aliases the rows as "EXCLUDED" for use within the [condition]).
                 (dml_replace target_alias::var_decl condition::(? expr) row_alias::(? var_decl))
 
-                // row_alias is made optional since dml_update is currently shared by UPSERT & INSERT ... ON CONFLICT DO UPDATE ...
+                // Represents the UPSERT statement as well as INSERT ... ON CONFLICT DO UPDATE ...
+                // [target-alias]: represents the alias for the table name. See the following syntactical example:
+                //  `INSERT INTO Table1 AS <alias> << { 'id': 1, 'name': 'Arash' } >> ON CONFLICT DO UPDATE ...`
+                // [condition]: represents the condition by which a row should be replaced. See the following syntactical example:
+                //  `INSERT INTO x << {'id': 1, 'name': 'John'}} >> ON CONFLICT DO UPDATE EXCLUDED WHERE <condition>`
+                // [row_alias]: represents the alias given to the rows meant to be inserted/updated. It is made optional
+                //  since dml_update is currently shared by UPSERT (which does not allow the aliasing of rows) and
+                //  INSERT ... ON CONFLICT DO UPDATE ... (which aliases the rows as "EXCLUDED" for use within the [condition]).
                 (dml_update target_alias::var_decl condition::(? expr) row_alias::(? var_decl))
             )
         )

--- a/partiql-ast/src/main/pig/partiql.ion
+++ b/partiql-ast/src/main/pig/partiql.ion
@@ -766,8 +766,12 @@ may then be further optimized by selecting better implementations of each operat
             (sum dml_operation
                 (dml_insert target_alias::var_decl)
                 (dml_delete)
-                (dml_replace target_alias::var_decl condition::(? expr))
-                (dml_update target_alias::var_decl condition::(? expr))
+
+                // row_alias is made optional since dml_replace is currently shared by REPLACE & INSERT ... ON CONFLICT DO REPLACE ...
+                (dml_replace target_alias::var_decl condition::(? expr) row_alias::(? var_decl))
+
+                // row_alias is made optional since dml_update is currently shared by UPSERT & INSERT ... ON CONFLICT DO UPDATE ...
+                (dml_update target_alias::var_decl condition::(? expr) row_alias::(? var_decl))
             )
         )
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -45,6 +45,10 @@ internal class AstToLogicalVisitorTransform(
     val problemHandler: ProblemHandler
 ) : PartiqlAstToPartiqlLogicalVisitorTransform() {
 
+    internal companion object {
+        internal const val EXCLUDED: String = "EXCLUDED"
+    }
+
     override fun transformExprSelect(node: PartiqlAst.Expr.Select): PartiqlLogical.Expr = PartiqlLogical.build {
         var algebra: PartiqlLogical.Bexpr = node.from.toBexpr(this@AstToLogicalVisitorTransform, problemHandler)
 
@@ -374,13 +378,15 @@ internal class AstToLogicalVisitorTransform(
                     is PartiqlAst.ConflictAction.DoReplace -> when (conflictAction.value) {
                         is PartiqlAst.OnConflictValue.Excluded -> PartiqlLogical.DmlOperation.DmlReplace(
                             targetAlias = alias,
-                            condition = conflictAction.condition?.let { transformExpr(it) }
+                            condition = conflictAction.condition?.let { transformExpr(it) },
+                            rowAlias = conflictAction.condition?.let { PartiqlLogical.VarDecl(SymbolPrimitive(EXCLUDED, emptyMetaContainer())) }
                         )
                     }
                     is PartiqlAst.ConflictAction.DoUpdate -> when (conflictAction.value) {
                         is PartiqlAst.OnConflictValue.Excluded -> PartiqlLogical.DmlOperation.DmlUpdate(
                             targetAlias = alias,
-                            condition = conflictAction.condition?.let { transformExpr(it) }
+                            condition = conflictAction.condition?.let { transformExpr(it) },
+                            rowAlias = conflictAction.condition?.let { PartiqlLogical.VarDecl(SymbolPrimitive(EXCLUDED, emptyMetaContainer())) }
                         )
                     }
                     is PartiqlAst.ConflictAction.DoNothing -> TODO("`ON CONFLICT DO NOTHING` is not supported in logical plan yet.")

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
@@ -385,13 +385,17 @@ internal data class LogicalToLogicalResolvedVisitorTransform(
     }
 
     override fun transformDmlOperationDmlReplace(node: PartiqlLogical.DmlOperation.DmlReplace): PartiqlLogicalResolved.DmlOperation {
-        return withInputScope(this.inputScope.concatenate(node.targetAlias)) {
+        val scopeWithTarget = this.inputScope.concatenate(node.targetAlias)
+        val inputScope = node.rowAlias?.let { scopeWithTarget.concatenate(it) } ?: scopeWithTarget
+        return withInputScope(inputScope) {
             super.transformDmlOperationDmlReplace(node)
         }
     }
 
     override fun transformDmlOperationDmlUpdate(node: PartiqlLogical.DmlOperation.DmlUpdate): PartiqlLogicalResolved.DmlOperation {
-        return withInputScope(this.inputScope.concatenate(node.targetAlias)) {
+        val scopeWithTarget = this.inputScope.concatenate(node.targetAlias)
+        val inputScope = node.rowAlias?.let { scopeWithTarget.concatenate(it) } ?: scopeWithTarget
+        return withInputScope(inputScope) {
             super.transformDmlOperationDmlUpdate(node)
         }
     }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
@@ -965,11 +965,18 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
 
     override fun visitExprTermWrappedQuery(ctx: PartiQLParser.ExprTermWrappedQueryContext) = visit(ctx.expr(), PartiqlAst.Expr::class)
 
-    override fun visitVarRefExpr(ctx: PartiQLParser.VarRefExprContext): PartiqlAst.PartiqlAstNode = PartiqlAst.build {
+    override fun visitVariableIdentifier(ctx: PartiQLParser.VariableIdentifierContext): PartiqlAst.PartiqlAstNode = PartiqlAst.build {
         val metas = ctx.ident.getSourceMetaContainer()
         val qualifier = if (ctx.qualifier == null) unqualified() else localsFirst()
         val sensitivity = if (ctx.ident.type == PartiQLParser.IDENTIFIER) caseInsensitive() else caseSensitive()
         id(ctx.ident.getStringValue(), sensitivity, qualifier, metas)
+    }
+
+    override fun visitVariableKeyword(ctx: PartiQLParser.VariableKeywordContext): PartiqlAst.PartiqlAstNode = PartiqlAst.build {
+        val keyword = ctx.nonReservedKeywords().start.text
+        val metas = ctx.start.getSourceMetaContainer()
+        val qualifier = ctx.qualifier?.let { localsFirst() } ?: unqualified()
+        id(keyword, caseInsensitive(), qualifier, metas)
     }
 
     override fun visitParameter(ctx: PartiQLParser.ParameterContext) = PartiqlAst.build {

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
@@ -836,6 +836,41 @@ class AstToLogicalVisitorTransformTests {
                     }
                 }
             ),
+
+            // A collection of values
+            TestCase(
+                "INSERT INTO foo AS f <<{'id': 1, 'name':'bob'}, {'id': 2, 'name':'alice'}>> ON CONFLICT DO REPLACE EXCLUDED WHERE f.id > 2",
+                PartiqlLogical.build {
+                    PartiqlLogical.build {
+                        dml(
+                            identifier("foo", caseInsensitive()),
+                            dmlReplace(
+                                varDecl("f"),
+                                condition = gt(
+                                    listOf(
+                                        path(
+                                            id("f", caseInsensitive(), unqualified()),
+                                            listOf(pathExpr(lit(ionString("id")), caseInsensitive()))
+                                        ),
+                                        lit(ionInt(2))
+                                    )
+                                ),
+                                rowAlias = varDecl(AstToLogicalVisitorTransform.EXCLUDED)
+                            ),
+                            bag(
+                                struct(
+                                    structField(lit(ionString("id")), lit(ionInt(1))),
+                                    structField(lit(ionString("name")), lit(ionString("bob")))
+                                ),
+                                struct(
+                                    structField(lit(ionString("id")), lit(ionInt(2))),
+                                    structField(lit(ionString("name")), lit(ionString("alice")))
+                                )
+                            )
+                        )
+                    }
+                }
+            ),
             // Testing using excluded non-reserved keyword in condition
             TestCase(
                 "INSERT INTO foo AS f <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO REPLACE EXCLUDED WHERE excluded.id > 2",

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransformTests.kt
@@ -780,7 +780,8 @@ class AstToLogicalVisitorTransformTests {
                                     ),
                                     lit(ionInt(2))
                                 )
-                            )
+                            ),
+                            rowAlias = varDecl(AstToLogicalVisitorTransform.EXCLUDED)
                         ),
                         bindingsToValues(
                             struct(structFields(id("x", caseInsensitive(), unqualified()))),
@@ -822,7 +823,38 @@ class AstToLogicalVisitorTransformTests {
                                         ),
                                         lit(ionInt(2))
                                     )
+                                ),
+                                rowAlias = varDecl(AstToLogicalVisitorTransform.EXCLUDED)
+                            ),
+                            bag(
+                                struct(
+                                    structField(lit(ionString("id")), lit(ionInt(1))),
+                                    structField(lit(ionString("name")), lit(ionString("bob")))
                                 )
+                            )
+                        )
+                    }
+                }
+            ),
+            // Testing using excluded non-reserved keyword in condition
+            TestCase(
+                "INSERT INTO foo AS f <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO REPLACE EXCLUDED WHERE excluded.id > 2",
+                PartiqlLogical.build {
+                    PartiqlLogical.build {
+                        dml(
+                            identifier("foo", caseInsensitive()),
+                            dmlReplace(
+                                varDecl("f"),
+                                condition = gt(
+                                    listOf(
+                                        path(
+                                            id("excluded", caseInsensitive(), unqualified()),
+                                            listOf(pathExpr(lit(ionString("id")), caseInsensitive()))
+                                        ),
+                                        lit(ionInt(2))
+                                    )
+                                ),
+                                rowAlias = varDecl(AstToLogicalVisitorTransform.EXCLUDED)
                             ),
                             bag(
                                 struct(
@@ -880,7 +912,38 @@ class AstToLogicalVisitorTransformTests {
                                         ),
                                         lit(ionInt(2))
                                     )
+                                ),
+                                rowAlias = varDecl(AstToLogicalVisitorTransform.EXCLUDED)
+                            ),
+                            bag(
+                                struct(
+                                    structField(lit(ionString("id")), lit(ionInt(1))),
+                                    structField(lit(ionString("name")), lit(ionString("bob")))
                                 )
+                            )
+                        )
+                    }
+                }
+            ),
+            // Testing using excluded non-reserved keyword in condition
+            TestCase(
+                "INSERT INTO foo AS f <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO UPDATE EXCLUDED WHERE excluded.id > 2",
+                PartiqlLogical.build {
+                    PartiqlLogical.build {
+                        dml(
+                            identifier("foo", caseInsensitive()),
+                            dmlUpdate(
+                                varDecl("f"),
+                                condition = gt(
+                                    listOf(
+                                        path(
+                                            id("excluded", caseInsensitive(), unqualified()),
+                                            listOf(pathExpr(lit(ionString("id")), caseInsensitive()))
+                                        ),
+                                        lit(ionInt(2))
+                                    )
+                                ),
+                                rowAlias = varDecl(AstToLogicalVisitorTransform.EXCLUDED)
                             ),
                             bag(
                                 struct(

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass.kt
@@ -270,7 +270,7 @@ class LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass {
                 PartiqlLogicalResolved.build {
                     dml(
                         uniqueId = "foo",
-                        operation = dmlReplace(varDecl(0)),
+                        operation = dmlReplace(varDecl(0), rowAlias = varDecl(1)),
                         rows = bindingsToValues(
                             struct(structFields(localId(0))),
                             scan(lit(ionInt(1)), varDecl(0))
@@ -280,7 +280,7 @@ class LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass {
                 PartiqlPhysical.build {
                     dml(
                         uniqueId = "foo",
-                        operation = dmlReplace(varDecl(0)),
+                        operation = dmlReplace(varDecl(0), rowAlias = varDecl(1)),
                         rows = bindingsToValues(
                             struct(structFields(localId(0))),
                             scan(DEFAULT_IMPL, lit(ionInt(1)), varDecl(0))
@@ -303,7 +303,8 @@ class LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass {
                                     ),
                                     lit(ionInt(1))
                                 )
-                            )
+                            ),
+                            rowAlias = varDecl(1)
                         ),
                         rows = bindingsToValues(
                             struct(structFields(localId(0))),
@@ -324,7 +325,8 @@ class LogicalResolvedToDefaultPartiQLPhysicalVisitorTransformTestsPass {
                                     ),
                                     lit(ionInt(1))
                                 )
-                            )
+                            ),
+                            rowAlias = varDecl(1)
                         ),
                         rows = bindingsToValues(
                             struct(structFields(localId(0))),

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -180,6 +180,18 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         "(id kumo (case_sensitive) (unqualified))"
     )
 
+    @Test
+    fun nonReservedKeyword() = assertExpression(
+        "excluded",
+        "(id excluded (case_insensitive) (unqualified))"
+    )
+
+    @Test
+    fun nonReservedKeywordQualified() = assertExpression(
+        "@excluded",
+        "(id excluded (case_insensitive) (locals_first))"
+    )
+
     // ****************************************
     // call
     // ****************************************
@@ -2282,6 +2294,37 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     )
 
     @Test
+    fun insertWithOnConflictReplaceExcludedWithExcludedInCondition() = assertExpression(
+        source = "INSERT into foo VALUES (1, 2), (3, 4) ON CONFLICT DO REPLACE EXCLUDED WHERE excluded.id > 2",
+        expectedPigAst = """
+        (dml
+            (operations
+                (dml_op_list
+                    (insert
+                        (id foo (case_insensitive) (unqualified))
+                        null
+                        (bag
+                            (list
+                                (lit 1)
+                                (lit 2))
+                            (list
+                                (lit 3)
+                                (lit 4)))
+                        (do_replace
+                            (excluded)
+                            (gt
+                                (path
+                                    (id excluded (case_insensitive) (unqualified))
+                                    (path_expr
+                                        (lit "id")
+                                        (case_insensitive)))
+                                (lit 2)
+                            )
+                        )))))
+        """
+    )
+
+    @Test
     fun insertWithOnConflictReplaceExcludedWithLiteralValueWithAlias() = assertExpression(
         source = "INSERT into foo AS f <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO REPLACE EXCLUDED",
         expectedPigAst = """
@@ -2329,6 +2372,38 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                             (gt
                                 (path
                                     (id f (case_insensitive) (unqualified))
+                                    (path_expr
+                                        (lit "id")
+                                        (case_insensitive)))
+                                (lit 2)
+                            )
+                            )))))
+        """
+    )
+
+    @Test
+    fun insertWithOnConflictReplaceExcludedWithAliasAndExcludedInCondition() = assertExpression(
+        source = "INSERT into foo AS f <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO REPLACE EXCLUDED WHERE excluded.id > 2",
+        expectedPigAst = """
+            (dml
+                (operations
+                    (dml_op_list
+                        (insert
+                            (id foo (case_insensitive) (unqualified))
+                            f
+                            (bag
+                                (struct
+                                    (expr_pair
+                                        (lit "id")
+                                        (lit 1))
+                                    (expr_pair
+                                        (lit "name")
+                                        (lit "bob"))))
+                            (do_replace
+                                (excluded)
+                            (gt
+                                (path
+                                    (id excluded (case_insensitive) (unqualified))
                                     (path_expr
                                         (lit "id")
                                         (case_insensitive)))
@@ -2434,6 +2509,37 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     )
 
     @Test
+    fun insertWithOnConflictUpdateExcludedWithExcludedCondition() = assertExpression(
+        source = "INSERT into foo VALUES (1, 2), (3, 4) ON CONFLICT DO UPDATE EXCLUDED WHERE excluded.id > 2",
+        expectedPigAst = """
+        (dml
+            (operations
+                (dml_op_list
+                    (insert
+                        (id foo (case_insensitive) (unqualified))
+                        null
+                        (bag
+                            (list
+                                (lit 1)
+                                (lit 2))
+                            (list
+                                (lit 3)
+                                (lit 4)))
+                        (do_update
+                            (excluded)
+                            (gt
+                                (path
+                                    (id excluded (case_insensitive) (unqualified))
+                                    (path_expr
+                                        (lit "id")
+                                        (case_insensitive)))
+                                (lit 2)
+                            )
+                        )))))
+        """
+    )
+
+    @Test
     fun insertWithOnConflictUpdateExcludedWithLiteralValueWithAlias() = assertExpression(
         source = "INSERT into foo AS f <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO UPDATE EXCLUDED",
         expectedPigAst = """
@@ -2481,6 +2587,38 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                             (gt
                                 (path
                                     (id f (case_insensitive) (unqualified))
+                                    (path_expr
+                                        (lit "id")
+                                        (case_insensitive)))
+                                (lit 2)
+                            )
+                            )))))
+        """
+    )
+
+    @Test
+    fun insertWithOnConflictUpdateExcludedWithAliasAndExcludedCondition() = assertExpression(
+        source = "INSERT into foo AS f <<{'id': 1, 'name':'bob'}>> ON CONFLICT DO UPDATE EXCLUDED WHERE excluded.id > 2",
+        expectedPigAst = """
+            (dml
+                (operations
+                    (dml_op_list
+                        (insert
+                            (id foo (case_insensitive) (unqualified))
+                            f
+                            (bag
+                                (struct
+                                    (expr_pair
+                                        (lit "id")
+                                        (lit 1))
+                                    (expr_pair
+                                        (lit "name")
+                                        (lit "bob"))))
+                            (do_update
+                                (excluded)
+                            (gt
+                                (path
+                                    (id excluded (case_insensitive) (unqualified))
                                     (path_expr
                                         (lit "id")
                                         (case_insensitive)))

--- a/partiql-parser/src/main/antlr/PartiQL.g4
+++ b/partiql-parser/src/main/antlr/PartiQL.g4
@@ -695,7 +695,13 @@ parameter
     : QUESTION_MARK;
 
 varRefExpr
-    : qualifier=AT_SIGN? ident=(IDENTIFIER|IDENTIFIER_QUOTED);
+    : qualifier=AT_SIGN? ident=(IDENTIFIER|IDENTIFIER_QUOTED)   # VariableIdentifier
+    | qualifier=AT_SIGN? key=nonReservedKeywords                # VariableKeyword
+    ;
+
+nonReservedKeywords
+    : EXCLUDED
+    ;
 
 /**
  *


### PR DESCRIPTION
## Relevant Issues
- Closes #1111 

## Description
- Adds support for `EXCLUDED` by:
  - Modifying `varRefExpr` in ANTLR to allow for non-reserved keywords. Marks `EXCLUDED` as non-reserved. It is still reserved immediately following `DO REPLACE` and `DO UPDATE`.
  - Modifying PIG Logical/LogicalResolved `dml_operation.dml_update` and `dml_operation.dml_replace` to have an optional `row_alias` (string).
    - I do this because `dml_update` is used for both `UPSERT` and `INSERT ... ON CONFLICT DO UPDATE ...`. `UPSERT` doesn't have the ability to use the `excluded` table.
    - Same goes for `dml_replace` with `REPLACE` and `INSERT ... ON CONFLICT DO REPLACE ...`.
  - So, the `row_alias` becomes a variable declaration and therefore gets a dedicated variable in the local registers.
  - For identifier resolution, we allow the ON CONFLICT ACTION `<condition>` have access to the new variable by adding it to the scope.

## Testing
- Added parsing tests for non-reserved keywords
- Added parsing tests for using `EXCLUDED` in the `<condition>`
- Added `AstToiLogical` and `LogicalToLogicalResolved` tests. Updated `LogicalResolvedToPhysical` tests to make sure the `rowAlias` was being passed.

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **YES**
  - See CHANGELOG.
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.