### PR TITLE
Timestamp eval Phase 1 - Constructor call, Rounding, equivalence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Thank you to all who have contributed!
 - Adds support for Timestamp constructor call in Parser/Compiler/Evaluator. 
 
 ### Changed
+- BREAKING: When converting to Ion, PartiQL Timestamp will be extended to full timestamp format, even if the value entered is an ION timestamp literal with reduced precision. 
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Thank you to all who have contributed!
 - Adds `org.partiql.value` (experimental) package for reading/writing PartiQL
   values
 - Adds PartiQL's Timestamp Data Model. 
-- Adds support for Timestamp constructor call in Parser. 
+- Adds support for Timestamp constructor call in Parser/Compiler/Evaluator. 
 
 ### Changed
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/EvaluationSession.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/EvaluationSession.kt
@@ -15,6 +15,7 @@
 package org.partiql.lang.eval
 
 import com.amazon.ion.Timestamp
+import org.partiql.value.datetime.TimeZone
 
 /**
  * Evaluation Session. Holds user defined constants used during evaluation. Each value has a default value that can
@@ -31,7 +32,8 @@ class EvaluationSession private constructor(
     val globals: Bindings<ExprValue>,
     val parameters: List<ExprValue>,
     val context: Map<String, Any>,
-    val now: Timestamp
+    val now: Timestamp,
+    val timeZone: TimeZone
 ) {
 
     companion object {
@@ -67,6 +69,12 @@ class EvaluationSession private constructor(
             return this
         }
 
+        private var timeZone: TimeZone? = null
+        fun timeZone(value: TimeZone): Builder {
+            timeZone = value
+            return this
+        }
+
         private var globals: Bindings<ExprValue> = Bindings.empty()
         fun globals(value: Bindings<ExprValue>): Builder {
             globals = value
@@ -93,6 +101,7 @@ class EvaluationSession private constructor(
 
         fun build(): EvaluationSession = EvaluationSession(
             now = now ?: Timestamp.nowZ(),
+            timeZone = timeZone ?: TimeZone.UtcOffset.of(0),
             parameters = parameters,
             context = contextVariables,
             globals = globals

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/NaturalExprValueComparators.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/NaturalExprValueComparators.kt
@@ -242,8 +242,8 @@ enum class NaturalExprValueComparators(private val order: Order, private val nul
         // Timestamp
         ifCompared(
             handle(lType == ExprValueType.TIMESTAMP, rType == ExprValueType.TIMESTAMP) {
-                val lVal = left.timestampValue()
-                val rVal = right.timestampValue()
+                val lVal = left.partiQLTimestampValue()
+                val rVal = right.partiQLTimestampValue()
 
                 return lVal.compareTo(rVal)
             }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/Scalar.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/Scalar.kt
@@ -43,7 +43,14 @@ interface Scalar {
      * Returns this value as a [Timestamp] or `null` if not applicable.
      * This operation is only applicable for [ExprValueType.TIMESTAMP]
      */
+    @Deprecated("Retrieve Ion timestamp Value is deprecated, please use partiqlTimestampValue()", ReplaceWith("partiQLTimestampValue()"))
     fun timestampValue(): Timestamp? = null
+
+    /**
+     * Returns this value as a [org.partiql.value.datetime.Timestamp] or `null` if not applicable.
+     * This operation is only applicable for [ExprValueType.TIMESTAMP]
+     */
+    fun partiQLTimestampValue(): org.partiql.value.datetime.Timestamp? = null
 
     /**
      * Returns this value as a [LocalDate] or `null` if not applicable.

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransform.kt
@@ -101,7 +101,7 @@ class SubqueryCoercionVisitorTransform : VisitorTransformBase() {
             is PartiqlAst.Expr.CanLosslessCast -> n
             is PartiqlAst.Expr.NullIf -> n
             is PartiqlAst.Expr.Coalesce -> n
-            is PartiqlAst.Expr.Timestamp -> TODO()
+            is PartiqlAst.Expr.Timestamp -> n
         }
     }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/util/ExprValueFormatter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/util/ExprValueFormatter.kt
@@ -6,9 +6,14 @@ import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.ExprValueType
 import org.partiql.lang.eval.dateValue
 import org.partiql.lang.eval.name
+import org.partiql.lang.eval.partiQLTimestampValue
 import org.partiql.lang.eval.timeValue
 import org.partiql.lang.eval.toIonValue
+import org.partiql.value.datetime.TimeZone
+import org.partiql.value.datetime.Timestamp
 import java.math.BigDecimal
+import java.math.RoundingMode
+import kotlin.math.absoluteValue
 
 private const val MISSING_STRING = "MISSING"
 private const val NULL_STRING = "NULL"
@@ -63,9 +68,13 @@ class ConfigurableExprValueFormatter(private val config: Configuration) : ExprVa
                     val prefix = if (time.offsetTime == null) "TIME" else "TIME WITH TIME ZONE"
                     out.append("$prefix '$time'")
                 }
+                ExprValueType.TIMESTAMP -> {
+                    val timestamp = value.partiQLTimestampValue()
+                    out.append("TIMESTAMP '${timestamp.toSQLString()}'")
+                }
 
                 // fallback to an Ion literal for all types that don't have a native PartiQL representation
-                ExprValueType.FLOAT, ExprValueType.TIMESTAMP, ExprValueType.SYMBOL,
+                ExprValueType.FLOAT, ExprValueType.SYMBOL,
                 ExprValueType.CLOB, ExprValueType.BLOB, ExprValueType.SEXP -> prettyPrintIonLiteral(value)
 
                 ExprValueType.LIST -> prettyPrintContainer(value, "[", "]")
@@ -136,6 +145,36 @@ class ConfigurableExprValueFormatter(private val config: Configuration) : ExprVa
         private fun writeIndentation() {
             if (config.indentation.isNotEmpty()) {
                 IntRange(1, currentIndentation).forEach { _ -> out.append(config.indentation) }
+            }
+        }
+
+        private fun Timestamp.toSQLString(): String {
+            val year = this.year.toString().padStart(4, '0')
+            val month = this.month.toString().padStart(2, '0')
+            val day = this.day.toString().padStart(2, '0')
+            val hour = this.hour.toString().padStart(2, '0')
+            val minute = this.minute.toString().padStart(2, '0')
+            val secondWhole = this.decimalSecond.setScale(0, RoundingMode.DOWN)
+            val second = secondWhole.toPlainString().toString().padStart(2, '0')
+            val fractions =
+                decimalSecond.subtract(secondWhole)
+                    .let {
+                        if (it.scale() == 0 && it == BigDecimal.ZERO)
+                            "" // the edge case here is no fraction second, in which case no character should be appended
+                        else it.toPlainString().drop(1) // this is guaranteed to be 0.xxxx we need to drop the zero
+                    }
+            val timestampNoTimeZone = "$year-$month-$day $hour:$minute:$second$fractions"
+            return when (val tz = this.timeZone) {
+                TimeZone.UnknownTimeZone -> "$timestampNoTimeZone-00:00"
+                is TimeZone.UtcOffset -> {
+                    val tzHour = tz.tzHour.absoluteValue.toString().padStart(2, '0')
+                    val tzMinute = tz.tzMinute.absoluteValue.toString().padStart(2, '0')
+                    if (tz.totalOffsetMinutes < 0)
+                        "$timestampNoTimeZone-$tzHour:$tzMinute"
+                    else
+                        "$timestampNoTimeZone+$tzHour:$tzMinute"
+                }
+                null -> timestampNoTimeZone
             }
         }
     }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/CastTestBase.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/CastTestBase.kt
@@ -581,13 +581,13 @@ abstract class CastTestBase : EvaluatorTestBase() {
                     case("1.1", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("-20.1", ErrorCode.EVALUATOR_INVALID_CAST),
                     // timestamp
-                    case("`2007-10-10T`", "2007-10-10T", CastQuality.LOSSLESS),
+                    case("`2007-10-10T`", "2007-10-10T00:00:00-00:00", CastQuality.LOSSLESS),
                     // text
                     case("'hello'", ErrorCode.EVALUATOR_CAST_FAILED),
                     case("'2016-03-01T01:12:12Z'", "2016-03-01T01:12:12Z", CastQuality.LOSSLESS),
-                    case("""`"2001-01-01"`""", "2001-01-01T", CastQuality.LOSSLESS),
-                    case("""`'2000T'`""", "2000T", CastQuality.LOSSLESS),
-                    case("""`'1999-04T'`""", "1999-04T", CastQuality.LOSSLESS),
+                    case("""`"2001-01-01"`""", "2001-01-01T00:00:00-00:00", CastQuality.LOSSLESS),
+                    case("""`'2000T'`""", "2000-01-01T00:00:00-00:00", CastQuality.LOSSLESS),
+                    case("""`'1999-04T'`""", "1999-04-01T00:00:00-00:00", CastQuality.LOSSLESS),
                     // lob
                     case("""`{{""}}`""", ErrorCode.EVALUATOR_INVALID_CAST),
                     case("`{{}}`", ErrorCode.EVALUATOR_INVALID_CAST),

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerDateTimeTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerDateTimeTests.kt
@@ -1,34 +1,44 @@
 package org.partiql.lang.eval
 
+import com.amazon.ion.Decimal
 import com.amazon.ion.IonStruct
-import org.junit.Test
+import com.amazon.ion.IonTimestamp
+import com.amazon.ion.IonValue
+import com.amazon.ionelement.api.field
+import com.amazon.ionelement.api.ionDecimal
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.ionStructOf
+import com.amazon.ionelement.api.ionTimestamp
+import com.amazon.ionelement.api.toIonValue
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.ION
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.eval.evaluatortestframework.ExpectedResultFormat
+import org.partiql.lang.eval.evaluatortestframework.strictEquals
 import org.partiql.lang.eval.time.MINUTES_PER_HOUR
 import org.partiql.lang.eval.time.NANOS_PER_SECOND
 import org.partiql.lang.eval.time.SECONDS_PER_MINUTE
 import org.partiql.lang.eval.time.Time
 import org.partiql.lang.util.ArgumentsProviderBase
 import org.partiql.lang.util.getOffsetHHmm
+import org.partiql.lang.util.timestampValue
+import org.partiql.value.datetime.TimeZone
+import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.ZoneOffset
 import kotlin.math.absoluteValue
 
 class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
 
-    @Test
-    fun testDateLiteral() {
-        runEvaluatorTestCase(
-            query = "DATE '2000-01-02'",
-            expectedResult = "$DATE_ANNOTATION::2000-01-02"
-        )
-    }
-
+    // ---------------
+    // |    TIME     |
+    // ---------------
     private fun secondsWithPrecision(time: TimeForValidation) =
-        ion.newDecimal(time.second.toBigDecimal() + time.nano.toBigDecimal().divide(NANOS_PER_SECOND.toBigDecimal()).setScale(time.precision, RoundingMode.HALF_UP))
+        ion.newDecimal(
+            time.second.toBigDecimal() + time.nano.toBigDecimal().divide(NANOS_PER_SECOND.toBigDecimal())
+                .setScale(time.precision, RoundingMode.HALF_UP)
+        )
 
     private fun assertEqualsIonTimeStruct(actual: IonStruct, expectedTime: TimeForValidation) {
         assertEquals(ion.newInt(expectedTime.hour), actual["hour"])
@@ -71,9 +81,15 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
         private val defaultTimezoneOffset = ZoneOffset.UTC
         private val defaultTzMinutes = defaultTimezoneOffset.totalSeconds / 60
 
-        private fun case(query: String, expected: String, expectedTime: TimeForValidation? = null) = TimeTestCase(query, expected, expectedTime) { }
+        private fun case(query: String, expected: String, expectedTime: TimeForValidation? = null) =
+            TimeTestCase(query, expected, expectedTime) { }
 
-        private fun case(query: String, expected: String, expectedTime: TimeForValidation, compileOptionsBlock: CompileOptions.Builder.() -> Unit) = TimeTestCase(query, expected, expectedTime, compileOptionsBlock)
+        private fun case(
+            query: String,
+            expected: String,
+            expectedTime: TimeForValidation,
+            compileOptionsBlock: CompileOptions.Builder.() -> Unit
+        ) = TimeTestCase(query, expected, expectedTime, compileOptionsBlock)
 
         private fun compileOptionsBlock(hours: Int = 0, minutes: Int = 0): CompileOptions.Builder.() -> Unit = {
             defaultTimezoneOffset(ZoneOffset.ofHoursMinutes(hours, minutes))
@@ -149,6 +165,320 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
         }
     }
 
+    // ---------------
+    // |  TIMESTAMP  |
+    // ---------------
+
+    private fun assertEqualsIonTimestamp(actual: IonValue, expectedTimestamp: TimestampForValidation) {
+        // Has time zone, directly serialized to ion
+
+        if (expectedTimestamp.hasTimeZone) {
+            if (expectedTimestamp.precision != null) {
+                actual as IonTimestamp
+                assertEquals(expectedTimestamp.ionValue, actual)
+            }
+            // if the time stamp is arbitrary precision
+            // we only want to compare if the instant refers to the same point in time.
+            else {
+                val expectedTimestampValue = expectedTimestamp.ionValue.timestampValue()
+                val actualTimestampValue = actual.timestampValue()
+                // check if time zone is known
+                if (expectedTimestamp.tzHour == null && actualTimestampValue.localOffset != null) {
+                    fail("Timezone mismatch, expected UNKNOWN TIME ZONE")
+                }
+                if (expectedTimestamp.tzHour != null && actualTimestampValue.localOffset == null) {
+                    fail("Timezone mismatch, expected Known TIME ZONE")
+                }
+                if (expectedTimestampValue.compareTo(actualTimestampValue) != 0) {
+                    println("expected: $expectedTimestampValue")
+                    println("actual  : $actualTimestampValue")
+                    fail("ion Timestamp value refers to different instant")
+                }
+            }
+        } else {
+            actual as IonStruct
+            val expectedIon = expectedTimestamp.ionValue as IonStruct
+            assertEquals(expectedIon, actual)
+        }
+    }
+
+    data class TimestampTestCase(
+        val queryInSqlLiteral: String,
+        val queryInIonLiteral: List<String>,
+        val expected: String,
+        val expectedTime: TimestampForValidation? = null,
+        val session: EvaluationSession = EvaluationSession.standard()
+    )
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgumentsForTimeLstampiterals::class)
+    fun testTimestamp(tc: TimestampTestCase) {
+        // run evaluatorTestCase for sql query
+        runEvaluatorTestCase(
+            query = tc.queryInSqlLiteral,
+            session = tc.session,
+            expectedResult = tc.expected,
+            expectedResultFormat = ExpectedResultFormat.STRICT,
+        ) { actualExprValueFromSql ->
+            // ion serialization check
+            val timestampIonValue = actualExprValueFromSql.toIonValue(ION)
+            println("actualExprValueFromSql $actualExprValueFromSql")
+            assertEqualsIonTimestamp(timestampIonValue, tc.expectedTime!!)
+
+            // also, for all the equivalent ion value, the result should be the same
+            tc.queryInIonLiteral.forEach { queryInIon ->
+                runEvaluatorTestCase(
+                    query = queryInIon,
+                    session = tc.session,
+                    expectedResult = tc.expected,
+                    expectedResultFormat = ExpectedResultFormat.STRICT,
+                ) { actualExprValueFromIon ->
+                    actualExprValueFromSql.strictEquals(actualExprValueFromIon)
+                }
+            }
+        }
+    }
+
+    private class ArgumentsForTimeLstampiterals : ArgumentsProviderBase() {
+        private fun case(
+            queryInSqlLiteral: String,
+            queryInIonLiteral: List<String>,
+            expected: String,
+            expectedTimestamp: TimestampForValidation? = null
+        ) =
+            TimestampTestCase(queryInSqlLiteral, queryInIonLiteral, expected, expectedTimestamp)
+
+        private fun case(
+            queryInSqlLiteral: List<String>,
+            queryInIonLiteral: List<String>,
+            expected: String,
+            expectedTimestamp: TimestampForValidation? = null
+        ) =
+            queryInSqlLiteral.map {
+                TimestampTestCase(it, queryInIonLiteral, expected, expectedTimestamp)
+            }
+
+        private fun case(
+            queryInSqlLiteral: String,
+            queryInIonLiteral: List<String>,
+            expected: String,
+            expectedTimestamp: TimestampForValidation,
+            sessionBlock: EvaluationSession.Builder.() -> Unit
+        ) =
+            TimestampTestCase(queryInSqlLiteral, queryInIonLiteral, expected, expectedTimestamp, EvaluationSession.build { sessionBlock })
+
+        private fun sessionBlock(timeZone: TimeZone): EvaluationSession.Builder.() -> Unit = {
+            timeZone(timeZone)
+        }
+
+        override fun getParameters() = listOf(
+            // TIMESTAMP WITHOUT TIME ZONE
+            // Only possible to achieve using PartiQL syntax
+            case(
+                "TIMESTAMP '2023-01-01 00:00:00.0000'", listOf(),
+                "TIMESTAMP '2023-01-01 00:00:00.0000'",
+                TimestampForValidation(2023, 1, 1, 0, 0, BigDecimal("00.0000"), null, null, null, false)
+            ),
+            // TIMESTAMP(p) WITHOUT TIME ZONE
+            //   WITH exact precision
+            case(
+                "TIMESTAMP(4) '2023-01-01 00:00:00.0000'", listOf(),
+                "TIMESTAMP(4) '2023-01-01 00:00:00.0000'",
+                TimestampForValidation(2023, 1, 1, 0, 0, BigDecimal("00.0000"), null, null, null, false)
+            ),
+            // case with more than sufficient precision
+            case(
+                "TIMESTAMP(5) '2023-01-01 00:00:00.0000'", listOf(),
+                "TIMESTAMP(5) '2023-01-01 00:00:00.00000'",
+                TimestampForValidation(2023, 1, 1, 0, 0, BigDecimal("00.00000"), null, null, null, false)
+            ),
+            // case with less than sufficent precision
+            case(
+                "TIMESTAMP(1) '2023-01-01 00:00:00.0000'", listOf(),
+                "TIMESTAMP(1) '2023-01-01 00:00:00.0'",
+                TimestampForValidation(2023, 1, 1, 0, 0, BigDecimal("00.0"), null, null, null, false)
+            ),
+            // case with less than sufficent precision, require rounding
+            case(
+                "TIMESTAMP(1) '2023-01-01 23:59:59.999'", listOf(),
+                "TIMESTAMP(1) '2023-01-02 00:00:00.0'",
+                TimestampForValidation(2023, 1, 2, 0, 0, BigDecimal("00.0"), null, null, null, false)
+            ),
+            // session time zone should have no effect here.
+            case(
+                "TIMESTAMP(1) '2023-01-01 23:59:59.999'", listOf(),
+                "TIMESTAMP(1) '2023-01-02 00:00:00.0'",
+                TimestampForValidation(2023, 1, 2, 0, 0, BigDecimal("00.0"), null, null, null, false),
+                sessionBlock(TimeZone.UtcOffset.of(60))
+            )
+        ) +
+            // -----------------------------------------------------------------------
+            // TIMESTAMP WITH TIME ZONE
+            // PartiQL support two ways to declare a timestamp with time zone literal
+            // The SQL style "TIMESTAMP '.....{+-}HH:MM'"
+            // Or the PartiQL extension "TIMESTAMP WITH TIME ZONE '.....{+-}HH:MM'
+            // -----------------------------------------------------------------------
+
+            // TIMESTAMP WITH TIME ZONE arbitrary precision
+            // Unknown TIME ZONE
+            case(
+                listOf(
+                    "TIMESTAMP '2023-01-01 00:00:00.0-00:00'",
+                    "TIMESTAMP WITH TIME ZONE '2023-01-01 00:00:00.0-00:00'"
+                ),
+                listOf("`2023T`", "`2023-01T`", "`2023-01-01T`", "`2023-01-01T00:00:00.0-00:00`"),
+                "TIMESTAMP WITH TIME ZONE '2023-01-01 00:00:00.0-00:00'",
+                TimestampForValidation(2023, 1, 1, 0, 0, BigDecimal("00.0"), null, null, null, true)
+            ) +
+            // Any pair of arbitrary precision timestamp
+            // should be considered equal if they refer to the same point in Time
+            // Meaning the decimalSecond fraction precision does not matter.
+            case(
+                listOf(
+                    "TIMESTAMP '2023-01-01 00:00:00.0000-00:00'",
+                    "TIMESTAMP WITH TIME ZONE '2023-01-01 00:00:00.0000-00:00'"
+                ),
+                listOf("`2023T`", "`2023-01T`", "`2023-01-01T`", "`2023-01-01T00:00:00.00-00:00`"),
+                "TIMESTAMP WITH TIME ZONE '2023-01-01 00:00:00.0-00:00'",
+                TimestampForValidation(2023, 1, 1, 0, 0, BigDecimal("00.0"), null, null, null, true)
+            ) +
+            // TIMESTAMP WITH TIME ZONE arbitrary precision
+            // KNOWN timezone
+            case(
+                listOf(
+                    "TIMESTAMP '2023-01-01 00:00:00.0000+00:00'",
+                    "TIMESTAMP WITH TIME ZONE '2023-01-01 00:00:00.0000+00:00'"
+                ),
+                listOf("`2023-01-01T00:00:00.00+00:00`"),
+                "TIMESTAMP WITH TIME ZONE '2023-01-01 00:00:00.0+00:00'",
+                TimestampForValidation(2023, 1, 1, 0, 0, BigDecimal("00.0"), 0, 0, null, true)
+            ) +
+            // TIMESTAMP WITH TIME ZONE specified precision
+            // UNKNOWN TIMEZONE, no rounding needed
+            case(
+                listOf(
+                    "TIMESTAMP(5) '2023-01-01 00:00:00.0000-00:00'",
+                    "TIMESTAMP(5) WITH TIME ZONE '2023-01-01 00:00:00.0000-00:00'"
+                ),
+                listOf(),
+                "TIMESTAMP(5) WITH TIME ZONE '2023-01-01 00:00:00.00000-00:00'",
+                TimestampForValidation(2023, 1, 1, 0, 0, BigDecimal("00.00000"), null, null, 5, true)
+            ) +
+            // TIMESTAMP WITH TIME ZONE arbitrary precision
+            // KNOWN timezone, no rounding needed
+            case(
+                listOf(
+                    "TIMESTAMP(5) '2023-01-01 00:00:00.0000+00:00'",
+                    "TIMESTAMP(5) WITH TIME ZONE '2023-01-01 00:00:00.0000+00:00'"
+                ),
+                listOf(),
+                "TIMESTAMP(5) WITH TIME ZONE '2023-01-01 00:00:00.00000+00:00'",
+                TimestampForValidation(2023, 1, 1, 0, 0, BigDecimal("00.00000"), 0, 0, 5, true)
+            ) +
+            // TIMESTAMP WITH TIME ZONE specified precision
+            // UNKNOWN TIMEZONE, rounding needed
+            case(
+                listOf(
+                    "TIMESTAMP(5) '2023-01-01 23:59:59.999999-00:00'",
+                    "TIMESTAMP(5) WITH TIME ZONE '2023-01-01 23:59:59.999999-00:00'"
+                ),
+                listOf(),
+                "TIMESTAMP(5) WITH TIME ZONE '2023-01-02 00:00:00.00000-00:00'",
+                TimestampForValidation(2023, 1, 2, 0, 0, BigDecimal("00.00000"), null, null, 5, true)
+            ) +
+            // TIMESTAMP WITH TIME ZONE arbitrary precision
+            // KNOWN timezone, rounding needed
+            case(
+                listOf(
+                    "TIMESTAMP(5) '2023-01-01 23:59:59.999999+00:00'",
+                    "TIMESTAMP(5) WITH TIME ZONE '2023-01-01 23:59:59.999999+00:00'"
+                ),
+                listOf(),
+                "TIMESTAMP(5) WITH TIME ZONE '2023-01-02 00:00:00.00000+00:00'",
+                TimestampForValidation(2023, 1, 2, 0, 0, BigDecimal("00.00000"), 0, 0, 5, true)
+            ) +
+            // TIMESTAMP WITH TIME ZONE specified precision
+            // UNKNOWN TIMEZONE, rounding needed
+            // session time zone should have no effect.
+            case(
+                "TIMESTAMP(5) '2023-01-01 23:59:59.999999-00:00'",
+                listOf(),
+                "TIMESTAMP(5) WITH TIME ZONE '2023-01-02 00:00:00.00000-00:00'",
+                TimestampForValidation(2023, 1, 2, 0, 0, BigDecimal("00.00000"), null, null, 5, true),
+                sessionBlock(TimeZone.UtcOffset.of(60))
+            ) +
+            // TIMESTAMP WITH TIME ZONE arbitrary precision
+            // KNOWN timezone, rounding needed
+            case(
+                "TIMESTAMP(5) '2023-01-01 23:59:59.999999+00:00'",
+                listOf(),
+                "TIMESTAMP(5) WITH TIME ZONE '2023-01-02 00:00:00.00000+00:00'",
+                TimestampForValidation(2023, 1, 2, 0, 0, BigDecimal("00.00000"), 0, 0, 5, true),
+                sessionBlock(TimeZone.UtcOffset.of(60))
+            )
+    }
+
+    // Note
+    // 1) For instance that we need to represent an unknown offset, set tzHour/tzMinutes to null, and hasTimezone to true
+    // 2) For instance that has no time zone, set tzHour/TzMinutes to null and hasTimezone to false
+    // 3) If tzHour is null, then Tz Minute must be null.
+    data class TimestampForValidation(
+        val year: Int,
+        val month: Int,
+        val day: Int,
+        val hour: Int,
+        val minute: Int,
+        val second: BigDecimal,
+        val tzHour: Int?,
+        val tzMinutes: Int?,
+        val precision: Int? = null,
+        val hasTimeZone: Boolean
+    ) {
+        init {
+            if (tzHour == null && tzMinutes != null) {
+                error("Offset hour value is null, but offset minute value is not null, check test cases")
+            }
+        }
+
+        val ionValue = when (hasTimeZone) {
+            true -> {
+                val sb = StringBuilder()
+                sb.append(
+                    "${year.toString().padStart(4, '0')}-${month.toString().padStart(2, '0')}-${
+                    day.toString().padStart(2, '0')
+                    }"
+                )
+                sb.append("T")
+                sb.append("${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}:")
+                val (secondPart, fractionPart) = second.toPlainString().split('.', limit = 2)
+                sb.append("${secondPart.padStart(2, '0')}.$fractionPart")
+                when {
+                    tzHour == null -> sb.append("-00:00")
+                    tzHour >= 0 -> sb.append(
+                        "+${tzHour.toString().padStart(2, '0')}:${
+                        tzMinutes.toString().padStart(2, '0')
+                        }"
+                    )
+
+                    else -> sb.append("${tzHour.toString().padStart(2, '0')}:${tzMinutes.toString().padStart(2, '0')}")
+                }
+                ionTimestamp(sb.toString()).toIonValue(ION)
+            }
+
+            false -> {
+                // OR should we do ionTimestamp with annotation?
+                ionStructOf(
+                    field("year", ionInt(year.toLong())),
+                    field("month", ionInt(month.toLong())),
+                    field("day", ionInt(day.toLong())),
+                    field("hour", ionInt(hour.toLong())),
+                    field("minute", ionInt(minute.toLong())),
+                    field("second", ionDecimal(Decimal.valueOf(second))),
+                ).withAnnotations(TIMESTAMP_ANNOTATION).toIonValue(ION)
+            }
+        }
+    }
+
     @ParameterizedTest
     @ArgumentsSource(ArgumentsForComparison::class)
     fun testComparison(tc: ComparisonTestCase) {
@@ -156,12 +486,15 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
             null ->
                 runEvaluatorErrorTestCase(
                     query = tc.query,
+                    session = tc.session,
                     expectedErrorCode = ErrorCode.EVALUATOR_INVALID_COMPARISION,
-                    expectedPermissiveModeResult = "MISSING"
+                    expectedPermissiveModeResult = "MISSING",
                 )
+
             else -> {
                 runEvaluatorTestCase(
                     query = tc.query,
+                    session = tc.session,
                     expectedResult = tc.expected,
                     expectedResultFormat = ExpectedResultFormat.STRICT
                 )
@@ -174,10 +507,21 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
      * [expected] is the expected value of the query.
      * The [null] [expected] value indicates that the comparison test case throws an error.
      */
