### PR TITLE
Updates to kotlin 1.6; compile target remains 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updates Kotlin from 1.5.+ to 1.6; compile target remains 1.4
 - Moves PartiqlAst, PartiqlLogical, PartiqlLogicalResolved, and PartiqlPhysical (along with the transforms)
   to a new project, `partiql-ast`. These are still imported into `partiql-lang` with the `api` annotation. Therefore,
   no action is required to consume the migrated classes. However, this now gives consumers of the AST, Experimental Plans,

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
 object Versions {
     const val detekt = "1.20.0-RC1"
     const val dokka = "1.6.10"
-    const val kotlin = "1.5.+"
+    const val kotlin = "1.6.20"
     const val ktlint = "10.2.1"
     const val pig = "0.6.1"
 }

--- a/buildSrc/src/main/kotlin/partiql.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/partiql.conventions.gradle.kts
@@ -49,7 +49,7 @@ java {
 
 tasks.test {
     useJUnitPlatform() // Enable JUnit5
-    jvmArgs!!.addAll(listOf("-Duser.language=en", "-Duser.country=US"))
+    jvmArgs.addAll(listOf("-Duser.language=en", "-Duser.country=US"))
     maxHeapSize = "4g"
     testLogging {
         events.add(TestLogEvent.FAILED)

--- a/buildSrc/src/main/kotlin/partiql.versions.kt
+++ b/buildSrc/src/main/kotlin/partiql.versions.kt
@@ -18,7 +18,7 @@
 
 object Versions {
     // Language
-    const val kotlin = "1.5.31"
+    const val kotlin = "1.6.20"
     const val kotlinTarget = "1.4"
     const val javaTarget = "1.8"
 

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -28,9 +28,8 @@ dependencies {
     implementation(Deps.awsSdkS3)
 }
 
-// TODO: Once we upgrade kotlin version to 1.6+, we need to change the compile option to -opt-in
 // Version 1.7+ removes the requirement for such compiler option.
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     kotlinOptions
-        .freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+        .freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
 }

--- a/partiql-cli/build.gradle.kts
+++ b/partiql-cli/build.gradle.kts
@@ -60,9 +60,8 @@ tasks.register<GradleBuild>("install") {
     tasks = listOf("assembleDist", "distZip", "installDist")
 }
 
-// TODO: Once we upgrade kotlin version to 1.6+, we need to change the compile option to -opt-in
 // Version 1.7+ removes the requirement for such compiler option.
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     kotlinOptions
-        .freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+        .freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
 }


### PR DESCRIPTION
## Relevant Issues

#1075

## Description

Updates language level from 1.5 to 1.6.

## Other Information

- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Yes

- Any backward-incompatible changes? **[YES/NO]**
From a consumer standpoint, the language target remains 1.4

- Any new external dependencies? **[YES/NO]**
Yes, using kotlin stdlib 1.6 now

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.