### PR TITLE
Removes project-all from the AST

### DIFF
--- a/partiql-ast/src/main/resources/partiql_ast.ion
+++ b/partiql-ast/src/main/resources/partiql_ast.ion
@@ -540,10 +540,11 @@ select::[
     items:  list::[item],
     setq:   optional::set_quantifier,
     _: [
-      item::[
-        all::{ expr: expr },                                                  // <expr>.*
-        expression::{ expr: expr, as_alias: optional::'.identifier.symbol' }  // <expr> [as <identifier>]
-      ],
+      // <expr> [as <identifier>]
+      item::{
+        expr: expr,
+        as_alias: optional::'.identifier.symbol',
+      },
     ],
   },
 

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
@@ -526,11 +526,14 @@ class ToLegacyAstTest {
              """
             ) {
                 selectProject {
-                    items += selectProjectItemAll {
+                    items += selectProjectItem {
                         expr =
-                            exprVar(identifierSymbol("a", Identifier.CaseSensitivity.SENSITIVE), Expr.Var.Scope.DEFAULT)
+                            exprPath {
+                                root = exprVar(identifierSymbol("a", Identifier.CaseSensitivity.SENSITIVE), Expr.Var.Scope.DEFAULT)
+                                steps += exprPathStepUnpivot()
+                            }
                     }
-                    items += selectProjectItemExpression {
+                    items += selectProjectItem {
                         expr = exprLit(int32Value(1))
                         asAlias = id("x")
                     }


### PR DESCRIPTION
## Description

A project-item in the projection-list has been modeled as either an expression with an alias, or a project-all. The project-all is really a path expression with an unpivot at the end ie `foo.bar.*` but have had two ways of expressing this. This PR removes the duplication.

This is also matches our grammar

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No, these changes are not released

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.