### PR TITLE
Replaces toUpperCase/toLowerCase with uppercase/lowercase

### DIFF
--- a/lib/isl/src/test/kotlin/org/partiql/ionschema/discovery/SchemaInferencerFromExampleTests.kt
+++ b/lib/isl/src/test/kotlin/org/partiql/ionschema/discovery/SchemaInferencerFromExampleTests.kt
@@ -1061,7 +1061,7 @@ class SchemaInferencerFromExampleTests {
                 examplesCombined += "{ foo: $it }"
             }
 
-            val fooType = ion.singleValue(examples.first()).type.name.toLowerCase()
+            val fooType = ion.singleValue(examples.first()).type.name.lowercase()
             var additionalConstraints = ""
             if (constraints.isNotEmpty()) {
                 constraints.map {

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/model/Model.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/model/Model.kt
@@ -105,7 +105,7 @@ sealed class TypeRef(
         val type: ScalarType,
         nullable: Boolean = false,
     ) : TypeRef(
-        id = type.toString().toLowerCase(),
+        id = type.toString().lowercase(),
         nullable = nullable,
     )
 

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/parser/ion/IonTypeParser.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/parser/ion/IonTypeParser.kt
@@ -248,7 +248,7 @@ internal object IonTypeParser : SproutParser {
             // 2. Attempt as scalar
             try {
                 return TypeRef.Scalar(
-                    type = ScalarType.valueOf(symbol.toUpperCase()),
+                    type = ScalarType.valueOf(symbol.uppercase()),
                     nullable = nullable,
                 )
             } catch (_: IllegalArgumentException) {
@@ -274,7 +274,7 @@ internal object IonTypeParser : SproutParser {
          */
         private fun resolve(v: IonList): TypeRef {
             val (symbol, nullable) = v.ref()
-            return when (symbol.toLowerCase()) {
+            return when (symbol.lowercase()) {
                 "list" -> {
                     assert(v.size == 1) { "list must have exactly one type" }
                     val t = resolve(v[0])

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/format/Utilities.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/format/Utilities.kt
@@ -18,5 +18,5 @@ import org.partiql.pig.runtime.DomainNode
 import kotlin.reflect.full.memberProperties
 
 internal fun DomainNode.properties() = this.javaClass.kotlin.memberProperties.filter { property ->
-    property.name.toLowerCase() != "metas" && property.name.toLowerCase() != "myhashcode"
+    property.name.lowercase() != "metas" && property.name.lowercase() != "myhashcode"
 }

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/format/dot/Dot.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/format/dot/Dot.kt
@@ -954,14 +954,14 @@ enum class DotArrowType {
     OBOX,
     HALFOPEN;
 
-    override fun toString(): String = super.toString().toLowerCase()
+    override fun toString(): String = super.toString().lowercase()
 }
 
 enum class DotDirType {
     FORWARD,
     NONE;
 
-    override fun toString(): String = super.toString().toLowerCase()
+    override fun toString(): String = super.toString().lowercase()
 }
 
 enum class DotPortPos {
@@ -978,7 +978,7 @@ enum class DotPortPos {
 
     override fun toString(): String = when (this) {
         DEF -> "_"
-        else -> super.toString().toLowerCase()
+        else -> super.toString().lowercase()
     }
 }
 
@@ -990,7 +990,7 @@ enum class DotEdgeStyle {
     BOLD,
     TAPERED;
 
-    override fun toString(): String = super.toString().toLowerCase()
+    override fun toString(): String = super.toString().lowercase()
 }
 
 enum class DotNodeStyle {
@@ -1005,7 +1005,7 @@ enum class DotNodeStyle {
     DIAGONALS,
     ROUNDED;
 
-    override fun toString(): String = super.toString().toLowerCase()
+    override fun toString(): String = super.toString().lowercase()
 }
 
 class DotRect(
@@ -1022,7 +1022,7 @@ enum class DotClusterMode {
     GLOBAL,
     NONE;
 
-    override fun toString(): String = super.toString().toLowerCase()
+    override fun toString(): String = super.toString().lowercase()
 }
 
 enum class DotOutputMode {
@@ -1030,7 +1030,7 @@ enum class DotOutputMode {
     NODESFIRST,
     EDGESFIRST;
 
-    override fun toString(): String = super.toString().toLowerCase()
+    override fun toString(): String = super.toString().lowercase()
 }
 
 enum class DotPageDir {
@@ -1049,7 +1049,7 @@ enum class DotQuadType {
     FAST,
     NONE;
 
-    override fun toString(): String = super.toString().toLowerCase()
+    override fun toString(): String = super.toString().lowercase()
 }
 
 enum class DotRankDir {
@@ -1068,7 +1068,7 @@ enum class DotSmoothType {
     SPRING,
     TRIANGLE;
 
-    override fun toString(): String = super.toString().toLowerCase()
+    override fun toString(): String = super.toString().lowercase()
 }
 
 enum class DotNodeShape {
@@ -1134,7 +1134,7 @@ enum class DotNodeShape {
     RECORD,
     MRECORD;
 
-    override fun toString(): String = super.toString().toLowerCase()
+    override fun toString(): String = super.toString().lowercase()
 }
 
 enum class DotSubgraphStyle {
@@ -1142,5 +1142,5 @@ enum class DotSubgraphStyle {
     STRIPED,
     ROUNDED;
 
-    override fun toString(): String = super.toString().toLowerCase()
+    override fun toString(): String = super.toString().lowercase()
 }

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/functions/ReadFile.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/functions/ReadFile.kt
@@ -42,7 +42,7 @@ internal class ReadFile(private val ion: IonSystem) : ExprFunction {
     )
 
     private fun conversionModeFor(name: String) =
-        ConversionMode.values().find { it.name.toLowerCase() == name }
+        ConversionMode.values().find { it.name.lowercase() == name }
             ?: throw IllegalArgumentException("Unknown conversion: $name")
 
     private fun fileReadHandler(csvFormat: CSVFormat): (InputStream, Bindings<ExprValue>) -> ExprValue = { input, bindings ->

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/shell/Shell.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/shell/Shell.kt
@@ -192,7 +192,7 @@ internal class Shell(
             val command = when (val end: Int = CharMatcher.`is`(';').or(CharMatcher.whitespace()).indexIn(line)) {
                 -1 -> ""
                 else -> line.substring(0, end)
-            }.toLowerCase(Locale.ENGLISH).trim()
+            }.lowercase(Locale.ENGLISH).trim()
             when (command) {
                 "!exit" -> return
                 "!add_to_global_env" -> {

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/shell/ShellHighlighter.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/shell/ShellHighlighter.kt
@@ -46,7 +46,7 @@ internal class ShellHighlighter : Highlighter {
 
     override fun highlight(reader: LineReader, line: String): AttributedString {
 
-        val hasAddToGlobalEnv = line.toLowerCase().startsWith(ADD_TO_GLOBAL_ENV_STR)
+        val hasAddToGlobalEnv = line.lowercase().startsWith(ADD_TO_GLOBAL_ENV_STR)
         val input = when (hasAddToGlobalEnv) {
             true -> line.substring(ADD_TO_GLOBAL_ENV_STR.length, line.length)
             false -> line

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/CompilerPipeline.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/CompilerPipeline.kt
@@ -237,7 +237,7 @@ internal class CompilerPipelineImpl(
         functions,
         customDataTypes.map { customType ->
             (customType.aliases + customType.name).map { alias ->
-                Pair(alias.toLowerCase(), customType.typedOpParameter)
+                Pair(alias.lowercase(), customType.typedOpParameter)
             }
         }.flatten().toMap(),
         procedures,
@@ -265,7 +265,7 @@ internal class CompilerPipelineImpl(
                                 customFunctionSignatures = functions.values.map { it.signature },
                                 customTypedOpParameters = customDataTypes.map { customType ->
                                     (customType.aliases + customType.name).map { alias ->
-                                        Pair(alias.toLowerCase(), customType.typedOpParameter)
+                                        Pair(alias.lowercase(), customType.typedOpParameter)
                                     }
                                 }.flatten().toMap()
                             )

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/Bindings.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/Bindings.kt
@@ -60,7 +60,7 @@ fun PartiqlAst.CaseSensitivity.toBindingCase(): BindingCase = when (this) {
  * Encapsulates the data necessary to perform a binding lookup.
  */
 data class BindingName(val name: String, val bindingCase: BindingCase) {
-    val loweredName: String by lazy(LazyThreadSafetyMode.PUBLICATION) { name.toLowerCase() }
+    val loweredName: String by lazy(LazyThreadSafetyMode.PUBLICATION) { name.lowercase() }
     /**
      * Compares [name] to [otherName] using the rules specified by [bindingCase].
      */
@@ -165,7 +165,7 @@ interface Bindings<T> {
  */
 class MapBindings<T>(val originalCaseMap: Map<String, T>) : Bindings<T> {
     private val loweredCaseMap: Map<String, List<Map.Entry<String, T>>> by lazy {
-        originalCaseMap.entries.groupBy { it.key.toLowerCase() }
+        originalCaseMap.entries.groupBy { it.key.lowercase() }
     }
 
     override fun get(bindingName: BindingName): T? =

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -1567,7 +1567,7 @@ internal class EvaluatingCompiler(
      * Compiles a Session Attribute. Currently supports CURRENT_USER.
      */
     private fun compileSessionAttribute(attr: PartiqlAst.Expr.SessionAttribute, metas: MetaContainer): ThunkEnv {
-        return when (attr.value.text.toLowerCase()) {
+        return when (attr.value.text.lowercase()) {
             "current_user" -> compileCurrentUser(metas)
             else -> err(
                 message = "${attr.value.text} is not a valid session attribute.",
@@ -2299,7 +2299,7 @@ internal class EvaluatingCompiler(
             )
         }
 
-        val aggFactory = getAggregatorFactory(expr.funcName.text.toLowerCase(), expr.setq, metas)
+        val aggFactory = getAggregatorFactory(expr.funcName.text.lowercase(), expr.setq, metas)
 
         val argThunk = nestCompilationContext(ExpressionContext.AGG_ARG, emptySet()) {
             compileAstExpr(expr.arg)
@@ -2347,7 +2347,7 @@ internal class EvaluatingCompiler(
         setQuantifier: PartiqlAst.SetQuantifier,
         metas: MetaContainer
     ): ExprAggregatorFactory {
-        val key = funcName.toLowerCase() to setQuantifier
+        val key = funcName.lowercase() to setQuantifier
 
         return builtinAggregates[key] ?: err(
             "No such built-in aggregate function: $funcName",

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/ExprValueExtensions.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/ExprValueExtensions.kt
@@ -434,7 +434,7 @@ fun ExprValue.cast(
                         numberValue().compareTo(0L) == 0 -> ExprValue.newBoolean(false)
                         else -> ExprValue.newBoolean(true)
                     }
-                    type.isText -> return when (stringValue().toLowerCase()) {
+                    type.isText -> return when (stringValue().lowercase()) {
                         "true" -> ExprValue.newBoolean(true)
                         "false" -> ExprValue.newBoolean(false)
                         else -> castFailedErr("can't convert string value to BOOL", internal = false)
@@ -636,7 +636,7 @@ fun ExprValue.cast(
 private fun String.normalizeForCastToInt(): String {
     fun Char.isSign() = this == '-' || this == '+'
     fun Char.isHexOrBase2Marker(): Boolean {
-        val c = this.toLowerCase()
+        val c = this.lowercaseChar()
 
         return c == 'x' || c == 'b'
     }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/IonStructBindings.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/IonStructBindings.kt
@@ -33,7 +33,7 @@ internal class IonStructBindings(private val myStruct: IonStruct) : Bindings<Exp
     private val caseInsensitiveFieldMap by lazy {
         HashMap<String, ArrayList<IonValue>>().apply {
             for (field in myStruct) {
-                val entries = getOrPut(field.fieldName.toLowerCase()) { ArrayList(1) }
+                val entries = getOrPut(field.fieldName.lowercase()) { ArrayList(1) }
                 entries.add(field)
             }
         }
@@ -52,7 +52,7 @@ internal class IonStructBindings(private val myStruct: IonStruct) : Bindings<Exp
         caseSensitiveFieldMap[fieldName]?.let { entries -> handleMatches(entries, fieldName) }
 
     private fun caseInsensitiveLookup(fieldName: String): IonValue? =
-        caseInsensitiveFieldMap[fieldName.toLowerCase()]?.let { entries -> handleMatches(entries, fieldName) }
+        caseInsensitiveFieldMap[fieldName.lowercase()]?.let { entries -> handleMatches(entries, fieldName) }
 
     private fun handleMatches(entries: List<IonValue>, fieldName: String): IonValue? =
         when (entries.size) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/binding/LocalsBinder.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/binding/LocalsBinder.kt
@@ -108,10 +108,10 @@ fun List<Alias>.localsBinder(missingValue: ExprValue): LocalsBinder {
     // Compile case-[in]sensitive bindings and return the accessor
     return object : LocalsBinder() {
         val caseSensitiveBindings = compileBindings()
-        val caseInsensitiveBindings = compileBindings { it.toLowerCase() }
+        val caseInsensitiveBindings = compileBindings { it.lowercase() }
         override fun binderForName(bindingName: BindingName): (List<ExprValue>) -> ExprValue? {
             return when (bindingName.bindingCase) {
-                BindingCase.INSENSITIVE -> caseInsensitiveBindings[bindingName.name.toLowerCase()]
+                BindingCase.INSENSITIVE -> caseInsensitiveBindings[bindingName.name.lowercase()]
                 BindingCase.SENSITIVE -> caseSensitiveBindings[bindingName.name]
             } ?: dynamicLocalsBinder(bindingName)
         }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/ScalarBuiltinsCollAgg.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/ScalarBuiltinsCollAgg.kt
@@ -100,7 +100,7 @@ internal sealed class CollectionAggregationFunction(
         return acc.compute()
     }
 
-    private fun ExprValue.asQuantifierFilter() = when (stringValue().toLowerCase().trim()) {
+    private fun ExprValue.asQuantifierFilter() = when (stringValue().lowercase().trim()) {
         "all" -> { _: ExprValue -> true }
         "distinct" -> createUniqueExprValueFilter()
         else -> throw IllegalArgumentException("Unrecognized set quantifier: $this")

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/ScalarBuiltinsSql.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/ScalarBuiltinsSql.kt
@@ -312,7 +312,7 @@ internal object ExprFunctionLn : ExprFunctionUnaryNumeric("ln") {
  * Given a string convert all upper case characters to lower case characters.
  *
  * Any non-upper cased characters remain unchanged. This operation does rely on the locale specified by the runtime
- * configuration. This implementation uses Java's String.toLowerCase().
+ * configuration. This implementation uses Java's String.lowercase().
  */
 internal object ExprFunctionLower : ExprFunction {
 
@@ -324,7 +324,7 @@ internal object ExprFunctionLower : ExprFunction {
 
     override fun callWithRequired(session: EvaluationSession, required: List<ExprValue>): ExprValue {
         val str = required[0].stringValue()
-        val result = str.toLowerCase()
+        val result = str.lowercase()
         return ExprValue.newString(result)
     }
 }
@@ -333,7 +333,7 @@ internal object ExprFunctionLower : ExprFunction {
  * Given a string convert all lower case characters to upper case characters.
  *
  * Any non-lower cases characters remain unchanged. This operation does rely on the locale specified by the runtime
- * configuration. The implementation uses Java's String.toLowerCase().
+ * configuration. The implementation uses Java's String.lowercase().
  */
 internal object ExprFunctionUpper : ExprFunction {
 
@@ -610,7 +610,7 @@ internal object ExprFunctionTrim : ExprFunction {
      * Return the behavior on switch rather than switch to get an enum then switch again on the enum for behavior.
      */
     private fun getTrimFnOrNull(trimSpecification: String): ((String, String?) -> String)? =
-        when (trimSpecification.toLowerCase().trim()) {
+        when (trimSpecification.lowercase().trim()) {
             "both" -> ::codepointTrim
             "leading" -> ::codepointLeadingTrim
             "trailing" -> ::codepointTrailingTrim

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/internal/TimestampExtensions.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/internal/TimestampExtensions.kt
@@ -53,7 +53,7 @@ internal fun Timestamp.adjustPrecisionTo(dateTimePart: DateTimePart): Timestamp 
             this.year, this.month, this.day, this.hour, this.minute, this.localOffset
         )
         else -> errNoContext(
-            "invalid datetime part for date_add: ${dateTimePart.toString().toLowerCase()}",
+            "invalid datetime part for date_add: ${dateTimePart.toString().lowercase()}",
             errorCode = ErrorCode.EVALUATOR_INVALID_ARGUMENTS_FOR_DATE_PART,
             internal = false
         )
@@ -89,7 +89,7 @@ internal fun LocalDate.extractedValue(dateTimePart: DateTimePart): BigDecimal {
         DateTimePart.DAY -> dayOfMonth
         DateTimePart.TIMEZONE_HOUR,
         DateTimePart.TIMEZONE_MINUTE -> errNoContext(
-            "Timestamp unit ${dateTimePart.name.toLowerCase()} not supported for DATE type",
+            "Timestamp unit ${dateTimePart.name.lowercase()} not supported for DATE type",
             ErrorCode.EVALUATOR_INVALID_ARGUMENTS_FOR_FUNC_CALL,
             internal = false
         )
@@ -103,17 +103,17 @@ internal fun Time.extractedValue(dateTimePart: DateTimePart): BigDecimal {
         DateTimePart.MINUTE -> localTime.minute.toBigDecimal()
         DateTimePart.SECOND -> secondsWithFractionalPart
         DateTimePart.TIMEZONE_HOUR -> timezoneHour?.toBigDecimal() ?: errNoContext(
-            "Time unit ${dateTimePart.name.toLowerCase()} not supported for TIME type without TIME ZONE",
+            "Time unit ${dateTimePart.name.lowercase()} not supported for TIME type without TIME ZONE",
             ErrorCode.EVALUATOR_INVALID_ARGUMENTS_FOR_FUNC_CALL,
             internal = false
         )
         DateTimePart.TIMEZONE_MINUTE -> timezoneMinute?.toBigDecimal() ?: errNoContext(
-            "Time unit ${dateTimePart.name.toLowerCase()} not supported for TIME type without TIME ZONE",
+            "Time unit ${dateTimePart.name.lowercase()} not supported for TIME type without TIME ZONE",
             ErrorCode.EVALUATOR_INVALID_ARGUMENTS_FOR_FUNC_CALL,
             internal = false
         )
         DateTimePart.YEAR, DateTimePart.MONTH, DateTimePart.DAY -> errNoContext(
-            "Time unit ${dateTimePart.name.toLowerCase()} not supported for TIME type.",
+            "Time unit ${dateTimePart.name.lowercase()} not supported for TIME type.",
             ErrorCode.EVALUATOR_INVALID_ARGUMENTS_FOR_FUNC_CALL,
             internal = false
         )

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/Accumulator.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/Accumulator.kt
@@ -39,7 +39,7 @@ internal sealed class Accumulator(
                 is PartiqlPhysical.SetQuantifier.Distinct -> createUniqueExprValueFilter()
                 is PartiqlPhysical.SetQuantifier.All -> { _: ExprValue -> true }
             }
-            return when (funcName.trim().toLowerCase()) {
+            return when (funcName.trim().lowercase()) {
                 "min" -> AccumulatorMin(filter)
                 "max" -> AccumulatorMax(filter)
                 "avg" -> AccumulatorAvg(filter)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/OrderBySortSpecVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/OrderBySortSpecVisitorTransform.kt
@@ -72,7 +72,7 @@ internal class OrderBySortSpecVisitorTransform : VisitorTransformBase() {
             val transformedExpr = super.transformExprId(node)
             return when (node.case) {
                 is PartiqlAst.CaseSensitivity.CaseSensitive -> aliases[node.name.text] ?: transformedExpr
-                else -> aliases[node.name.text.toLowerCase()] ?: aliases[node.name.text.toUpperCase()] ?: transformedExpr
+                else -> aliases[node.name.text.lowercase()] ?: aliases[node.name.text.toUpperCase()] ?: transformedExpr
             }
         }
     }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -113,7 +113,7 @@ internal class AstToLogicalVisitorTransform(
         call(
             "${CollectionAggregationFunction.PREFIX}${node.funcName.text}",
             listOf(
-                lit(ionString(node.setq.javaClass.simpleName.toLowerCase())),
+                lit(ionString(node.setq.javaClass.simpleName.lowercase())),
                 transformExpr(node.arg)
             )
         )

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
@@ -479,7 +479,7 @@ internal data class LogicalToLogicalResolvedVisitorTransform(
     private fun checkForDuplicateVariables(varDecls: List<PartiqlLogical.VarDecl>) {
         val usedVariableNames = hashSetOf<String>()
         varDecls.forEach { varDecl ->
-            val loweredVariableName = varDecl.name.text.toLowerCase()
+            val loweredVariableName = varDecl.name.text.lowercase()
             if (usedVariableNames.contains(loweredVariableName)) {
                 this.problemHandler.handleProblem(
                     Problem(
@@ -575,7 +575,7 @@ internal data class LogicalToLogicalResolvedVisitorTransform(
                 is PartiqlLogical.ScopeQualifier.LocalsFirst -> VariableLookupStrategy.LOCALS_THEN_GLOBALS
                 is PartiqlLogical.ScopeQualifier.Unqualified -> VariableLookupStrategy.GLOBALS_THEN_LOCALS
             }
-        }.toString().toLowerCase()
+        }.toString().lowercase()
         return PartiqlLogicalResolved.build {
             call(
                 funcName = DYNAMIC_LOOKUP_FUNCTION_NAME,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
@@ -84,12 +84,12 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
         internal val TRIM_SPECIFICATION_KEYWORDS = setOf("both", "leading", "trailing")
     }
 
-    private val customKeywords = customTypes.map { it.name.toLowerCase() }
+    private val customKeywords = customTypes.map { it.name.lowercase() }
 
     private val customTypeAliases =
         customTypes.map { customType ->
             customType.aliases.map { alias ->
-                Pair(alias.toLowerCase(), customType.name.toLowerCase())
+                Pair(alias.lowercase(), customType.name.lowercase())
             }
         }.flatten().toMap()
 
@@ -233,7 +233,7 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
         val name = visitExpr(ctx.name).getStringValue(ctx.name.getStart())
         val args = visitOrEmpty(ctx.args, PartiqlAst.Expr::class)
         exec_(
-            SymbolPrimitive(name.toLowerCase(), emptyMetaContainer()),
+            SymbolPrimitive(name.lowercase(), emptyMetaContainer()),
             args,
             ctx.name.getStart().getSourceMetaContainer()
         )
@@ -799,7 +799,7 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
 
     override fun visitPatternRestrictor(ctx: PartiQLParser.PatternRestrictorContext) = PartiqlAst.build {
         val metas = ctx.restrictor.getSourceMetaContainer()
-        when (ctx.restrictor.text.toLowerCase()) {
+        when (ctx.restrictor.text.lowercase()) {
             "trail" -> restrictorTrail(metas)
             "acyclic" -> restrictorAcyclic(metas)
             "simple" -> restrictorSimple(metas)
@@ -1097,14 +1097,14 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
     }
 
     override fun visitFunctionCallIdent(ctx: PartiQLParser.FunctionCallIdentContext) = PartiqlAst.build {
-        val name = ctx.name.getString().toLowerCase()
+        val name = ctx.name.getString().lowercase()
         val args = visitOrEmpty(ctx.expr(), PartiqlAst.Expr::class)
         val metas = ctx.name.getSourceMetaContainer()
         call(name, args = args, metas = metas)
     }
 
     override fun visitFunctionCallReserved(ctx: PartiQLParser.FunctionCallReservedContext) = PartiqlAst.build {
-        val name = ctx.name.text.toLowerCase()
+        val name = ctx.name.text.lowercase()
         val args = visitOrEmpty(ctx.expr(), PartiqlAst.Expr::class)
         val metas = ctx.name.getSourceMetaContainer()
         call(name, args = args, metas = metas)
@@ -1118,31 +1118,31 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
         val secondaryArgs = visitOrEmpty(ctx.expr(), PartiqlAst.Expr::class)
         val args = listOf(datetimePart) + secondaryArgs
         val metas = ctx.func.getSourceMetaContainer()
-        call(ctx.func.text.toLowerCase(), args, metas)
+        call(ctx.func.text.lowercase(), args, metas)
     }
 
     override fun visitSubstring(ctx: PartiQLParser.SubstringContext) = PartiqlAst.build {
         val args = visitOrEmpty(ctx.expr(), PartiqlAst.Expr::class)
         val metas = ctx.SUBSTRING().getSourceMetaContainer()
-        call(ctx.SUBSTRING().text.toLowerCase(), args, metas)
+        call(ctx.SUBSTRING().text.lowercase(), args, metas)
     }
 
     override fun visitPosition(ctx: PartiQLParser.PositionContext) = PartiqlAst.build {
         val args = visitOrEmpty(ctx.expr(), PartiqlAst.Expr::class)
         val metas = ctx.POSITION().getSourceMetaContainer()
-        call(ctx.POSITION().text.toLowerCase(), args, metas)
+        call(ctx.POSITION().text.lowercase(), args, metas)
     }
 
     override fun visitOverlay(ctx: PartiQLParser.OverlayContext) = PartiqlAst.build {
         val args = visitOrEmpty(ctx.expr(), PartiqlAst.Expr::class)
         val metas = ctx.OVERLAY().getSourceMetaContainer()
-        call(ctx.OVERLAY().text.toLowerCase(), args, metas)
+        call(ctx.OVERLAY().text.lowercase(), args, metas)
     }
 
     override fun visitCountAll(ctx: PartiQLParser.CountAllContext) = PartiqlAst.build {
         callAgg(
             all(),
-            ctx.func.text.toLowerCase(),
+            ctx.func.text.lowercase(),
             lit(ionInt(1)),
             ctx.COUNT().getSourceMetaContainer() + metaContainerOf(IsCountStarMeta.instance)
         )
@@ -1156,7 +1156,7 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
         val timeExpr = visit(ctx.rhs, PartiqlAst.Expr::class)
         val args = listOf(datetimePart, timeExpr)
         val metas = ctx.EXTRACT().getSourceMetaContainer()
-        call(ctx.EXTRACT().text.toLowerCase(), args, metas)
+        call(ctx.EXTRACT().text.lowercase(), args, metas)
     }
 
     /**
@@ -1166,7 +1166,7 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
      * null, we need to make the substring equal to the <spec> (and make <spec> null).
      */
     override fun visitTrimFunction(ctx: PartiQLParser.TrimFunctionContext) = PartiqlAst.build {
-        val possibleModText = if (ctx.mod != null) ctx.mod.text.toLowerCase() else null
+        val possibleModText = if (ctx.mod != null) ctx.mod.text.lowercase() else null
         val isTrimSpec = TRIM_SPECIFICATION_KEYWORDS.contains(possibleModText)
         val (modifier, substring) = when {
             // if <spec> is not null and <substring> is null
@@ -1198,14 +1198,14 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
         val target = visitExpr(ctx.target)
         val args = listOfNotNull(modifier, substring, target)
         val metas = ctx.func.getSourceMetaContainer()
-        call(ctx.func.text.toLowerCase(), args, metas)
+        call(ctx.func.text.lowercase(), args, metas)
     }
 
     override fun visitAggregateBase(ctx: PartiQLParser.AggregateBaseContext) = PartiqlAst.build {
         val strategy = getStrategy(ctx.setQuantifierStrategy(), default = all())
         val arg = visitExpr(ctx.expr())
         val metas = ctx.func.getSourceMetaContainer()
-        callAgg(strategy, ctx.func.text.toLowerCase(), arg, metas)
+        callAgg(strategy, ctx.func.text.lowercase(), arg, metas)
     }
 
     /**
@@ -1221,7 +1221,7 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
         // LAG and LEAD will require a Window ORDER BY
         if (over.orderBy == null) {
             val errorContext = PropertyValueMap()
-            errorContext[Property.TOKEN_STRING] = ctx.func.text.toLowerCase()
+            errorContext[Property.TOKEN_STRING] = ctx.func.text.lowercase()
             throw ctx.func.err(
                 "${ctx.func.text} requires Window ORDER BY",
                 ErrorCode.PARSE_EXPECTED_WINDOW_ORDER_BY,
@@ -1229,7 +1229,7 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
             )
         }
         val metas = ctx.func.getSourceMetaContainer()
-        callWindow(ctx.func.text.toLowerCase(), over, args, metas)
+        callWindow(ctx.func.text.lowercase(), over, args, metas)
     }
     override fun visitOver(ctx: PartiQLParser.OverContext) = PartiqlAst.build {
         val windowPartitionList = if (ctx.windowPartitionList() != null) visitWindowPartitionList(ctx.windowPartitionList()) else null
@@ -1437,7 +1437,7 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
 
     override fun visitTypeCustom(ctx: PartiQLParser.TypeCustomContext) = PartiqlAst.build {
         val metas = ctx.symbolPrimitive().getSourceMetaContainer()
-        val customName: String = when (val name = ctx.symbolPrimitive().getString().toLowerCase()) {
+        val customName: String = when (val name = ctx.symbolPrimitive().getString().lowercase()) {
             in customKeywords -> name
             in customTypeAliases.keys -> customTypeAliases.getOrDefault(name, name)
             else -> throw ParserException("Invalid custom type name: $name", ErrorCode.PARSE_INVALID_QUERY)
@@ -1572,11 +1572,11 @@ internal class PartiQLPigVisitor(val customTypes: List<CustomType> = listOf(), p
     }
 
     private fun PartiqlAst.Expr.getStringValue(token: Token? = null): String = when (this) {
-        is PartiqlAst.Expr.Id -> this.name.text.toLowerCase()
+        is PartiqlAst.Expr.Id -> this.name.text.lowercase()
         is PartiqlAst.Expr.Lit -> {
             when (this.value) {
-                is SymbolElement -> this.value.symbolValue.toLowerCase()
-                is StringElement -> this.value.stringValue.toLowerCase()
+                is SymbolElement -> this.value.symbolValue.lowercase()
+                is StringElement -> this.value.stringValue.lowercase()
                 else ->
                     this.value.stringValueOrNull ?: throw token.err("Unable to pass the string value", ErrorCode.PARSE_UNEXPECTED_TOKEN)
             }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/types/PartiqlPhysicalTypeExtensions.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/types/PartiqlPhysicalTypeExtensions.kt
@@ -100,8 +100,8 @@ internal fun PartiqlPhysical.Type.toTypedOpParameter(customTypedOpParameters: Ma
         is PartiqlPhysical.Type.AnyType -> TypedOpParameter(StaticType.ANY)
         is PartiqlPhysical.Type.CustomType ->
             customTypedOpParameters.mapKeys { (k, _) ->
-                k.toLowerCase()
-            }[this.name.text.toLowerCase()] ?: error("Could not find parameter for $this")
+                k.lowercase()
+            }[this.name.text.lowercase()] ?: error("Could not find parameter for $this")
         is PartiqlPhysical.Type.DateType -> TypedOpParameter(StaticType.DATE)
         is PartiqlPhysical.Type.TimeType -> TypedOpParameter(
             TimeType(this.precision?.value?.toInt(), withTimeZone = false)

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/util/AstExtensions.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/util/AstExtensions.kt
@@ -33,7 +33,7 @@ internal fun IonSexp.mixIdentifierCase(): IonSexp {
         val mixedCase = stringValue()!!.foldIndexed("") { index, acc, c ->
             acc + when (index % 2 == 0) {
                 true -> c.toUpperCase()
-                false -> c.toLowerCase()
+                false -> c.lowercase()
             }
         }
 

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/BindingName.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/BindingName.kt
@@ -18,7 +18,7 @@ package org.partiql.spi
  * Encapsulates the data necessary to perform a binding lookup.
  */
 public data class BindingName(val name: String, val bindingCase: BindingCase) {
-    val loweredName: String by lazy(LazyThreadSafetyMode.PUBLICATION) { name.toLowerCase() }
+    val loweredName: String by lazy(LazyThreadSafetyMode.PUBLICATION) { name.lowercase() }
 
     /**
      * Compares [name] to [otherName] using the rules specified by [bindingCase].


### PR DESCRIPTION
## Relevant Issues

#1075 

## Description

The string functions toUpperCase/toLowerCase are deprecated. Cleaning up the warnings.

## Other Information
No

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**

Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.