### PR TITLE
[Sprout] Fixes rewriter for null valued collections

### DIFF
--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/poems/KotlinUtilsPoem.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/poems/KotlinUtilsPoem.kt
@@ -39,6 +39,7 @@ class KotlinUtilsPoem(symbols: KotlinSymbols) : KotlinPoem(symbols) {
     private val suppressUnused = AnnotationSpec.builder(Suppress::class)
         .useSiteTarget(AnnotationSpec.UseSiteTarget.FILE)
         .addMember("%S", "UNUSED_PARAMETER")
+        .addMember("%S", "UNUSED_VARIABLE")
         .build()
 
     // Not taking a dep on builder or visitor poems, as this is temporary
@@ -107,8 +108,8 @@ class KotlinUtilsPoem(symbols: KotlinSymbols) : KotlinPoem(symbols) {
     // Node N           -> visitN(node.n, ctx) as N
     // Node N?          -> node.n?.let { visitN(it, ctx) as N }
     // Collection<N>    -> rewrite(node, ctx, ::method)
-    // Collection?<N>   -> node.n?.let { rewrite(it, ctx, ::method) }
-    // Collection?<N?>  -> node.n?.let { rewrite(it, ctx, ::method) }
+    // Collection<N>?   -> node.n?.let { rewrite(it, ctx, ::method) }
+    // Collection<N?>?  -> node.n?.let { rewrite(it, ctx, ::method) }
     // Collection<N?>   -> rewrite(node, ctx, ::method)
 
     private fun KotlinNodeSpec.Product.rewriter(): FunSpec {
@@ -139,17 +140,25 @@ class KotlinUtilsPoem(symbols: KotlinSymbols) : KotlinPoem(symbols) {
                         (ref is TypeRef.List && isNode(ref.type)) -> {
                             // Collections
                             val method = (ref.type as TypeRef.Path).visitMethodName()
+                            val helper = when (ref.type.nullable) {
+                                true -> "_visitListNull"
+                                else -> "_visitList"
+                            }
                             when (ref.nullable) {
-                                true -> addStatement("val $name = $child?.let { _visitListNull(it, ctx, ::$method) }")
-                                false -> addStatement("val $name = _visitList($child, ctx, ::$method)")
+                                true -> addStatement("val $name = $child?.let { $helper(it, ctx, ::$method) }")
+                                false -> addStatement("val $name = $helper($child, ctx, ::$method)")
                             }
                         }
                         (ref is TypeRef.Set && isNode(ref.type)) -> {
                             // Collections
                             val method = (ref.type as TypeRef.Path).visitMethodName()
+                            val helper = when (ref.type.nullable) {
+                                true -> "_visitSetNull"
+                                else -> "_visitSet"
+                            }
                             when (ref.nullable) {
-                                true -> addStatement("val $name = $child?.let { _visitSetNull(it, ctx, ::$method) }")
-                                false -> addStatement("val $name = _visitSet($child, ctx, ::$method)")
+                                true -> addStatement("val $name = $child?.let { $helper(it, ctx, ::$method) }")
+                                false -> addStatement("val $name = $helper($child, ctx, ::$method)")
                             }
                         }
                         else -> {


### PR DESCRIPTION
## Relevant Issues
N/A

## Description

The rewriter was incorrectly generating code for `Collection<T?>`. This changes enables the rewriter to handle the four variations of a collection
- List<T>
- List<T>?
- List<T?>
- List<T?>?

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.