### PR TITLE
Updates contributing/style guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,9 @@ errors for users that are using our public APIs or the entities that have `publi
   - < If YES, which ones and why? >
   - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >
 
+- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
+  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
+
 ## License Information
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Security
+
+### Contributors
+Thank you to all who have contributed!
+- @<your-username>
+
 -->
 
 
@@ -93,6 +98,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+### Contributors
+Thank you to all who have contributed!
+- @johnedquinn
+- @RCHowell
+- @vgapeyev
 
 ## [0.11.0] - 2023-05-22
 

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -1,0 +1,49 @@
+# Coding Style
+
+All contributions to the project must comply with the guidelines set forth in this document. Some older parts of the
+codebase do not follow these guidelines. If you are modifying such code, it is generally best to clean it up to comply
+with the current guidelines.
+
+### Explicit API Mode
+
+In order to better position our developers to produce quality, public-facing code, all new PartiQL projects will enable
+[strict explicit API mode](https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors). In this
+Kotlin compilation mode, "the compiler performs additional checks that help make the library's API clearer and more consistent".
+The implications are **required** visibility modifiers and return types.
+
+### Implementation Packages
+
+All `internal` classes should be placed within `impl` packages to help distinguish our public APIs from the internal
+codebase.
+
+See an example below:
+```text
+⚬ partiql-types
+└── src/main/kotlin/org/partiql/types
+    ├── impl
+    |  ├── StructElement.kt (internal)
+    |  ├── StructType.kt (internal)
+    |  ├── ...
+    |  └── IntElement.kt
+    ├── PartiQLElement.kt (Public Interface & Builder)
+    └── PartiQLType.kt (Public Interface & Builder)
+```
+
+### Top-Level Functions
+
+For Public APIs, the Kotlin implementation will not allow top-level functions. Similarly, due to the resulting JVM bytecode,
+there shall not be `internal` top-level functions. They should be generally avoided.
+
+### General Styling
+
+All contributions must abide by the styling guidelines set by `ktlint`. To automatically format the codebase to comply
+with `ktlint`, run:
+```
+./gradlew ktlintFormat
+```
+
+To check whether your contributions already comply with the style
+guidelines, run:
+```
+./gradlew ktlintCheck
+```

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -47,3 +47,23 @@ guidelines, run:
 ```
 ./gradlew ktlintCheck
 ```
+
+### Copyright Notices
+
+Always include the copyright notice at the top of every file containing source code.
+
+```kotlin
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,10 @@ To send us a pull request, please:
 5. Send us a pull request, answering any default questions in the pull request interface.
    1. Ensure you add the details on the change to the [CHANGELOG.md](CHANGELOG.md) file under `Unreleased` section.
       If your change is a breaking change, label your change with `[breaking-change]` as prefix in `CHANGELOG.md`.
+   2. Feel free to add your GitHub username to the [CHANGELOG.md](CHANGELOG.md) under the `Contributors` section. This
+   will add your name to the
+      [contributor list](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
+      in the next GitHub release.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and 
@@ -48,6 +52,9 @@ Looking at the existing issues is a great way to find something to contribute on
 As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), 
 looking at any ['help wanted'](https://github.com/partiql/partiql-lang-kotlin/labels/help%20wanted) issues is a great place to start. 
 
+## Code Style Guidelines
+Patches must comply with the [code style guidelines](./CODE_STYLE.md). Some older parts of the codebase do not follow
+these guidelines. If you are modifying such code, it is generally best to clean it up to comply with the current guidelines.
 
 ## Code of Conduct
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). 


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds Code Style guidelines
- Adds a Contributors section for releases. See [v0.11.0](https://github.com/partiql/partiql-lang-kotlin/releases/tag/v0.11.0-alpha) to see what the contributors list rendering looks like.
- Updates GH PR template

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.