### PR TITLE
Updates Kotlin target to 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updates Kotlin from 1.5.+ to 1.6; compile target remains 1.4
+- Updates Kotlin target from 1.4 (DEPRECATED) to 1.6
 - Moves PartiqlAst, PartiqlLogical, PartiqlLogicalResolved, and PartiqlPhysical (along with the transforms)
   to a new project, `partiql-ast`. These are still imported into `partiql-lang` with the `api` annotation. Therefore,
   no action is required to consume the migrated classes. However, this now gives consumers of the AST, Experimental Plans,

--- a/buildSrc/src/main/kotlin/partiql.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/partiql.conventions.gradle.kts
@@ -43,8 +43,8 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.toVersion(Versions.javaTarget)
-    targetCompatibility = JavaVersion.toVersion(Versions.javaTarget)
+    sourceCompatibility = JavaVersion.toVersion(Versions.jvmTarget)
+    targetCompatibility = JavaVersion.toVersion(Versions.jvmTarget)
 }
 
 tasks.test {
@@ -60,15 +60,15 @@ tasks.test {
 }
 
 tasks.compileKotlin {
-    kotlinOptions.jvmTarget = Versions.javaTarget
-    kotlinOptions.apiVersion = Versions.kotlinTarget
-    kotlinOptions.languageVersion = Versions.kotlinTarget
+    kotlinOptions.jvmTarget = Versions.jvmTarget
+    kotlinOptions.apiVersion = Versions.kotlinApi
+    kotlinOptions.languageVersion = Versions.kotlinLanguage
 }
 
 tasks.compileTestKotlin {
-    kotlinOptions.jvmTarget = Versions.javaTarget
-    kotlinOptions.apiVersion = Versions.kotlinTarget
-    kotlinOptions.languageVersion = Versions.kotlinTarget
+    kotlinOptions.jvmTarget = Versions.jvmTarget
+    kotlinOptions.apiVersion = Versions.kotlinApi
+    kotlinOptions.languageVersion = Versions.kotlinLanguage
 }
 
 configure<KtlintExtension> {

--- a/buildSrc/src/main/kotlin/partiql.versions.kt
+++ b/buildSrc/src/main/kotlin/partiql.versions.kt
@@ -19,8 +19,9 @@
 object Versions {
     // Language
     const val kotlin = "1.6.20"
-    const val kotlinTarget = "1.4"
-    const val javaTarget = "1.8"
+    const val kotlinLanguage = "1.6"
+    const val kotlinApi = "1.6"
+    const val jvmTarget = "1.8"
 
     // Dependencies
     const val antlr = "4.10.1"
@@ -29,7 +30,6 @@ object Versions {
     const val dotlin = "1.0.2"
     const val gson = "2.10.1"
     const val guava = "31.1-jre"
-    const val ionBuilder = "1.0.0"
     const val ionElement = "1.0.0"
     const val ionJava = "1.9.0"
     const val ionSchema = "1.2.1"
@@ -70,7 +70,6 @@ object Deps {
     const val guava = "com.google.guava:guava:${Versions.guava}"
     const val ionJava = "com.amazon.ion:ion-java:${Versions.ionJava}"
     const val ionElement = "com.amazon.ion:ion-element:${Versions.ionElement}"
-    const val ionBuilder = "com.amazon.ion:ion-kotlin-builder:${Versions.ionBuilder}"
     const val ionSchema = "com.amazon.ion:ion-schema-kotlin:${Versions.ionSchema}"
     const val jansi = "org.fusesource.jansi:jansi:${Versions.jansi}"
     const val jline = "org.jline:jline:${Versions.jline}"


### PR DESCRIPTION
## Relevant Issues

#1075 

## Description

Updates Kotlin target to 1.6

## Other Information

- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Yes

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**

Kind of yes? Kotlin Std Libs are being changed from 1.5+ to 1.6.20

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.