### PR TITLE
Fixes Nullable PartiQLCollectionValue

### DIFF
--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
@@ -465,11 +465,10 @@ public sealed interface NullableScalarValue<T> : PartiQLValue {
 }
 
 @PartiQLValueExperimental
-public sealed interface NullableCollectionValue<T : PartiQLValue> : PartiQLValue, Collection<T> {
+public sealed interface NullableCollectionValue<T : PartiQLValue> : PartiQLValue {
+    public fun isNull(): Boolean
 
-    public override val size: Int
-
-    public val elements: Collection<T>?
+    public fun promote(): CollectionValue<T>
 
     override fun copy(annotations: Annotations): NullableCollectionValue<T>
 
@@ -787,6 +786,8 @@ public abstract class NullableBagValue<T : PartiQLValue> : NullableCollectionVal
 
     override val type: PartiQLValueType = PartiQLValueType.NULLABLE_BAG
 
+    abstract override fun promote(): BagValue<T>
+
     abstract override fun copy(annotations: Annotations): NullableBagValue<T>
 
     abstract override fun withAnnotations(annotations: Annotations): NullableBagValue<T>
@@ -798,6 +799,8 @@ public abstract class NullableBagValue<T : PartiQLValue> : NullableCollectionVal
 public abstract class NullableListValue<T : PartiQLValue> : NullableCollectionValue<T> {
 
     override val type: PartiQLValueType = PartiQLValueType.NULLABLE_LIST
+
+    abstract override fun promote(): ListValue<T>
 
     abstract override fun copy(annotations: Annotations): NullableListValue<T>
 
@@ -811,6 +814,8 @@ public abstract class NullableSexpValue<T : PartiQLValue> : NullableCollectionVa
 
     override val type: PartiQLValueType = PartiQLValueType.NULLABLE_SEXP
 
+    abstract override fun promote(): SexpValue<T>
+
     abstract override fun copy(annotations: Annotations): NullableSexpValue<T>
 
     abstract override fun withAnnotations(annotations: Annotations): NullableSexpValue<T>
@@ -819,9 +824,10 @@ public abstract class NullableSexpValue<T : PartiQLValue> : NullableCollectionVa
 }
 
 @PartiQLValueExperimental
-public abstract class NullableStructValue<T : PartiQLValue> : PartiQLValue, Collection<Pair<String, T>> {
+public abstract class NullableStructValue<T : PartiQLValue> : PartiQLValue {
+    public abstract fun isNull(): Boolean
 
-    public abstract val fields: List<Pair<String, T>>?
+    public abstract fun promote(): StructValue<T>
 
     override val type: PartiQLValueType = PartiQLValueType.NULLABLE_STRUCT
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/PartiQLValueNullableImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/PartiQLValueNullableImpl.kt
@@ -17,9 +17,9 @@
 package org.partiql.value.impl
 
 import kotlinx.collections.immutable.PersistentList
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentList
 import org.partiql.value.Annotations
+import org.partiql.value.BagValue
 import org.partiql.value.MissingValue
 import org.partiql.value.NullValue
 import org.partiql.value.NullableBagValue
@@ -398,18 +398,9 @@ internal data class NullableBagValueImpl<T : PartiQLValue>(
     private val delegate: PersistentList<T>?,
     override val annotations: PersistentList<String>,
 ) : NullableBagValue<T>() {
+    override fun isNull(): Boolean = delegate == null
 
-    override fun contains(element: T) = delegate!!.contains(element)
-
-    override fun containsAll(elements: Collection<T>) = delegate!!.containsAll(elements)
-
-    override fun isEmpty() = delegate!!.isEmpty()
-
-    override fun iterator() = delegate!!.iterator()
-
-    override val size = delegate!!.size
-
-    override val elements = delegate!!.toImmutableList()
+    override fun promote(): BagValue<T> = BagValueImpl(delegate!!, annotations)
 
     override fun copy(annotations: Annotations) = NullableBagValueImpl(delegate, annotations.toPersistentList())
 
@@ -424,18 +415,9 @@ internal data class NullableListValueImpl<T : PartiQLValue>(
     private val delegate: PersistentList<T>?,
     override val annotations: PersistentList<String>,
 ) : NullableListValue<T>() {
+    override fun isNull() = delegate == null
 
-    override fun contains(element: T) = delegate!!.contains(element)
-
-    override fun containsAll(elements: Collection<T>) = delegate!!.containsAll(elements)
-
-    override fun isEmpty() = delegate!!.isEmpty()
-
-    override fun iterator() = delegate!!.iterator()
-
-    override val size = delegate!!.size
-
-    override val elements = delegate!!.toImmutableList()
+    override fun promote() = ListValueImpl(delegate!!, annotations)
 
     override fun copy(annotations: Annotations) = NullableListValueImpl(delegate, annotations.toPersistentList())
 
@@ -451,17 +433,9 @@ internal data class NullableSexpValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : NullableSexpValue<T>() {
 
-    override fun contains(element: T) = delegate!!.contains(element)
+    override fun isNull(): Boolean = delegate == null
 
-    override fun containsAll(elements: Collection<T>) = delegate!!.containsAll(elements)
-
-    override fun isEmpty() = delegate!!.isEmpty()
-
-    override fun iterator() = delegate!!.iterator()
-
-    override val size = delegate!!.size
-
-    override val elements = delegate!!.toImmutableList()
+    override fun promote() = SexpValueImpl(delegate!!, annotations)
 
     override fun copy(annotations: Annotations) = NullableSexpValueImpl(delegate, annotations.toPersistentList())
 
@@ -476,18 +450,9 @@ internal data class NullableStructValueImpl<T : PartiQLValue>(
     private val values: PersistentList<Pair<String, T>>?,
     override val annotations: PersistentList<String>,
 ) : NullableStructValue<T>() {
+    override fun isNull(): Boolean = values == null
 
-    override val fields = values!!.toImmutableList()
-
-    override val size = values!!.size
-
-    override fun isEmpty() = values!!.isEmpty()
-
-    override fun iterator(): Iterator<Pair<String, T>> = values!!.iterator()
-
-    override fun containsAll(elements: Collection<Pair<String, T>>) = values!!.containsAll(elements)
-
-    override fun contains(element: Pair<String, T>) = values!!.contains(element)
+    override fun promote() = StructValueImpl(values!!, annotations)
 
     override fun copy(annotations: Annotations) = NullableStructValueImpl(values, annotations.toPersistentList())
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueTextWriter.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueTextWriter.kt
@@ -51,7 +51,6 @@ import org.partiql.value.SexpValue
 import org.partiql.value.StringValue
 import org.partiql.value.StructValue
 import org.partiql.value.SymbolValue
-import org.partiql.value.bagValue
 import org.partiql.value.boolValue
 import org.partiql.value.charValue
 import org.partiql.value.decimalValue
@@ -62,10 +61,7 @@ import org.partiql.value.int32Value
 import org.partiql.value.int64Value
 import org.partiql.value.int8Value
 import org.partiql.value.intValue
-import org.partiql.value.listValue
-import org.partiql.value.sexpValue
 import org.partiql.value.stringValue
-import org.partiql.value.structValue
 import org.partiql.value.symbolValue
 import org.partiql.value.util.PartiQLValueBaseVisitor
 import java.io.PrintStream
@@ -295,24 +291,24 @@ internal class PartiQLValueTextWriter(
             else -> visitSymbol(symbolValue(v.value!!, v.annotations), ctx)
         }
 
-        override fun visitNullableBag(v: NullableBagValue<*>, ctx: Format?) = when (v.elements) {
-            null -> "null"
-            else -> visitBag(bagValue(v.elements!!.toList(), v.annotations), ctx)
+        override fun visitNullableBag(v: NullableBagValue<*>, ctx: Format?) = when (v.isNull()) {
+            true -> "null"
+            else -> visitBag(v.promote(), ctx)
         }
 
-        override fun visitNullableList(v: NullableListValue<*>, ctx: Format?) = when (v.elements) {
-            null -> "null"
-            else -> visitList(listValue(v.elements!!.toList(), v.annotations), ctx)
+        override fun visitNullableList(v: NullableListValue<*>, ctx: Format?) = when (v.isNull()) {
+            true -> "null"
+            else -> visitList(v.promote(), ctx)
         }
 
-        override fun visitNullableSexp(v: NullableSexpValue<*>, ctx: Format?) = when (v.elements) {
-            null -> "null"
-            else -> visitSexp(sexpValue(v.elements!!.toList(), v.annotations), ctx)
+        override fun visitNullableSexp(v: NullableSexpValue<*>, ctx: Format?) = when (v.isNull()) {
+            true -> "null"
+            else -> visitSexp(v.promote(), ctx)
         }
 
-        override fun visitNullableStruct(v: NullableStructValue<*>, ctx: Format?) = when (v.fields) {
-            null -> "null"
-            else -> visitStruct(structValue(v.fields!!.toList(), v.annotations), ctx)
+        override fun visitNullableStruct(v: NullableStructValue<*>, ctx: Format?) = when (v.isNull()) {
+            true -> "null"
+            else -> visitStruct(v.promote(), ctx)
         }
     }
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/util/PartiQLValueBaseVisitor.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/util/PartiQLValueBaseVisitor.kt
@@ -87,10 +87,14 @@ public abstract class PartiQLValueBaseVisitor<R, C> : PartiQLValueVisitor<R, C> 
                 v.fields.forEach { it.second.accept(this, ctx) }
             }
             is NullableCollectionValue<*> -> {
-                v.elements?.forEach { it.accept(this, ctx) }
+                if (!v.isNull()) {
+                    v.promote().elements.forEach { it.accept(this, ctx) }
+                }
             }
             is NullableStructValue<*> -> {
-                v.fields?.forEach { it.second.accept(this, ctx) }
+                if (!v.isNull()) {
+                    v.promote().fields.forEach { it.second.accept(this, ctx) }
+                }
             }
             else -> {}
         }

--- a/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueTextWriterTest.kt
+++ b/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueTextWriterTest.kt
@@ -24,6 +24,7 @@ import org.partiql.value.intValue
 import org.partiql.value.listValue
 import org.partiql.value.missingValue
 import org.partiql.value.nullValue
+import org.partiql.value.nullableBagValue
 import org.partiql.value.nullableBoolValue
 import org.partiql.value.nullableCharValue
 import org.partiql.value.nullableDecimalValue
@@ -34,7 +35,10 @@ import org.partiql.value.nullableInt32Value
 import org.partiql.value.nullableInt64Value
 import org.partiql.value.nullableInt8Value
 import org.partiql.value.nullableIntValue
+import org.partiql.value.nullableListValue
+import org.partiql.value.nullableSexpValue
 import org.partiql.value.nullableStringValue
+import org.partiql.value.nullableStructValue
 import org.partiql.value.nullableSymbolValue
 import org.partiql.value.sexpValue
 import org.partiql.value.stringValue
@@ -374,6 +378,23 @@ class PartiQLValueTextWriterTest {
                     )
                 ),
                 expected = "(1 2 3)",
+            ),
+            // nullable collections
+            case(
+                value = nullableBagValue<PartiQLValue>(null),
+                expected = "null",
+            ),
+            case(
+                value = nullableListValue<PartiQLValue>(null),
+                expected = "null",
+            ),
+            case(
+                value = nullableSexpValue<PartiQLValue>(null),
+                expected = "null",
+            ),
+            case(
+                value = nullableStructValue<PartiQLValue>(null),
+                expected = "null",
             ),
         )
 


### PR DESCRIPTION
## Relevant Issues
#1141 

## Description

This PR fixes instantiation of nullable collection values by using `isNull()` and `promote()` This is Yingtao's solution from https://github.com/partiql/partiql-lang-kotlin/pull/1131

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.