### PR TITLE
[Sprout] Adds configurable OptIns to Kotlin target

### DIFF
--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/KotlinCommand.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/KotlinCommand.kt
@@ -46,6 +46,12 @@ class KotlinCommand : Callable<Int> {
     )
     var poems: List<String> = emptyList()
 
+    @CommandLine.Option(
+        names = ["--opt-in"],
+        description = ["Opt-in annotations to add to generated sources"],
+    )
+    var optIns: List<String> = emptyList()
+
     override fun call(): Int {
         val input = BufferedReader(FileInputStream(file).reader()).readText()
         val parser = SproutParser.default()
@@ -53,6 +59,7 @@ class KotlinCommand : Callable<Int> {
         val options = KotlinOptions(
             packageRoot = packageRoot,
             poems = poems,
+            optIns = optIns,
         )
         val generator = KotlinGenerator(options)
         val result = generator.generate(universe)

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/KotlinGenerator.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/KotlinGenerator.kt
@@ -1,5 +1,6 @@
 package org.partiql.sprout.generator.target.kotlin
 
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
@@ -56,7 +57,20 @@ class KotlinGenerator(private val options: KotlinOptions) : Generator<KotlinResu
             // Apply each poem
             poems.forEach { it.apply(this) }
             // Finalize each spec/builder
-            build(options.packageRoot).map { KotlinFileSpec(it) }
+            build(options.packageRoot).map {
+                if (options.optIns.isNotEmpty()) {
+                    val f = it.toBuilder()
+                    val optin = AnnotationSpec.builder(ClassName("kotlin", "OptIn"))
+                    options.optIns.forEach { o ->
+                        val i = o.lastIndexOf(".")
+                        optin.addMember("%T::class", ClassName(o.substring(0, i), o.substring(i + 1)))
+                    }
+                    f.addAnnotation(optin.build())
+                    KotlinFileSpec(f.build())
+                } else {
+                    KotlinFileSpec(it)
+                }
+            }
         }
         return KotlinResult(specs)
     }

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/KotlinOptions.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/KotlinOptions.kt
@@ -8,4 +8,5 @@ package org.partiql.sprout.generator.target.kotlin
 class KotlinOptions(
     val packageRoot: String,
     val poems: List<String>,
+    val optIns: List<String> = emptyList(),
 )


### PR DESCRIPTION
## Relevant Issues
n/a

## Description

Adds configurable `@file:OptIn(...)` annotations to Kotlin generated sourcse.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No, sprout is an internal build tool

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.