### PR TITLE
Updates all aliases to identifier.symbol to match SQL grammar

### DIFF
--- a/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
@@ -700,7 +700,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
     override fun visitSelectProjectItemExpression(node: Select.Project.Item.Expression, ctx: Ctx) =
         translate(node) { metas ->
             val expr = visitExpr(node.expr, ctx)
-            val alias = node.asAlias
+            val alias = node.asAlias?.symbol
             projectExpr(expr, alias, metas)
         }
 
@@ -718,9 +718,9 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
     override fun visitFrom(node: From, ctx: Ctx) = super.visitFrom(node, ctx) as PartiqlAst.FromSource
     override fun visitFromValue(node: From.Value, ctx: Ctx) = translate(node) { metas ->
         val expr = visitExpr(node.expr, ctx)
-        val asAlias = node.asAlias
-        val atAlias = node.atAlias
-        val byAlias = node.byAlias
+        val asAlias = node.asAlias?.symbol
+        val atAlias = node.atAlias?.symbol
+        val byAlias = node.byAlias?.symbol
         when (node.type) {
             From.Value.Type.SCAN -> scan(expr, asAlias, atAlias, byAlias, metas)
             From.Value.Type.UNPIVOT -> unpivot(expr, asAlias, atAlias, byAlias, metas)
@@ -755,7 +755,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitLetBinding(node: Let.Binding, ctx: Ctx) = translate(node) { metas ->
         val expr = visitExpr(node.expr, ctx)
-        val name = node.asAlias
+        val name = node.asAlias?.symbol
         letBinding(expr, name, metas)
     }
 
@@ -765,13 +765,13 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
             GroupBy.Strategy.PARTIAL -> groupPartial()
         }
         val keyList = groupKeyList(node.keys.translate<PartiqlAst.GroupKey>(ctx))
-        val groupAsAlias = node.asAlias
+        val groupAsAlias = node.asAlias?.symbol
         groupBy(strategy, keyList, groupAsAlias, metas)
     }
 
     override fun visitGroupByKey(node: GroupBy.Key, ctx: Ctx) = translate(node) { metas ->
         val expr = visitExpr(node.expr, ctx)
-        val asAlias = node.asAlias
+        val asAlias = node.asAlias?.symbol
         groupKey(expr, asAlias, metas)
     }
 
