### PR TITLE
Adds support for Sprout-generated equality/hashCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,13 @@ Thank you to all who have contributed!
 - Adds support for Timestamp constructor call in Parser.
 - Parsing of label patterns within node and edge graph patterns now supports
   disjunction `|`, conjunction `&`, negation `!`, and grouping.
+- Adds default `equals` and `hashCode` methods for each generated abstract class of Sprout. This affects the generated
+classes in `:partiql-ast` and `:partiql-plan`.
 
 ### Changed
+- **Breaking**: all product types defined by the internal Sprout tool no longer generate interfaces. They are now abstract
+  classes due to the generation of `equals` and `hashCode` methods. This change impacts many generated interfaces exposed
+  in `:partiql-ast` and `:partiql-plan`.
 - Standardizes `org/partiql/cli/functions/QueryDDB` and other built-in functions in `org/partiql/lang/eval/builtins` by the new `ExprFunction` format.
 - **Breaking**: Redefines `org/partiql/lang/eval/ExprFunctionkt.call()` method by only invoking `callWithRequired` function.
 - **Breaking**: Redefines `org/partiql/lang/eval/builtins/DynamicLookupExprFunction` by merging `variadicParameter` into `requiredParameters` as a `StaticType.LIST`. `callWithVariadic` is now replaced by `callWithRequired`.

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/poems/KotlinBuilderPoem.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/poems/KotlinBuilderPoem.kt
@@ -44,7 +44,7 @@ class KotlinBuilderPoem(symbols: KotlinSymbols) : KotlinPoem(symbols) {
     private val baseFactoryClass = ClassName(builderPackageName, baseFactoryName)
     private val baseFactory = TypeSpec.classBuilder(baseFactoryClass)
         .addSuperinterface(factoryClass)
-        .addModifiers(KModifier.ABSTRACT)
+        .addModifiers(KModifier.OPEN)
         .addProperty(
             idProvider.toBuilder()
                 .addModifiers(KModifier.OVERRIDE)
@@ -289,7 +289,7 @@ class KotlinBuilderPoem(symbols: KotlinSymbols) : KotlinPoem(symbols) {
     private fun factoryCompanion() = TypeSpec.companionObjectBuilder()
         .addProperty(
             PropertySpec.builder("DEFAULT", factoryClass)
-                .initializer("%T", factoryDefault)
+                .initializer("%T()", baseFactoryClass)
                 .build()
         )
         .addFunction(factoryFunc)

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/spec/KotlinNodeSpec.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/spec/KotlinNodeSpec.kt
@@ -78,7 +78,7 @@ sealed class KotlinNodeSpec(
     ) : KotlinNodeSpec(
         def = product,
         clazz = clazz,
-        builder = TypeSpec.interfaceBuilder(clazz),
+        builder = TypeSpec.classBuilder(clazz).addModifiers(KModifier.ABSTRACT),
         companion = TypeSpec.companionObjectBuilder(),
         ext = ext,
     ) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,5 +27,6 @@ include(
     "lib:sprout",
     "test:partiql-tests-runner",
     "test:partiql-randomized-tests",
+    "test:sprout-tests",
     "examples",
 )

--- a/test/sprout-tests/build.gradle.kts
+++ b/test/sprout-tests/build.gradle.kts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+plugins {
+    id(Plugins.conventions)
+}
+
+dependencies {
+    api(Deps.ionElement)
+    api(project(":partiql-types"))
+}
+
+val generate = tasks.register<Exec>("generate") {
+    dependsOn(":lib:sprout:install")
+    workingDir(projectDir)
+    commandLine(
+        "../../lib/sprout/build/install/sprout/bin/sprout", "generate", "kotlin",
+        "-o", "$buildDir/generated-src",
+        "-p", "org.partiql.sprout.tests.example",
+        "-u", "Example",
+        "--poems", "visitor",
+        "--poems", "builder",
+        "--poems", "util",
+        "./src/main/resources/example.ion"
+    )
+}
+
+tasks.compileKotlin {
+    dependsOn(generate)
+}

--- a/test/sprout-tests/src/main/resources/example.ion
+++ b/test/sprout-tests/src/main/resources/example.ion
@@ -1,0 +1,60 @@
+imports::{
+  kotlin: [
+    ion::'com.amazon.ionelement.api.IonElement'
+  ],
+}
+
+statement::[
+
+  // PartiQL Expressions
+  query::{
+    expr: expr,
+  },
+]
+
+expr::[
+
+  // Ion Literal Value, ie `<ion>`
+  ion::{
+    value: '.ion',
+  },
+
+  // Variable Reference
+  var::{
+    identifier: identifier,
+    scope: [
+      DEFAULT,
+      //  x.y.z
+      LOCAL,
+      // @x.y.z
+    ],
+  },
+  empty::{}
+]
+// Identifiers and Qualified Identifiers
+//----------------------------------------------
+// <identifier > ::= <id symbol> | <id path>
+//
+// <id symbol> ::=  <symbol>    // case-insensitive
+//               | "<symbol>"   // case-sensitive
+//
+// <id qualified> ::= <id symbol> ('.' <id symbol>)+;
+//
+identifier::[
+  symbol::{
+    symbol: string,
+    case_sensitivity: case_sensitivity,
+  },
+  qualified::{
+    root: symbol,
+    steps: list::[
+      symbol
+    ],
+  },
+  _::[
+    case_sensitivity::[
+      SENSITIVE,
+      INSENSITIVE,
+    ],
+  ],
+]

--- a/test/sprout-tests/src/test/kotlin/org/partiql/sprout/tests/ArgumentsProviderBase.kt
+++ b/test/sprout-tests/src/test/kotlin/org/partiql/sprout/tests/ArgumentsProviderBase.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.sprout.tests
+
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import java.util.stream.Stream
+
+/**
+ * Reduces some of the boilerplate associated with the style of parameterized testing frequently
+ * utilized in this package.
+ *
+ * Since JUnit5 requires `@JvmStatic` on its `@MethodSource` argument factory methods, this requires all
+ * of the argument lists to reside in the companion object of a test class.  This can be annoying since it
+ * forces the test to be separated from its tests cases.
+ *
+ * Classes that derive from this class can be defined near the `@ParameterizedTest` functions instead.
+ */
+abstract class ArgumentsProviderBase : ArgumentsProvider {
+
+    abstract fun getParameters(): List<Any>
+
+    @Throws(Exception::class)
+    override fun provideArguments(extensionContext: ExtensionContext): Stream<out Arguments>? {
+        return getParameters().map { Arguments.of(it) }.stream()
+    }
+}

--- a/test/sprout-tests/src/test/kotlin/org/partiql/sprout/tests/example/EqualityTests.kt
+++ b/test/sprout-tests/src/test/kotlin/org/partiql/sprout/tests/example/EqualityTests.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.sprout.tests.example
+
+import com.amazon.ionelement.api.ionInt
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+import org.partiql.sprout.tests.ArgumentsProviderBase
+import org.partiql.sprout.tests.example.builder.ExampleFactoryImpl
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Tests the generated equals and hashCode methods
+ */
+class EqualityTests {
+
+    @ParameterizedTest
+    @ArgumentsSource(EqualArgumentsProvider::class)
+    fun testEquality(tc: EqualArgumentsProvider.TestCase) {
+        assertEquals(tc.first, tc.second)
+        assertEquals(tc.first.hashCode(), tc.second.hashCode())
+    }
+
+    /**
+     * We do not check that hashCode produces unequal results due to the `hashCode()` JavaDocs:
+     * > It is not required that if two objects are unequal according to the equals(java.lang.Object) method, then
+     * > calling the hashCode method on each of the two objects must produce distinct integer results.
+     */
+    @ParameterizedTest
+    @ArgumentsSource(NotEqualArgumentsProvider::class)
+    fun testNotEquality(tc: NotEqualArgumentsProvider.TestCase) {
+        assertNotEquals(tc.first, tc.second)
+    }
+
+    class EqualArgumentsProvider : ArgumentsProviderBase() {
+        private val factory = ExampleFactoryImpl()
+        override fun getParameters(): List<TestCase> = listOf(
+            TestCase(factory.exprEmpty(), factory.exprEmpty()),
+            TestCase(factory.exprIon(ionInt(1)), factory.exprIon(ionInt(1))),
+            TestCase(
+                factory.identifierQualified(
+                    factory.identifierSymbol("hello", Identifier.CaseSensitivity.INSENSITIVE),
+                    emptyList()
+                ),
+                factory.identifierQualified(
+                    factory.identifierSymbol("hello", Identifier.CaseSensitivity.INSENSITIVE),
+                    emptyList()
+                )
+            ),
+            TestCase(
+                factory.identifierQualified(
+                    factory.identifierSymbol("hello", Identifier.CaseSensitivity.INSENSITIVE),
+                    listOf(
+                        factory.identifierSymbol("world", Identifier.CaseSensitivity.SENSITIVE),
+                        factory.identifierSymbol("yeah", Identifier.CaseSensitivity.INSENSITIVE),
+                        factory.identifierSymbol("foliage", Identifier.CaseSensitivity.INSENSITIVE),
+                    )
+                ),
+                factory.identifierQualified(
+                    factory.identifierSymbol("hello", Identifier.CaseSensitivity.INSENSITIVE),
+                    listOf(
+                        factory.identifierSymbol("world", Identifier.CaseSensitivity.SENSITIVE),
+                        factory.identifierSymbol("yeah", Identifier.CaseSensitivity.INSENSITIVE),
+                        factory.identifierSymbol("foliage", Identifier.CaseSensitivity.INSENSITIVE),
+                    )
+                )
+            ),
+            TestCase(
+                factory.statementQuery(factory.exprEmpty()),
+                factory.statementQuery(factory.exprEmpty())
+            )
+        )
+
+        class TestCase(
+            val first: ExampleNode,
+            val second: ExampleNode
+        )
+    }
+
+    class NotEqualArgumentsProvider : ArgumentsProviderBase() {
+        private val factory = ExampleFactoryImpl()
+        override fun getParameters(): List<TestCase> = listOf(
+            TestCase(factory.exprEmpty(), factory.exprIon(ionInt(1))),
+            TestCase(factory.exprIon(ionInt(1)), factory.exprIon(ionInt(2))),
+            TestCase(
+                factory.identifierSymbol("hello", Identifier.CaseSensitivity.INSENSITIVE),
+                factory.identifierSymbol("hello", Identifier.CaseSensitivity.SENSITIVE)
+            ),
+            TestCase(
+                factory.identifierQualified(
+                    factory.identifierSymbol("hello", Identifier.CaseSensitivity.INSENSITIVE),
+                    listOf(
+                        factory.identifierSymbol("world", Identifier.CaseSensitivity.SENSITIVE),
+                        factory.identifierSymbol("yeah", Identifier.CaseSensitivity.INSENSITIVE),
+                        factory.identifierSymbol("foliage", Identifier.CaseSensitivity.INSENSITIVE),
+                    )
+                ),
+                factory.identifierQualified(
+                    factory.identifierSymbol("hello", Identifier.CaseSensitivity.INSENSITIVE),
+                    listOf(
+                        factory.identifierSymbol("NOT_WORLD", Identifier.CaseSensitivity.SENSITIVE),
+                        factory.identifierSymbol("yeah", Identifier.CaseSensitivity.INSENSITIVE),
+                        factory.identifierSymbol("foliage", Identifier.CaseSensitivity.INSENSITIVE),
+                    )
+                )
+            )
+        )
+
+        class TestCase(
+            val first: ExampleNode,
+            val second: ExampleNode
+        )
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Converts generation of Sprout product types to be abstract classes
- Adds default  equality and hashCode methods to each product
- Previous generation resulted in interfaces
- Added a `:test/sprout-tests` subproject to run integration tests on generated code

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **YES**
  - Yes, see CHANGELOG
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **NO**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.