### PR TITLE
Tweaks to identifier handling in the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ Thank you to all who have contributed!
   - `org.partiql.lang.errors.ProblemSeverity` -> `org.partiql.errors.ProblemSeverity`
   - `org.partiql.lang.errors.ProblemHandler` -> `org.partiql.errors.ProblemHandler`
 - **Breaking** the `sourceLocation` field of `org.partiql.errors.Problem` was changed from `org.partiql.lang.ast.SoureceLocationMeta` to `org.partiql.errors.ProblemLocation`.
+- **Breaking** changes around parsing of identifiers: 
+  - Renamed grammar terminals: `IDENTIFIER` to `REGULAR_IDENTIFIER`, `IDENTIFIER_QUOTED` to `DELIMITED_IDENTIFIER`.
+  - Renamed grammar non-terminals: `symbolPrimitive` to `identifier`, `patternRestrictor` to `pathRestrictor`.
+  - The rule for `varRefExpr` now refers to `identifier` non-terminal (formerly `symbolPrimitive`), 
+    instead of its in-lined definition. 
+  - Introduced a new non-terminal `localKeyword` and its aliases.  They are now used instead 
+    of `REGULAR_IDENTIFIER` (formerly `IDENTIFIER`) in the rules for `extract`, `dateFunction`, 
+    and `pathRestrictor` (formerly `patternRestrictor`).
 
 ### Deprecated
 

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
@@ -128,7 +128,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         if (node.name !is Identifier.Symbol) {
             error("The legacy AST does not support qualified identifiers as table names")
         }
-        val tableName = (node.name as Identifier.Symbol).symbol
+        val tableName = visitIdentifierSymbol((node.name as Identifier.Symbol), ctx)
         val def = node.definition?.let { visitTableDefinition(it, ctx) }
         ddl(createTable(tableName, def), metas)
     }

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
@@ -1333,7 +1333,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
     }
 
     private fun DatetimeField.toLegacyDatetimePart(): PartiqlAst.Expr.Lit {
-        val symbol = this.toString().lowercase()
+        val symbol = this.toString()
         return pig.lit(ionSymbol(symbol))
     }
 

--- a/partiql-ast/src/main/pig/partiql.ion
+++ b/partiql-ast/src/main/pig/partiql.ion
@@ -87,8 +87,6 @@ may then be further optimized by selecting better implementations of each operat
             (lit value::ion)
 
             // A variable reference
-            // wVG-TODO: In Phase 2, this will change to (varref id::lexid),
-            //   similar to what Sprout's partiql_ast.ion does in expr.var
             (id name::symbol case::case_sensitivity qualifier::scope_qualifier)
 
             // A parameter, i.e. `?`

--- a/partiql-ast/src/main/pig/partiql.ion
+++ b/partiql-ast/src/main/pig/partiql.ion
@@ -87,6 +87,8 @@ may then be further optimized by selecting better implementations of each operat
             (lit value::ion)
 
             // A variable reference
+            // wVG-TODO: In Phase 2, this will change to (varref id::lexid),
+            //   similar to what Sprout's partiql_ast.ion does in expr.var
             (id name::symbol case::case_sensitivity qualifier::scope_qualifier)
 
             // A parameter, i.e. `?`
