### PR TITLE
Add tests for Ion's typed nulls

### DIFF
--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/TypedNullTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/TypedNullTests.kt
@@ -1,0 +1,57 @@
+package org.partiql.lang.eval
+
+import com.amazon.ion.IonSystem
+import com.amazon.ion.system.IonSystemBuilder
+import org.junit.Test
+import org.partiql.lang.CompilerPipeline
+
+/**
+ * The following tests demonstrate the current typed null behavior and tracks possible regressions in future commits.
+ * This behavior is what the Kotlin implementation defines and is subject to change pending resolution of
+ * https://github.com/partiql/partiql-spec/issues/61.
+ */
+class TypedNullTests : EvaluatorTestBase() {
+    // Round-tripped typed nulls (IonValue -> ExprValue -> IonValue) results in same typed null value
+    @Test
+    fun typedNullIonValueExprValueRoundTrip() {
+        val ion: IonSystem = IonSystemBuilder.standard().build()
+        val ionValue = ion.singleValue("null.int")
+        val exprValue = ExprValue.of(ionValue)
+        val roundTripped = exprValue.toIonValue(ion)
+        assertEquals(ionValue, roundTripped)
+    }
+
+    // Evaluated typed nulls converted to an IonValue preserve the typed null.
+    @Test
+    fun typedNullIonLiteralEvaluation() {
+        val pipeline = CompilerPipeline.standard()
+        val ionValueAsString = "null.int"
+        val expr = pipeline.compile("`$ionValueAsString`")
+        val session = EvaluationSession.standard()
+        val result = expr.eval(session)
+        val ionValueRoundtripped = result.toIonValue(ion)
+        assertEquals(ion.singleValue(ionValueAsString), ionValueRoundtripped)
+    }
+
+    // Evaluated typed nulls in an SFW projection. Converting result to an IonValue preserves the typed null.
+    @Test
+    fun typedNullInSFW() {
+        val pipeline = CompilerPipeline.standard()
+        val expr = pipeline.compile("SELECT t.a FROM [{'a': `null.int`}] AS t")
+        val session = EvaluationSession.standard()
+        val result = expr.eval(session)
+        val ionValueRoundtripped = result.toIonValue(ion)
+        assertEquals(ion.singleValue("\$bag::[{a: null.int}]"), ionValueRoundtripped)
+    }
+
+    // Evaluated typed nulls in an arithmetic expression will NOT preserve the type when converting back to IonValue.
+    @Test
+    fun typedNullInArithmeticOperation() {
+        val pipeline = CompilerPipeline.standard()
+        val expr = pipeline.compile("`null.int` + `null.int`")
+        val session = EvaluationSession.standard()
+        val result = expr.eval(session)
+        val ionValueRoundtripped = result.toIonValue(ion)
+        assertEquals(ion.singleValue("null"), ionValueRoundtripped)
+    }
+}


### PR DESCRIPTION
## Relevant Issues
PartiQL spec issue related to Ion's typed nulls.

## Description
Adds some tests demonstrating the Kotlin implementation's current handling of typed nulls. This behavior is consistent across the partiql-lang-kotlin versions.

## Other Information
- Updated Unreleased Section in CHANGELOG: No -- no update to public API. Just some tests.

- Any backward-incompatible changes? No

- Any new external dependencies? No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.