@@ -911,7 +911,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitStatementDMLInsert(node: Statement.DML.Insert, ctx: Ctx) = translate(node) { metas ->
         val target = visitIdentifier(node.target, ctx)
-        val asAlias = node.asAlias
+        val asAlias = node.asAlias?.symbol
         val values = visitExpr(node.values, ctx)
         val conflictAction = node.onConflict?.let { visitOnConflictAction(it.action, ctx) }
         val op = insert(target, asAlias, values, conflictAction)
@@ -935,7 +935,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitStatementDMLUpsert(node: Statement.DML.Upsert, ctx: Ctx) = translate(node) { metas ->
         val target = visitIdentifier(node.target, ctx)
-        val asAlias = node.asAlias
+        val asAlias = node.asAlias?.symbol
         val values = visitExpr(node.values, ctx)
         val conflictAction = doUpdate(excluded())
         // UPSERT overloads legacy INSERT
@@ -945,7 +945,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitStatementDMLReplace(node: Statement.DML.Replace, ctx: Ctx) = translate(node) { metas ->
         val target = visitIdentifier(node.target, ctx)
-        val asAlias = node.asAlias
+        val asAlias = node.asAlias?.symbol
         val values = visitExpr(node.values, ctx)
         val conflictAction = doReplace(excluded())
         // REPLACE overloads legacy INSERT
@@ -991,9 +991,9 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitStatementDMLDeleteTarget(node: Statement.DML.Delete.Target, ctx: Ctx) = translate(node) { metas ->
         val path = visitPathUnpack(node.path, ctx)
-        val asAlias = node.asAlias
-        val atAlias = node.atAlias
-        val byAlias = node.byAlias
+        val asAlias = node.asAlias?.symbol
+        val atAlias = node.atAlias?.symbol
+        val byAlias = node.byAlias?.symbol
         scan(path, asAlias, atAlias, byAlias, metas)
     }
 
@@ -1041,7 +1041,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         ctx: Ctx,
     ) = translate(node) { metas ->
         val target = visitIdentifier(node.target, ctx)
-        val asAlias = node.asAlias
+        val asAlias = node.asAlias?.symbol
         val values = visitExpr(node.values, ctx)
         val conflictAction = node.onConflict?.let { visitOnConflictAction(it.action, ctx) }
         dmlOpList(insert(target, asAlias, values, conflictAction, metas))

--- a/partiql-ast/src/main/resources/partiql_ast.ion
+++ b/partiql-ast/src/main/resources/partiql_ast.ion
@@ -18,7 +18,7 @@ statement::[
     insert::{
       target:       identifier,
       values:       expr,
-      as_alias:     optional::string,
+      as_alias:     optional::'.identifier.symbol',
       on_conflict:  optional::on_conflict,
     },
 
@@ -34,14 +34,14 @@ statement::[
     upsert::{
       target:   identifier,
       values:   expr,
-      as_alias: optional::string,
+      as_alias: optional::'.identifier.symbol',
     },
 
     // REPLACE INTO <target> [AS <alias>] <values>
     replace::{
       target:   identifier,
       values:   expr,
-      as_alias: optional::string,
+      as_alias: optional::'.identifier.symbol',
     },
 
     // UPDATE <target> SET <set clause list> WHERE <expr>
@@ -65,9 +65,9 @@ statement::[
     delete::{
       target: {
         path:     path,
-        as_alias: optional::string,
-        at_alias: optional::string,
-        by_alias: optional::string,
+        as_alias: optional::'.identifier.symbol',
+        at_alias: optional::'.identifier.symbol',
+        by_alias: optional::'.identifier.symbol',
       },
       where:      optional::expr,
       returning:  optional::returning,
@@ -84,7 +84,7 @@ statement::[
           insert::{
             target:       identifier,
             values:       expr,
-            as_alias:     optional::string,
+            as_alias:     optional::'.identifier.symbol',
             on_conflict:  optional::on_conflict,
           },
           insert_legacy::{
@@ -541,8 +541,8 @@ select::[
     setq:   optional::set_quantifier,
     _: [
       item::[
-        all::{ expr: expr },                                    // <expr>.*
-        expression::{ expr: expr, as_alias: optional::string }  // <expr> [as <identifier>]
+        all::{ expr: expr },                                                  // <expr>.*
+        expression::{ expr: expr, as_alias: optional::'.identifier.symbol' }  // <expr> [as <identifier>]
       ],
     ],
   },
@@ -567,9 +567,9 @@ from::[
   value::{
     expr:     expr,
     type:     [ SCAN, UNPIVOT ],
-    as_alias: optional::string,
-    at_alias: optional::string,
-    by_alias: optional::string,
+    as_alias: optional::'.identifier.symbol',
+    at_alias: optional::'.identifier.symbol',
+    by_alias: optional::'.identifier.symbol',
   },
 
   // TODO https://github.com/partiql/partiql-spec/issues/41
@@ -597,7 +597,7 @@ let::{
   _: [
     binding::{
       expr:     expr,
-      as_alias: string,
+      as_alias: '.identifier.symbol',
     },
   ],
 }
@@ -606,11 +606,11 @@ let::{
 group_by::{
   strategy: [ FULL, PARTIAL ],
   keys:     list::[key],
-  as_alias: optional::string,
+  as_alias: optional::'.identifier.symbol',
   _: [
     key::{
       expr:     expr,
-      as_alias: optional::string,
+      as_alias: optional::'.identifier.symbol',
     },
   ],
 }

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
@@ -532,7 +532,7 @@ class ToLegacyAstTest {
                     }
                     items += selectProjectItemExpression {
                         expr = exprLit(int32Value(1))
-                        asAlias = "x"
+                        asAlias = id("x")
                     }
                 }
             },
@@ -558,9 +558,9 @@ class ToLegacyAstTest {
                 fromValue {
                     expr = NULL
                     type = From.Value.Type.SCAN
-                    asAlias = "a"
-                    atAlias = "b"
-                    byAlias = "c"
+                    asAlias = id("a")
+                    atAlias = id("b")
+                    byAlias = id("c")
                 }
             },
             expect("(unpivot (lit null) null null null)") {
@@ -573,9 +573,9 @@ class ToLegacyAstTest {
                 fromValue {
                     expr = NULL
                     type = From.Value.Type.UNPIVOT
-                    asAlias = "a"
-                    atAlias = "b"
-                    byAlias = "c"
+                    asAlias = id("a")
+                    atAlias = id("b")
+                    byAlias = id("c")
                 }
             },
             expect(
@@ -626,7 +626,7 @@ class ToLegacyAstTest {
                 let {
                     bindings += letBinding {
                         expr = NULL
-                        asAlias = "x"
+                        asAlias = id("x")
                     }
                 }
             },
@@ -644,7 +644,7 @@ class ToLegacyAstTest {
                 groupBy {
                     strategy = GroupBy.Strategy.FULL
                     keys += groupByKey(exprLit(stringValue("a")), null)
-                    keys += groupByKey(exprLit(stringValue("b")), "x")
+                    keys += groupByKey(exprLit(stringValue("b")), id("x"))
                 }
             },
             expect(
@@ -661,8 +661,8 @@ class ToLegacyAstTest {
                 groupBy {
                     strategy = GroupBy.Strategy.PARTIAL
                     keys += groupByKey(exprLit(stringValue("a")), null)
-                    keys += groupByKey(exprLit(stringValue("b")), "x")
-                    asAlias = "as"
+                    keys += groupByKey(exprLit(stringValue("b")), id("x"))
+                    asAlias = id("as")
                 }
             },
             expect(

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
@@ -464,7 +464,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitColumnDeclaration(ctx: GeneratedParser.ColumnDeclarationContext) = translate(ctx) {
-            val name = symbol(ctx.columnName().symbolPrimitive())
+            val name = symbolToString(ctx.columnName().symbolPrimitive())
             val type = visit(ctx.type()) as Type
             val constraints = ctx.columnConstraint().map {
                 visitColumnConstraint(it)
@@ -473,7 +473,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitColumnConstraint(ctx: GeneratedParser.ColumnConstraintContext) = translate(ctx) {
-            val identifier = ctx.columnConstraintName()?.let { symbol(it.symbolPrimitive()) }
+            val identifier = ctx.columnConstraintName()?.let { symbolToString(it.symbolPrimitive()) }
             val body = visit(ctx.columnConstraintDef()) as TableDefinition.Column.Constraint.Body
             tableDefinitionColumnConstraint(identifier, body)
         }
@@ -611,7 +611,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitInsertStatement(ctx: GeneratedParser.InsertStatementContext) = translate(ctx) {
             val target = visitSymbolPrimitive(ctx.symbolPrimitive())
             val values = visitExpr(ctx.value)
-            val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())?.symbol
+            val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
             val onConflict = ctx.onConflict()?.let { visitOnConflictClause(it) }
             statementDMLInsert(target, values, asAlias, onConflict)
         }
@@ -619,14 +619,14 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitReplaceCommand(ctx: GeneratedParser.ReplaceCommandContext) = translate(ctx) {
             val target = visitSymbolPrimitive(ctx.symbolPrimitive())
             val values = visitExpr(ctx.value)
-            val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())?.symbol
+            val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
             statementDMLReplace(target, values, asAlias)
         }
 
         override fun visitUpsertCommand(ctx: GeneratedParser.UpsertCommandContext) = translate(ctx) {
             val target = visitSymbolPrimitive(ctx.symbolPrimitive())
             val values = visitExpr(ctx.value)
-            val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())?.symbol
+            val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
             statementDMLUpsert(target, values, asAlias)
         }
 
@@ -804,7 +804,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitProjectionItem(ctx: GeneratedParser.ProjectionItemContext) = translate(ctx) {
             val expr = visitExpr(ctx.expr())
-            val alias = ctx.symbolPrimitive()?.let { symbol(it) }
+            val alias = ctx.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
             if (expr is Expr.Path) {
                 convertPathToProjectionItem(ctx, expr, alias)
             } else {
@@ -848,7 +848,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitLetBinding(ctx: GeneratedParser.LetBindingContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.expr())
-            val alias = symbol(ctx.symbolPrimitive())
+            val alias = visitSymbolPrimitive(ctx.symbolPrimitive())
             letBinding(expr, alias)
         }
 
@@ -889,13 +889,13 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitGroupClause(ctx: GeneratedParser.GroupClauseContext) = translate(ctx) {
             val strategy = if (ctx.PARTIAL() != null) GroupBy.Strategy.PARTIAL else GroupBy.Strategy.FULL
             val keys = visitOrEmpty<GroupBy.Key>(ctx.groupKey())
-            val alias = ctx.groupAlias()?.let { symbol(ctx.groupAlias().symbolPrimitive()) }
+            val alias = ctx.groupAlias()?.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
             groupBy(strategy, keys, alias)
         }
 
         override fun visitGroupKey(ctx: GeneratedParser.GroupKeyContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.key)
-            val alias = ctx.symbolPrimitive()?.let { symbol(it) }
+            val alias = ctx.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
             groupByKey(expr, alias)
         }
 
@@ -1124,17 +1124,17 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitTableBaseRefClauses(ctx: GeneratedParser.TableBaseRefClausesContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = ctx.asIdent()?.let { symbol(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { symbol(it.symbolPrimitive()) }
-            val byAlias = ctx.byIdent()?.let { symbol(it.symbolPrimitive()) }
+            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
             fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
 
         override fun visitTableBaseRefMatch(ctx: GeneratedParser.TableBaseRefMatchContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = ctx.asIdent()?.let { symbol(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { symbol(it.symbolPrimitive()) }
-            val byAlias = ctx.byIdent()?.let { symbol(it.symbolPrimitive()) }
+            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
             fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
 
@@ -1144,9 +1144,9 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitFromClauseSimpleExplicit(ctx: GeneratedParser.FromClauseSimpleExplicitContext) =
             translate(ctx) {
                 val path = visitPathSimple(ctx.pathSimple())
-                val asAlias = ctx.asIdent()?.let { visitAsIdent(it) }?.symbol
-                val atAlias = ctx.atIdent()?.let { visitAtIdent(it) }?.symbol
-                val byAlias = ctx.byIdent()?.let { visitByIdent(it) }?.symbol
+                val asAlias = ctx.asIdent()?.let { visitAsIdent(it) }
+                val atAlias = ctx.atIdent()?.let { visitAtIdent(it) }
+                val byAlias = ctx.byIdent()?.let { visitByIdent(it) }
                 statementDMLDeleteTarget(path, asAlias, atAlias, byAlias)
             }
 
@@ -1156,15 +1156,15 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitFromClauseSimpleImplicit(ctx: GeneratedParser.FromClauseSimpleImplicitContext) =
             translate(ctx) {
                 val path = visitPathSimple(ctx.pathSimple())
-                val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive()).symbol
+                val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive())
                 statementDMLDeleteTarget(path, asAlias, null, null)
             }
 
         override fun visitTableUnpivot(ctx: GeneratedParser.TableUnpivotContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.expr())
-            val asAlias = ctx.asIdent()?.let { symbol(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { symbol(it.symbolPrimitive()) }
-            val byAlias = ctx.byIdent()?.let { symbol(it.symbolPrimitive()) }
+            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
             fromValue(expr, From.Value.Type.UNPIVOT, asAlias, atAlias, byAlias)
         }
 
@@ -1210,7 +1210,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitTableBaseRefSymbol(ctx: GeneratedParser.TableBaseRefSymbolContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = symbol(ctx.symbolPrimitive())
+            val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive())
             fromValue(expr, From.Value.Type.SCAN, asAlias, null, null)
         }
 
@@ -1857,7 +1857,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         /**
          * Visiting a symbol to get a string, skip the wrapping, unwrapping, and location tracking.
          */
-        private fun symbol(ctx: GeneratedParser.SymbolPrimitiveContext) = when (ctx.ident.type) {
+        private fun symbolToString(ctx: GeneratedParser.SymbolPrimitiveContext) = when (ctx.ident.type) {
             GeneratedParser.IDENTIFIER_QUOTED -> ctx.IDENTIFIER_QUOTED().getStringValue()
             GeneratedParser.IDENTIFIER -> ctx.IDENTIFIER().getStringValue()
             else -> throw error(ctx, "Invalid symbol reference.")
@@ -1931,7 +1931,7 @@ internal class PartiQLParserDefault : PartiQLParser {
          *      SELECT foo.*.bar FROM foo
          * ```
          */
-        protected fun convertPathToProjectionItem(ctx: ParserRuleContext, path: Expr.Path, alias: String?) =
+        protected fun convertPathToProjectionItem(ctx: ParserRuleContext, path: Expr.Path, alias: Identifier.Symbol?) =
             translate(ctx) {
                 val steps = mutableListOf<Expr.Path.Step>()
                 var containsIndex = false


### PR DESCRIPTION
## Relevant Issues
n/a

## Description

Our grammar specifies that aliases are symbol primitives which are either quote or unquoted identifiers.

```antlr
asIdent
    : AS symbolPrimitive;

symbolPrimitive
    : ident=( IDENTIFIER | IDENTIFIER_QUOTED )
    ;
```

This PR updates the AST model to match the SQL grammar for symbol identifier as aliases.


## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No, these changes this is based upon has not been released

- Any backward-incompatible changes? **[YES/NO]**
No, reason same as above

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.