@@ -458,7 +460,7 @@ may then be further optimized by selecting better implementations of each operat
         // A data definition operation.
         (sum ddl_op
             // `CREATE TABLE <symbol> ( <table_def> )?`
-            (create_table table_name::symbol def::(? table_def))
+            (create_table table_name::identifier def::(? table_def))
 
             // `DROP TABLE <identifier>`
             (drop_table table_name::identifier)

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/shell/ShellHighlighter.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/shell/ShellHighlighter.kt
@@ -178,8 +178,8 @@ internal class ShellHighlighter : Highlighter {
     private fun isEOF(type: Int) = type == PartiQLTokens.EOF
 
     private fun isIdentifier(type: Int) = when (type) {
-        PartiQLTokens.IDENTIFIER,
-        PartiQLTokens.IDENTIFIER_QUOTED -> true
+        PartiQLTokens.REGULAR_IDENTIFIER,
+        PartiQLTokens.DELIMITED_IDENTIFIER -> true
         else -> false
     }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
@@ -116,7 +116,8 @@ class QueryPrettyPrinter {
     }
 
     private fun writeAstNode(node: PartiqlAst.DdlOp.CreateTable, sb: StringBuilder) {
-        sb.append("CREATE TABLE ${node.tableName.text}")
+        sb.append("CREATE TABLE ")
+        writeAstNode(node.tableName, sb)
         node.def?.let {
             var separator = "\n\t"
             sb.append(" (")

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/DateTimePart.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/DateTimePart.kt
@@ -19,7 +19,7 @@ internal enum class DateTimePart {
 
     companion object {
         fun safeValueOf(value: String): DateTimePart? = try {
-            valueOf(value.toUpperCase().trim())
+            valueOf(value)
         } catch (_: IllegalArgumentException) {
             null
         }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
@@ -247,6 +247,12 @@ internal class PartiQLPigVisitor(
         }
     }
 
+    // wVG This method is functionally equivalent to the legacy visitLexid()
+    fun readLexidAsExprId(ctx: PartiQLParser.LexidContext): PartiqlAst.Expr.Id = PartiqlAst.build {
+        val ident = readLexidAsIdentifier(ctx)
+        id(ident.name.text, ident.case, unqualified(), ident.metas)
+    }
+
     /**
      *
      * DATA DEFINITION LANGUAGE (DDL)
@@ -386,7 +392,7 @@ internal class PartiQLPigVisitor(
 
     override fun visitInsertStatement(ctx: PartiQLParser.InsertStatementContext) = PartiqlAst.build {
         insert_(
-            target = visitLexid(ctx.lexid()),
+            target = readLexidAsExprId(ctx.lexid()),
             asAlias = ctx.asIdent()?.let { visitAsIdent(it).name },
             values = visitExpr(ctx.value),
             conflictAction = ctx.onConflict()?.let { visitOnConflict(it) },
@@ -396,7 +402,7 @@ internal class PartiQLPigVisitor(
 
     override fun visitReplaceCommand(ctx: PartiQLParser.ReplaceCommandContext) = PartiqlAst.build {
         insert_(
-            target = visitLexid(ctx.lexid()),
+            target = readLexidAsExprId(ctx.lexid()),
             asAlias = ctx.asIdent()?.let { visitAsIdent(it).name },
             values = visitExpr(ctx.value),
             conflictAction = doReplace(excluded()),
@@ -407,7 +413,7 @@ internal class PartiQLPigVisitor(
     // Based on https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md
     override fun visitUpsertCommand(ctx: PartiQLParser.UpsertCommandContext) = PartiqlAst.build {
         insert_(
-            target = visitLexid(ctx.lexid()),
+            target = readLexidAsExprId(ctx.lexid()),
             asAlias = ctx.asIdent()?.let { visitAsIdent(it).name },
             values = visitExpr(ctx.value),
             conflictAction = doUpdate(excluded()),
@@ -501,7 +507,7 @@ internal class PartiQLPigVisitor(
     }
 
     override fun visitPathSimple(ctx: PartiQLParser.PathSimpleContext) = PartiqlAst.build {
-        val root = visitLexid(ctx.lexid())
+        val root = readLexidAsExprId(ctx.lexid())
         if (ctx.pathSimpleSteps().isEmpty()) return@build root
         val steps = ctx.pathSimpleSteps().map { visit(it) as PartiqlAst.PathStep }
         path(root, steps, root.metas)
@@ -512,7 +518,7 @@ internal class PartiQLPigVisitor(
     }
 
     override fun visitPathSimpleSymbol(ctx: PartiQLParser.PathSimpleSymbolContext) = PartiqlAst.build {
-        pathExpr(visitLexid(ctx.lexid()), caseSensitive())
+        pathExpr(readLexidAsExprId(ctx.lexid()), caseSensitive())
     }
 
     override fun visitPathSimpleDotSymbol(ctx: PartiQLParser.PathSimpleDotSymbolContext) =

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
@@ -235,11 +235,13 @@ internal class PartiQLPigVisitor(
         when (ctx.ident.type) {
             PartiQLParser.REGULAR_IDENTIFIER -> {
                 val strId = ctx.REGULAR_IDENTIFIER().text
-                identifier(strId, caseInsensitive(), metas)
+                val symId = SymbolPrimitive(strId, metas)
+                identifier_(symId, caseInsensitive(), metas)
             }
             PartiQLParser.DELIMITED_IDENTIFIER -> {
                 val strId = ctx.DELIMITED_IDENTIFIER().text.trim('\"').replace("\"\"", "\"")
-                identifier(strId, caseSensitive(), metas)
+                val symId = SymbolPrimitive(strId, metas)
+                identifier_(symId, caseSensitive(), metas)
             }
             else -> throw ParserException("Bug: only REGULAR_IDENTIFIER or DELIMITED_IDENTIFIER should be possible", ErrorCode.PARSE_UNEXPECTED_TOKEN)
         }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/util/AntlrUtilities.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/util/AntlrUtilities.kt
@@ -89,7 +89,7 @@ internal fun getIonElement(token: Token): IonElement {
         } catch (e: NumberFormatException) {
             throw token.error(e.localizedMessage, ErrorCode.PARSE_EXPECTED_NUMBER, cause = e)
         }
-        PartiQLParser.IDENTIFIER_QUOTED -> ionSymbol(text.trim('\"').replace("\"\"", "\""))
+        PartiQLParser.DELIMITED_IDENTIFIER -> ionSymbol(text.trim('\"').replace("\"\"", "\""))
         else -> ionSymbol(text)
     }
 }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -438,7 +438,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 27L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("b")
             )
         )
@@ -746,7 +746,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 6L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("something")
             ),
         )
@@ -1056,7 +1056,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 31L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("bar")
             )
         )
@@ -1294,7 +1294,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 25L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("ON_CONFLICT")
             )
         )
@@ -1364,7 +1364,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 50L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("SOMETHING")
             ),
         )
@@ -1378,7 +1378,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 32L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("ON_CONFLICT")
             )
         )
@@ -1448,7 +1448,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 57L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("SOMETHING")
             ),
         )
@@ -1476,7 +1476,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 38L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("ECSAPE")
             )
         )
@@ -1664,7 +1664,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 14L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("b")
             ),
 
@@ -1739,7 +1739,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 9L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("b")
             )
         )
@@ -1859,7 +1859,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 15L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("a"),
             ),
 
@@ -1874,7 +1874,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 10L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("a")
             )
         )
@@ -2140,7 +2140,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
         mapOf(
             Property.LINE_NUMBER to 1L,
             Property.COLUMN_NUMBER to 8L,
-            Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+            Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
             Property.TOKEN_VALUE to ion.newSymbol("x")
         )
     )
@@ -2498,7 +2498,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
         mapOf(
             Property.LINE_NUMBER to 1L,
             Property.COLUMN_NUMBER to 25L,
-            Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+            Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
             Property.TOKEN_VALUE to ion.newSymbol("RETURING")
         )
     )
@@ -2511,7 +2511,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 35L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("UPDATED")
             ),
 
@@ -2541,7 +2541,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 50L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("b")
             ),
 
@@ -2627,7 +2627,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
         mapOf(
             Property.LINE_NUMBER to 1L,
             Property.COLUMN_NUMBER to 36L,
-            Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+            Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
             Property.TOKEN_VALUE to ion.newSymbol("name_is_present")
         )
     )
@@ -2656,7 +2656,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
         mapOf(
             Property.LINE_NUMBER to 3L,
             Property.COLUMN_NUMBER to 16L,
-            Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+            Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
             Property.TOKEN_VALUE to ion.newSymbol("city")
         )
     )
@@ -2704,7 +2704,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
         mapOf(
             Property.LINE_NUMBER to 1L,
             Property.COLUMN_NUMBER to 14L,
-            Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+            Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
             Property.TOKEN_VALUE to ion.newSymbol("foo_index")
         )
     )
@@ -2728,7 +2728,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
         mapOf(
             Property.LINE_NUMBER to 1L,
             Property.COLUMN_NUMBER to 21L,
-            Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+            Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
             Property.TOKEN_VALUE to ion.newSymbol("bar")
         )
     )
@@ -2821,7 +2821,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
         mapOf(
             Property.LINE_NUMBER to 1L,
             Property.COLUMN_NUMBER to 16L,
-            Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+            Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
             Property.TOKEN_VALUE to ion.newSymbol("foo")
         )
     )
@@ -3054,7 +3054,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
             mapOf(
                 Property.LINE_NUMBER to 1L,
                 Property.COLUMN_NUMBER to 6L,
-                Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                 Property.TOKEN_VALUE to ion.newSymbol("foo")
             ),
         )

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinterTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinterTest.kt
@@ -63,7 +63,7 @@ class ASTPrettyPrinterTest {
             """
                 Ddl
                     op: CreateTable
-                        tableName: Symbol foo
+                        tableName: Identifier foo (case_insensitive)
             """.trimIndent()
         )
     }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserDateTimeTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserDateTimeTests.kt
@@ -656,7 +656,7 @@ class PartiQLParserDateTimeTests : PartiQLParserTestBase() {
                 errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
                 line = 1L,
                 col = 11L,
-                tokenType = PartiQLParser.IDENTIFIER,
+                tokenType = PartiQLParser.REGULAR_IDENTIFIER,
                 tokenValue = ION.newSymbol("TIMEZONE")
             ),
             createErrorCaseForDateTime(
@@ -664,7 +664,7 @@ class PartiQLParserDateTimeTests : PartiQLParserTestBase() {
                 line = 1L,
                 col = 6L,
                 errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
-                tokenType = PartiQLParser.IDENTIFIER,
+                tokenType = PartiQLParser.REGULAR_IDENTIFIER,
                 tokenValue = ION.newSymbol("WITH_TIME_ZONE")
             ),
             createErrorCaseForDateTime(
@@ -672,7 +672,7 @@ class PartiQLParserDateTimeTests : PartiQLParserTestBase() {
                 line = 1L,
                 col = 6L,
                 errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
-                tokenType = PartiQLParser.IDENTIFIER,
+                tokenType = PartiQLParser.REGULAR_IDENTIFIER,
                 tokenValue = ION.newSymbol("WITHTIMEZONE")
             ),
             // PartiQL doesn't support "WITHOUT TIME ZONE" yet. TIME '<time_string>' is in effect the same as TIME WITHOUT TIME ZONE '<time_string>'
@@ -681,7 +681,7 @@ class PartiQLParserDateTimeTests : PartiQLParserTestBase() {
                 line = 1L,
                 col = 6L,
                 errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
-                tokenType = PartiQLParser.IDENTIFIER,
+                tokenType = PartiQLParser.REGULAR_IDENTIFIER,
                 tokenValue = ION.newSymbol("WITHOUT")
             ),
             createErrorCaseForDateTime(
@@ -690,7 +690,7 @@ class PartiQLParserDateTimeTests : PartiQLParserTestBase() {
                 errorContext = mapOf(
                     Property.LINE_NUMBER to 1L,
                     Property.COLUMN_NUMBER to 16L,
-                    Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                    Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                     Property.TOKEN_VALUE to ION.newSymbol("PHONE")
                 )
             ),
@@ -1070,7 +1070,7 @@ class PartiQLParserDateTimeTests : PartiQLParserTestBase() {
                 errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
                 line = 1L,
                 col = 16L,
-                tokenType = PartiQLParser.IDENTIFIER,
+                tokenType = PartiQLParser.REGULAR_IDENTIFIER,
                 tokenValue = ION.newSymbol("TIMEZONE")
             ),
             createErrorCaseForDateTime(
@@ -1078,7 +1078,7 @@ class PartiQLParserDateTimeTests : PartiQLParserTestBase() {
                 line = 1L,
                 col = 11L,
                 errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
-                tokenType = PartiQLParser.IDENTIFIER,
+                tokenType = PartiQLParser.REGULAR_IDENTIFIER,
                 tokenValue = ION.newSymbol("WITH_TIME_ZONE")
             ),
             createErrorCaseForDateTime(
@@ -1086,7 +1086,7 @@ class PartiQLParserDateTimeTests : PartiQLParserTestBase() {
                 line = 1L,
                 col = 11L,
                 errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
-                tokenType = PartiQLParser.IDENTIFIER,
+                tokenType = PartiQLParser.REGULAR_IDENTIFIER,
                 tokenValue = ION.newSymbol("WITHTIMEZONE")
             ),
             createErrorCaseForDateTime(
@@ -1094,7 +1094,7 @@ class PartiQLParserDateTimeTests : PartiQLParserTestBase() {
                 line = 1L,
                 col = 11L,
                 errorCode = ErrorCode.PARSE_UNEXPECTED_TOKEN,
-                tokenType = PartiQLParser.IDENTIFIER,
+                tokenType = PartiQLParser.REGULAR_IDENTIFIER,
                 tokenValue = ION.newSymbol("WITHOUT")
             ),
             createErrorCaseForDateTime(
@@ -1103,7 +1103,7 @@ class PartiQLParserDateTimeTests : PartiQLParserTestBase() {
                 errorContext = mapOf(
                     Property.LINE_NUMBER to 1L,
                     Property.COLUMN_NUMBER to 21L,
-                    Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                    Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                     Property.TOKEN_VALUE to ION.newSymbol("PHONE")
                 )
             ),

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserExplainTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserExplainTest.kt
@@ -134,7 +134,7 @@ class PartiQLParserExplainTest : PartiQLParserTestBase() {
                 context = mapOf(
                     Property.LINE_NUMBER to 1L,
                     Property.COLUMN_NUMBER to 10L,
-                    Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                    Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                     Property.TOKEN_VALUE to ION.newSymbol("typ")
                 )
             ),
@@ -156,7 +156,7 @@ class PartiQLParserExplainTest : PartiQLParserTestBase() {
                 context = mapOf(
                     Property.LINE_NUMBER to 1L,
                     Property.COLUMN_NUMBER to 25L,
-                    Property.TOKEN_DESCRIPTION to PartiQLParser.IDENTIFIER.getAntlrDisplayString(),
+                    Property.TOKEN_DESCRIPTION to PartiQLParser.REGULAR_IDENTIFIER.getAntlrDisplayString(),
                     Property.TOKEN_VALUE to ION.newSymbol("logical")
                 )
             )

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -3928,14 +3928,15 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun createTable() = assertExpression(
         "CREATE TABLE foo",
-        "(ddl (create_table foo null))"
+        "(ddl (create_table (identifier foo (case_insensitive)) null))"
     )
 
     @Test
     fun createTableWithColumn() = assertExpression(
         "CREATE TABLE foo (boo string)",
         """
-            (ddl (create_table foo  (table_def
+            (ddl (create_table (identifier foo (case_insensitive))  
+              (table_def
                 (column_declaration boo (string_type)))))
         """.trimIndent()
     )
@@ -3944,7 +3945,8 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     fun createTableWithQuotedIdentifier() = assertExpression(
         "CREATE TABLE \"user\" (\"lastname\" string)",
         """
-            (ddl (create_table user (table_def
+            (ddl (create_table (identifier user (case_sensitive)) 
+              (table_def
                 (column_declaration lastname (string_type)))))
         """.trimIndent()
     )
@@ -3962,7 +3964,10 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         """
             (ddl
                 (create_table
-                    Customer (table_def
+                    (identifier
+                        Customer
+                        (case_insensitive)) 
+                    (table_def
                         (column_declaration name (string_type)
                             (column_constraint name_is_present (column_notnull)))
                         (column_declaration age (integer_type))

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -828,49 +828,49 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun callDateArithYear() = assertDateArithmetic(
         "date_<op>(year, a, b)",
-        "(call date_<op> (lit year) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit YEAR) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithMonth() = assertDateArithmetic(
         "date_<op>(month, a, b)",
-        "(call date_<op> (lit month) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit MONTH) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithDay() = assertDateArithmetic(
         "date_<op>(day, a, b)",
-        "(call date_<op> (lit day) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit DAY) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithHour() = assertDateArithmetic(
         "date_<op>(hour, a, b)",
-        "(call date_<op> (lit hour) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit HOUR) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithMinute() = assertDateArithmetic(
         "date_<op>(minute, a, b)",
-        "(call date_<op> (lit minute) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit MINUTE) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithSecond() = assertDateArithmetic(
         "date_<op>(second, a, b)",
-        "(call date_<op> (lit second) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit SECOND) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test // invalid evaluation, but valid parsing
     fun callDateArithTimezoneHour() = assertDateArithmetic(
         "date_<op>(timezone_hour, a, b)",
-        "(call date_<op> (lit timezone_hour) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit TIMEZONE_HOUR) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test // invalid evaluation, but valid parsing
     fun callDateArithTimezoneMinute() = assertDateArithmetic(
         "date_<op>(timezone_minute, a, b)",
-        "(call date_<op> (lit timezone_minute) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call date_<op> (lit TIMEZONE_MINUTE) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     // ****************************************
@@ -879,49 +879,49 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun callExtractYear() = assertExpression(
         "extract(year from a)",
-        "(call extract (lit year) (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit YEAR) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractMonth() = assertExpression(
         "extract(month from a)",
-        "(call extract (lit month) (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit MONTH) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractDay() = assertExpression(
         "extract(day from a)",
-        "(call extract (lit day) (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit DAY) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractHour() = assertExpression(
         "extract(hour from a)",
-        "(call extract (lit hour) (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit HOUR) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractMinute() = assertExpression(
         "extract(minute from a)",
-        "(call extract (lit minute) (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit MINUTE) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractSecond() = assertExpression(
         "extract(second from a)",
-        "(call extract (lit second) (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit SECOND) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractTimezoneHour() = assertExpression(
         "extract(timezone_hour from a)",
-        "(call extract (lit timezone_hour) (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit TIMEZONE_HOUR) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractTimezoneMinute() = assertExpression(
         "extract(timezone_minute from a)",
-        "(call extract (lit timezone_minute) (id a (case_insensitive) (unqualified)))"
+        "(call extract (lit TIMEZONE_MINUTE) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test

--- a/partiql-parser/src/main/antlr/PartiQL.g4
+++ b/partiql-parser/src/main/antlr/PartiQL.g4
@@ -28,7 +28,7 @@ statement
  */
 
 explainOption
-    : param=IDENTIFIER value=IDENTIFIER;
+    : param=REGULAR_IDENTIFIER value=REGULAR_IDENTIFIER;
 
 asIdent
     : AS symbolPrimitive;
@@ -40,7 +40,7 @@ byIdent
     : BY symbolPrimitive;
 
 symbolPrimitive
-    : ident=( IDENTIFIER | IDENTIFIER_QUOTED )
+    : ident=( REGULAR_IDENTIFIER | DELIMITED_IDENTIFIER )
     ;
 
 /**
@@ -377,7 +377,7 @@ patternPathVariable
     : symbolPrimitive EQ;
 
 patternRestrictor    // Should be TRAIL / ACYCLIC / SIMPLE
-    : restrictor=IDENTIFIER;
+    : restrictor=REGULAR_IDENTIFIER;
 
 node
     : PAREN_LEFT symbolPrimitive? ( COLON labelSpec )? whereClause? PAREN_RIGHT;
@@ -680,13 +680,13 @@ canCast
     : CAN_CAST PAREN_LEFT expr AS type PAREN_RIGHT;
 
 extract
-    : EXTRACT PAREN_LEFT IDENTIFIER FROM rhs=expr PAREN_RIGHT;
+    : EXTRACT PAREN_LEFT REGULAR_IDENTIFIER FROM rhs=expr PAREN_RIGHT;
 
 trimFunction
-    : func=TRIM PAREN_LEFT ( mod=IDENTIFIER? sub=expr? FROM )? target=expr PAREN_RIGHT;
+    : func=TRIM PAREN_LEFT ( mod=REGULAR_IDENTIFIER? sub=expr? FROM )? target=expr PAREN_RIGHT;
 
 dateFunction
-    : func=(DATE_ADD|DATE_DIFF) PAREN_LEFT dt=IDENTIFIER COMMA expr COMMA expr PAREN_RIGHT;
+    : func=(DATE_ADD|DATE_DIFF) PAREN_LEFT dt=REGULAR_IDENTIFIER COMMA expr COMMA expr PAREN_RIGHT;
 
 functionCall
     : name=( CHAR_LENGTH | CHARACTER_LENGTH | OCTET_LENGTH |
@@ -713,7 +713,7 @@ parameter
     : QUESTION_MARK;
 
 varRefExpr
-    : qualifier=AT_SIGN? ident=(IDENTIFIER|IDENTIFIER_QUOTED)   # VariableIdentifier
+    : qualifier=AT_SIGN? ident=(REGULAR_IDENTIFIER|DELIMITED_IDENTIFIER)   # VariableIdentifier
     | qualifier=AT_SIGN? key=nonReservedKeywords                # VariableKeyword
     ;
 

--- a/partiql-parser/src/main/antlr/PartiQL.g4
+++ b/partiql-parser/src/main/antlr/PartiQL.g4
@@ -723,7 +723,7 @@ parameter
     : QUESTION_MARK;
 
 varRefExpr
-    : qualifier=AT_SIGN? ident=(REGULAR_IDENTIFIER|DELIMITED_IDENTIFIER)   # VariableIdentifier
+    : qualifier=AT_SIGN? ident=lexid                            # VariableIdentifier
     | qualifier=AT_SIGN? key=nonReservedKeywords                # VariableKeyword
     ;
 

--- a/partiql-parser/src/main/antlr/PartiQL.g4
+++ b/partiql-parser/src/main/antlr/PartiQL.g4
@@ -30,8 +30,8 @@ statement
  *
  */
 
-// A local keyword is treated as a keyword only in a limited context (such as DAY, HOUR within a call to a date-time function),
-// while being available as a regular identifier in other contexts.
+// A local keyword is treated as a keyword (in post-ANTLR processing) only in a limited context (such as DAY, HOUR
+// within a call to a date-time function), while being available as a regular identifier in other contexts.
 localKeyword
     : REGULAR_IDENTIFIER ;
 

--- a/partiql-parser/src/main/antlr/PartiQL.g4
+++ b/partiql-parser/src/main/antlr/PartiQL.g4
@@ -14,6 +14,9 @@ options {
 root
     : (EXPLAIN (PAREN_LEFT explainOption (COMMA explainOption)* PAREN_RIGHT)? )? statement;
 
+explainOption
+    : param=REGULAR_IDENTIFIER value=REGULAR_IDENTIFIER;
+
 statement
     : dql COLON_SEMI? EOF          # QueryDql
     | dml COLON_SEMI? EOF          # QueryDml
@@ -27,8 +30,12 @@ statement
  *
  */
 
-explainOption
-    : param=REGULAR_IDENTIFIER value=REGULAR_IDENTIFIER;
+localKeyword
+    : REGULAR_IDENTIFIER ;
+
+symbolPrimitive
+    : ident=( REGULAR_IDENTIFIER | DELIMITED_IDENTIFIER )
+    ;
 
 asIdent
     : AS symbolPrimitive;
@@ -38,10 +45,6 @@ atIdent
 
 byIdent
     : BY symbolPrimitive;
-
-symbolPrimitive
-    : ident=( REGULAR_IDENTIFIER | DELIMITED_IDENTIFIER )
-    ;
 
 /**
  *
@@ -679,14 +682,17 @@ canLosslessCast
 canCast
     : CAN_CAST PAREN_LEFT expr AS type PAREN_RIGHT;
 
+// Must be one of: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, TIMEZONE_HOUR, TIMEZONE_MINUTE
+dateTimeField : localKeyword ;
+
 extract
-    : EXTRACT PAREN_LEFT REGULAR_IDENTIFIER FROM rhs=expr PAREN_RIGHT;
+    : EXTRACT PAREN_LEFT field=dateTimeField FROM rhs=expr PAREN_RIGHT;
+
+dateFunction
+    : func=(DATE_ADD|DATE_DIFF) PAREN_LEFT field=dateTimeField COMMA expr COMMA expr PAREN_RIGHT;
 
 trimFunction
     : func=TRIM PAREN_LEFT ( mod=REGULAR_IDENTIFIER? sub=expr? FROM )? target=expr PAREN_RIGHT;
-
-dateFunction
-    : func=(DATE_ADD|DATE_DIFF) PAREN_LEFT dt=REGULAR_IDENTIFIER COMMA expr COMMA expr PAREN_RIGHT;
 
 functionCall
     : name=( CHAR_LENGTH | CHARACTER_LENGTH | OCTET_LENGTH |

--- a/partiql-parser/src/main/antlr/PartiQL.g4
+++ b/partiql-parser/src/main/antlr/PartiQL.g4
@@ -30,6 +30,8 @@ statement
  *
  */
 
+// A local keyword is treated as a keyword only in a limited context (such as DAY, HOUR within a call to a date-time function),
+// while being available as a regular identifier in other contexts.
 localKeyword
     : REGULAR_IDENTIFIER ;
 
@@ -362,7 +364,7 @@ gpmlPatternList
     : selector=matchSelector? matchPattern ( COMMA matchPattern )*;
 
 matchPattern
-    : restrictor=patternRestrictor? variable=patternPathVariable? graphPart*;
+    : restrictor=pathRestrictor? variable=patternPathVariable? graphPart*;
 
 graphPart
     : node
@@ -379,8 +381,8 @@ matchSelector
 patternPathVariable
     : symbolPrimitive EQ;
 
-patternRestrictor    // Should be TRAIL / ACYCLIC / SIMPLE
-    : restrictor=REGULAR_IDENTIFIER;
+// Must be one of: TRAIL / ACYCLIC / SIMPLE
+pathRestrictor : localKeyword ;
 
 node
     : PAREN_LEFT symbolPrimitive? ( COLON labelSpec )? whereClause? PAREN_RIGHT;
@@ -391,8 +393,8 @@ edge
     ;
 
 pattern
-    : PAREN_LEFT restrictor=patternRestrictor? variable=patternPathVariable? graphPart+ where=whereClause? PAREN_RIGHT quantifier=patternQuantifier?
-    | BRACKET_LEFT restrictor=patternRestrictor? variable=patternPathVariable? graphPart+ where=whereClause? BRACKET_RIGHT quantifier=patternQuantifier?
+    : PAREN_LEFT restrictor=pathRestrictor? variable=patternPathVariable? graphPart+ where=whereClause? PAREN_RIGHT quantifier=patternQuantifier?
+    | BRACKET_LEFT restrictor=pathRestrictor? variable=patternPathVariable? graphPart+ where=whereClause? BRACKET_RIGHT quantifier=patternQuantifier?
     ;
 
 patternQuantifier

--- a/partiql-parser/src/main/antlr/PartiQLTokens.g4
+++ b/partiql-parser/src/main/antlr/PartiQLTokens.g4
@@ -368,10 +368,10 @@ LITERAL_DECIMAL:
     | DIGIT DIGIT* ([e] [+-]? DIGIT+)?
     ;
 
-IDENTIFIER
+REGULAR_IDENTIFIER
     : [A-Z$_][A-Z0-9$_]*;
 
-IDENTIFIER_QUOTED
+DELIMITED_IDENTIFIER
     : '"' ( ('""') | ~('"') )* '"';
 
 /**

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
@@ -402,11 +402,11 @@ internal class PartiQLParserDefault : PartiQLParser {
          *
          */
 
-        override fun visitAsIdent(ctx: GeneratedParser.AsIdentContext) = visitSymbolPrimitive(ctx.symbolPrimitive())
+        override fun visitAsIdent(ctx: GeneratedParser.AsIdentContext) = visitLexid(ctx.lexid())
 
-        override fun visitAtIdent(ctx: GeneratedParser.AtIdentContext) = visitSymbolPrimitive(ctx.symbolPrimitive())
+        override fun visitAtIdent(ctx: GeneratedParser.AtIdentContext) = visitLexid(ctx.lexid())
 
-        override fun visitByIdent(ctx: GeneratedParser.ByIdentContext) = visitSymbolPrimitive(ctx.symbolPrimitive())
+        override fun visitByIdent(ctx: GeneratedParser.ByIdentContext) = visitLexid(ctx.lexid())
 
         /** Interpret an ANTLR-parsed regular identifier as one of expected local keywords. */
         private fun readLocalKeyword(
@@ -419,7 +419,7 @@ internal class PartiQLParserDefault : PartiQLParser {
                 return keyword
             else throw error(ctx, "Expected one of: ${expected.joinToString(", ")}.")
         }
-        override fun visitSymbolPrimitive(ctx: GeneratedParser.SymbolPrimitiveContext) = translate(ctx) {
+        override fun visitLexid(ctx: GeneratedParser.LexidContext) = translate(ctx) {
             when (ctx.ident.type) {
                 GeneratedParser.DELIMITED_IDENTIFIER -> identifierSymbol(
                     ctx.DELIMITED_IDENTIFIER().getStringValue(),
@@ -442,18 +442,18 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitQueryDdl(ctx: GeneratedParser.QueryDdlContext): AstNode = visitDdl(ctx.ddl())
 
         override fun visitDropTable(ctx: GeneratedParser.DropTableContext) = translate(ctx) {
-            val table = visitSymbolPrimitive(ctx.tableName().symbolPrimitive())
+            val table = visitLexid(ctx.tableName().lexid())
             statementDDLDropTable(table)
         }
 
         override fun visitDropIndex(ctx: GeneratedParser.DropIndexContext) = translate(ctx) {
-            val table = visitSymbolPrimitive(ctx.on)
-            val index = visitSymbolPrimitive(ctx.target)
+            val table = visitLexid(ctx.on)
+            val index = visitLexid(ctx.target)
             statementDDLDropIndex(index, table)
         }
 
         override fun visitCreateTable(ctx: GeneratedParser.CreateTableContext) = translate(ctx) {
-            val table = visitSymbolPrimitive(ctx.tableName().symbolPrimitive())
+            val table = visitLexid(ctx.tableName().lexid())
             val definition = ctx.tableDef()?.let { visitTableDef(it) }
             statementDDLCreateTable(table, definition)
         }
@@ -461,7 +461,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitCreateIndex(ctx: GeneratedParser.CreateIndexContext) = translate(ctx) {
             // TODO add index name to ANTLR grammar
             val name: Identifier? = null
-            val table = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val table = visitLexid(ctx.lexid())
             val fields = ctx.pathSimple().map { path -> visitPathSimple(path) }
             statementDDLCreateIndex(name, table, fields)
         }
@@ -475,7 +475,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitColumnDeclaration(ctx: GeneratedParser.ColumnDeclarationContext) = translate(ctx) {
-            val name = symbolToString(ctx.columnName().symbolPrimitive())
+            val name = symbolToString(ctx.columnName().lexid())
             val type = visit(ctx.type()) as Type
             val constraints = ctx.columnConstraint().map {
                 visitColumnConstraint(it)
@@ -484,7 +484,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitColumnConstraint(ctx: GeneratedParser.ColumnConstraintContext) = translate(ctx) {
-            val identifier = ctx.columnConstraintName()?.let { symbolToString(it.symbolPrimitive()) }
+            val identifier = ctx.columnConstraintName()?.let { symbolToString(it.lexid()) }
             val body = visit(ctx.columnConstraintDef()) as TableDefinition.Column.Constraint.Body
             tableDefinitionColumnConstraint(identifier, body)
         }
@@ -620,7 +620,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitInsertStatement(ctx: GeneratedParser.InsertStatementContext) = translate(ctx) {
-            val target = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val target = visitLexid(ctx.lexid())
             val values = visitExpr(ctx.value)
             val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
             val onConflict = ctx.onConflict()?.let { visitOnConflictClause(it) }
@@ -628,14 +628,14 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitReplaceCommand(ctx: GeneratedParser.ReplaceCommandContext) = translate(ctx) {
-            val target = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val target = visitLexid(ctx.lexid())
             val values = visitExpr(ctx.value)
             val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
             statementDMLReplace(target, values, asAlias)
         }
 
         override fun visitUpsertCommand(ctx: GeneratedParser.UpsertCommandContext) = translate(ctx) {
-            val target = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val target = visitLexid(ctx.lexid())
             val values = visitExpr(ctx.value)
             val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
             statementDMLUpsert(target, values, asAlias)
@@ -681,9 +681,9 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitConflictTarget(ctx: GeneratedParser.ConflictTargetContext) = translate(ctx) {
             if (ctx.constraintName() != null) {
-                onConflictTargetConstraint(visitSymbolPrimitive(ctx.constraintName().symbolPrimitive()))
+                onConflictTargetConstraint(visitLexid(ctx.constraintName().lexid()))
             } else {
-                val symbols = ctx.symbolPrimitive().map { visitSymbolPrimitive(it) }
+                val symbols = ctx.lexid().map { visitLexid(it) }
                 onConflictTargetSymbols(symbols)
             }
         }
@@ -706,7 +706,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitPathSimple(ctx: GeneratedParser.PathSimpleContext) = translate(ctx) {
-            val root = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val root = visitLexid(ctx.lexid())
             val steps = visitOrEmpty<Path.Step>(ctx.pathSimpleSteps())
             path(root, steps)
         }
@@ -728,12 +728,12 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitPathSimpleSymbol(ctx: GeneratedParser.PathSimpleSymbolContext) = translate(ctx) {
-            val identifier = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val identifier = visitLexid(ctx.lexid())
             pathStepSymbol(identifier)
         }
 
         override fun visitPathSimpleDotSymbol(ctx: GeneratedParser.PathSimpleDotSymbolContext) = translate(ctx) {
-            val identifier = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val identifier = visitLexid(ctx.lexid())
             pathStepSymbol(identifier)
         }
 
@@ -815,7 +815,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitProjectionItem(ctx: GeneratedParser.ProjectionItemContext) = translate(ctx) {
             val expr = visitExpr(ctx.expr())
-            val alias = ctx.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
+            val alias = ctx.lexid()?.let { visitLexid(it) }
             if (expr is Expr.Path) {
                 convertPathToProjectionItem(ctx, expr, alias)
             } else {
@@ -859,7 +859,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitLetBinding(ctx: GeneratedParser.LetBindingContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.expr())
-            val alias = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val alias = visitLexid(ctx.lexid())
             letBinding(expr, alias)
         }
 
@@ -900,13 +900,13 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitGroupClause(ctx: GeneratedParser.GroupClauseContext) = translate(ctx) {
             val strategy = if (ctx.PARTIAL() != null) GroupBy.Strategy.PARTIAL else GroupBy.Strategy.FULL
             val keys = visitOrEmpty<GroupBy.Key>(ctx.groupKey())
-            val alias = ctx.groupAlias()?.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
+            val alias = ctx.groupAlias()?.lexid()?.let { visitLexid(it) }
             groupBy(strategy, keys, alias)
         }
 
         override fun visitGroupKey(ctx: GeneratedParser.GroupKeyContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.key)
-            val alias = ctx.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
+            val alias = ctx.lexid()?.let { visitLexid(it) }
             groupByKey(expr, alias)
         }
 
@@ -981,7 +981,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitPatternPathVariable(ctx: GeneratedParser.PatternPathVariableContext) =
-            visitSymbolPrimitive(ctx.symbolPrimitive())
+            visitLexid(ctx.lexid())
 
         override fun visitSelectorBasic(ctx: GeneratedParser.SelectorBasicContext) = translate(ctx) {
             when (ctx.mod.type) {
@@ -1024,7 +1024,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitLabelPrimaryName(ctx: GeneratedParser.LabelPrimaryNameContext) = translate(ctx) {
-            val x = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val x = visitLexid(ctx.lexid())
             graphMatchLabelName(x.symbol)
         }
 
@@ -1058,7 +1058,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitEdgeSpec(ctx: GeneratedParser.EdgeSpecContext) = translate(ctx) {
             val placeholderDirection = GraphMatch.Direction.RIGHT
-            val variable = visitOrNull<Identifier.Symbol>(ctx.symbolPrimitive())?.symbol
+            val variable = visitOrNull<Identifier.Symbol>(ctx.lexid())?.symbol
             val prefilter = ctx.whereClause()?.let { visitExpr(it.expr()) }
             val label = visitOrNull<GraphMatch.Label>(ctx.labelSpec())
             graphMatchPatternPartEdge(placeholderDirection, null, prefilter, variable, label)
@@ -1128,7 +1128,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitNode(ctx: GeneratedParser.NodeContext) = translate(ctx) {
-            val variable = visitOrNull<Identifier.Symbol>(ctx.symbolPrimitive())?.symbol
+            val variable = visitOrNull<Identifier.Symbol>(ctx.lexid())?.symbol
             val prefilter = ctx.whereClause()?.let { visitExpr(it.expr()) }
             val label = visitOrNull<GraphMatch.Label>(ctx.labelSpec())
             graphMatchPatternPartNode(prefilter, variable, label)
@@ -1155,17 +1155,17 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitTableBaseRefClauses(ctx: GeneratedParser.TableBaseRefClausesContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val asAlias = ctx.asIdent()?.let { visitLexid(it.lexid()) }
+            val atAlias = ctx.atIdent()?.let { visitLexid(it.lexid()) }
+            val byAlias = ctx.byIdent()?.let { visitLexid(it.lexid()) }
             fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
 
         override fun visitTableBaseRefMatch(ctx: GeneratedParser.TableBaseRefMatchContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val asAlias = ctx.asIdent()?.let { visitLexid(it.lexid()) }
+            val atAlias = ctx.atIdent()?.let { visitLexid(it.lexid()) }
+            val byAlias = ctx.byIdent()?.let { visitLexid(it.lexid()) }
             fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
 
@@ -1187,15 +1187,15 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitFromClauseSimpleImplicit(ctx: GeneratedParser.FromClauseSimpleImplicitContext) =
             translate(ctx) {
                 val path = visitPathSimple(ctx.pathSimple())
-                val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive())
+                val asAlias = visitLexid(ctx.lexid())
                 statementDMLDeleteTarget(path, asAlias, null, null)
             }
 
         override fun visitTableUnpivot(ctx: GeneratedParser.TableUnpivotContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.expr())
-            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val asAlias = ctx.asIdent()?.let { visitLexid(it.lexid()) }
+            val atAlias = ctx.atIdent()?.let { visitLexid(it.lexid()) }
+            val byAlias = ctx.byIdent()?.let { visitLexid(it.lexid()) }
             fromValue(expr, From.Value.Type.UNPIVOT, asAlias, atAlias, byAlias)
         }
 
@@ -1241,7 +1241,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitTableBaseRefSymbol(ctx: GeneratedParser.TableBaseRefSymbolContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val asAlias = visitLexid(ctx.lexid())
             fromValue(expr, From.Value.Type.SCAN, asAlias, null, null)
         }
 
@@ -1437,7 +1437,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitPathStepDotExpr(ctx: GeneratedParser.PathStepDotExprContext) = translate(ctx) {
-            val symbol = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val symbol = visitLexid(ctx.lexid())
             exprPathStepSymbol(symbol)
         }
 
@@ -1528,7 +1528,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitFunctionCallIdent(ctx: GeneratedParser.FunctionCallIdentContext) = translate(ctx) {
-            val function = visitSymbolPrimitive(ctx.name)
+            val function = visitLexid(ctx.name)
             val args = visitOrEmpty<Expr>(ctx.expr())
             exprCall(function, args)
         }
@@ -1886,7 +1886,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         /**
          * Visiting a symbol to get a string, skip the wrapping, unwrapping, and location tracking.
          */
-        private fun symbolToString(ctx: GeneratedParser.SymbolPrimitiveContext) = when (ctx.ident.type) {
+        private fun symbolToString(ctx: GeneratedParser.LexidContext) = when (ctx.ident.type) {
             GeneratedParser.DELIMITED_IDENTIFIER -> ctx.DELIMITED_IDENTIFIER().getStringValue()
             GeneratedParser.REGULAR_IDENTIFIER -> ctx.REGULAR_IDENTIFIER().getStringValue()
             else -> throw error(ctx, "Invalid symbol reference.")

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
@@ -402,11 +402,11 @@ internal class PartiQLParserDefault : PartiQLParser {
          *
          */
 
-        override fun visitAsIdent(ctx: GeneratedParser.AsIdentContext) = visitLexid(ctx.lexid())
+        override fun visitAsIdent(ctx: GeneratedParser.AsIdentContext) = visitIdentifier(ctx.identifier())
 
-        override fun visitAtIdent(ctx: GeneratedParser.AtIdentContext) = visitLexid(ctx.lexid())
+        override fun visitAtIdent(ctx: GeneratedParser.AtIdentContext) = visitIdentifier(ctx.identifier())
 
-        override fun visitByIdent(ctx: GeneratedParser.ByIdentContext) = visitLexid(ctx.lexid())
+        override fun visitByIdent(ctx: GeneratedParser.ByIdentContext) = visitIdentifier(ctx.identifier())
 
         /** Interpret an ANTLR-parsed regular identifier as one of expected local keywords. */
         private fun readLocalKeyword(
@@ -419,7 +419,7 @@ internal class PartiQLParserDefault : PartiQLParser {
                 return keyword
             else throw error(ctx, "Expected one of: ${expected.joinToString(", ")}.")
         }
-        override fun visitLexid(ctx: GeneratedParser.LexidContext) = translate(ctx) {
+        override fun visitIdentifier(ctx: GeneratedParser.IdentifierContext) = translate(ctx) {
             when (ctx.ident.type) {
                 GeneratedParser.REGULAR_IDENTIFIER -> identifierSymbol(
                     ctx.REGULAR_IDENTIFIER().text,
@@ -442,18 +442,18 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitQueryDdl(ctx: GeneratedParser.QueryDdlContext): AstNode = visitDdl(ctx.ddl())
 
         override fun visitDropTable(ctx: GeneratedParser.DropTableContext) = translate(ctx) {
-            val table = visitLexid(ctx.tableName().lexid())
+            val table = visitIdentifier(ctx.tableName().identifier())
             statementDDLDropTable(table)
         }
 
         override fun visitDropIndex(ctx: GeneratedParser.DropIndexContext) = translate(ctx) {
-            val table = visitLexid(ctx.on)
-            val index = visitLexid(ctx.target)
+            val table = visitIdentifier(ctx.on)
+            val index = visitIdentifier(ctx.target)
             statementDDLDropIndex(index, table)
         }
 
         override fun visitCreateTable(ctx: GeneratedParser.CreateTableContext) = translate(ctx) {
-            val table = visitLexid(ctx.tableName().lexid())
+            val table = visitIdentifier(ctx.tableName().identifier())
             val definition = ctx.tableDef()?.let { visitTableDef(it) }
             statementDDLCreateTable(table, definition)
         }
@@ -461,7 +461,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitCreateIndex(ctx: GeneratedParser.CreateIndexContext) = translate(ctx) {
             // TODO add index name to ANTLR grammar
             val name: Identifier? = null
-            val table = visitLexid(ctx.lexid())
+            val table = visitIdentifier(ctx.identifier())
             val fields = ctx.pathSimple().map { path -> visitPathSimple(path) }
             statementDDLCreateIndex(name, table, fields)
         }
@@ -475,7 +475,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitColumnDeclaration(ctx: GeneratedParser.ColumnDeclarationContext) = translate(ctx) {
-            val name = symbolToString(ctx.columnName().lexid())
+            val name = symbolToString(ctx.columnName().identifier())
             val type = visit(ctx.type()) as Type
             val constraints = ctx.columnConstraint().map {
                 visitColumnConstraint(it)
@@ -484,7 +484,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitColumnConstraint(ctx: GeneratedParser.ColumnConstraintContext) = translate(ctx) {
-            val identifier = ctx.columnConstraintName()?.let { symbolToString(it.lexid()) }
+            val identifier = ctx.columnConstraintName()?.let { symbolToString(it.identifier()) }
             val body = visit(ctx.columnConstraintDef()) as TableDefinition.Column.Constraint.Body
             tableDefinitionColumnConstraint(identifier, body)
         }
@@ -620,7 +620,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitInsertStatement(ctx: GeneratedParser.InsertStatementContext) = translate(ctx) {
-            val target = visitLexid(ctx.lexid())
+            val target = visitIdentifier(ctx.identifier())
             val values = visitExpr(ctx.value)
             val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
             val onConflict = ctx.onConflict()?.let { visitOnConflictClause(it) }
@@ -628,14 +628,14 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitReplaceCommand(ctx: GeneratedParser.ReplaceCommandContext) = translate(ctx) {
-            val target = visitLexid(ctx.lexid())
+            val target = visitIdentifier(ctx.identifier())
             val values = visitExpr(ctx.value)
             val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
             statementDMLReplace(target, values, asAlias)
         }
 
         override fun visitUpsertCommand(ctx: GeneratedParser.UpsertCommandContext) = translate(ctx) {
-            val target = visitLexid(ctx.lexid())
+            val target = visitIdentifier(ctx.identifier())
             val values = visitExpr(ctx.value)
             val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
             statementDMLUpsert(target, values, asAlias)
@@ -681,9 +681,9 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitConflictTarget(ctx: GeneratedParser.ConflictTargetContext) = translate(ctx) {
             if (ctx.constraintName() != null) {
-                onConflictTargetConstraint(visitLexid(ctx.constraintName().lexid()))
+                onConflictTargetConstraint(visitIdentifier(ctx.constraintName().identifier()))
             } else {
-                val symbols = ctx.lexid().map { visitLexid(it) }
+                val symbols = ctx.identifier().map { visitIdentifier(it) }
                 onConflictTargetSymbols(symbols)
             }
         }
@@ -706,7 +706,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitPathSimple(ctx: GeneratedParser.PathSimpleContext) = translate(ctx) {
-            val root = visitLexid(ctx.lexid())
+            val root = visitIdentifier(ctx.identifier())
             val steps = visitOrEmpty<Path.Step>(ctx.pathSimpleSteps())
             path(root, steps)
         }
@@ -728,12 +728,12 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitPathSimpleSymbol(ctx: GeneratedParser.PathSimpleSymbolContext) = translate(ctx) {
-            val identifier = visitLexid(ctx.lexid())
+            val identifier = visitIdentifier(ctx.identifier())
             pathStepSymbol(identifier)
         }
 
         override fun visitPathSimpleDotSymbol(ctx: GeneratedParser.PathSimpleDotSymbolContext) = translate(ctx) {
-            val identifier = visitLexid(ctx.lexid())
+            val identifier = visitIdentifier(ctx.identifier())
             pathStepSymbol(identifier)
         }
 
@@ -815,7 +815,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitProjectionItem(ctx: GeneratedParser.ProjectionItemContext) = translate(ctx) {
             val expr = visitExpr(ctx.expr())
-            val alias = ctx.lexid()?.let { visitLexid(it) }
+            val alias = ctx.identifier()?.let { visitIdentifier(it) }
             if (expr is Expr.Path) {
                 convertPathToProjectionItem(ctx, expr, alias)
             } else {
@@ -859,7 +859,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitLetBinding(ctx: GeneratedParser.LetBindingContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.expr())
-            val alias = visitLexid(ctx.lexid())
+            val alias = visitIdentifier(ctx.identifier())
             letBinding(expr, alias)
         }
 
@@ -900,13 +900,13 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitGroupClause(ctx: GeneratedParser.GroupClauseContext) = translate(ctx) {
             val strategy = if (ctx.PARTIAL() != null) GroupBy.Strategy.PARTIAL else GroupBy.Strategy.FULL
             val keys = visitOrEmpty<GroupBy.Key>(ctx.groupKey())
-            val alias = ctx.groupAlias()?.lexid()?.let { visitLexid(it) }
+            val alias = ctx.groupAlias()?.identifier()?.let { visitIdentifier(it) }
             groupBy(strategy, keys, alias)
         }
 
         override fun visitGroupKey(ctx: GeneratedParser.GroupKeyContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.key)
-            val alias = ctx.lexid()?.let { visitLexid(it) }
+            val alias = ctx.identifier()?.let { visitIdentifier(it) }
             groupByKey(expr, alias)
         }
 
@@ -981,7 +981,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitPatternPathVariable(ctx: GeneratedParser.PatternPathVariableContext) =
-            visitLexid(ctx.lexid())
+            visitIdentifier(ctx.identifier())
 
         override fun visitSelectorBasic(ctx: GeneratedParser.SelectorBasicContext) = translate(ctx) {
             when (ctx.mod.type) {
@@ -1024,7 +1024,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitLabelPrimaryName(ctx: GeneratedParser.LabelPrimaryNameContext) = translate(ctx) {
-            val x = visitLexid(ctx.lexid())
+            val x = visitIdentifier(ctx.identifier())
             graphMatchLabelName(x.symbol)
         }
 
@@ -1058,7 +1058,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitEdgeSpec(ctx: GeneratedParser.EdgeSpecContext) = translate(ctx) {
             val placeholderDirection = GraphMatch.Direction.RIGHT
-            val variable = visitOrNull<Identifier.Symbol>(ctx.lexid())?.symbol
+            val variable = visitOrNull<Identifier.Symbol>(ctx.identifier())?.symbol
             val prefilter = ctx.whereClause()?.let { visitExpr(it.expr()) }
             val label = visitOrNull<GraphMatch.Label>(ctx.labelSpec())
             graphMatchPatternPartEdge(placeholderDirection, null, prefilter, variable, label)
@@ -1128,7 +1128,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitNode(ctx: GeneratedParser.NodeContext) = translate(ctx) {
-            val variable = visitOrNull<Identifier.Symbol>(ctx.lexid())?.symbol
+            val variable = visitOrNull<Identifier.Symbol>(ctx.identifier())?.symbol
             val prefilter = ctx.whereClause()?.let { visitExpr(it.expr()) }
             val label = visitOrNull<GraphMatch.Label>(ctx.labelSpec())
             graphMatchPatternPartNode(prefilter, variable, label)
@@ -1155,17 +1155,17 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitTableBaseRefClauses(ctx: GeneratedParser.TableBaseRefClausesContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = ctx.asIdent()?.let { visitLexid(it.lexid()) }
-            val atAlias = ctx.atIdent()?.let { visitLexid(it.lexid()) }
-            val byAlias = ctx.byIdent()?.let { visitLexid(it.lexid()) }
+            val asAlias = ctx.asIdent()?.let { visitIdentifier(it.identifier()) }
+            val atAlias = ctx.atIdent()?.let { visitIdentifier(it.identifier()) }
+            val byAlias = ctx.byIdent()?.let { visitIdentifier(it.identifier()) }
             fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
 
         override fun visitTableBaseRefMatch(ctx: GeneratedParser.TableBaseRefMatchContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = ctx.asIdent()?.let { visitLexid(it.lexid()) }
-            val atAlias = ctx.atIdent()?.let { visitLexid(it.lexid()) }
-            val byAlias = ctx.byIdent()?.let { visitLexid(it.lexid()) }
+            val asAlias = ctx.asIdent()?.let { visitIdentifier(it.identifier()) }
+            val atAlias = ctx.atIdent()?.let { visitIdentifier(it.identifier()) }
+            val byAlias = ctx.byIdent()?.let { visitIdentifier(it.identifier()) }
             fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
 
@@ -1187,15 +1187,15 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitFromClauseSimpleImplicit(ctx: GeneratedParser.FromClauseSimpleImplicitContext) =
             translate(ctx) {
                 val path = visitPathSimple(ctx.pathSimple())
-                val asAlias = visitLexid(ctx.lexid())
+                val asAlias = visitIdentifier(ctx.identifier())
                 statementDMLDeleteTarget(path, asAlias, null, null)
             }
 
         override fun visitTableUnpivot(ctx: GeneratedParser.TableUnpivotContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.expr())
-            val asAlias = ctx.asIdent()?.let { visitLexid(it.lexid()) }
-            val atAlias = ctx.atIdent()?.let { visitLexid(it.lexid()) }
-            val byAlias = ctx.byIdent()?.let { visitLexid(it.lexid()) }
+            val asAlias = ctx.asIdent()?.let { visitIdentifier(it.identifier()) }
+            val atAlias = ctx.atIdent()?.let { visitIdentifier(it.identifier()) }
+            val byAlias = ctx.byIdent()?.let { visitIdentifier(it.identifier()) }
             fromValue(expr, From.Value.Type.UNPIVOT, asAlias, atAlias, byAlias)
         }
 
@@ -1241,7 +1241,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitTableBaseRefSymbol(ctx: GeneratedParser.TableBaseRefSymbolContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = visitLexid(ctx.lexid())
+            val asAlias = visitIdentifier(ctx.identifier())
             fromValue(expr, From.Value.Type.SCAN, asAlias, null, null)
         }
 
@@ -1385,7 +1385,7 @@ internal class PartiQLParserDefault : PartiQLParser {
             visit(ctx.expr())
 
         override fun visitVariableIdentifier(ctx: GeneratedParser.VariableIdentifierContext) = translate(ctx) {
-            val symbol = visitLexid(ctx.ident)
+            val symbol = visitIdentifier(ctx.ident)
             val scope = when (ctx.qualifier) {
                 null -> Expr.Var.Scope.DEFAULT
                 else -> Expr.Var.Scope.LOCAL
@@ -1433,7 +1433,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitPathStepDotExpr(ctx: GeneratedParser.PathStepDotExprContext) = translate(ctx) {
-            val symbol = visitLexid(ctx.lexid())
+            val symbol = visitIdentifier(ctx.identifier())
             exprPathStepSymbol(symbol)
         }
 
@@ -1524,7 +1524,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitFunctionCallIdent(ctx: GeneratedParser.FunctionCallIdentContext) = translate(ctx) {
-            val function = visitLexid(ctx.name)
+            val function = visitIdentifier(ctx.name)
             val args = visitOrEmpty<Expr>(ctx.expr())
             exprCall(function, args)
         }
@@ -1882,7 +1882,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         /**
          * Visiting a symbol to get a string, skip the wrapping, unwrapping, and location tracking.
          */
-        private fun symbolToString(ctx: GeneratedParser.LexidContext) = when (ctx.ident.type) {
+        private fun symbolToString(ctx: GeneratedParser.IdentifierContext) = when (ctx.ident.type) {
             GeneratedParser.DELIMITED_IDENTIFIER -> ctx.DELIMITED_IDENTIFIER().getStringValue()
             GeneratedParser.REGULAR_IDENTIFIER -> ctx.REGULAR_IDENTIFIER().getStringValue()
             else -> throw error(ctx, "Invalid symbol reference.")

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
@@ -1385,16 +1385,12 @@ internal class PartiQLParserDefault : PartiQLParser {
             visit(ctx.expr())
 
         override fun visitVariableIdentifier(ctx: GeneratedParser.VariableIdentifierContext) = translate(ctx) {
-            val symbol = ctx.ident.getStringValue()
-            val case = when (ctx.ident.type) {
-                GeneratedParser.REGULAR_IDENTIFIER -> Identifier.CaseSensitivity.INSENSITIVE
-                else -> Identifier.CaseSensitivity.SENSITIVE
-            }
+            val symbol = visitLexid(ctx.ident)
             val scope = when (ctx.qualifier) {
                 null -> Expr.Var.Scope.DEFAULT
                 else -> Expr.Var.Scope.LOCAL
             }
-            exprVar(identifierSymbol(symbol, case), scope)
+            exprVar(symbol, scope)
         }
 
         override fun visitVariableKeyword(ctx: GeneratedParser.VariableKeywordContext) = translate(ctx) {

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
@@ -421,13 +421,13 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
         override fun visitLexid(ctx: GeneratedParser.LexidContext) = translate(ctx) {
             when (ctx.ident.type) {
-                GeneratedParser.DELIMITED_IDENTIFIER -> identifierSymbol(
-                    ctx.DELIMITED_IDENTIFIER().getStringValue(),
-                    Identifier.CaseSensitivity.SENSITIVE,
-                )
                 GeneratedParser.REGULAR_IDENTIFIER -> identifierSymbol(
-                    ctx.REGULAR_IDENTIFIER().getStringValue(),
+                    ctx.REGULAR_IDENTIFIER().text,
                     Identifier.CaseSensitivity.INSENSITIVE,
+                )
+                GeneratedParser.DELIMITED_IDENTIFIER -> identifierSymbol(
+                    ctx.DELIMITED_IDENTIFIER().text.trim('\"').replace("\"\"", "\""),
+                    Identifier.CaseSensitivity.SENSITIVE,
                 )
                 else -> throw error(ctx, "Invalid symbol reference.")
             }
@@ -1999,6 +1999,8 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         private fun TerminalNode.getStringValue(): String = this.symbol.getStringValue()
 
+        // wVG-TODO It is doubtful it is useful to have these extractions gathered here.
+        // The part for identifiers is now in visitLexid.  Move others to better places as well?
         private fun Token.getStringValue(): String = when (this.type) {
             GeneratedParser.REGULAR_IDENTIFIER -> this.text
             GeneratedParser.DELIMITED_IDENTIFIER -> this.text.removePrefix("\"").removeSuffix("\"").replace("\"\"", "\"")


### PR DESCRIPTION
## Relevant Issues
Some preliminary clean-up before moving to SQL-conformant identifiers -- related to Issue#1122. 
While it would be prudent to hold the merge until the SQL-conformant fate is more clear, comments and reviews are welcome at this point, since this PR, I think, will be worth merging regardless. 

## Description
Changes in this PR are semantically benign, but may have to be considered breaking backward compatibility, due to renamings in the grammar). 

- The grammar rule for identifiers changed from 
  ```symbolPrimitive : ident=( IDENTIFIER | IDENTIFIER_QUOTED ) ; ```
  to 
  ```identifier : ident=( REGULAR_IDENTIFIER | DELIMITED_IDENTIFIER ) ; ```
  The driving need was getting rid of `symbolPrimitive`, because it did not correspond to PIG `SymbolPrimitive`, making things unnecessarily confusing. 
  Then it was opportunistic to rename the terminals as well, to follow SQL terminology.  

- Introduced the concept of a "local keyword" in the parser. These are things understood as keywords only in limited contexts (such as DAY, HOUR within a call to a date-time function), while available as regular identifiers in other contexts. In the grammar, a local keyword is a non-terminal that is a synonym of `REGULAR_IDENTIFIER` which, when needed, is checked at a post-ANTLR stage. Like the regular keywords, local keywords are now canonicalized to upper case and do not preserve the original case during AST round-tripping. (Previously, what now became local keywords, had inconsistent capitalization treatment.)
  This PR employs local keywords in a few places (in rules for `extract` and `dateFunction` nonterminals and in graph path restrictors TRAIL, ACYCLIC, SIMPLE), but there are a few more places where it could be used. 
  Overall, local keywords need more work, and that was not intended to be carried out in this PR.

- The less-trivial changes are the clean-up of internal parsing functions for identifiers, in `PartiQLPigVisitor` (and repeated in `PartiQLParserDefault`). There have been code duplication, repeated dispatch, dummy stuff created and then discarded, location information lost when it could be preserved. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**

- Any backward-incompatible changes? **[YES]**
  - See changelog and above. 

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.