-    data class ComparisonTestCase(val query: String, val expected: String?)
+    data class ComparisonTestCase(
+        val query: String,
+        val expected: String?,
+        val session: EvaluationSession = EvaluationSession.standard()
+    )
 
     private class ArgumentsForComparison : ArgumentsProviderBase() {
         private fun case(query: String, expected: String) = ComparisonTestCase(query, expected)
+
+        private fun case(query: String, expected: String, sessionBlock: EvaluationSession.Builder.() -> Unit) =
+            ComparisonTestCase(query, expected, EvaluationSession.build { sessionBlock })
+
+        private fun sessionBlock(timeZone: TimeZone): EvaluationSession.Builder.() -> Unit = {
+            timeZone(timeZone)
+        }
         private fun errorCase(query: String) = ComparisonTestCase(query, null)
         override fun getParameters() = listOf(
             case("DATE '2012-02-29' > DATE '2012-02-28'", "true"),
@@ -195,6 +539,38 @@ class EvaluatingCompilerDateTimeTests : EvaluatorTestBase() {
             case("TIME WITH TIME ZONE '12:12:12.123+00:00' = TIME WITH TIME ZONE '12:12:12.123+00:00'", "true"),
             case("TIME WITH TIME ZONE '12:12:12.123-08:00' > TIME WITH TIME ZONE '12:12:12.123+00:00'", "true"),
             case("TIME WITH TIME ZONE '12:12:12.123-08:00' < TIME WITH TIME ZONE '12:12:12.123+00:00'", "false"),
+            case("TIMESTAMP '2012-02-29 12:12:12' = TIMESTAMP '2012-02-29 12:12:12'", "true"),
+            case("TIMESTAMP '2012-02-29 12:12:12.000' = TIMESTAMP '2012-02-29 12:12:12'", "true"),
+            case("TIMESTAMP '2012-02-29 12:12:12.000' < TIMESTAMP '2012-02-29 13:12:12'", "true"),
+            case("TIMESTAMP '2012-02-29 12:12:12.000' > TIMESTAMP '2012-02-29 11:12:12'", "true"),
+            case("TIMESTAMP(1) '2012-02-29 12:12:12.000' = TIMESTAMP '2012-02-29 12:12:12'", "true"),
+            case("TIMESTAMP(5) '2012-02-29 12:12:12.000' = TIMESTAMP '2012-02-29 12:12:12'", "true"),
+            case("TIMESTAMP(4) '2012-02-29 12:12:11.99999' = TIMESTAMP '2012-02-29 12:12:12'", "true"),
+            case("TIMESTAMP '2012-02-29 12:12:12+00:00' = TIMESTAMP WITH TIME ZONE '2012-02-29 11:12:12-01:00'", "true"),
+            case("TIMESTAMP '2012-02-29 12:12:12+00:00' = TIMESTAMP WITH TIME ZONE '2012-02-29 11:12:12-01:00'", "true"),
+            case("TIMESTAMP '2012-02-29 12:12:12+00:00' = TIMESTAMP '2012-02-29 12:12:12-00:00'", "true"),
+            // SQL has an interesting implicit casting behavior defined for datetime type
+            // and if such implicit casting behavior should apply, we will see some the weird equivalence case.
+            // For example:
+            // 1. TIMESTAMP '2012-02-29 12:12:12+00:00' = TIMESTAMP '2012-02-29 12:12:12' will be true if session time zone is UTC.
+            // 2. DATE '2023-06-01' = TIMESTAMP '2023-06-01 00:00:00+00:00' if timestamp is UTC.
+            // 3. DATE '2023-06-01' = TIMESTAMP '2023-06-01 00:00:00' regardless of session time zone
+            // 4. TIME '00:00:00' = TIMESTAMP '2023-06-01 00:00:00' if session now has a date of 2023-06-01
+            // 5. TIME '00:00:00' = TIMESTAMP '2023-06-01 00:00:00+00:00' if session now has a date of 2023-06-01 and session offset if UTC.
+            // 6. TIME '00:00:00+00:00' = TIMESTAMP '2023-06-01 00:00:00' if session now has a date of 2023-06-01 and session offset if UTC.
+            // 7. TIME '00:00:00+00:00' = TIMESTAMP '2023-06-01 00:00:00' if session now has a date of 2023-06-01.
+            // Same logic applies to other comparison operator.
+            // Notice that time <op> timestamp will create a confusing situation, where the same query, ran against the same data,
+            // will yield different result 24 hours later.
+            // Moreover, in SQL everything is strongly typed, wheras in PartiQL it is possible to have an value whose type is unionOf(timestamp, date/time).
+            // We would need to be careful with the comparison ( <, =, >) vs the order by less than operator (used in order by, group by) etc.
+            // TODO: To support the following case, we need a new comparator, let halt on those after RFC.
+            //  https://github.com/partiql/partiql-docs/issues/41
+            // case("TIMESTAMP '2012-02-29 12:12:12+00:00' = TIMESTAMP '2012-02-29 12:12:12'", "true", sessionBlock(TimeZone.UtcOffset.of(0))),
+            // case("TIMESTAMP '2012-02-29 12:12:12+00:00' = TIMESTAMP '2012-02-29 12:12:12'", "false", sessionBlock(TimeZone.UtcOffset.of(60))),
+            // case("TIMESTAMP '2012-02-29 12:12:12+00:00' = TIMESTAMP '2012-02-29 12:12:12'", "false", sessionBlock(TimeZone.UnknownTimeZone)),
+            // TODO: other implicit casting between date time types
+
             case("CAST('12:12:12.123' AS TIME WITH TIME ZONE) = TIME WITH TIME ZONE '12:12:12.123'", "true"),
             case("CAST(TIME WITH TIME ZONE '12:12:12.123' AS TIME) = TIME '12:12:12.123'", "true"),
             // Following are the error cases.

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/DateAddEvaluationTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/DateAddEvaluationTest.kt
@@ -5,11 +5,11 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.eval.EvaluatorTestBase
-import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
 import org.partiql.lang.eval.builtins.toSession
+import org.partiql.lang.eval.evaluatortestframework.ExpectedResultFormat
 import org.partiql.lang.util.ArgumentsProviderBase
 import org.partiql.lang.util.propertyValueMapOf
 import org.partiql.types.StaticType
@@ -19,131 +19,140 @@ class DateAddEvaluationTest : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(DateAddPassCases::class)
     fun runPassTests(testCase: ExprFunctionTestCase) =
-        runEvaluatorTestCase(testCase.source, testCase.session, testCase.expectedLegacyModeResult, expectedPermissiveModeResult = testCase.expectedPermissiveModeResult)
+        runEvaluatorTestCase(
+            query = testCase.source,
+            session = testCase.session,
+            expectedResult = testCase.expectedLegacyModeResult,
+            expectedPermissiveModeResult = testCase.expectedPermissiveModeResult,
+            expectedResultFormat = ExpectedResultFormat.STRICT
+        )
 
     class DateAddPassCases : ArgumentsProviderBase() {
-        override fun getParameters(): List<Any> = listOf(
+        override fun getParameters() =
+            ionTestCases
+
+        // All the following tests case has a ion literal for timestamp parameter in date add function
+        private val ionTestCases = listOf(
+            // Against Ion Timestamp
             ExprFunctionTestCase("date_add(second, null, `2017-01-10T05:30:55Z`)", "null"),
             ExprFunctionTestCase("date_add(second, 1, null)", "null"),
-            ExprFunctionTestCase("date_add(second, missing, `2017-01-10T05:30:55Z`)", "null", "$MISSING_ANNOTATION::null"),
-            ExprFunctionTestCase("date_add(second, 1, missing)", "null", "$MISSING_ANNOTATION::null"),
-            ExprFunctionTestCase("date_add(year, `1`, `2017T`)", "2018T"),
+            ExprFunctionTestCase("date_add(second, missing, `2017-01-10T05:30:55Z`)", "null", "MISSING"),
+            ExprFunctionTestCase("date_add(second, 1, missing)", "null", "MISSING"),
+            ExprFunctionTestCase("date_add(year, `1`, `2017T`)", "TIMESTAMP '2018-01-01T00:00:00-00:00'"),
             ExprFunctionTestCase(
                 "date_add(second, a, b)",
-                "2017-01-10T05:30:56Z",
+                "TIMESTAMP '2017-01-10T05:30:56+00:00'",
                 session = mapOf("a" to "1", "b" to "2017-01-10T05:30:55Z").toSession()
             ),
+            ExprFunctionTestCase("date_add(year, 1, `2017T`)", "TIMESTAMP '2018-01-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(month, 1, `2017T`)", "TIMESTAMP '2017-02-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(day, 1, `2017T`)", "TIMESTAMP '2017-01-02T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(hour, 1, `2017T`)", "TIMESTAMP '2017-01-01T01:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(minute, 1, `2017T`)", "TIMESTAMP '2017-01-01T00:01:00-00:00'"),
+            ExprFunctionTestCase("date_add(second, 1, `2017T`)", "TIMESTAMP '2017-01-01T00:00:01-00:00'"),
 
-            // add 1 at different precision levels
-            ExprFunctionTestCase("date_add(year, 1, `2017T`)", "2018T"),
-            ExprFunctionTestCase("date_add(month, 1, `2017T`)", "2017-02T"),
-            ExprFunctionTestCase("date_add(day, 1, `2017T`)", "2017-01-02T"),
-            ExprFunctionTestCase("date_add(hour, 1, `2017T`)", "2017-01-01T01:00-00:00"),
-            ExprFunctionTestCase("date_add(minute, 1, `2017T`)", "2017-01-01T00:01-00:00"),
-            ExprFunctionTestCase("date_add(second, 1, `2017T`)", "2017-01-01T00:00:01-00:00"),
+            ExprFunctionTestCase("date_add(year, 1, `2017-01T`)", "TIMESTAMP '2018-01-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(month, 1, `2017-01T`)", "TIMESTAMP '2017-02-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(day, 1, `2017-01T`)", "TIMESTAMP '2017-01-02T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(hour, 1, `2017-01T`)", "TIMESTAMP '2017-01-01T01:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(minute, 1, `2017-01T`)", "TIMESTAMP '2017-01-01T00:01:00-00:00'"),
+            ExprFunctionTestCase("date_add(second, 1, `2017-01T`)", "TIMESTAMP '2017-01-01T00:00:01-00:00'"),
 
-            ExprFunctionTestCase("date_add(year, 1, `2017-01T`)", "2018-01T"),
-            ExprFunctionTestCase("date_add(month, 1, `2017-01T`)", "2017-02T"),
-            ExprFunctionTestCase("date_add(day, 1, `2017-01T`)", "2017-01-02T"),
-            ExprFunctionTestCase("date_add(hour, 1, `2017-01T`)", "2017-01-01T01:00-00:00"),
-            ExprFunctionTestCase("date_add(minute, 1, `2017-01T`)", "2017-01-01T00:01-00:00"),
-            ExprFunctionTestCase("date_add(second, 1, `2017-01T`)", "2017-01-01T00:00:01-00:00"),
+            ExprFunctionTestCase("date_add(year, 1, `2017-01-02T`)", "TIMESTAMP '2018-01-02T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(month, 1, `2017-01-02T`)", "TIMESTAMP '2017-02-02T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(day, 1, `2017-01-02T`)", "TIMESTAMP '2017-01-03T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(hour, 1, `2017-01-02T`)", "TIMESTAMP '2017-01-02T01:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(minute, 1, `2017-01-02T`)", "TIMESTAMP '2017-01-02T00:01:00-00:00'"),
+            ExprFunctionTestCase("date_add(second, 1, `2017-01-02T`)", "TIMESTAMP '2017-01-02T00:00:01-00:00'"),
 
-            ExprFunctionTestCase("date_add(year, 1, `2017-01-02T`)", "2018-01-02T"),
-            ExprFunctionTestCase("date_add(month, 1, `2017-01-02T`)", "2017-02-02T"),
-            ExprFunctionTestCase("date_add(day, 1, `2017-01-02T`)", "2017-01-03T"),
-            ExprFunctionTestCase("date_add(hour, 1, `2017-01-02T`)", "2017-01-02T01:00-00:00"),
-            ExprFunctionTestCase("date_add(minute, 1, `2017-01-02T`)", "2017-01-02T00:01-00:00"),
-            ExprFunctionTestCase("date_add(second, 1, `2017-01-02T`)", "2017-01-02T00:00:01-00:00"),
+            ExprFunctionTestCase("date_add(year, 1, `2017-01-02T03:04Z`)", "TIMESTAMP '2018-01-02T03:04:00+00:00'"),
+            ExprFunctionTestCase("date_add(month, 1, `2017-01-02T03:04Z`)", "TIMESTAMP '2017-02-02T03:04:00+00:00'"),
+            ExprFunctionTestCase("date_add(day, 1, `2017-01-02T03:04Z`)", "TIMESTAMP '2017-01-03T03:04:00+00:00'"),
+            ExprFunctionTestCase("date_add(hour, 1, `2017-01-02T03:04Z`)", "TIMESTAMP '2017-01-02T04:04:00+00:00'"),
+            ExprFunctionTestCase("date_add(minute, 1, `2017-01-02T03:04Z`)", "TIMESTAMP '2017-01-02T03:05:00+00:00'"),
+            ExprFunctionTestCase("date_add(second, 1, `2017-01-02T03:04Z`)", "TIMESTAMP '2017-01-02T03:04:01+00:00'"),
 
-            ExprFunctionTestCase("date_add(year, 1, `2017-01-02T03:04Z`)", "2018-01-02T03:04Z"),
-            ExprFunctionTestCase("date_add(month, 1, `2017-01-02T03:04Z`)", "2017-02-02T03:04Z"),
-            ExprFunctionTestCase("date_add(day, 1, `2017-01-02T03:04Z`)", "2017-01-03T03:04Z"),
-            ExprFunctionTestCase("date_add(hour, 1, `2017-01-02T03:04Z`)", "2017-01-02T04:04Z"),
-            ExprFunctionTestCase("date_add(minute, 1, `2017-01-02T03:04Z`)", "2017-01-02T03:05Z"),
-            ExprFunctionTestCase("date_add(second, 1, `2017-01-02T03:04Z`)", "2017-01-02T03:04:01Z"),
+            ExprFunctionTestCase("date_add(year, 1, `2017-01-02T03:04:05Z`)", "TIMESTAMP '2018-01-02T03:04:05+00:00'"),
+            ExprFunctionTestCase("date_add(month, 1, `2017-01-02T03:04:05Z`)", "TIMESTAMP '2017-02-02T03:04:05+00:00'"),
+            ExprFunctionTestCase("date_add(day, 1, `2017-01-02T03:04:05Z`)", "TIMESTAMP '2017-01-03T03:04:05+00:00'"),
+            ExprFunctionTestCase("date_add(hour, 1, `2017-01-02T03:04:05Z`)", "TIMESTAMP '2017-01-02T04:04:05+00:00'"),
+            ExprFunctionTestCase("date_add(minute, 1, `2017-01-02T03:04:05Z`)", "TIMESTAMP '2017-01-02T03:05:05+00:00'"),
+            ExprFunctionTestCase("date_add(second, 1, `2017-01-02T03:04:05Z`)", "TIMESTAMP '2017-01-02T03:04:06+00:00'"),
 
-            ExprFunctionTestCase("date_add(year, 1, `2017-01-02T03:04:05Z`)", "2018-01-02T03:04:05Z"),
-            ExprFunctionTestCase("date_add(month, 1, `2017-01-02T03:04:05Z`)", "2017-02-02T03:04:05Z"),
-            ExprFunctionTestCase("date_add(day, 1, `2017-01-02T03:04:05Z`)", "2017-01-03T03:04:05Z"),
-            ExprFunctionTestCase("date_add(hour, 1, `2017-01-02T03:04:05Z`)", "2017-01-02T04:04:05Z"),
-            ExprFunctionTestCase("date_add(minute, 1, `2017-01-02T03:04:05Z`)", "2017-01-02T03:05:05Z"),
-            ExprFunctionTestCase("date_add(second, 1, `2017-01-02T03:04:05Z`)", "2017-01-02T03:04:06Z"),
-
-            ExprFunctionTestCase("date_add(year, 1, `2017-01-02T03:04:05.006Z`)", "2018-01-02T03:04:05.006Z"),
-            ExprFunctionTestCase("date_add(month, 1, `2017-01-02T03:04:05.006Z`)", "2017-02-02T03:04:05.006Z"),
-            ExprFunctionTestCase("date_add(day, 1, `2017-01-02T03:04:05.006Z`)", "2017-01-03T03:04:05.006Z"),
-            ExprFunctionTestCase("date_add(hour, 1, `2017-01-02T03:04:05.006Z`)", "2017-01-02T04:04:05.006Z"),
-            ExprFunctionTestCase("date_add(minute, 1, `2017-01-02T03:04:05.006Z`)", "2017-01-02T03:05:05.006Z"),
-            ExprFunctionTestCase("date_add(second, 1, `2017-01-02T03:04:05.006Z`)", "2017-01-02T03:04:06.006Z"),
+            ExprFunctionTestCase("date_add(year, 1, `2017-01-02T03:04:05.006Z`)", "TIMESTAMP '2018-01-02T03:04:05.006+00:00'"),
+            ExprFunctionTestCase("date_add(month, 1, `2017-01-02T03:04:05.006Z`)", "TIMESTAMP '2017-02-02T03:04:05.006+00:00'"),
+            ExprFunctionTestCase("date_add(day, 1, `2017-01-02T03:04:05.006Z`)", "TIMESTAMP '2017-01-03T03:04:05.006+00:00'"),
+            ExprFunctionTestCase("date_add(hour, 1, `2017-01-02T03:04:05.006Z`)", "TIMESTAMP '2017-01-02T04:04:05.006+00:00'"),
+            ExprFunctionTestCase("date_add(minute, 1, `2017-01-02T03:04:05.006Z`)", "TIMESTAMP '2017-01-02T03:05:05.006+00:00'"),
+            ExprFunctionTestCase("date_add(second, 1, `2017-01-02T03:04:05.006Z`)", "TIMESTAMP '2017-01-02T03:04:06.006+00:00'"),
 
             // add enough to flip a year. Skipping milliseconds as it overflows Long
-            ExprFunctionTestCase("date_add(month, 12, `2017T`)", "2018-01T"),
-            ExprFunctionTestCase("date_add(day, 365, `2017T`)", "2018-01-01T"),
-            ExprFunctionTestCase("date_add(hour, ${365 * 24}, `2017T`)", "2018-01-01T00:00-00:00"),
-            ExprFunctionTestCase("date_add(minute, ${365 * 24 * 60}, `2017T`)", "2018-01-01T00:00-00:00"),
-            ExprFunctionTestCase("date_add(minute, ${365 * 24 * 60 * 60}, `2017T`)", "2076-12-17T00:00-00:00"),
+            ExprFunctionTestCase("date_add(month, 12, `2017T`)", "TIMESTAMP '2018-01-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(day, 365, `2017T`)", "TIMESTAMP '2018-01-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(hour, ${365 * 24}, `2017T`)", "TIMESTAMP '2018-01-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(minute, ${365 * 24 * 60}, `2017T`)", "TIMESTAMP '2018-01-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(minute, ${365 * 24 * 60 * 60}, `2017T`)", "TIMESTAMP '2076-12-17T00:00:00-00:00'"),
 
             // add enough to flip a month. Skipping milliseconds as it overflows Long
-            ExprFunctionTestCase("date_add(day, 31, `2017-01T`)", "2017-02-01T"),
-            ExprFunctionTestCase("date_add(hour, ${31 * 24}, `2017-01T`)", "2017-02-01T00:00-00:00"),
-            ExprFunctionTestCase("date_add(minute, ${31 * 24 * 60}, `2017-01T`)", "2017-02-01T00:00-00:00"),
-            ExprFunctionTestCase("date_add(second, ${31 * 24 * 60 * 60}, `2017-01T`)", "2017-02-01T00:00:00-00:00"),
+            ExprFunctionTestCase("date_add(day, 31, `2017-01T`)", "TIMESTAMP '2017-02-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(hour, ${31 * 24}, `2017-01T`)", "TIMESTAMP '2017-02-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(minute, ${31 * 24 * 60}, `2017-01T`)", "TIMESTAMP '2017-02-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(second, ${31 * 24 * 60 * 60}, `2017-01T`)", "TIMESTAMP '2017-02-01T00:00:00-00:00'"),
 
             // add enough to flip a day
-            ExprFunctionTestCase("date_add(hour, 24, `2017-02-03T`)", "2017-02-04T00:00-00:00"),
-            ExprFunctionTestCase("date_add(minute, ${24 * 60}, `2017-02-03T`)", "2017-02-04T00:00-00:00"),
-            ExprFunctionTestCase("date_add(second, ${24 * 60 * 60}, `2017-02-03T`)", "2017-02-04T00:00:00-00:00"),
+            ExprFunctionTestCase("date_add(hour, 24, `2017-02-03T`)", "TIMESTAMP '2017-02-04T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(minute, ${24 * 60}, `2017-02-03T`)", "TIMESTAMP '2017-02-04T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(second, ${24 * 60 * 60}, `2017-02-03T`)", "TIMESTAMP '2017-02-04T00:00:00-00:00'"),
 
             // add enough to flip the hour
-            ExprFunctionTestCase("date_add(minute, 60, `2017-02-04T05:06Z`)", "2017-02-04T06:06Z"),
-            ExprFunctionTestCase("date_add(second, ${60 * 60}, `2017-02-04T05:06Z`)", "2017-02-04T06:06:00Z"),
+            ExprFunctionTestCase("date_add(minute, 60, `2017-02-04T05:06Z`)", "TIMESTAMP '2017-02-04T06:06:00+00:00'"),
+            ExprFunctionTestCase("date_add(second, ${60 * 60}, `2017-02-04T05:06Z`)", "TIMESTAMP '2017-02-04T06:06:00+00:00'"),
 
             // add enough to flip the minute
-            ExprFunctionTestCase("date_add(second, 60, `2017-02-04T05:06Z`)", "2017-02-04T05:07:00Z"),
+            ExprFunctionTestCase("date_add(second, 60, `2017-02-04T05:06Z`)", "TIMESTAMP '2017-02-04T05:07:00+00:00'"),
 
             // subtract 1 at different precision levels
-            ExprFunctionTestCase("date_add(year, -1, `2017T`)", "2016T"),
-            ExprFunctionTestCase("date_add(month, -1, `2017T`)", "2016-12T"),
-            ExprFunctionTestCase("date_add(day, -1, `2017T`)", "2016-12-31T"),
-            ExprFunctionTestCase("date_add(hour, -1, `2017T`)", "2016-12-31T23:00-00:00"),
-            ExprFunctionTestCase("date_add(minute, -1, `2017T`)", "2016-12-31T23:59-00:00"),
-            ExprFunctionTestCase("date_add(second, -1, `2017T`)", "2016-12-31T23:59:59-00:00"),
+            ExprFunctionTestCase("date_add(year, -1, `2017T`)", "TIMESTAMP '2016-01-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(month, -1, `2017T`)", "TIMESTAMP '2016-12-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(day, -1, `2017T`)", "TIMESTAMP '2016-12-31T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(hour, -1, `2017T`)", "TIMESTAMP '2016-12-31T23:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(minute, -1, `2017T`)", "TIMESTAMP '2016-12-31T23:59:00-00:00'"),
+            ExprFunctionTestCase("date_add(second, -1, `2017T`)", "TIMESTAMP '2016-12-31T23:59:59-00:00'"),
 
-            ExprFunctionTestCase("date_add(year, -1, `2017-02T`)", "2016-02T"),
-            ExprFunctionTestCase("date_add(month, -1, `2017-02T`)", "2017-01T"),
-            ExprFunctionTestCase("date_add(day, -1, `2017-02T`)", "2017-01-31T"),
-            ExprFunctionTestCase("date_add(hour, -1, `2017-02T`)", "2017-01-31T23:00-00:00"),
-            ExprFunctionTestCase("date_add(minute, -1, `2017-02T`)", "2017-01-31T23:59-00:00"),
-            ExprFunctionTestCase("date_add(second, -1, `2017-02T`)", "2017-01-31T23:59:59-00:00"),
+            ExprFunctionTestCase("date_add(year, -1, `2017-02T`)", "TIMESTAMP '2016-02-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(month, -1, `2017-02T`)", "TIMESTAMP '2017-01-01T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(day, -1, `2017-02T`)", "TIMESTAMP '2017-01-31T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(hour, -1, `2017-02T`)", "TIMESTAMP '2017-01-31T23:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(minute, -1, `2017-02T`)", "TIMESTAMP '2017-01-31T23:59:00-00:00'"),
+            ExprFunctionTestCase("date_add(second, -1, `2017-02T`)", "TIMESTAMP '2017-01-31T23:59:59-00:00'"),
 
-            ExprFunctionTestCase("date_add(year, -1, `2017-02-03T`)", "2016-02-03T"),
-            ExprFunctionTestCase("date_add(month, -1, `2017-02-03T`)", "2017-01-03T"),
-            ExprFunctionTestCase("date_add(day, -1, `2017-02-03T`)", "2017-02-02T"),
-            ExprFunctionTestCase("date_add(hour, -1, `2017-02-03T`)", "2017-02-02T23:00-00:00"),
-            ExprFunctionTestCase("date_add(minute, -1, `2017-02-03T`)", "2017-02-02T23:59-00:00"),
-            ExprFunctionTestCase("date_add(second, -1, `2017-02-03T`)", "2017-02-02T23:59:59-00:00"),
+            ExprFunctionTestCase("date_add(year, -1, `2017-02-03T`)", "TIMESTAMP '2016-02-03T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(month, -1, `2017-02-03T`)", "TIMESTAMP '2017-01-03T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(day, -1, `2017-02-03T`)", "TIMESTAMP '2017-02-02T00:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(hour, -1, `2017-02-03T`)", "TIMESTAMP '2017-02-02T23:00:00-00:00'"),
+            ExprFunctionTestCase("date_add(minute, -1, `2017-02-03T`)", "TIMESTAMP '2017-02-02T23:59:00-00:00'"),
+            ExprFunctionTestCase("date_add(second, -1, `2017-02-03T`)", "TIMESTAMP '2017-02-02T23:59:59-00:00'"),
 
-            ExprFunctionTestCase("date_add(year, -1, `2017-02-03T04:05Z`)", "2016-02-03T04:05Z"),
-            ExprFunctionTestCase("date_add(month, -1, `2017-02-03T04:05Z`)", "2017-01-03T04:05Z"),
-            ExprFunctionTestCase("date_add(day, -1, `2017-02-03T04:05Z`)", "2017-02-02T04:05Z"),
-            ExprFunctionTestCase("date_add(hour, -1, `2017-02-03T04:05Z`)", "2017-02-03T03:05Z"),
-            ExprFunctionTestCase("date_add(minute, -1, `2017-02-03T04:05Z`)", "2017-02-03T04:04Z"),
-            ExprFunctionTestCase("date_add(second, -1, `2017-02-03T04:05Z`)", "2017-02-03T04:04:59Z"),
+            ExprFunctionTestCase("date_add(year, -1, `2017-02-03T04:05Z`)", "TIMESTAMP '2016-02-03T04:05:00+00:00'"),
+            ExprFunctionTestCase("date_add(month, -1, `2017-02-03T04:05Z`)", "TIMESTAMP '2017-01-03T04:05:00+00:00'"),
+            ExprFunctionTestCase("date_add(day, -1, `2017-02-03T04:05Z`)", "TIMESTAMP '2017-02-02T04:05:00+00:00'"),
+            ExprFunctionTestCase("date_add(hour, -1, `2017-02-03T04:05Z`)", "TIMESTAMP '2017-02-03T03:05:00+00:00'"),
+            ExprFunctionTestCase("date_add(minute, -1, `2017-02-03T04:05Z`)", "TIMESTAMP '2017-02-03T04:04:00+00:00'"),
+            ExprFunctionTestCase("date_add(second, -1, `2017-02-03T04:05Z`)", "TIMESTAMP '2017-02-03T04:04:59+00:00'"),
 
-            ExprFunctionTestCase("date_add(year, -1, `2017-02-03T04:05:06Z`)", "2016-02-03T04:05:06Z"),
-            ExprFunctionTestCase("date_add(month, -1, `2017-02-03T04:05:06Z`)", "2017-01-03T04:05:06Z"),
-            ExprFunctionTestCase("date_add(day, -1, `2017-02-03T04:05:06Z`)", "2017-02-02T04:05:06Z"),
-            ExprFunctionTestCase("date_add(hour, -1, `2017-02-03T04:05:06Z`)", "2017-02-03T03:05:06Z"),
-            ExprFunctionTestCase("date_add(minute, -1, `2017-02-03T04:05:06Z`)", "2017-02-03T04:04:06Z"),
-            ExprFunctionTestCase("date_add(second, -1, `2017-02-03T04:05:06Z`)", "2017-02-03T04:05:05Z"),
+            ExprFunctionTestCase("date_add(year, -1, `2017-02-03T04:05:06Z`)", "TIMESTAMP '2016-02-03T04:05:06+00:00'"),
+            ExprFunctionTestCase("date_add(month, -1, `2017-02-03T04:05:06Z`)", "TIMESTAMP '2017-01-03T04:05:06+00:00'"),
+            ExprFunctionTestCase("date_add(day, -1, `2017-02-03T04:05:06Z`)", "TIMESTAMP '2017-02-02T04:05:06+00:00'"),
+            ExprFunctionTestCase("date_add(hour, -1, `2017-02-03T04:05:06Z`)", "TIMESTAMP '2017-02-03T03:05:06+00:00'"),
+            ExprFunctionTestCase("date_add(minute, -1, `2017-02-03T04:05:06Z`)", "TIMESTAMP '2017-02-03T04:04:06+00:00'"),
+            ExprFunctionTestCase("date_add(second, -1, `2017-02-03T04:05:06Z`)", "TIMESTAMP '2017-02-03T04:05:05+00:00'"),
 
-            ExprFunctionTestCase("date_add(year, -1, `2017-02-03T04:05:06.007Z`)", "2016-02-03T04:05:06.007Z"),
-            ExprFunctionTestCase("date_add(month, -1, `2017-02-03T04:05:06.007Z`)", "2017-01-03T04:05:06.007Z"),
-            ExprFunctionTestCase("date_add(day, -1, `2017-02-03T04:05:06.007Z`)", "2017-02-02T04:05:06.007Z"),
-            ExprFunctionTestCase("date_add(hour, -1, `2017-02-03T04:05:06.007Z`)", "2017-02-03T03:05:06.007Z"),
-            ExprFunctionTestCase("date_add(minute, -1, `2017-02-03T04:05:06.007Z`)", "2017-02-03T04:04:06.007Z"),
-            ExprFunctionTestCase("date_add(second, -1, `2017-02-03T04:05:06.007Z`)", "2017-02-03T04:05:05.007Z")
+            ExprFunctionTestCase("date_add(year, -1, `2017-02-03T04:05:06.007Z`)", "TIMESTAMP '2016-02-03T04:05:06.007+00:00'"),
+            ExprFunctionTestCase("date_add(month, -1, `2017-02-03T04:05:06.007Z`)", "TIMESTAMP '2017-01-03T04:05:06.007+00:00'"),
+            ExprFunctionTestCase("date_add(day, -1, `2017-02-03T04:05:06.007Z`)", "TIMESTAMP '2017-02-02T04:05:06.007+00:00'"),
+            ExprFunctionTestCase("date_add(hour, -1, `2017-02-03T04:05:06.007Z`)", "TIMESTAMP '2017-02-03T03:05:06.007+00:00'"),
+            ExprFunctionTestCase("date_add(minute, -1, `2017-02-03T04:05:06.007Z`)", "TIMESTAMP '2017-02-03T04:04:06.007+00:00'"),
+            ExprFunctionTestCase("date_add(second, -1, `2017-02-03T04:05:06.007Z`)", "TIMESTAMP '2017-02-03T04:05:05.007+00:00'")
         )
     }
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/ToTimestampEvaluationTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/ToTimestampEvaluationTest.kt
@@ -6,11 +6,11 @@ import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.lang.errors.ErrorCode
 import org.partiql.lang.errors.Property
 import org.partiql.lang.eval.EvaluatorTestBase
-import org.partiql.lang.eval.MISSING_ANNOTATION
 import org.partiql.lang.eval.builtins.Argument
 import org.partiql.lang.eval.builtins.ExprFunctionTestCase
 import org.partiql.lang.eval.builtins.checkInvalidArgType
 import org.partiql.lang.eval.builtins.checkInvalidArity
+import org.partiql.lang.eval.evaluatortestframework.ExpectedResultFormat
 import org.partiql.lang.util.ArgumentsProviderBase
 import org.partiql.lang.util.propertyValueMapOf
 import org.partiql.lang.util.to
@@ -21,34 +21,42 @@ class ToTimestampEvaluationTest : EvaluatorTestBase() {
     @ParameterizedTest
     @ArgumentsSource(ToTimestampPassCases::class)
     fun runPassTests(testCase: ExprFunctionTestCase) =
-        runEvaluatorTestCase(testCase.source, expectedResult = testCase.expectedLegacyModeResult, expectedPermissiveModeResult = testCase.expectedPermissiveModeResult)
+        runEvaluatorTestCase(
+            testCase.source,
+            expectedResult = testCase.expectedLegacyModeResult,
+            expectedPermissiveModeResult = testCase.expectedPermissiveModeResult,
+            expectedResultFormat = ExpectedResultFormat.STRICT
+        )
 
     class ToTimestampPassCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
-            ExprFunctionTestCase("to_timestamp('1969-07-20T20:18:00Z')", "1969-07-20T20:18:00Z"),
-            ExprFunctionTestCase("to_timestamp('July 20, 1969', 'MMMM d, y')", "1969-07-20T"),
-            ExprFunctionTestCase("to_timestamp('Jul 20, 1969', 'MMM d, yyyy')", "1969-07-20T"),
-            ExprFunctionTestCase("to_timestamp('1969-07-20T20:18Z', 'yyyy-MM-dd''T''HH:mmX')", "1969-07-20T20:18Z"),
-            ExprFunctionTestCase("to_timestamp('July 20, 1969 8:18 PM', 'MMMM d, y h:m a')", "1969-07-20T20:18-00:00"),
-            ExprFunctionTestCase("to_timestamp('1969-07-20T20:18:00Z', 'yyyy-MM-dd''T''H:m:ssX')", "1969-07-20T20:18:00Z"),
-            ExprFunctionTestCase("to_timestamp('1969-07-20T20:18:01+08', 'yyyy-MM-dd''T''H:m:ssX')", "1969-07-20T20:18:01+08:00"),
+            ExprFunctionTestCase("to_timestamp('1969-07-20T20:18:00Z')", "TIMESTAMP '1969-07-20T20:18:00Z'"),
+            // TODO: This should be TIMESTAMP '1969-07-20T00:00:00'.
+            ExprFunctionTestCase("to_timestamp('July 20, 1969', 'MMMM d, y')", "TIMESTAMP '1969-07-20T00:00:00-00:00'"),
+            // TODO: This should be TIMESTAMP '1969-07-20T00:00:00'.
+            ExprFunctionTestCase("to_timestamp('Jul 20, 1969', 'MMM d, yyyy')", "TIMESTAMP '1969-07-20T00:00:00-00:00'"),
+            ExprFunctionTestCase("to_timestamp('1969-07-20T20:18Z', 'yyyy-MM-dd''T''HH:mmX')", "TIMESTAMP '1969-07-20T20:18:00Z'"),
+            // TODO: This should be TIMESTAMP '1969-07-20T20:18:00'.
+            ExprFunctionTestCase("to_timestamp('July 20, 1969 8:18 PM', 'MMMM d, y h:m a')", "TIMESTAMP '1969-07-20T20:18:00-00:00'"),
+            ExprFunctionTestCase("to_timestamp('1969-07-20T20:18:00Z', 'yyyy-MM-dd''T''H:m:ssX')", "TIMESTAMP '1969-07-20T20:18:00Z'"),
+            ExprFunctionTestCase("to_timestamp('1969-07-20T20:18:01+08', 'yyyy-MM-dd''T''H:m:ssX')", "TIMESTAMP '1969-07-20T20:18:01+08:00'"),
             ExprFunctionTestCase(
                 "to_timestamp('1969-07-20T20:18:02+0800', 'yyyy-MM-dd''T''H:m:ssXXXX')",
-                "1969-07-20T20:18:02+08:00"
+                "TIMESTAMP '1969-07-20T20:18:02+08:00'"
             ),
             ExprFunctionTestCase(
                 "to_timestamp('1969-07-20T20:18:03+08:00', 'yyyy-MM-dd''T''H:m:ssXXXXX')",
-                "1969-07-20T20:18:03+08:00"
+                "TIMESTAMP '1969-07-20T20:18:03+08:00'"
             ),
-            ExprFunctionTestCase("to_timestamp('1969-07-20T20:18:00Z')", "1969-07-20T20:18:00Z"),
-            ExprFunctionTestCase("to_timestamp('1969-07-20T20:18:03+08:00')", "1969-07-20T20:18:03+08:00"),
+            ExprFunctionTestCase("to_timestamp('1969-07-20T20:18:00Z')", "TIMESTAMP '1969-07-20T20:18:00Z'"),
+            ExprFunctionTestCase("to_timestamp('1969-07-20T20:18:03+08:00')", "TIMESTAMP '1969-07-20T20:18:03+08:00'"),
             ExprFunctionTestCase("to_timestamp(null)", "null"),
             ExprFunctionTestCase("to_timestamp(null, 'M-d-yyyy')", "null"),
             ExprFunctionTestCase("to_timestamp('07-20-1969', null)", "null"),
             ExprFunctionTestCase("to_timestamp(null, null)", "null"),
-            ExprFunctionTestCase("to_timestamp(missing)", "null", "$MISSING_ANNOTATION::null"),
-            ExprFunctionTestCase("to_timestamp(missing, 'M-d-yyyy')", "null", "$MISSING_ANNOTATION::null"),
-            ExprFunctionTestCase("to_timestamp('07-20-1969', missing)", "null", "$MISSING_ANNOTATION::null"),
+            ExprFunctionTestCase("to_timestamp(missing)", "null", "missing"),
+            ExprFunctionTestCase("to_timestamp(missing, 'M-d-yyyy')", "null", "missing"),
+            ExprFunctionTestCase("to_timestamp('07-20-1969', missing)", "null", "missing"),
             ExprFunctionTestCase("to_timestamp(null, null)", "null")
         )
     }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/ExprValueStrictEquals.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/ExprValueStrictEquals.kt
@@ -10,9 +10,9 @@ import org.partiql.lang.eval.dateValue
 import org.partiql.lang.eval.intValue
 import org.partiql.lang.eval.name
 import org.partiql.lang.eval.numberValue
+import org.partiql.lang.eval.partiQLTimestampValue
 import org.partiql.lang.eval.stringValue
 import org.partiql.lang.eval.timeValue
-import org.partiql.lang.eval.timestampValue
 
 /**
  * Strict equality that captures equality in the PartQL data model. That is, for 2 scalars, they are considered as equal
@@ -50,7 +50,7 @@ private object ExprValueStrictComparator : Comparator<ExprValue> {
             ExprValueType.FLOAT -> v1.numberValue().toDouble().compareTo(v2.numberValue().toDouble())
             ExprValueType.DECIMAL -> v1.bigDecimalValue().compareTo(v2.bigDecimalValue())
             ExprValueType.DATE -> v1.dateValue().compareTo(v2.dateValue())
-            ExprValueType.TIMESTAMP -> v1.timestampValue().compareTo(v2.timestampValue())
+            ExprValueType.TIMESTAMP -> v1.partiQLTimestampValue().compareTo(v2.partiQLTimestampValue())
             ExprValueType.TIME -> {
                 val (localTime1, precision1, zoneOffset1) = v1.timeValue()
                 val (localTime2, precision2, zoneOffset2) = v2.timeValue()

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/io/DelimitedValuesTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/io/DelimitedValuesTest.kt
@@ -164,7 +164,7 @@ class DelimitedValuesTest : TestBase() {
         """
         |1,2,3
         |null,2e0,3.0
-        |moo,cow,2012-10-10
+        |moo,cow,2012-10-10T00:00:00-00:00
         |4,true,null
         |null,null,null
         """.trimMargin() + "\n",

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/util/ConfigurableExprValueFormatterTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/util/ConfigurableExprValueFormatterTest.kt
@@ -58,7 +58,6 @@ class ConfigurableExprValueFormatterTest {
 
         // Ion Literals
         "`1e0`" to "`1e0`",
-        "`2019T`" to "`2019T`",
         "`symbol`" to "`symbol`",
         "`{{\"clob value\"}}`" to "`{{\"clob value\"}}`",
         "`{{VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE=}}`" to "`{{VG8gaW5maW5pdHkuLi4gYW5kIGJleW9uZCE=}}`",
@@ -67,9 +66,14 @@ class ConfigurableExprValueFormatterTest {
         // EmptyContainers
         "[]" to "[]",
         "<<>>" to "<<>>",
-//        TODO: This should succeed.
-//         Check https://github.com/partiql/partiql-lang-kotlin/issues/386.
-//        "DATE '2021-02-28'" to "DATE '2021-02-28'",
+
+        // Date time
+        "DATE '2021-02-28'" to "DATE '2021-02-28'",
+        "TIME '00:00:00.00'" to "TIME '00:00:00.00'",
+        "TIMESTAMP '2021-02-28 00:00:00'" to "TIMESTAMP '2021-02-28 00:00:00'",
+        "TIMESTAMP '2021-02-28T00:00:00'" to "TIMESTAMP '2021-02-28 00:00:00'",
+        "TIMESTAMP '2021-02-28T00:00:00Z'" to "TIMESTAMP '2021-02-28 00:00:00+00:00'",
+        "`2019T`" to "TIMESTAMP '2019-01-01 00:00:00-00:00'",
         "{}" to "{}"
     ).map { listOf(it.first, it.second) }
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/DateTime.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/DateTime.kt
@@ -117,7 +117,7 @@ public sealed interface Date : DateTime, Comparable<Date> {
      * Returns a [Date] value with the specified number of months added.
      * [years] can be negative.
      */
-    public fun plusYear(years: Long): Date
+    public fun plusYears(years: Long): Date
 
     /**
      * Comparison method for [Date] value.
@@ -253,7 +253,7 @@ public sealed interface Timestamp : DateTime, Comparable<Timestamp> {
      * Returns a [Timestamp] value with the specified number of years added.
      * [years] can be negative.
      */
-    public fun plusYear(years: Long): Timestamp
+    public fun plusYears(years: Long): Timestamp
 
     /**
      * Returns a [Timestamp] value with the specified number of years added.
@@ -470,7 +470,7 @@ public abstract class TimestampWithTimeZone : Timestamp {
         epochSecond.movePointRight(3)
     }
 
-    public abstract override fun plusYear(years: Long): TimestampWithTimeZone
+    public abstract override fun plusYears(years: Long): TimestampWithTimeZone
     public abstract override fun plusMonths(months: Long): TimestampWithTimeZone
     public abstract override fun plusDays(days: Long): TimestampWithTimeZone
     public abstract override fun plusHours(hours: Long): TimestampWithTimeZone
@@ -521,7 +521,7 @@ public abstract class TimestampWithTimeZone : Timestamp {
  */
 public abstract class TimestampWithoutTimeZone : Timestamp {
     public override val timeZone: TimeZone? = null
-    public abstract override fun plusYear(years: Long): TimestampWithoutTimeZone
+    public abstract override fun plusYears(years: Long): TimestampWithoutTimeZone
     public abstract override fun plusMonths(months: Long): TimestampWithoutTimeZone
     public abstract override fun plusDays(days: Long): TimestampWithoutTimeZone
     public abstract override fun plusHours(hours: Long): TimestampWithoutTimeZone

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/DateTimeValue.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/DateTimeValue.kt
@@ -123,7 +123,7 @@ public object DateTimeValue {
      * The created timestamp will always be an instance of [TimestampWithTimeZone]
      */
     public fun timestamp(ionTimestamp: com.amazon.ion.Timestamp): TimestampWithTimeZone =
-        if (ionTimestamp.localOffset != null && ionTimestamp.localOffset > JAVA_MAX_OFFSET) {
+        if (ionTimestamp.localOffset != null && ionTimestamp.localOffset.absoluteValue > JAVA_MAX_OFFSET) {
             OffsetTimestampHighPrecision.forIonTimestamp(ionTimestamp)
         } else if (ionTimestamp.decimalSecond.scale() <= 9) {
             OffsetTimestampLowPrecision.forIonTimestamp(ionTimestamp)
@@ -136,23 +136,20 @@ public object DateTimeValue {
      * The created timestamp will always be an instance of [TimestampWithTimeZone]
      */
     public fun timestamp(epochSeconds: BigDecimal, timeZone: TimeZone): TimestampWithTimeZone =
-        when(timeZone){
+        when (timeZone) {
             TimeZone.UnknownTimeZone -> {
                 if (epochSeconds.scale() <= 9) {
                     OffsetTimestampLowPrecision.forEpochSeconds(epochSeconds, timeZone)
-                }
-                else {
+                } else {
                     OffsetTimestampHighPrecision.forEpochSeconds(epochSeconds, timeZone)
                 }
             }
             is TimeZone.UtcOffset -> {
                 if (timeZone.totalOffsetMinutes > JAVA_MAX_OFFSET) {
                     OffsetTimestampHighPrecision.forEpochSeconds(epochSeconds, timeZone)
-                }
-                else if (epochSeconds.scale() <= 9) {
+                } else if (epochSeconds.scale() <= 9) {
                     OffsetTimestampLowPrecision.forEpochSeconds(epochSeconds, timeZone)
-                }
-                else {
+                } else {
                     OffsetTimestampHighPrecision.forEpochSeconds(epochSeconds, timeZone)
                 }
             }

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/DateTimeValue.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/DateTimeValue.kt
@@ -16,16 +16,28 @@ import kotlin.math.absoluteValue
 
 public object DateTimeValue {
 
-    public val nowZ: TimestampWithTimeZone = OffsetTimestampLowPrecision.nowZ()
-
+    /**
+     * Create a timestamp value.
+     *
+     * If time zone is null, then the value created is timestamp without timezone.
+     * Otherwise, a timestamp with timezone is created.
+     *
+     * @param year Proleptic Year
+     * @param month Month of Year
+     * @param day Day Of Month
+     * @param hour Hour of Day
+     * @param minute Minute of Hour
+     * @param second Second, include any fraction second.
+     * @param timeZone TimeZone offset, see [TimeZone]
+     */
     @JvmOverloads
     public fun timestamp(
         year: Int,
-        month: Int,
-        day: Int,
-        hour: Int,
-        minute: Int,
-        second: BigDecimal,
+        month: Int = 1,
+        day: Int = 1,
+        hour: Int = 0,
+        minute: Int = 0,
+        second: BigDecimal = BigDecimal.ZERO,
         timeZone: TimeZone? = null
     ): Timestamp =
         when (timeZone) {
@@ -52,6 +64,18 @@ public object DateTimeValue {
             }
         }
 
+    /**
+     * Create a timestamp value.
+     * The timestamp created will have precision 0 (no fractional second).
+     *
+     * @param year Proleptic Year
+     * @param month Month of Year
+     * @param day Day Of Month
+     * @param hour Hour of Day
+     * @param minute Minute of Hour
+     * @param second whole Second.
+     * @param timeZone TimeZone offset, see [TimeZone]
+     */
     @JvmOverloads
     public fun timestamp(
         year: Int,
@@ -64,6 +88,14 @@ public object DateTimeValue {
     ): Timestamp =
         timestamp(year, month, day, hour, minute, second.toBigDecimal(), timeZone)
 
+    /**
+     * Create a timestamp value.
+     * If time is an instance of [TimeWithTimeZone], then the timestamp created will be [TimestampWithTimeZone],
+     * Otherwise it will be a [TimestampWithoutTimeZone].
+     *
+     * @param date: Date. See [Date]
+     * @param time: Time. See [Time]
+     */
     public fun timestamp(date: Date, time: Time): Timestamp =
         when (time) {
             is TimeWithTimeZone -> timestamp(
@@ -86,13 +118,57 @@ public object DateTimeValue {
             )
         }
 
+    /**
+     * Create a timestamp value based on [com.amazon.ion.Timestamp]
+     * The created timestamp will always be an instance of [TimestampWithTimeZone]
+     */
     public fun timestamp(ionTimestamp: com.amazon.ion.Timestamp): TimestampWithTimeZone =
-        if (ionTimestamp.decimalSecond.scale() <= 9) {
+        if (ionTimestamp.localOffset != null && ionTimestamp.localOffset > JAVA_MAX_OFFSET) {
+            OffsetTimestampHighPrecision.forIonTimestamp(ionTimestamp)
+        } else if (ionTimestamp.decimalSecond.scale() <= 9) {
             OffsetTimestampLowPrecision.forIonTimestamp(ionTimestamp)
         } else {
             OffsetTimestampHighPrecision.forIonTimestamp(ionTimestamp)
         }
 
+    /**
+     * Create a timestamp value based on displacement of Unix Epoch, at given time zone.
+     * The created timestamp will always be an instance of [TimestampWithTimeZone]
+     */
+    public fun timestamp(epochSeconds: BigDecimal, timeZone: TimeZone): TimestampWithTimeZone =
+        when(timeZone){
+            TimeZone.UnknownTimeZone -> {
+                if (epochSeconds.scale() <= 9) {
+                    OffsetTimestampLowPrecision.forEpochSeconds(epochSeconds, timeZone)
+                }
+                else {
+                    OffsetTimestampHighPrecision.forEpochSeconds(epochSeconds, timeZone)
+                }
+            }
+            is TimeZone.UtcOffset -> {
+                if (timeZone.totalOffsetMinutes > JAVA_MAX_OFFSET) {
+                    OffsetTimestampHighPrecision.forEpochSeconds(epochSeconds, timeZone)
+                }
+                else if (epochSeconds.scale() <= 9) {
+                    OffsetTimestampLowPrecision.forEpochSeconds(epochSeconds, timeZone)
+                }
+                else {
+                    OffsetTimestampHighPrecision.forEpochSeconds(epochSeconds, timeZone)
+                }
+            }
+        }
+
+    /**
+     * Create a time value.
+     *
+     * If time zone is null, then the value created is time without timezone.
+     * Otherwise, a time with timezone is created.
+     *
+     * @param hour Hour of Day
+     * @param minute Minute of Hour
+     * @param second Second, include any fraction second.
+     * @param timeZone TimeZone offset, see [TimeZone]
+     */
     @JvmOverloads
     public fun time(
         hour: Int,
@@ -124,6 +200,15 @@ public object DateTimeValue {
             }
         }
 
+    /**
+     * Create a time value.
+     * The time created will have precision 0 (no fractional second).
+     *
+     * @param hour Hour of Day
+     * @param minute Minute of Hour
+     * @param second whole Second.
+     * @param timeZone TimeZone offset, see [TimeZone]
+     */
     @JvmOverloads
     public fun time(
         hour: Int,
@@ -133,13 +218,23 @@ public object DateTimeValue {
     ): Time =
         time(hour, minute, second.toBigDecimal(), timeZone)
 
+    /**
+     * Create a time value.
+     * The time created will have precision 9 (nanosecond precision).
+     *
+     * @param hour Hour of Day
+     * @param minute Minute of Hour
+     * @param second whole Second.
+     * @param nano Nano offset.
+     * @param timeZone TimeZone offset, see [TimeZone]
+     */
     @JvmOverloads
     public fun time(
         hour: Int,
         minute: Int,
         second: Int,
         nano: Int,
-        timeZone: TimeZone?
+        timeZone: TimeZone? = null
     ): Time {
         val decimalSecond = second.toBigDecimal().plus(nano.toBigDecimal().movePointLeft(9))
         return time(hour, minute, decimalSecond, timeZone)

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/LocalTimeLowPrecision.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/LocalTimeLowPrecision.kt
@@ -6,12 +6,17 @@ import org.partiql.value.datetime.DateTimeUtil
 import org.partiql.value.datetime.TimeWithTimeZone
 import org.partiql.value.datetime.TimeWithoutTimeZone
 import org.partiql.value.datetime.TimeZone
-import org.partiql.value.datetime.TimestampWithoutTimeZone
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalTime
 import kotlin.math.max
 
+/**
+ * This implementation utilize [java.time.LocalTime] to handle time without time zone if :
+ * 1. The desired precision is below nanosecond (9 digits after decimal point).
+ *
+ * The constructor functions assumes the above condition to be true.
+ */
 internal class LocalTimeLowPrecision private constructor(
     private val localTime: LocalTime,
     _hour: Int? = null,
@@ -34,9 +39,11 @@ internal class LocalTimeLowPrecision private constructor(
         fun of(hour: Int, minute: Int, decimalSecond: BigDecimal): LocalTimeLowPrecision {
             val wholeSecond = decimalSecond.setScale(0, RoundingMode.DOWN)
             val nano = decimalSecond.minus(wholeSecond).movePointRight(9)
-            return forNano(hour, minute, wholeSecond.intValueExact(), nano.intValueExact()).let {
-                LocalTimeLowPrecision(it.localTime, hour, minute, decimalSecond)
-            }
+            return forNano(hour, minute, wholeSecond.intValueExact(), nano.intValueExact()).copy(
+                _hour = hour,
+                _minute = minute,
+                _decimalSecond = decimalSecond
+            )
         }
     }
 
@@ -53,17 +60,17 @@ internal class LocalTimeLowPrecision private constructor(
      */
     internal val nano: Int = localTime.nano
     override val decimalSecond: BigDecimal =
-        _decimalSecond ?: BigDecimal.valueOf(second.toLong()).plus(BigDecimal.valueOf(nano.toLong(), 9))
+        _decimalSecond ?: Utils.getDecimalSecondFromSecondAndNano(this.second.toLong(), this.nano.toLong())
     override val elapsedSecond: BigDecimal by lazy {
         BigDecimal.valueOf(this.hour * DateTimeUtil.SECONDS_IN_HOUR + this.minute * DateTimeUtil.SECONDS_IN_MINUTE) + this.decimalSecond
     }
 
-    override fun plusHours(hours: Long): TimeWithoutTimeZone =
+    override fun plusHours(hours: Long): LocalTimeLowPrecision =
         localTime.plusHours(hours).let {
             of(it.hour, it.minute, decimalSecond)
         }
 
-    override fun plusMinutes(minutes: Long): TimeWithoutTimeZone =
+    override fun plusMinutes(minutes: Long): LocalTimeLowPrecision =
         localTime.plusMinutes(minutes).let {
             of(it.hour, it.minute, decimalSecond)
         }
@@ -72,17 +79,19 @@ internal class LocalTimeLowPrecision private constructor(
         if (seconds.scale() > 9) {
             LocalTimeHighPrecision.of(hour, minute, decimalSecond).plusSeconds(seconds)
         } else {
-            val wholeSecond = seconds.setScale(0, RoundingMode.DOWN)
-            val nano = seconds.minus(wholeSecond).let { it.movePointRight(it.scale()) }
-            val newTime = localTime.plusSeconds(wholeSecond.longValueExact()).plusNanos(nano.longValueExact())
-            val newDecimalSecond = newTime.second.toBigDecimal() + newTime.nano.toBigDecimal().movePointLeft(9)
+            val (wholeSecond, nano) = Utils.getSecondAndNanoFromDecimalSecond(seconds)
+            val newTime = localTime.plusSeconds(wholeSecond).plusNanos(nano)
+            val newDecimalSecond = Utils.getDecimalSecondFromSecondAndNano(newTime.second.toLong(), newTime.nano.toLong())
             val roundedDecimalSecond = newDecimalSecond.setScale(max(this.decimalSecond.scale(), seconds.scale()), RoundingMode.UNNECESSARY)
             of(newTime.hour, newTime.minute, roundedDecimalSecond)
         }
 
-    override fun atDate(date: Date): TimestampWithoutTimeZone =
-        LocalTimestampLowPrecision.forDateTime(date, this)
+    override fun atDate(date: Date): LocalTimestampLowPrecision =
+        LocalTimestampLowPrecision.forDateTime(date as SqlDate, this)
 
-    override fun withTimeZone(timeZone: TimeZone): TimeWithTimeZone =
+    override fun withTimeZone(timeZone: TimeZone): OffsetTimeLowPrecision =
         OffsetTimeLowPrecision.of(hour, minute, decimalSecond, timeZone)
+
+    fun copy(_hour: Int? = null, _minute: Int? = null, _decimalSecond: BigDecimal?) =
+        LocalTimeLowPrecision(this.localTime, _hour, _minute, _decimalSecond)
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/LocalTimestampHighPrecision.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/LocalTimestampHighPrecision.kt
@@ -1,30 +1,30 @@
 package org.partiql.value.datetime.impl
 
-import org.partiql.value.datetime.Date
-import org.partiql.value.datetime.DateTimeUtil.toBigDecimal
-import org.partiql.value.datetime.TimeWithoutTimeZone
 import org.partiql.value.datetime.TimeZone
-import org.partiql.value.datetime.TimestampWithTimeZone
 import org.partiql.value.datetime.TimestampWithoutTimeZone
 import java.math.BigDecimal
 import java.math.RoundingMode
 
 /**
- * A Timestamp without time zone value implementation.
+ * This implementation handles edge cases that can not be supported by [LocalTimestampLowPrecision], that is:
+ * 1. The desired precision exceeds nanosecond.
+ * 2. The desired timestamp exceeds the range of +18:00 to -18:00
  *
- * This implementation supports arbitrary precision upto system limit.
  */
 internal class LocalTimestampHighPrecision private constructor(
-    override val year: Int,
-    override val month: Int,
-    override val day: Int,
-    override val hour: Int,
-    override val minute: Int,
-    override val decimalSecond: BigDecimal,
-    _date: Date? = null,
-    _time: TimeWithoutTimeZone? = null
+    val date: SqlDate,
+    val time: LocalTimeHighPrecision
 ) : TimestampWithoutTimeZone() {
     companion object {
+        /**
+         * Construct a timestamp without time zone value using its date component and time component.
+         *
+         * Notes the time component can not have time zone.
+         */
+        @JvmStatic
+        fun forDateTime(date: SqlDate, time: LocalTimeHighPrecision): LocalTimestampHighPrecision =
+            LocalTimestampHighPrecision(date, time)
+
         /**
          * Construct a timestamp value using date time field.
          *
@@ -46,42 +46,32 @@ internal class LocalTimestampHighPrecision private constructor(
             val time = LocalTimeHighPrecision.of(hour, minute, decimalSecond)
             return forDateTime(date, time)
         }
-
-        /**
-         * Construct a timestamp without time zone value using its date component and time component.
-         *
-         * Notes the time component can not have time zone.
-         */
-        @JvmStatic
-        fun forDateTime(date: Date, time: TimeWithoutTimeZone): LocalTimestampHighPrecision =
-            LocalTimestampHighPrecision(
-                date.year, date.month, date.day,
-                time.hour, time.minute, time.decimalSecond.toBigDecimal(),
-                date, time
-            )
     }
 
-    private val date: Date = _date ?: SqlDate.of(year, month, day)
+    override val year: Int = date.year
+    override val month: Int = date.month
+    override val day: Int = date.day
+    override val hour: Int = time.hour
+    override val minute: Int = time.minute
+    override val decimalSecond: BigDecimal = time.decimalSecond
 
-    private val time: TimeWithoutTimeZone = _time ?: LocalTimeHighPrecision.of(hour, minute, decimalSecond)
+    override fun plusYears(years: Long): LocalTimestampHighPrecision =
+        forDateTime(this.date.plusYears(years), this.time)
 
-    override fun plusYear(years: Long): TimestampWithoutTimeZone =
-        forDateTime(this.date.plusYear(years), this.time)
-
-    override fun plusMonths(months: Long): TimestampWithoutTimeZone =
+    override fun plusMonths(months: Long): LocalTimestampHighPrecision =
         forDateTime(this.date.plusMonths(months), this.time)
 
-    override fun plusDays(days: Long): TimestampWithoutTimeZone =
+    override fun plusDays(days: Long): LocalTimestampHighPrecision =
         forDateTime(this.date.plusDays(days), this.time)
 
-    override fun plusHours(hours: Long): TimestampWithoutTimeZone {
+    override fun plusHours(hours: Long): LocalTimestampHighPrecision {
         val rawHour = this.hour + hours
         val daysToCarry = if (rawHour >= 0) rawHour / 24 else rawHour / 24 - 1
         val afterHour = (rawHour % 24).toInt().let { if (it < 0) it + 24 else it }
         return forDateTime(date.plusDays(daysToCarry), LocalTimeHighPrecision.of(afterHour, minute, decimalSecond))
     }
 
-    override fun plusMinutes(minutes: Long): TimestampWithoutTimeZone {
+    override fun plusMinutes(minutes: Long): LocalTimestampHighPrecision {
         val rawMinute = this.minute + minutes
         val hoursToCarry = if (rawMinute >= 0) rawMinute / 60 else rawMinute / 60 - 1
         val afterMinute = (rawMinute % 60).toInt().let { if (it < 0) it + 60 else it }
@@ -89,7 +79,7 @@ internal class LocalTimestampHighPrecision private constructor(
             .let { of(it.year, it.month, it.day, it.hour, afterMinute, it.decimalSecond) }
     }
 
-    override fun plusSeconds(seconds: BigDecimal): TimestampWithoutTimeZone {
+    override fun plusSeconds(seconds: BigDecimal): LocalTimestampHighPrecision {
         val rawSecond = decimalSecond.plus(seconds)
         val minutesToCarry = if (rawSecond >= BigDecimal.ZERO) {
             rawSecond.div(BigDecimal.valueOf(60L))
@@ -106,7 +96,7 @@ internal class LocalTimestampHighPrecision private constructor(
         return this.plusMonths(minutesToCarry).let { of(it.year, it.month, it.day, it.hour, it.minute, afterSecond) }
     }
 
-    override fun withTimeZone(timeZone: TimeZone): TimestampWithTimeZone =
+    override fun withTimeZone(timeZone: TimeZone): OffsetTimestampHighPrecision =
         OffsetTimestampHighPrecision.of(
             year, month, day, hour, minute, decimalSecond, timeZone
         )

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/LocalTimestampLowPrecision.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/LocalTimestampLowPrecision.kt
@@ -1,24 +1,32 @@
 package org.partiql.value.datetime.impl
 
-import org.partiql.value.datetime.Date
 import org.partiql.value.datetime.TimeZone
-import org.partiql.value.datetime.TimestampWithTimeZone
 import org.partiql.value.datetime.TimestampWithoutTimeZone
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDateTime
 import kotlin.math.max
 
+/**
+ * This implementation utilize [java.time.LocalDateTime] to handle timestamp without time zone if :
+ * 1. The desired precision is below nanosecond (9 digits after decimal point).
+ * 2. The desired timezone is within +18:00 to -18:00.
+ *
+ * The constructor functions assumes the above conditions to be true.
+ */
 internal class LocalTimestampLowPrecision private constructor(
     private val localDateTime: LocalDateTime,
-    _year: Int? = null,
-    _month: Int? = null,
-    _day: Int? = null,
-    _hour: Int? = null,
-    _minute: Int? = null,
-    _decimalSecond: BigDecimal? = null
+    val date: SqlDate,
+    val time: LocalTimeLowPrecision
 ) : TimestampWithoutTimeZone() {
     companion object {
+        fun forDateTime(date: SqlDate, time: LocalTimeLowPrecision): LocalTimestampLowPrecision {
+            val localDateTime = LocalDateTime.of(
+                date.year, date.month, date.day,
+                time.hour, time.minute, time.second, time.nano
+            )
+            return LocalTimestampLowPrecision(localDateTime, date, time)
+        }
         fun of(
             year: Int,
             month: Int,
@@ -27,53 +35,44 @@ internal class LocalTimestampLowPrecision private constructor(
             minute: Int,
             decimalSecond: BigDecimal
         ): LocalTimestampLowPrecision {
+            val date = SqlDate.of(year, month, day)
             val time = LocalTimeLowPrecision.of(hour, minute, decimalSecond)
             val localDateTime = LocalDateTime.of(
                 year, month, day,
                 time.hour, time.minute, time.second, time.nano
             )
-            return LocalTimestampLowPrecision(localDateTime, year, month, day, hour, minute, decimalSecond)
-        }
-
-        @JvmStatic
-        fun forDateTime(date: Date, time: LocalTimeLowPrecision): LocalTimestampLowPrecision {
-            val localDateTime = LocalDateTime.of(
-                date.year, date.month, date.day,
-                time.hour, time.minute, time.second, time.nano
-            )
-            return LocalTimestampLowPrecision(localDateTime)
+            return LocalTimestampLowPrecision(localDateTime, date, time)
         }
     }
 
-    override val year: Int = _year ?: localDateTime.year
-    override val month: Int = _month ?: localDateTime.monthValue
-    override val day: Int = _day ?: localDateTime.dayOfMonth
-    override val hour: Int = _hour ?: localDateTime.hour
-    override val minute: Int = _minute ?: localDateTime.minute
-    override val decimalSecond: BigDecimal =
-        _decimalSecond ?: BigDecimal.valueOf(localDateTime.second.toLong()).plus(BigDecimal.valueOf(localDateTime.nano.toLong(), 9))
+    override val year: Int = date.year
+    override val month: Int = date.month
+    override val day: Int = date.day
+    override val hour: Int = time.hour
+    override val minute: Int = time.minute
+    override val decimalSecond: BigDecimal = time.decimalSecond
 
-    override fun plusYear(years: Long): TimestampWithoutTimeZone =
+    override fun plusYears(years: Long): LocalTimestampLowPrecision =
         localDateTime.plusYears(years).let {
             of(it.year, it.monthValue, it.dayOfMonth, it.hour, it.minute, decimalSecond)
         }
 
-    override fun plusMonths(months: Long): TimestampWithoutTimeZone =
+    override fun plusMonths(months: Long): LocalTimestampLowPrecision =
         localDateTime.plusMonths(months).let {
             of(it.year, it.monthValue, it.dayOfMonth, it.hour, it.minute, decimalSecond)
         }
 
-    override fun plusDays(days: Long): TimestampWithoutTimeZone =
+    override fun plusDays(days: Long): LocalTimestampLowPrecision =
         localDateTime.plusDays(days).let {
             of(it.year, it.monthValue, it.dayOfMonth, it.hour, it.minute, decimalSecond)
         }
 
-    override fun plusHours(hours: Long): TimestampWithoutTimeZone =
+    override fun plusHours(hours: Long): LocalTimestampLowPrecision =
         localDateTime.plusHours(hours).let {
             of(it.year, it.monthValue, it.dayOfMonth, it.hour, it.minute, decimalSecond)
         }
 
-    override fun plusMinutes(minutes: Long): TimestampWithoutTimeZone =
+    override fun plusMinutes(minutes: Long): LocalTimestampLowPrecision =
         localDateTime.plusMinutes(minutes).let {
             of(it.year, it.monthValue, it.dayOfMonth, it.hour, it.minute, decimalSecond)
         }
@@ -82,15 +81,14 @@ internal class LocalTimestampLowPrecision private constructor(
         if (seconds.scale() > 9) {
             LocalTimestampHighPrecision.of(year, month, day, hour, minute, decimalSecond).plusSeconds(seconds)
         } else {
-            val wholeSecond = seconds.setScale(0, RoundingMode.DOWN)
-            val nano = seconds.minus(wholeSecond).let { it.movePointRight(it.scale()) }
-            val newTime = localDateTime.plusSeconds(wholeSecond.longValueExact()).plusNanos(nano.longValueExact())
+            val (wholeSecond, nano) = Utils.getSecondAndNanoFromDecimalSecond(seconds)
+            val newTime = localDateTime.plusSeconds(wholeSecond).plusNanos(nano)
             // the real precision of this operation, should be max(original_value.decimalSecond.precision, seconds.precision)
-            val newDecimalSecond = newTime.second.toBigDecimal() + newTime.nano.toBigDecimal().movePointLeft(9)
+            val newDecimalSecond = Utils.getDecimalSecondFromSecondAndNano(newTime.second.toLong(), newTime.nano.toLong())
             val roundedDecimalSecond = newDecimalSecond.setScale(max(this.decimalSecond.scale(), seconds.scale()), RoundingMode.UNNECESSARY)
             of(newTime.year, newTime.monthValue, newTime.dayOfMonth, newTime.hour, newTime.minute, roundedDecimalSecond)
         }
 
-    override fun withTimeZone(timeZone: TimeZone): TimestampWithTimeZone =
+    override fun withTimeZone(timeZone: TimeZone): OffsetTimestampLowPrecision =
         OffsetTimestampLowPrecision.of(year, month, day, hour, minute, decimalSecond, timeZone)
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/OffsetTimeHighPrecision.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/OffsetTimeHighPrecision.kt
@@ -1,23 +1,21 @@
 package org.partiql.value.datetime.impl
 
 import org.partiql.value.datetime.Date
-import org.partiql.value.datetime.DateTimeException
 import org.partiql.value.datetime.DateTimeUtil
 import org.partiql.value.datetime.DateTimeUtil.SECONDS_IN_HOUR
 import org.partiql.value.datetime.DateTimeUtil.toBigDecimal
 import org.partiql.value.datetime.TimeWithTimeZone
-import org.partiql.value.datetime.TimeWithoutTimeZone
 import org.partiql.value.datetime.TimeZone
-import org.partiql.value.datetime.TimestampWithTimeZone
 import java.math.BigDecimal
 
+/**
+ * This implementation handles edge cases that can not be supported by [OffsetTimeLowPrecision], that is:
+ * 1. The desired precision exceeds nanosecond.
+ * 2. The desired timestamp exceeds the range of +18:00 to -18:00
+ */
 internal class OffsetTimeHighPrecision private constructor(
-    override val hour: Int,
-    override val minute: Int,
-    override val decimalSecond: BigDecimal,
-    override val timeZone: TimeZone,
-    _localTime: LocalTimeHighPrecision,
-    _elapsedSecond: BigDecimal? = null
+    val localTime: LocalTimeHighPrecision,
+    override val timeZone: TimeZone
 ) : TimeWithTimeZone() {
 
     companion object {
@@ -27,45 +25,56 @@ internal class OffsetTimeHighPrecision private constructor(
             decimalSecond: BigDecimal,
             timeZone: TimeZone
         ): OffsetTimeHighPrecision {
-            try {
-                val localTime = LocalTimeHighPrecision.of(hour, minute, decimalSecond)
-                return OffsetTimeHighPrecision(localTime.hour, localTime.minute, localTime.decimalSecond, timeZone, localTime)
-            } catch (e: java.time.DateTimeException) {
-                throw DateTimeException(e.localizedMessage, e)
-            }
+            val localTime = LocalTimeHighPrecision.of(hour, minute, decimalSecond)
+            return OffsetTimeHighPrecision(localTime, timeZone)
         }
 
         fun forSeconds(elapsedSeconds: BigDecimal, timeZone: TimeZone): OffsetTimeHighPrecision {
             val localTime = LocalTimeHighPrecision.forSeconds(elapsedSeconds)
-            return OffsetTimeHighPrecision(
-                localTime.hour, localTime.minute, localTime.decimalSecond,
-                timeZone, localTime, elapsedSeconds
-            )
+            return OffsetTimeHighPrecision(localTime, timeZone)
         }
+
+        private const val MAX_ELAPSED_SECOND = 24 * SECONDS_IN_HOUR + 60 + SECONDS_IN_HOUR + 60
     }
+
+    override val hour: Int = localTime.hour
+    override val minute: Int = localTime.minute
+    override val decimalSecond: BigDecimal = localTime.decimalSecond
 
     override val elapsedSecond: BigDecimal by lazy {
-        _elapsedSecond ?: _localTime.elapsedSecond
+        localTime.elapsedSecond
     }
 
-    override fun plusHours(hours: Long): TimeWithTimeZone =
-        forSeconds(this.elapsedSecond.plus((hours * SECONDS_IN_HOUR).toBigDecimal()), timeZone)
+    override fun plusHours(hours: Long): OffsetTimeHighPrecision {
+        val timePassed = this.elapsedSecond
+            .plus((hours * SECONDS_IN_HOUR).toBigDecimal())
+            .let { normalizeElapsedTime(it) }
+        return forSeconds(timePassed, timeZone)
+    }
 
-    override fun plusMinutes(minutes: Long): TimeWithTimeZone =
-        forSeconds(this.elapsedSecond.plus((minutes * DateTimeUtil.SECONDS_IN_MINUTE).toBigDecimal()), timeZone)
+    override fun plusMinutes(minutes: Long): OffsetTimeHighPrecision {
+        val timePassed = this.elapsedSecond
+            .plus((minutes * DateTimeUtil.SECONDS_IN_MINUTE).toBigDecimal())
+            .let { normalizeElapsedTime(it) }
+        return forSeconds(timePassed, timeZone)
+    }
 
-    override fun plusSeconds(seconds: BigDecimal): TimeWithTimeZone =
-        forSeconds(this.elapsedSecond.plus(seconds.toBigDecimal()), timeZone)
+    override fun plusSeconds(seconds: BigDecimal): OffsetTimeHighPrecision {
+        val timePassed = this.elapsedSecond
+            .plus(seconds)
+            .let { normalizeElapsedTime(it) }
+        return forSeconds(timePassed, timeZone)
+    }
 
-    override fun atDate(date: Date): TimestampWithTimeZone =
+    override fun atDate(date: Date): OffsetTimestampHighPrecision =
         OffsetTimestampHighPrecision.forDateTime(date, this)
 
-    override fun toTimeWithoutTimeZone(timeZone: TimeZone): TimeWithoutTimeZone =
+    override fun toTimeWithoutTimeZone(timeZone: TimeZone): LocalTimeHighPrecision =
         this.atTimeZone(timeZone).let {
             LocalTimeHighPrecision.of(it.hour, it.minute, it.decimalSecond)
         }
 
-    override fun atTimeZone(timeZone: TimeZone): TimeWithTimeZone =
+    override fun atTimeZone(timeZone: TimeZone): OffsetTimeHighPrecision =
         when (val valueTimeZone = this.timeZone) {
             TimeZone.UnknownTimeZone -> {
                 when (timeZone) {
@@ -86,4 +95,10 @@ internal class OffsetTimeHighPrecision private constructor(
                 }
             }
         }
+
+    private fun normalizeElapsedTime(timePassed: BigDecimal): BigDecimal {
+        val maxBD = BigDecimal.valueOf(MAX_ELAPSED_SECOND)
+        val mod = timePassed % maxBD
+        return if (mod < BigDecimal.ZERO) maxBD + mod else mod
+    }
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/OffsetTimeLowPrecision.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/OffsetTimeLowPrecision.kt
@@ -4,18 +4,23 @@ import org.partiql.value.datetime.Date
 import org.partiql.value.datetime.DateTimeException
 import org.partiql.value.datetime.DateTimeUtil
 import org.partiql.value.datetime.TimeWithTimeZone
-import org.partiql.value.datetime.TimeWithoutTimeZone
 import org.partiql.value.datetime.TimeZone
-import org.partiql.value.datetime.TimestampWithTimeZone
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.OffsetTime
 import java.time.ZoneOffset
 import kotlin.math.max
 
+/**
+ * This implementation utilize [java.time.OffsetTime] to handle time without time zone if :
+ * 1. The desired precision is below nanosecond (9 digits after decimal point).
+ * 2. The desired timezone is within +18:00 to -18:00.
+ *
+ * The constructor functions assumes the above conditions to be true.
+ */
 internal class OffsetTimeLowPrecision private constructor(
-    private val offsetTime: OffsetTime,
-    private val isUnknownTimeZone: Boolean,
+    val offsetTime: OffsetTime,
+    val isUnknownTimeZone: Boolean,
     _hour: Int? = null,
     _minute: Int? = null,
     _decimalSecond: BigDecimal? = null,
@@ -51,11 +56,9 @@ internal class OffsetTimeLowPrecision private constructor(
         }
 
         fun of(hour: Int, minute: Int, decimalSecond: BigDecimal, timeZone: TimeZone): OffsetTimeLowPrecision {
-            val wholeSecond = decimalSecond.setScale(0, RoundingMode.DOWN)
-            val nano = decimalSecond.minus(wholeSecond).let { it.movePointRight(it.scale()) }
-            return of(hour, minute, wholeSecond.intValueExact(), nano.intValueExact(), timeZone).let {
-                OffsetTimeLowPrecision(it.offsetTime, it.isUnknownTimeZone, it.hour, it.minute, decimalSecond, timeZone)
-            }
+            val (wholeSecond, nano) = Utils.getSecondAndNanoFromDecimalSecond(decimalSecond)
+            return of(hour, minute, wholeSecond.toInt(), nano.toInt(), timeZone)
+                .copy(_hour = hour, _minute = minute, _decimalSecond = decimalSecond, _timeZone = timeZone)
         }
     }
 
@@ -63,7 +66,7 @@ internal class OffsetTimeLowPrecision private constructor(
     override val minute: Int = _minute ?: offsetTime.minute
     override val decimalSecond: BigDecimal =
         _decimalSecond
-            ?: BigDecimal.valueOf(offsetTime.second.toLong()).plus(BigDecimal.valueOf(offsetTime.nano.toLong(), 9))
+            ?: Utils.getDecimalSecondFromSecondAndNano(this.offsetTime.second.toLong(), this.offsetTime.nano.toLong())
     override val timeZone: TimeZone =
         _timeZone
             ?: if (isUnknownTimeZone) TimeZone.UnknownTimeZone else TimeZone.UtcOffset.of(offsetTime.offset.totalSeconds / 60)
@@ -71,12 +74,12 @@ internal class OffsetTimeLowPrecision private constructor(
         BigDecimal.valueOf(this.hour * DateTimeUtil.SECONDS_IN_HOUR + this.minute * DateTimeUtil.SECONDS_IN_MINUTE) + this.decimalSecond
     }
 
-    override fun plusHours(hours: Long): TimeWithTimeZone =
+    override fun plusHours(hours: Long): OffsetTimeLowPrecision =
         offsetTime.plusHours(hours).let {
             of(it.hour, it.minute, decimalSecond, timeZone)
         }
 
-    override fun plusMinutes(minutes: Long): TimeWithTimeZone =
+    override fun plusMinutes(minutes: Long): OffsetTimeLowPrecision =
         offsetTime.plusMinutes(minutes).let {
             of(it.hour, it.minute, decimalSecond, timeZone)
         }
@@ -85,18 +88,17 @@ internal class OffsetTimeLowPrecision private constructor(
         if (seconds.scale() > 9) {
             OffsetTimeHighPrecision.of(hour, minute, decimalSecond, timeZone).plusSeconds(seconds)
         } else {
-            val wholeSecond = seconds.setScale(0, RoundingMode.DOWN)
-            val nano = seconds.minus(wholeSecond).let { it.movePointRight(it.scale()) }
-            val newTime = offsetTime.plusSeconds(wholeSecond.longValueExact()).plusNanos(nano.longValueExact())
-            val newDecimalSecond = newTime.second.toBigDecimal() + newTime.nano.toBigDecimal().movePointLeft(9)
+            val (wholeSecond, nano) = Utils.getSecondAndNanoFromDecimalSecond(seconds)
+            val newTime = offsetTime.plusSeconds(wholeSecond).plusNanos(nano)
+            val newDecimalSecond = Utils.getDecimalSecondFromSecondAndNano(newTime.second.toLong(), newTime.nano.toLong())
             val roundedDecimalSecond = newDecimalSecond.setScale(max(this.decimalSecond.scale(), seconds.scale()), RoundingMode.UNNECESSARY)
             of(newTime.hour, newTime.minute, roundedDecimalSecond, timeZone)
         }
 
-    override fun atDate(date: Date): TimestampWithTimeZone =
+    override fun atDate(date: Date): OffsetTimestampLowPrecision =
         OffsetTimestampLowPrecision.forDateTime(date, this)
 
-    override fun toTimeWithoutTimeZone(timeZone: TimeZone): TimeWithoutTimeZone {
+    override fun toTimeWithoutTimeZone(timeZone: TimeZone): LocalTimeLowPrecision {
         val local = when (timeZone) {
             TimeZone.UnknownTimeZone -> offsetTime.withOffsetSameInstant(ZoneOffset.UTC)
             is TimeZone.UtcOffset -> offsetTime.withOffsetSameInstant(ZoneOffset.ofTotalSeconds(timeZone.totalOffsetMinutes * 60))
@@ -105,11 +107,14 @@ internal class OffsetTimeLowPrecision private constructor(
         return LocalTimeLowPrecision.of(local.hour, local.minute, this.decimalSecond)
     }
 
-    override fun atTimeZone(timeZone: TimeZone): TimeWithTimeZone {
+    override fun atTimeZone(timeZone: TimeZone): OffsetTimeLowPrecision {
         val local = when (timeZone) {
             TimeZone.UnknownTimeZone -> offsetTime.withOffsetSameInstant(ZoneOffset.UTC)
             is TimeZone.UtcOffset -> offsetTime.withOffsetSameInstant(ZoneOffset.ofTotalSeconds(timeZone.totalOffsetMinutes * 60))
         }
         return of(local.hour, local.minute, this.decimalSecond, timeZone)
     }
+
+    fun copy(_hour: Int? = null, _minute: Int? = null, _decimalSecond: BigDecimal? = null, _timeZone: TimeZone? = null) =
+        OffsetTimeLowPrecision(this.offsetTime, this.isUnknownTimeZone, _hour, _minute, _decimalSecond, _timeZone)
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/OffsetTimestampHighPrecision.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/OffsetTimestampHighPrecision.kt
@@ -8,26 +8,34 @@ import org.partiql.value.datetime.DateTimeUtil.toBigDecimal
 import org.partiql.value.datetime.TimeWithTimeZone
 import org.partiql.value.datetime.TimeZone
 import org.partiql.value.datetime.TimestampWithTimeZone
-import org.partiql.value.datetime.TimestampWithoutTimeZone
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.LocalDate
 import java.time.ZoneOffset
 
+/**
+ * This implementation handles edge cases that can not be supported by [OffsetTimestampLowPrecision], that is:
+ * 1. The desired precision exceeds nanosecond.
+ * 2. The desired timestamp exceeds the range of +18:00 to -18:00
+ */
 internal class OffsetTimestampHighPrecision private constructor(
-    override val year: Int,
-    override val month: Int,
-    override val day: Int,
-    override val hour: Int,
-    override val minute: Int,
-    override val decimalSecond: BigDecimal,
-    override val timeZone: TimeZone,
+    val date: Date,
+    val time: TimeWithTimeZone,
     _inputIonTimestamp: com.amazon.ion.Timestamp? = null,
     _epochSecond: BigDecimal? = null,
-    _date: Date?,
-    _time: TimeWithTimeZone?,
 ) : TimestampWithTimeZone() {
     companion object {
+        /**
+         * Construct a Timestamp by concatenate a Date and a Time component.
+         *
+         * The time component should have a TimeZone.
+         *
+         * This should be called by other constructors for validation date / time.
+         */
+        @JvmStatic
+        fun forDateTime(date: Date, time: TimeWithTimeZone): OffsetTimestampHighPrecision =
+            OffsetTimestampHighPrecision(date, time, null, null)
+
         /**
          * Construct a timestamp value using date time field and a given precision.
          *
@@ -53,19 +61,6 @@ internal class OffsetTimestampHighPrecision private constructor(
         }
 
         /**
-         * The intention of this API is to create a Timestamp using a Date and a Time component.
-         * It is assumed that the time component has already been rounded,
-         * meaning this API will not be responsible, if the rounding requires carrying in to day field.
-         */
-        @JvmStatic
-        fun forDateTime(date: Date, time: TimeWithTimeZone): OffsetTimestampHighPrecision =
-            OffsetTimestampHighPrecision(
-                date.year, date.month, date.day,
-                time.hour, time.minute, time.decimalSecond.toBigDecimal(),
-                time.timeZone, null, null, date, time
-            )
-
-        /**
          * Construct a PartiQL timestamp based on an Ion Timestamp.
          * The created timestamp always has [TimeZone] and arbitrary precision.
          * Notice that Ion Value allows for "lower precision", year, month, etc.
@@ -77,20 +72,18 @@ internal class OffsetTimestampHighPrecision private constructor(
         fun forIonTimestamp(ionTs: com.amazon.ion.Timestamp): OffsetTimestampHighPrecision {
             val timestamp = when (ionTs.localOffset) {
                 null ->
-                    OffsetTimestampHighPrecision(
+                    of(
                         ionTs.year, ionTs.month, ionTs.day,
                         ionTs.hour, ionTs.minute, ionTs.decimalSecond,
-                        TimeZone.UnknownTimeZone, ionTs,
-                        null, null, null
-                    )
+                        TimeZone.UnknownTimeZone
+                    ).copy(_inputIonTimestamp = ionTs)
 
                 else ->
-                    OffsetTimestampHighPrecision(
+                    of(
                         ionTs.year, ionTs.month, ionTs.day,
                         ionTs.hour, ionTs.minute, ionTs.decimalSecond,
-                        TimeZone.UtcOffset.of(ionTs.localOffset), ionTs,
-                        null, null, null
-                    )
+                        TimeZone.UtcOffset.of(ionTs.localOffset)
+                    ).copy(_inputIonTimestamp = ionTs)
             }
             return timestamp
         }
@@ -103,14 +96,23 @@ internal class OffsetTimestampHighPrecision private constructor(
          * and timestamp without time zone does not refer to a point forEpochSecond time.
          */
         @JvmStatic
-        fun forEpochSecond(
+        fun forEpochSeconds(
             epochSeconds: BigDecimal,
             timeZone: TimeZone = TimeZone.UnknownTimeZone,
         ): OffsetTimestampHighPrecision {
+            // hack to bootstrap attribute calculation
+            val modifiedEpoch = when (timeZone) {
+                TimeZone.UnknownTimeZone -> epochSeconds
+                is TimeZone.UtcOffset ->
+                    timeZone.totalOffsetMinutes.toBigDecimal()
+                        .multiply(BigDecimal.valueOf(60))
+                        .plus(epochSeconds)
+            }
             val offsetDateTime =
-                java.time.Instant.ofEpochSecond(epochSeconds.setScale(0, RoundingMode.DOWN).longValueExact()).atOffset(
+                java.time.Instant.ofEpochSecond(modifiedEpoch.setScale(0, RoundingMode.DOWN).longValueExact()).atOffset(
                     ZoneOffset.UTC
                 )
+
             val year = offsetDateTime.year
             val month = offsetDateTime.monthValue
             val day = offsetDateTime.dayOfMonth
@@ -124,16 +126,17 @@ internal class OffsetTimestampHighPrecision private constructor(
                 hour, minute,
                 fractionSecond.add(BigDecimal.valueOf(wholeSecond.toLong())),
                 timeZone
-            ).let {
-                OffsetTimestampHighPrecision(
-                    it.year, it.month, it.day,
-                    it.hour, it.minute, it.decimalSecond,
-                    it.timeZone, null,
-                    epochSeconds, null, null
-                )
-            }
+            )
         }
     }
+
+    override val year: Int = date.year
+    override val month: Int = date.month
+    override val day: Int = date.day
+    override val hour: Int = time.hour
+    override val minute: Int = time.minute
+    override val decimalSecond: BigDecimal = time.decimalSecond
+    override val timeZone: TimeZone = time.timeZone
 
     @Deprecated("We will not store raw Ion Timestamp Value in the next release.")
     override val ionRaw: com.amazon.ion.Timestamp? = _inputIonTimestamp
@@ -143,33 +146,31 @@ internal class OffsetTimestampHighPrecision private constructor(
             is TimeZone.UtcOffset -> getUTCEpoch(timeZone.totalOffsetMinutes)
         }
     }
-    internal val date = _date ?: SqlDate.of(year, month, day)
-    internal val time = _time ?: OffsetTimeHighPrecision.of(this.hour, this.minute, this.decimalSecond, this.timeZone)
 
-    override fun plusYear(years: Long): TimestampWithTimeZone =
-        forDateTime(this.date.plusYear(years), this.time)
+    override fun plusYears(years: Long): OffsetTimestampHighPrecision =
+        forDateTime(this.date.plusYears(years), this.time)
 
-    override fun plusMonths(months: Long): TimestampWithTimeZone =
+    override fun plusMonths(months: Long): OffsetTimestampHighPrecision =
         forDateTime(this.date.plusMonths(months), this.time)
 
-    override fun plusDays(days: Long): TimestampWithTimeZone =
+    override fun plusDays(days: Long): OffsetTimestampHighPrecision =
         forDateTime(this.date.plusDays(days), this.time)
 
-    override fun plusHours(hours: Long): TimestampWithTimeZone =
-        forEpochSecond(this.epochSecond.plus((hours * SECONDS_IN_HOUR).toBigDecimal()), timeZone)
+    override fun plusHours(hours: Long): OffsetTimestampHighPrecision =
+        forEpochSeconds(this.epochSecond.plus((hours * SECONDS_IN_HOUR).toBigDecimal()), timeZone)
 
-    override fun plusMinutes(minutes: Long): TimestampWithTimeZone =
-        forEpochSecond(this.epochSecond.plus((minutes * SECONDS_IN_MINUTE).toBigDecimal()), timeZone)
+    override fun plusMinutes(minutes: Long): OffsetTimestampHighPrecision =
+        forEpochSeconds(this.epochSecond.plus((minutes * SECONDS_IN_MINUTE).toBigDecimal()), timeZone)
 
-    override fun plusSeconds(seconds: BigDecimal): TimestampWithTimeZone =
-        forEpochSecond(this.epochSecond.plus(seconds.toBigDecimal()), timeZone)
+    override fun plusSeconds(seconds: BigDecimal): OffsetTimestampHighPrecision =
+        forEpochSeconds(this.epochSecond.plus(seconds.toBigDecimal()), timeZone)
 
-    override fun toTimeWithoutTimeZone(timeZone: TimeZone): TimestampWithoutTimeZone =
+    override fun toTimeWithoutTimeZone(timeZone: TimeZone): LocalTimestampHighPrecision =
         this.atTimeZone(timeZone).let {
             LocalTimestampHighPrecision.of(it.year, it.month, it.day, it.hour, it.minute, it.decimalSecond)
         }
 
-    override fun atTimeZone(timeZone: TimeZone): TimestampWithTimeZone =
+    override fun atTimeZone(timeZone: TimeZone): OffsetTimestampHighPrecision =
         when (val valueTimeZone = this.timeZone) {
             TimeZone.UnknownTimeZone -> {
                 when (timeZone) {
@@ -188,8 +189,11 @@ internal class OffsetTimestampHighPrecision private constructor(
                         utc.hour, utc.minute, utc.decimalSecond,
                         timeZone
                     )
-                    is TimeZone.UtcOffset -> utc.plusMinutes(timeZone.totalOffsetMinutes.toLong())
-                        .let { of(it.year, it.month, it.day, it.hour, it.minute, it.decimalSecond, timeZone) }
+                    is TimeZone.UtcOffset -> {
+                        if (valueTimeZone == timeZone) this
+                        else utc.plusMinutes(timeZone.totalOffsetMinutes.toLong())
+                            .let { of(it.year, it.month, it.day, it.hour, it.minute, it.decimalSecond, timeZone) }
+                    }
                 }
             }
         }
@@ -201,17 +205,12 @@ internal class OffsetTimestampHighPrecision private constructor(
 
         return BigDecimal.valueOf(adjustForTimeZoneInSecond).plus(this.time.elapsedSecond)
     }
-
     internal fun copy(
         _inputIonTimestamp: com.amazon.ion.Timestamp? = null,
-        _epochSecond: BigDecimal? = null,
-        _date: Date? = null,
-        _time: TimeWithTimeZone? = null
+        _epochSecond: BigDecimal? = null
     ) =
         OffsetTimestampHighPrecision(
-            this.year, this.month, this.day,
-            this.hour, this.minute, this.decimalSecond, this.timeZone,
-            _inputIonTimestamp ?: this.ionTimestampValue, _epochSecond ?: this.epochSecond,
-            _date ?: this.date, _time ?: this.time
+            this.date, this.time,
+            _inputIonTimestamp ?: this.ionTimestampValue, _epochSecond ?: this.epochSecond
         )
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/OffsetTimestampLowPrecision.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/OffsetTimestampLowPrecision.kt
@@ -1,7 +1,6 @@
 package org.partiql.value.datetime.impl
 
 import org.partiql.value.datetime.Date
-import org.partiql.value.datetime.DateTimeUtil.JAVA_MAX_OFFSET
 import org.partiql.value.datetime.DateTimeUtil.toBigDecimal
 import org.partiql.value.datetime.TimeZone
 import org.partiql.value.datetime.Timestamp
@@ -12,7 +11,6 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
-import kotlin.math.absoluteValue
 import kotlin.math.max
 
 /**

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/OffsetTimestampLowPrecision.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/OffsetTimestampLowPrecision.kt
@@ -1,35 +1,57 @@
 package org.partiql.value.datetime.impl
 
 import org.partiql.value.datetime.Date
-import org.partiql.value.datetime.DateTimeException
 import org.partiql.value.datetime.DateTimeUtil.JAVA_MAX_OFFSET
 import org.partiql.value.datetime.DateTimeUtil.toBigDecimal
-import org.partiql.value.datetime.TimeWithTimeZone
 import org.partiql.value.datetime.TimeZone
 import org.partiql.value.datetime.Timestamp
 import org.partiql.value.datetime.TimestampWithTimeZone
-import org.partiql.value.datetime.TimestampWithoutTimeZone
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.time.Instant
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import kotlin.math.absoluteValue
 import kotlin.math.max
 
+/**
+ * This implementation utilize [java.time.OffsetDateTime] to handle timestamp with time zone if :
+ * 1. The desired precision is below nanosecond (9 digits after decimal point).
+ * 2. The desired timezone is within +18:00 to -18:00.
+ *
+ * The constructor functions assumes the above conditions to be true.
+ */
 internal class OffsetTimestampLowPrecision(
     val offsetDateTime: OffsetDateTime,
     val isUnknownTimeZone: Boolean,
-    _year: Int? = null,
-    _month: Int? = null,
-    _day: Int? = null,
-    _hour: Int? = null,
-    _minute: Int? = null,
-    _decimalSecond: BigDecimal? = null,
-    _timeZone: TimeZone? = null,
-    _inputIonTimestamp: com.amazon.ion.Timestamp? = null
+    val date: Date,
+    val time: OffsetTimeLowPrecision,
+    _inputIonTimestamp: com.amazon.ion.Timestamp? = null,
+    _epochSecond: BigDecimal? = null
 ) : TimestampWithTimeZone() {
 
     companion object {
+        /**
+         * Construct a Timestamp by concatenate a Date and a Time component.
+         *
+         * The time component should have a TimeZone.
+         *
+         * This should be called by other constructors for validation date / time.
+         */
+        fun forDateTime(date: Date, time: OffsetTimeLowPrecision): OffsetTimestampLowPrecision {
+            val offsetDateTime =
+                OffsetDateTime.of(
+                    LocalDate.of(date.year, date.month, date.day),
+                    time.offsetTime.toLocalTime(),
+                    time.offsetTime.offset
+                )
+            return OffsetTimestampLowPrecision(offsetDateTime, time.isUnknownTimeZone, date, time)
+        }
+
+        /**
+         * Construct a Timestamp with nanosecond precision.
+         */
         fun of(
             year: Int,
             month: Int,
@@ -40,28 +62,9 @@ internal class OffsetTimestampLowPrecision(
             nanoOfSecond: Int,
             timeZone: TimeZone,
         ): OffsetTimestampLowPrecision {
-            try {
-                return when (timeZone) {
-                    TimeZone.UnknownTimeZone ->
-                        OffsetTimestampLowPrecision(
-                            OffsetDateTime.of(year, month, day, hour, minute, second, nanoOfSecond, ZoneOffset.UTC),
-                            true,
-                            year, month, day, hour, minute, null, timeZone, null
-                        )
-
-                    is TimeZone.UtcOffset -> OffsetTimestampLowPrecision(
-                        OffsetDateTime.of(
-                            year, month, day,
-                            hour, minute, second, nanoOfSecond,
-                            ZoneOffset.ofTotalSeconds(timeZone.totalOffsetMinutes * 60)
-                        ),
-                        false,
-                        year, month, day, hour, minute, null, timeZone, null
-                    )
-                }
-            } catch (e: java.time.DateTimeException) {
-                throw DateTimeException(e.localizedMessage)
-            }
+            val date = SqlDate.of(year, month, day)
+            val time = OffsetTimeLowPrecision.of(hour, minute, second, nanoOfSecond, timeZone)
+            return forDateTime(date, time)
         }
 
         fun of(
@@ -73,20 +76,9 @@ internal class OffsetTimestampLowPrecision(
             decimalSecond: BigDecimal,
             timeZone: TimeZone
         ): OffsetTimestampLowPrecision {
-            val wholeSecond = decimalSecond.setScale(0, RoundingMode.DOWN)
-            val nano = decimalSecond.minus(wholeSecond).movePointRight(9)
-            return of(year, month, day, hour, minute, wholeSecond.intValueExact(), nano.intValueExact(), timeZone).let {
-                OffsetTimestampLowPrecision(
-                    it.offsetDateTime, it.isUnknownTimeZone,
-                    year, month, day,
-                    hour, minute, decimalSecond,
-                    timeZone, null
-                )
-            }
-        }
-
-        fun forDateTime(date: Date, time: TimeWithTimeZone): OffsetTimestampLowPrecision {
-            return of(date.year, date.month, date.day, time.hour, time.minute, time.decimalSecond, time.timeZone)
+            val date = SqlDate.of(year, month, day)
+            val time = OffsetTimeLowPrecision.of(hour, minute, decimalSecond, timeZone)
+            return forDateTime(date, time)
         }
 
         fun forIonTimestamp(ionTs: com.amazon.ion.Timestamp): TimestampWithTimeZone {
@@ -97,12 +89,7 @@ internal class OffsetTimestampLowPrecision(
                         ionTs.hour, ionTs.minute, ionTs.decimalSecond,
                         TimeZone.UnknownTimeZone
                     ).copy(_inputIonTimestamp = ionTs)
-                ionTs.localOffset.absoluteValue > JAVA_MAX_OFFSET ->
-                    OffsetTimestampHighPrecision.of(
-                        ionTs.year, ionTs.month, ionTs.day,
-                        ionTs.hour, ionTs.minute, ionTs.decimalSecond,
-                        TimeZone.UtcOffset.of(ionTs.localOffset)
-                    ).copy(_inputIonTimestamp = ionTs)
+                // it should never have reached the case where offset exceeds Java max offset.
                 else ->
                     of(
                         ionTs.year, ionTs.month, ionTs.day,
@@ -113,100 +100,135 @@ internal class OffsetTimestampLowPrecision(
             return timestamp
         }
 
+        fun forEpochSeconds(epochSeconds: BigDecimal, timeZone: TimeZone): OffsetTimestampLowPrecision {
+            val wholeSeconds = epochSeconds.setScale(0, RoundingMode.DOWN)
+            val nano = (epochSeconds - wholeSeconds).let { it.movePointRight(9) }
+            val offsetDateTime = OffsetDateTime.ofInstant(
+                Instant.ofEpochSecond(wholeSeconds.longValueExact(), nano.longValueExact()),
+                when (timeZone) {
+                    TimeZone.UnknownTimeZone -> ZoneOffset.ofTotalSeconds(0)
+                    is TimeZone.UtcOffset -> ZoneOffset.ofTotalSeconds(timeZone.totalOffsetMinutes * 60)
+                }
+            )
+            val date = SqlDate.of(offsetDateTime.year, offsetDateTime.monthValue, offsetDateTime.dayOfMonth)
+            // we need to assign a precision based on the input epochSecond
+            val time =
+                OffsetTimeLowPrecision
+                    .of(offsetDateTime.hour, offsetDateTime.minute, offsetDateTime.second, offsetDateTime.nano, timeZone)
+                    .let { it.copy(_decimalSecond = it.decimalSecond.setScale(epochSeconds.scale(), RoundingMode.UNNECESSARY)) }
+            return forDateTime(date, time).copy(_epochSecond = epochSeconds)
+        }
+
         @JvmStatic
-        fun nowZ() =
-            OffsetTimestampLowPrecision(OffsetDateTime.now(ZoneOffset.UTC), false)
+        fun nowZ(): OffsetTimestampLowPrecision {
+            val javaNowZ = OffsetDateTime.now(ZoneOffset.UTC)
+            val date = SqlDate.of(javaNowZ.year, javaNowZ.monthValue, javaNowZ.dayOfMonth)
+            val time = OffsetTimeLowPrecision.of(javaNowZ.hour, javaNowZ.minute, javaNowZ.second, javaNowZ.nano, TimeZone.UtcOffset.of(0))
+            return forDateTime(date, time)
+        }
     }
 
-    override val year: Int = _year ?: offsetDateTime.year
-    override val month: Int = _month ?: offsetDateTime.monthValue
-    override val day: Int = _day ?: offsetDateTime.dayOfMonth
-    override val hour: Int = _hour ?: offsetDateTime.hour
-    override val minute: Int = _minute ?: offsetDateTime.minute
-    override val decimalSecond: BigDecimal =
-        _decimalSecond
-            ?: BigDecimal.valueOf(offsetDateTime.second.toLong())
-                .plus(BigDecimal.valueOf(offsetDateTime.nano.toLong(), 9))
-    override val timeZone: TimeZone =
-        _timeZone
-            ?: if (isUnknownTimeZone) TimeZone.UnknownTimeZone else TimeZone.UtcOffset.of(offsetDateTime.offset.totalSeconds / 60)
+    override val year: Int = date.year
+    override val month: Int = date.month
+    override val day: Int = date.day
+    override val hour: Int = time.hour
+    override val minute: Int = time.minute
+    override val decimalSecond: BigDecimal = time.decimalSecond
+    override val timeZone: TimeZone = time.timeZone
     override val ionRaw: com.amazon.ion.Timestamp? = _inputIonTimestamp
     val second: Int = offsetDateTime.second
     val nano: Int = offsetDateTime.nano
     override val epochSecond: BigDecimal by lazy {
-        (offsetDateTime.toEpochSecond() - second).toBigDecimal() + decimalSecond
+        _epochSecond
+            ?: ((offsetDateTime.toEpochSecond() - second).toBigDecimal() + decimalSecond)
     }
 
-    override fun plusYear(years: Long): TimestampWithTimeZone =
+    override fun plusYears(years: Long): OffsetTimestampLowPrecision =
         offsetDateTime.plusYears(years).let {
             of(it.year, it.monthValue, it.dayOfMonth, it.hour, it.minute, decimalSecond, timeZone)
         }
 
-    override fun plusMonths(months: Long): TimestampWithTimeZone =
+    override fun plusMonths(months: Long): OffsetTimestampLowPrecision =
         offsetDateTime.plusMonths(months).let {
             of(it.year, it.monthValue, it.dayOfMonth, it.hour, it.minute, decimalSecond, timeZone)
         }
 
-    override fun plusDays(days: Long): TimestampWithTimeZone =
+    override fun plusDays(days: Long): OffsetTimestampLowPrecision =
         offsetDateTime.plusDays(days).let {
             of(it.year, it.monthValue, it.dayOfMonth, it.hour, it.minute, decimalSecond, timeZone)
         }
 
-    override fun plusHours(hours: Long): TimestampWithTimeZone =
+    override fun plusHours(hours: Long): OffsetTimestampLowPrecision =
         offsetDateTime.plusHours(hours).let {
             of(it.year, it.monthValue, it.dayOfMonth, it.hour, it.minute, decimalSecond, timeZone)
         }
 
-    override fun plusMinutes(minutes: Long): TimestampWithTimeZone =
+    override fun plusMinutes(minutes: Long): OffsetTimestampLowPrecision =
         offsetDateTime.plusMinutes(minutes).let {
             of(it.year, it.monthValue, it.dayOfMonth, it.hour, it.minute, decimalSecond, timeZone)
         }
 
     override fun plusSeconds(seconds: BigDecimal): TimestampWithTimeZone =
         if (seconds.scale() > 9) {
-            OffsetTimestampHighPrecision.of(year, month, day, hour, minute, decimalSecond, timeZone).plusSeconds(seconds)
+            OffsetTimestampHighPrecision.of(year, month, day, hour, minute, decimalSecond, timeZone)
+                .plusSeconds(seconds)
         } else {
             val wholeSecond = seconds.setScale(0, RoundingMode.DOWN)
-            val nano = seconds.minus(wholeSecond).let { it.movePointRight(it.scale()) }
+            val nano = seconds.minus(wholeSecond).movePointRight(9)
             val newTime = offsetDateTime.plusSeconds(wholeSecond.longValueExact()).plusNanos(nano.longValueExact())
             // the real precision of this operation, should be max(original_value.decimalSecond.precision, seconds.precision)
             val newDecimalSecond = newTime.second.toBigDecimal() + newTime.nano.toBigDecimal().movePointLeft(9)
             val roundedDecimalSecond =
-                newDecimalSecond.setScale(max(this.decimalSecond.scale(), seconds.scale()), RoundingMode.UNNECESSARY)
-            of(newTime.year, newTime.monthValue, newTime.dayOfMonth, newTime.hour, newTime.minute, roundedDecimalSecond, timeZone)
+                newDecimalSecond.stripTrailingZeros().setScale(max(this.decimalSecond.scale(), seconds.scale()), RoundingMode.UNNECESSARY)
+            of(
+                newTime.year,
+                newTime.monthValue,
+                newTime.dayOfMonth,
+                newTime.hour,
+                newTime.minute,
+                roundedDecimalSecond,
+                timeZone
+            )
         }
 
-    override fun toTimeWithoutTimeZone(timeZone: TimeZone): TimestampWithoutTimeZone {
+    override fun toTimeWithoutTimeZone(timeZone: TimeZone): LocalTimestampLowPrecision {
         val local = when (timeZone) {
             TimeZone.UnknownTimeZone -> offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC)
             is TimeZone.UtcOffset -> offsetDateTime.withOffsetSameInstant(ZoneOffset.ofTotalSeconds(timeZone.totalOffsetMinutes * 60))
         }
         // Second field should be intact from this operation
-        return LocalTimestampLowPrecision.of(local.year, local.monthValue, local.dayOfMonth, local.hour, local.minute, decimalSecond)
+        return LocalTimestampLowPrecision.of(
+            local.year,
+            local.monthValue,
+            local.dayOfMonth,
+            local.hour,
+            local.minute,
+            decimalSecond
+        )
     }
 
-    override fun atTimeZone(timeZone: TimeZone): TimestampWithTimeZone {
+    override fun atTimeZone(timeZone: TimeZone): OffsetTimestampLowPrecision {
         val local = when (timeZone) {
             TimeZone.UnknownTimeZone -> offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC)
             is TimeZone.UtcOffset -> offsetDateTime.withOffsetSameInstant(ZoneOffset.ofTotalSeconds(timeZone.totalOffsetMinutes * 60))
         }
-        return of(local.year, local.monthValue, local.dayOfMonth, local.hour, local.minute, this.decimalSecond, timeZone)
+        return of(
+            local.year,
+            local.monthValue,
+            local.dayOfMonth,
+            local.hour,
+            local.minute,
+            this.decimalSecond,
+            timeZone
+        )
     }
 
     internal fun copy(
-        _year: Int? = null,
-        _month: Int? = null,
-        _day: Int? = null,
-        _hour: Int? = null,
-        _minute: Int? = null,
-        _decimalSecond: BigDecimal? = null,
-        _timeZone: TimeZone? = null,
-        _inputIonTimestamp: com.amazon.ion.Timestamp? = null
+        _inputIonTimestamp: com.amazon.ion.Timestamp? = null,
+        _epochSecond: BigDecimal? = null
     ) =
         OffsetTimestampLowPrecision(
-            this.offsetDateTime, this.isUnknownTimeZone,
-            _year ?: this.year, _month ?: this.month, _day ?: this.day,
-            _hour ?: this.hour, _minute ?: this.minute, _decimalSecond ?: this.decimalSecond,
-            _timeZone ?: this.timeZone, _inputIonTimestamp ?: this.ionRaw
+            this.offsetDateTime, this.isUnknownTimeZone, this.date, this.time,
+            _inputIonTimestamp ?: this.ionRaw, _epochSecond ?: this.epochSecond
         )
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/SqlDate.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/SqlDate.kt
@@ -14,7 +14,6 @@
 
 package org.partiql.value.datetime.impl
 
-import org.partiql.value.datetime.Date
 import org.partiql.value.datetime.DateImpl
 import org.partiql.value.datetime.DateTimeException
 import org.partiql.value.datetime.DateTimeValue.timestamp
@@ -28,11 +27,11 @@ internal data class SqlDate private constructor(
 ) : DateImpl() {
     companion object {
         /**
-         * Construct a Date object using
+         * Construct a Date object.
          */
         @JvmStatic
         @Throws(DateTimeException::class)
-        fun of(year: Int, month: Int, day: Int): Date {
+        fun of(year: Int, month: Int, day: Int): SqlDate {
             if (year < 1 || year > 9999)
                 throw DateTimeException("Expect Year Field to be between 1 to 9999, but received $year")
             try {
@@ -52,17 +51,17 @@ internal data class SqlDate private constructor(
     override fun atTime(time: Time): Timestamp = timestamp(this, time)
 
     // Operation
-    override fun plusDays(days: Long): Date =
+    override fun plusDays(days: Long): SqlDate =
         this.localDate.plusDays(days)
             .let { newDate ->
                 of(newDate.year, newDate.monthValue, newDate.dayOfMonth)
             }
-    override fun plusMonths(months: Long): Date =
+    override fun plusMonths(months: Long): SqlDate =
         this.localDate.plusMonths(months)
             .let { newDate ->
                 of(newDate.year, newDate.monthValue, newDate.dayOfMonth)
             }
-    override fun plusYear(years: Long): Date =
+    override fun plusYears(years: Long): SqlDate =
         this.localDate.plusYears(years)
             .let { newDate ->
                 of(newDate.year, newDate.monthValue, newDate.dayOfMonth)

--- a/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/Utils.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/datetime/impl/Utils.kt
@@ -1,0 +1,16 @@
+package org.partiql.value.datetime.impl
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+internal object Utils {
+    // For low precision only, do not use for high precision implementation, as longValueExact will not work
+    fun getSecondAndNanoFromDecimalSecond(decimalSecond: BigDecimal): Pair<Long, Long> {
+        val wholeSecond = decimalSecond.setScale(0, RoundingMode.DOWN)
+        val nano = decimalSecond.minus(wholeSecond).movePointRight(9)
+        return (wholeSecond.longValueExact() to nano.longValueExact())
+    }
+
+    fun getDecimalSecondFromSecondAndNano(second: Long, nano: Long): BigDecimal =
+        second.toBigDecimal() + nano.toBigDecimal().movePointLeft(9)
+}


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
- Three major parts of the PR are:
-  1. Clean up data model code, add documents. 
- 2. Adding support in compiler/evaluator with respect to constructor call to create a timestamp literal.
- 3. Equivalence definition. 
Additional code is the necessary modification to make all existing test case pass. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - Yes. 

- Any backward-incompatible changes? **[YES/NO]**
  - Yes.  Ion Timestamp will be extended to full timestamp format to avoid confusion. 

- Any new external dependencies? **[YES/NO]**
  - No. 

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
 - Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.