### PR TITLE
Introduces "definitional identifier" AST node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Thank you to all who have contributed!
 - Adds support for Timestamp constructor call in Parser. 
 - Parsing of label patterns within node and edge graph patterns now supports 
   disjunction `|`, conjunction `&`, negation `!`, and grouping.
+- AST node `defnid` (for "definitional identifier") in `partiql.ion`.
+- Class `Ident`, a beginning of an ADT for identifiers, to be used internally instead of `String`s.
+
 
 ### Changed
 
@@ -68,6 +71,12 @@ Thank you to all who have contributed!
   - Introduced a new non-terminal `localKeyword` and its aliases.  They are now used instead 
     of `REGULAR_IDENTIFIER` (formerly `IDENTIFIER`) in the rules for `extract`, `dateFunction`, 
     and `pathRestrictor` (formerly `patternRestrictor`).
+- **Breaking** change in several PartiqlAst nodes of a field type from `SymbolPrimitive` to `Defnid`, 
+  in conjunction with the introduction of `defnid` in partiql.ion.  
+  The affected nodes are: `Expr.Call`, `Expr.CallAgg`, `Expr.CallWindow`, `ProjectItem.ProjectExpr`, 
+  `LetBinding`, `FromSource.Scan`, `FromSource.Unpivot`, `GraphLabelSpec.GraphLabelName`, 
+  `GraphMatchPatternPart.Node`, `GraphMatchPatternPart.Edge`, `GraphMatchPattern`, `GroupBy`, `GroupKey`, 
+  `DmlOp.Insert`, `TableDefPart.ColumnDeclaration`, `ColumnConstraint`, `Type.CustomType`. 
 
 ### Deprecated
 

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
@@ -39,6 +39,7 @@ import org.partiql.lang.ast.IsListParenthesizedMeta
 import org.partiql.lang.ast.IsValuesExprMeta
 import org.partiql.lang.ast.Meta
 import org.partiql.lang.domains.PartiqlAst
+import org.partiql.pig.runtime.SymbolPrimitive
 import org.partiql.value.DateValue
 import org.partiql.value.MissingValue
 import org.partiql.value.PartiQLValueExperimental
@@ -53,7 +54,7 @@ import java.math.BigInteger
  *
  * Optionally, you can provide a Map of MetaContainers to attach to the legacy AST nodes.
  */
-public fun AstNode.toLegacyAst(metas: Map<String, MetaContainer> = emptyMap()): PartiqlAst.PartiqlAstNode {
+fun AstNode.toLegacyAst(metas: Map<String, MetaContainer> = emptyMap()): PartiqlAst.PartiqlAstNode {
     val translator = AstTranslator(metas)
     return accept(translator, Ctx())
 }
@@ -177,7 +178,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
     }
 
     override fun visitTableDefinitionColumn(node: TableDefinition.Column, ctx: Ctx) = translate(node) { metas ->
-        val name = node.name
+        val name = stringToDefnid(node.name)
         val type = visitType(node.type, ctx)
         val constraints = node.constraints.translate<PartiqlAst.ColumnConstraint>(ctx)
         columnDeclaration(name, type, constraints, metas)
@@ -187,7 +188,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         node: TableDefinition.Column.Constraint,
         ctx: Ctx,
     ) = translate(node) { metas ->
-        val name = node.name
+        val name = node.name?.let { stringToDefnid(it) }
         val def = when (node.body) {
             is TableDefinition.Column.Constraint.Body.Check -> {
                 throw IllegalArgumentException("PIG AST does not support CHECK (<expr>) constraint")
@@ -292,16 +293,17 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         if (node.function is Identifier.Qualified) {
             error("Qualified identifiers are not allowed in legacy AST `call` function identifiers")
         }
-        val funcName = (node.function as Identifier.Symbol).symbol.lowercase()
+        val funcName = stringToDefnid((node.function as Identifier.Symbol).symbol)
         val args = node.args.translate<PartiqlAst.Expr>(ctx)
-        call(funcName, args, metas)
+        call(funcName.lowercase(), args, metas)
     }
 
     override fun visitExprAgg(node: Expr.Agg, ctx: Ctx) = translate(node) { metas ->
         val setq = node.setq?.toLegacySetQuantifier() ?: all()
         // Legacy AST translates COUNT(*) to COUNT(1)
         if (node.function is Identifier.Symbol && (node.function as Identifier.Symbol).symbol == "COUNT_STAR") {
-            return callAgg(setq, "count", lit(ionInt(1)), metas)
+            val funId = stringToDefnid("count")
+            return callAgg(setq, funId, lit(ionInt(1)), metas)
         }
         // Default Case
         if (node.args.size != 1) {
@@ -311,9 +313,9 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
             error("Qualified identifiers are not allowed in legacy AST `call_agg` function identifiers")
         }
         // Legacy parser/ast always inserts ALL quantifier
-        val funcName = (node.function as Identifier.Symbol).symbol.lowercase()
+        val funcId = stringToDefnid((node.function as Identifier.Symbol).symbol)
         val arg = visitExpr(node.args[0], ctx)
-        callAgg(setq, funcName, arg, metas)
+        callAgg(setq, funcId.lowercase(), arg, metas)
     }
 
     override fun visitExprUnary(node: Expr.Unary, ctx: Ctx) = translate(node) { metas ->
@@ -525,14 +527,16 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         val start = visitOrNull<PartiqlAst.Expr>(node.start, ctx)
         val length = visitOrNull<PartiqlAst.Expr>(node.length, ctx)
         val operands = listOfNotNull(value, start, length)
-        call("substring", operands, metas)
+        val funId = stringToDefnid("substring")
+        call(funId, operands, metas)
     }
 
     override fun visitExprPosition(node: Expr.Position, ctx: Ctx) = translate(node) { metas ->
         val lhs = visitExpr(node.lhs, ctx)
         val rhs = visitExpr(node.rhs, ctx)
         val operands = listOf(lhs, rhs)
-        call("position", operands, metas)
+        val funId = stringToDefnid("position")
+        call(funId, operands, metas)
     }
 
     override fun visitExprTrim(node: Expr.Trim, ctx: Ctx) = translate(node) { metas ->
@@ -544,7 +548,8 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         if (spec != null) operands.add(lit(ionSymbol(spec)))
         if (chars != null) operands.add(chars)
         operands.add(value)
-        call("trim", operands, metas)
+        val funId = stringToDefnid("trim")
+        call(funId, operands, metas)
     }
 
     override fun visitExprOverlay(node: Expr.Overlay, ctx: Ctx) = translate(node) { metas ->
@@ -553,14 +558,16 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         val start = visitExpr(node.start, ctx)
         val length = visitOrNull<PartiqlAst.Expr>(node.length, ctx)
         val operands = listOfNotNull(value, overlay, start, length)
-        call("overlay", operands, metas)
+        val funId = stringToDefnid("overlay")
+        call(funId, operands, metas)
     }
 
     override fun visitExprExtract(node: Expr.Extract, ctx: Ctx) = translate(node) { metas ->
         val field = node.field.toLegacyDatetimePart()
         val source = visitExpr(node.source, ctx)
         val operands = listOf(field, source)
-        call("extract", operands, metas)
+        val funId = stringToDefnid("extract")
+        call(funId, operands, metas)
     }
 
     override fun visitExprCast(node: Expr.Cast, ctx: Ctx) = translate(node) { metas ->
@@ -586,7 +593,8 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         val lhs = visitExpr(node.lhs, ctx)
         val rhs = visitExpr(node.rhs, ctx)
         val operands = listOf(field, lhs, rhs)
-        call("date_add", operands, metas)
+        val funId = stringToDefnid("date_add")
+        call(funId, operands, metas)
     }
 
     override fun visitExprDateDiff(node: Expr.DateDiff, ctx: Ctx) = translate(node) { metas ->
@@ -594,7 +602,8 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         val lhs = visitExpr(node.lhs, ctx)
         val rhs = visitExpr(node.rhs, ctx)
         val operands = listOf(field, lhs, rhs)
-        call("date_diff", operands, metas)
+        val funId = stringToDefnid("date_diff")
+        call(funId, operands, metas)
     }
 
     override fun visitExprBagOp(node: Expr.BagOp, ctx: Ctx) = translate(node) { metas ->
@@ -624,10 +633,10 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
     }
 
     override fun visitExprWindow(node: Expr.Window, ctx: Ctx) = translate(node) { metas ->
-        val funcName = node.function.name.lowercase()
         val over = visitExprWindowOver(node.over, ctx)
         val args = listOfNotNull(node.expression, node.offset, node.default).translate<PartiqlAst.Expr>(ctx)
-        callWindow(funcName, over, args, metas)
+        val funId = stringToDefnid(node.function.name)
+        callWindow(funId.lowercase(), over, args, metas)
     }
 
     override fun visitExprWindowOver(node: Expr.Window.Over, ctx: Ctx) = translate(node) { metas ->
@@ -700,7 +709,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
     override fun visitSelectProjectItemExpression(node: Select.Project.Item.Expression, ctx: Ctx) =
         translate(node) { metas ->
             val expr = visitExpr(node.expr, ctx)
-            val alias = node.asAlias?.symbol
+            val alias = node.asAlias?.let { stringToDefnid(it.symbol) }
             projectExpr(expr, alias, metas)
         }
 
@@ -718,9 +727,9 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
     override fun visitFrom(node: From, ctx: Ctx) = super.visitFrom(node, ctx) as PartiqlAst.FromSource
     override fun visitFromValue(node: From.Value, ctx: Ctx) = translate(node) { metas ->
         val expr = visitExpr(node.expr, ctx)
-        val asAlias = node.asAlias?.symbol
-        val atAlias = node.atAlias?.symbol
-        val byAlias = node.byAlias?.symbol
+        val asAlias = node.asAlias?.let { stringToDefnid(it.symbol) }
+        val atAlias = node.atAlias?.let { stringToDefnid(it.symbol) }
+        val byAlias = node.byAlias?.let { stringToDefnid(it.symbol) }
         when (node.type) {
             From.Value.Type.SCAN -> scan(expr, asAlias, atAlias, byAlias, metas)
             From.Value.Type.UNPIVOT -> unpivot(expr, asAlias, atAlias, byAlias, metas)
@@ -755,7 +764,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitLetBinding(node: Let.Binding, ctx: Ctx) = translate(node) { metas ->
         val expr = visitExpr(node.expr, ctx)
-        val name = node.asAlias?.symbol
+        val name = stringToDefnid(node.asAlias.symbol)
         letBinding(expr, name, metas)
     }
 
@@ -765,13 +774,13 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
             GroupBy.Strategy.PARTIAL -> groupPartial()
         }
         val keyList = groupKeyList(node.keys.translate<PartiqlAst.GroupKey>(ctx))
-        val groupAsAlias = node.asAlias?.symbol
+        val groupAsAlias = node.asAlias?.let { stringToDefnid(it.symbol) }
         groupBy(strategy, keyList, groupAsAlias, metas)
     }
 
     override fun visitGroupByKey(node: GroupBy.Key, ctx: Ctx) = translate(node) { metas ->
         val expr = visitExpr(node.expr, ctx)
-        val asAlias = node.asAlias?.symbol
+        val asAlias = node.asAlias?.let { stringToDefnid(it.symbol) }
         groupKey(expr, asAlias, metas)
     }
 
@@ -818,7 +827,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
             null -> null
         }
         val prefilter = node.prefilter?.let { visitExpr(it, ctx) }
-        val variable = node.variable
+        val variable = node.variable?.let { stringToDefnid(it) }
         val quantifier = node.quantifier?.let { visitGraphMatchQuantifier(it, ctx) }
         val parts = node.parts.translate<PartiqlAst.GraphMatchPatternPart>(ctx)
         graphMatchPattern(restrictor, prefilter, variable, quantifier, parts, metas)
@@ -830,7 +839,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
     override fun visitGraphMatchPatternPartNode(node: GraphMatch.Pattern.Part.Node, ctx: Ctx) =
         translate(node) { metas ->
             val prefilter = node.prefilter?.let { visitExpr(it, ctx) }
-            val variable = node.variable
+            val variable = node.variable?.let { stringToDefnid(it) }
             val label = node.label?.let { visitGraphMatchLabel(it, ctx) }
             node(prefilter, variable, label, metas)
         }
@@ -848,7 +857,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
             }
             val quantifier = node.quantifier?.let { visitGraphMatchQuantifier(it, ctx) }
             val prefilter = node.prefilter?.let { visitExpr(it, ctx) }
-            val variable = node.variable
+            val variable = node.variable?.let { stringToDefnid(it) }
             val label = node.label?.let { visitGraphMatchLabel(it, ctx) }
             edge(direction, quantifier, prefilter, variable, label, metas)
         }
@@ -907,7 +916,8 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitGraphMatchLabelName(node: GraphMatch.Label.Name, ctx: Ctx) =
         translate(node) { metas ->
-            graphLabelName(node.name, metas)
+            val id = stringToDefnid(node.name)
+            graphLabelName(id, metas)
         }
 
     override fun visitGraphMatchLabelWildcard(node: GraphMatch.Label.Wildcard, ctx: Ctx) =
@@ -944,7 +954,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitStatementDMLInsert(node: Statement.DML.Insert, ctx: Ctx) = translate(node) { metas ->
         val target = visitIdentifier(node.target, ctx)
-        val asAlias = node.asAlias?.symbol
+        val asAlias = node.asAlias?.let { stringToDefnid(it.symbol) }
         val values = visitExpr(node.values, ctx)
         val conflictAction = node.onConflict?.let { visitOnConflictAction(it.action, ctx) }
         val op = insert(target, asAlias, values, conflictAction)
@@ -968,7 +978,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitStatementDMLUpsert(node: Statement.DML.Upsert, ctx: Ctx) = translate(node) { metas ->
         val target = visitIdentifier(node.target, ctx)
-        val asAlias = node.asAlias?.symbol
+        val asAlias = node.asAlias?.let { stringToDefnid(it.symbol) }
         val values = visitExpr(node.values, ctx)
         val conflictAction = doUpdate(excluded())
         // UPSERT overloads legacy INSERT
@@ -978,7 +988,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitStatementDMLReplace(node: Statement.DML.Replace, ctx: Ctx) = translate(node) { metas ->
         val target = visitIdentifier(node.target, ctx)
-        val asAlias = node.asAlias?.symbol
+        val asAlias = node.asAlias?.let { stringToDefnid(it.symbol) }
         val values = visitExpr(node.values, ctx)
         val conflictAction = doReplace(excluded())
         // REPLACE overloads legacy INSERT
@@ -1024,9 +1034,9 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitStatementDMLDeleteTarget(node: Statement.DML.Delete.Target, ctx: Ctx) = translate(node) { metas ->
         val path = visitPathUnpack(node.path, ctx)
-        val asAlias = node.asAlias?.symbol
-        val atAlias = node.atAlias?.symbol
-        val byAlias = node.byAlias?.symbol
+        val asAlias = node.asAlias?.let { stringToDefnid(it.symbol) }
+        val atAlias = node.atAlias?.let { stringToDefnid(it.symbol) }
+        val byAlias = node.byAlias?.let { stringToDefnid(it.symbol) }
         scan(path, asAlias, atAlias, byAlias, metas)
     }
 
@@ -1074,7 +1084,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         ctx: Ctx,
     ) = translate(node) { metas ->
         val target = visitIdentifier(node.target, ctx)
-        val asAlias = node.asAlias?.symbol
+        val asAlias = node.asAlias?.let { stringToDefnid(it.symbol) }
         val values = visitExpr(node.values, ctx)
         val conflictAction = node.onConflict?.let { visitOnConflictAction(it.action, ctx) }
         dmlOpList(insert(target, asAlias, values, conflictAction, metas))
@@ -1305,7 +1315,10 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
     override fun visitTypeAny(node: Type.Any, ctx: Ctx) = translate(node) { metas -> anyType(metas) }
 
     override fun visitTypeCustom(node: Type.Custom, ctx: Ctx) =
-        translate(node) { metas -> customType(node.name.lowercase(), metas) }
+        translate(node) { metas ->
+            val id = stringToDefnid(node.name)
+            customType(id.lowercase(), metas)
+        }
 
     /**
      * HELPERS
@@ -1316,6 +1329,14 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     private inline fun <reified T : PartiqlAst.PartiqlAstNode> visitOrNull(node: AstNode?, ctx: Ctx): T? =
         node?.let { visit(it, ctx) as T }
+
+    private fun stringToDefnid(str: String, metas: MetaContainer = emptyMetaContainer()): PartiqlAst.Defnid =
+        PartiqlAst.build {
+            defnid_(SymbolPrimitive(str, metas))
+        }
+
+    private fun PartiqlAst.Defnid.lowercase(): PartiqlAst.Defnid =
+        this.copy(symb = this.symb.copy(text = this.symb.text.lowercase()))
 
     private fun Identifier.CaseSensitivity.toLegacyCaseSensitivity() = when (this) {
         Identifier.CaseSensitivity.SENSITIVE -> PartiqlAst.CaseSensitivity.CaseSensitive()

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
@@ -526,16 +526,14 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         val start = visitOrNull<PartiqlAst.Expr>(node.start, ctx)
         val length = visitOrNull<PartiqlAst.Expr>(node.length, ctx)
         val operands = listOfNotNull(value, start, length)
-        val funId = defnid("substring")
-        call(funId, operands, metas)
+        call(defnid("substring"), operands, metas)
     }
 
     override fun visitExprPosition(node: Expr.Position, ctx: Ctx) = translate(node) { metas ->
         val lhs = visitExpr(node.lhs, ctx)
         val rhs = visitExpr(node.rhs, ctx)
         val operands = listOf(lhs, rhs)
-        val funId = defnid("position")
-        call(funId, operands, metas)
+        call(defnid("position"), operands, metas)
     }
 
     override fun visitExprTrim(node: Expr.Trim, ctx: Ctx) = translate(node) { metas ->
@@ -547,8 +545,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         if (spec != null) operands.add(lit(ionSymbol(spec)))
         if (chars != null) operands.add(chars)
         operands.add(value)
-        val funId = defnid("trim")
-        call(funId, operands, metas)
+        call(defnid("trim"), operands, metas)
     }
 
     override fun visitExprOverlay(node: Expr.Overlay, ctx: Ctx) = translate(node) { metas ->
@@ -557,16 +554,14 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         val start = visitExpr(node.start, ctx)
         val length = visitOrNull<PartiqlAst.Expr>(node.length, ctx)
         val operands = listOfNotNull(value, overlay, start, length)
-        val funId = defnid("overlay")
-        call(funId, operands, metas)
+        call(defnid("overlay"), operands, metas)
     }
 
     override fun visitExprExtract(node: Expr.Extract, ctx: Ctx) = translate(node) { metas ->
         val field = node.field.toLegacyDatetimePart()
         val source = visitExpr(node.source, ctx)
         val operands = listOf(field, source)
-        val funId = defnid("extract")
-        call(funId, operands, metas)
+        call(defnid("extract"), operands, metas)
     }
 
     override fun visitExprCast(node: Expr.Cast, ctx: Ctx) = translate(node) { metas ->
@@ -592,8 +587,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         val lhs = visitExpr(node.lhs, ctx)
         val rhs = visitExpr(node.rhs, ctx)
         val operands = listOf(field, lhs, rhs)
-        val funId = defnid("date_add")
-        call(funId, operands, metas)
+        call(defnid("date_add"), operands, metas)
     }
 
     override fun visitExprDateDiff(node: Expr.DateDiff, ctx: Ctx) = translate(node) { metas ->
@@ -601,8 +595,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         val lhs = visitExpr(node.lhs, ctx)
         val rhs = visitExpr(node.rhs, ctx)
         val operands = listOf(field, lhs, rhs)
-        val funId = defnid("date_diff")
-        call(funId, operands, metas)
+        call(defnid("date_diff"), operands, metas)
     }
 
     override fun visitExprBagOp(node: Expr.BagOp, ctx: Ctx) = translate(node) { metas ->
@@ -915,8 +908,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitGraphMatchLabelName(node: GraphMatch.Label.Name, ctx: Ctx) =
         translate(node) { metas ->
-            val id = defnid(node.name)
-            graphLabelName(id, metas)
+            graphLabelName(defnid(node.name), metas)
         }
 
     override fun visitGraphMatchLabelWildcard(node: GraphMatch.Label.Wildcard, ctx: Ctx) =

--- a/partiql-ast/src/main/kotlin/org/partiql/lang/domains/utils.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/lang/domains/utils.kt
@@ -1,0 +1,20 @@
+package org.partiql.lang.domains
+
+/** PartiqlAst.Defnid.string() is a bridge method, indicating places from which introduction of semantic identifiers should spread further.
+ *  Given e: SymbolPrimitive (formerly) or e: PartiqlAst.Defnid (currently),
+ *  the former usage pattern was
+ *      e.text         // results in a String
+ *  which now, with this bridge method, became
+ *      e.string()     // results is a String
+ *  and should, in the future, transition to something like
+ *      e.ident()      // results in an identifier
+ *  with the downstream code using identifiers rather than strings.
+ */
+fun PartiqlAst.Defnid.string(): String =
+    this.symb.text
+
+fun PartiqlLogicalResolved.Defnid.string(): String =
+    this.symb.text
+
+fun PartiqlPhysical.Defnid.string(): String =
+    this.symb.text

--- a/partiql-ast/src/main/pig/partiql.ion
+++ b/partiql-ast/src/main/pig/partiql.ion
@@ -150,13 +150,17 @@ may then be further optimized by selecting better implementations of each operat
 
             // Other expression types
             (path root::expr steps::(* path_step 1))
-            // wVG It is `defnid` in call, call_agg, and call_window because it was `symbol` there before,
-            // but logically, these are references, not definitions, so even in the legacy implementation,
-            // they should have been someting more like `identifier` or Expr.Id.
+
+            // It is `defnid` in call, call_agg, and call_window because it was `symbol` there before,
+            // and other usages of `symbol` became `definid`.
+            // However, these are references, not definitions, so even in the legacy implementation,
+            // they should have been someting more like `identifier` (i.e., had a case_sensitivity field).
+            // Not certain whether this wrinkle is worth straightening prior to transitioning to SQL-conformant identifiers.
             (call func_name::defnid args::(* expr 0))
             (call_agg setq::set_quantifier func_name::defnid arg::expr)
             // TODO: In the feature, when we allow use of aggregation function as window function, we need to consider incorporate in setq
             (call_window func_name::defnid over::over args::(* expr 1))
+
             (cast value::expr as_type::type)
             (can_cast value::expr as_type::type)
             (can_lossless_cast value::expr as_type::type)
@@ -738,7 +742,6 @@ may then be further optimized by selecting better implementations of each operat
             // permuted domains we can add information to this type such as the variable's assigned index.
             // Elements:
             // - `name`: the name of the variable as specified by the query author or determined statically.
-            // wVG-TODO: var_decl seems to be exactly the defnid of partiql_ast domain, so maybe no need in var_dec?
             (product var_decl name::symbol)
 
             // The operators of PartiQL's relational algebra.

--- a/partiql-ast/src/main/pig/partiql.ion
+++ b/partiql-ast/src/main/pig/partiql.ion
@@ -150,6 +150,9 @@ may then be further optimized by selecting better implementations of each operat
 
             // Other expression types
             (path root::expr steps::(* path_step 1))
+            // wVG It is `defnid` in call, call_agg, and call_window because it was `symbol` there before,
+            // but logically, these are references, not definitions, so even in the legacy implementation,
+            // they should have been someting more like `identifier` or Expr.Id.
             (call func_name::defnid args::(* expr 0))
             (call_agg setq::set_quantifier func_name::defnid arg::expr)
             // TODO: In the feature, when we allow use of aggregation function as window function, we need to consider incorporate in setq
@@ -735,6 +738,7 @@ may then be further optimized by selecting better implementations of each operat
             // permuted domains we can add information to this type such as the variable's assigned index.
             // Elements:
             // - `name`: the name of the variable as specified by the query author or determined statically.
+            // wVG-TODO: var_decl seems to be exactly the defnid of partiql_ast domain, so maybe no need in var_dec?
             (product var_decl name::symbol)
 
             // The operators of PartiQL's relational algebra.

--- a/partiql-ast/src/main/pig/partiql.ion
+++ b/partiql-ast/src/main/pig/partiql.ion
@@ -150,10 +150,10 @@ may then be further optimized by selecting better implementations of each operat
 
             // Other expression types
             (path root::expr steps::(* path_step 1))
-            (call func_name::symbol args::(* expr 0))
-            (call_agg setq::set_quantifier func_name::symbol arg::expr)
+            (call func_name::defnid args::(* expr 0))
+            (call_agg setq::set_quantifier func_name::defnid arg::expr)
             // TODO: In the feature, when we allow use of aggregation function as window function, we need to consider incorporate in setq
-            (call_window func_name::symbol over::over args::(* expr 1))
+            (call_window func_name::defnid over::over args::(* expr 1))
             (cast value::expr as_type::type)
             (can_cast value::expr as_type::type)
             (can_lossless_cast value::expr as_type::type)
@@ -217,13 +217,13 @@ may then be further optimized by selecting better implementations of each operat
             // For `.*` in SELECT list
             (project_all expr::expr)
             // For `<expr> [AS <id>]`
-            (project_expr expr::expr as_alias::(? symbol)))
+            (project_expr expr::expr as_alias::(? defnid)))
 
         // A list of LET bindings
         (product let let_bindings::(* let_binding 1))
 
         // A LET binding
-        (product let_binding expr::expr name::symbol)
+        (product let_binding expr::expr name::defnid)
 
         // Models the FROM clause of an SFW query
         // Note that modeling `scan` and `unpivot` separately is effectively re-introducing the same problem described
@@ -237,10 +237,10 @@ may then be further optimized by selecting better implementations of each operat
         //          (join ...))
         (sum from_source
             // <expr> [AS <id>] [AT <id>] [BY <id>]
-            (scan expr::expr as_alias::(? symbol) at_alias::(? symbol) by_alias::(? symbol))
+            (scan expr::expr as_alias::(? defnid) at_alias::(? defnid) by_alias::(? defnid))
 
             // UNPIVOT <expr> [AS <id>] [AT <id>] [BY <id>]
-            (unpivot expr::expr as_alias::(? symbol) at_alias::(? symbol) by_alias::(? symbol))
+            (unpivot expr::expr as_alias::(? defnid) at_alias::(? defnid) by_alias::(? defnid))
 
             // <from_source> JOIN [INNER | LEFT | RIGHT | FULL] <from_source> ON <expr>
             (join type::join_type left::from_source right::from_source predicate::(? expr))
@@ -273,7 +273,7 @@ may then be further optimized by selecting better implementations of each operat
 
         // A label spec in a node pattern like `MATCH (x : <lab>)` or in an edge pattern like `MATCH −[t : <lab>]−>`
         (sum graph_label_spec
-            (graph_label_name name::symbol)                   // as in `MATCH (x:Account)` or `MATCH -[x:Transfer]->`
+            (graph_label_name name::defnid)                   // as in `MATCH (x:Account)` or `MATCH -[x:Transfer]->`
             (graph_label_wildcard)                            // as in `MATCH (x: %)`
             (graph_label_negation arg::graph_label_spec)      // as in `MATCH (x: !Account)`
             (graph_label_conj lhs::graph_label_spec rhs::graph_label_spec)   // as in `MATCH (x: City&Country)` - Monaco can do
@@ -285,7 +285,7 @@ may then be further optimized by selecting better implementations of each operat
              // A single node in a graph pattern.
              (node
                  prefilter::(? expr)   // an optional node pre-filter, e.g.: `WHERE c.name='Alarm'` in `MATCH (c WHERE c.name='Alarm')`
-                 variable::(? symbol)  // the optional element variable of the node match, e.g.: `x` in `MATCH (x)`
+                 variable::(? defnid)  // the optional element variable of the node match, e.g.: `x` in `MATCH (x)`
                  label::(? graph_label_spec))  // the optional label spec to match for the node, e.g.: `Entity` in `MATCH (x:Entity)`
 
              // A single edge in a graph pattern.
@@ -293,7 +293,7 @@ may then be further optimized by selecting better implementations of each operat
                  direction::graph_match_direction       // edge direction
                  quantifier::(? graph_match_quantifier) // an optional quantifier for the entire pattern match, e.g. `{2,5}` in `MATCH (a:Account)−[:Transfer]−>{2,5}(b:Account)`
                  prefilter::(? expr)   // an optional edge pre-filter, e.g.: `WHERE t.capacity>100` in `MATCH −[t:hasSupply WHERE t.capacity>100]−>`
-                 variable::(? symbol)  // the optional element variable of the edge match, e.g.: `t` in `MATCH −[t]−>`
+                 variable::(? defnid)  // the optional element variable of the edge match, e.g.: `t` in `MATCH −[t]−>`
                  label::(? graph_label_spec))  // the optional label spec to match for the edge. e.g.: `Target` in `MATCH −[t:Target]−>`
 
              // A sub-pattern.
@@ -320,7 +320,7 @@ may then be further optimized by selecting better implementations of each operat
         (product graph_match_pattern
              restrictor::(? graph_match_restrictor)
              prefilter::(? expr)    // an optional pattern pre-filter, e.g.: `WHERE a.name=b.name` in `MATCH [(a)->(b) WHERE a.name=b.name]`
-             variable::(? symbol)   // the optional element variable of the pattern, e.g.: `p` in `MATCH p = (a) −[t]−> (b)`
+             variable::(? defnid)   // the optional element variable of the pattern, e.g.: `p` in `MATCH p = (a) −[t]−> (b)`
              quantifier::(? graph_match_quantifier) // an optional quantifier for the entire pattern match, e.g. `{2,5}` in `MATCH (a:Account)−[:Transfer]−>{2,5}(b:Account)`
              parts::(* graph_match_pattern_part 1)) // the ordered pattern parts
 
@@ -363,7 +363,7 @@ may then be further optimized by selecting better implementations of each operat
             // Note that `group_key_list` is a separate type instead of a variadic element because of the
             // PIG limitation that product types cannot have both optional and variadic elements.
             key_list::group_key_list
-            group_as_alias::(? symbol))  // `GROUP AS` alias
+            group_as_alias::(? defnid))  // `GROUP AS` alias
 
         // Desired grouping qualifier:  ALL or PARTIAL.  Note: the `group_` prefix is needed to avoid naming clashes.
         (sum grouping_strategy
@@ -374,7 +374,7 @@ may then be further optimized by selecting better implementations of each operat
         (product group_key_list keys::(* group_key 1))
 
         // <expr> [AS <symbol>]
-        (product group_key expr::expr as_alias::(? symbol))
+        (product group_key expr::expr as_alias::(? defnid))
 
         // ORDER BY <sort_spec>...
         (product order_by sort_specs::(* sort_spec 1))
@@ -428,7 +428,7 @@ may then be further optimized by selecting better implementations of each operat
         (sum dml_op
             // See the following RFC for more details:
             // https://github.com/partiql/partiql-docs/blob/main/RFCs/0011-partiql-insert.md
-            (insert target::expr as_alias::(? symbol) values::expr conflict_action::(? conflict_action))
+            (insert target::expr as_alias::(? defnid) values::expr conflict_action::(? conflict_action))
 
             // `INSERT INTO <expr> VALUE <expr> [AT <expr>]` [ON CONFLICT WHERE <expr> DO NOTHING]`
             (insert_value target::expr value::expr index::(? expr) on_conflict::(? on_conflict))
@@ -477,10 +477,10 @@ may then be further optimized by selecting better implementations of each operat
 
         (sum table_def_part
             // `<column_name> <type> <column_constraint>*`
-            (column_declaration name::symbol type::type constraints::(* column_constraint 0)))
+            (column_declaration name::defnid type::type constraints::(* column_constraint 0)))
 
         // `( CONSTRAINT <column_constraint_name> )?  <column_constraint_def>`
-        (product column_constraint name::(? symbol) def::column_constraint_def)
+        (product column_constraint name::(? defnid) def::column_constraint_def)
 
         //  `NULL | NOT NULL | CHECK ( <expr> )`
         (sum column_constraint_def
@@ -506,6 +506,8 @@ may then be further optimized by selecting better implementations of each operat
             (all_old)
         )
 
+        // `identifier` is a "reference identifier" for referring to / looking up an entity
+        // that is elsewhere bound to a 'defnid', a "definitional identifier".
         // `identifier` can be used for names that need to be looked up with a notion of case-sensitivity.
 
         // For both `create_index` and `create_table`, there is no notion of case-sensitivity
@@ -517,6 +519,11 @@ may then be further optimized by selecting better implementations of each operat
         // define an `identifier` type above which can be used without opening up an element's domain to all of
         // `expr`.
         (product identifier name::symbol case::case_sensitivity)
+
+        // A "definitional identifier" is for use in places that introduce, or bind, a name/identifier.
+        // This does not keep track of "case sensitivity", in the current design of identifiers.
+        // Upon transition to SQL-conforming identifiers, `defnid` will merge with `identifier`.
+        (product defnid symb::symbol)
 
         // Represents `<expr> = <expr>` in a DML SET operation.  Note that in this case, `=` is representing
         // an assignment operation and *not* the equality operator.
@@ -590,7 +597,7 @@ may then be further optimized by selecting better implementations of each operat
             // Special types
             (any_type)
 
-            (custom_type name::symbol)
+            (custom_type name::defnid)
         )
 
 

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
@@ -248,26 +248,26 @@ class ToLegacyAstTest {
 
         @JvmStatic
         fun calls() = listOf(
-            expect("(call 'a' (lit null))") {
+            expect("(call (defnid 'a') (lit null))") {
                 exprCall {
                     function = id("a")
                     args += NULL
                 }
             },
-            expect("(call_agg (all) 'a' (lit null))") {
+            expect("(call_agg (all) (defnid 'a') (lit null))") {
                 exprAgg {
                     function = id("a")
                     args += NULL
                 }
             },
-            expect("(call_agg (all) 'a' (lit null))") {
+            expect("(call_agg (all) (defnid 'a') (lit null))") {
                 exprAgg {
                     setq = SetQuantifier.ALL
                     function = id("a")
                     args += NULL
                 }
             },
-            expect("(call_agg (distinct) 'a' (lit null))") {
+            expect("(call_agg (distinct) (defnid 'a') (lit null))") {
                 exprAgg {
                     setq = SetQuantifier.DISTINCT
                     function = id("a")
@@ -413,7 +413,7 @@ class ToLegacyAstTest {
             // Other (??)
             expect("(integer4_type)") { typeInt4() },
             expect("(integer8_type)") { typeInt8() },
-            expect("(custom_type dog)") { typeCustom("dog") }
+            expect("(custom_type (defnid 'dog'))") { typeCustom("dog") }
             // LEGACY AST does not have TIMESTAMP or INTERVAL
             // LEGACY AST does not have parameterized blob/clob
         )
@@ -487,17 +487,17 @@ class ToLegacyAstTest {
             // TODO nullif
             // TODO substring
             // TODO position
-            expect("""(call 'trim' (lit "xyz"))""") {
+            expect("""(call (defnid 'trim') (lit "xyz"))""") {
                 exprTrim {
                     value = exprLit(stringValue("xyz"))
                 }
             },
-            expect("""(call 'trim' (lit "xyz"))""") {
+            expect("""(call (defnid 'trim') (lit "xyz"))""") {
                 exprTrim {
                     value = exprLit(stringValue("xyz"))
                 }
             },
-            expect("""(call 'trim' (lit "xyz"))""") {
+            expect("""(call (defnid 'trim') (lit "xyz"))""") {
                 exprTrim {
                     value = exprLit(stringValue("xyz"))
                 }
@@ -521,7 +521,7 @@ class ToLegacyAstTest {
                 """
                 (project_list
                     (project_all (id 'a' (case_sensitive) (unqualified)))
-                    (project_expr (lit 1) 'x')
+                    (project_expr (lit 1) (defnid 'x'))
                 )
              """
             ) {
@@ -554,7 +554,13 @@ class ToLegacyAstTest {
                     type = From.Value.Type.SCAN
                 }
             },
-            expect("(scan (lit null) 'a' 'b' 'c')") {
+            expect(
+                """(scan (lit null) 
+                |          (defnid 'a') 
+                |          (defnid 'b') 
+                |          (defnid 'c')
+                |      )""".trimMargin()
+            ) {
                 fromValue {
                     expr = NULL
                     type = From.Value.Type.SCAN
@@ -569,7 +575,13 @@ class ToLegacyAstTest {
                     type = From.Value.Type.UNPIVOT
                 }
             },
-            expect("(unpivot (lit null) 'a' 'b' 'c')") {
+            expect(
+                """(unpivot (lit null) 
+                |          (defnid 'a') 
+                |          (defnid 'b') 
+                |          (defnid 'c')
+                   )""".trimMargin()
+            ) {
                 fromValue {
                     expr = NULL
                     type = From.Value.Type.UNPIVOT
@@ -622,7 +634,7 @@ class ToLegacyAstTest {
                     condition = exprLit(boolValue(true))
                 }
             },
-            expect("(let (let_binding (lit null) 'x'))") {
+            expect("(let (let_binding (lit null) (defnid 'x')))") {
                 let {
                     bindings += letBinding {
                         expr = NULL
@@ -635,7 +647,7 @@ class ToLegacyAstTest {
                (group_by (group_full)
                     (group_key_list
                         (group_key (lit "a") null)
-                        (group_key (lit "b") 'x')
+                        (group_key (lit "b") (defnid 'x'))
                     )
                     null
                )
@@ -652,9 +664,9 @@ class ToLegacyAstTest {
                (group_by (group_partial)
                     (group_key_list
                         (group_key (lit "a") null)
-                        (group_key (lit "b") 'x')
+                        (group_key (lit "b") (defnid 'x'))
                     )
-                    'as'
+                    (defnid 'as')
                )
             """
             ) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/Ident.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/Ident.kt
@@ -1,0 +1,68 @@
+package org.partiql.lang
+
+/** Beginnings of the internal "semantic" identifier ADT
+ *  that is to replace the current use of String for this purpose.
+ */
+class Ident private constructor (
+    private val str: String
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null) return false
+        if (this === other) return true
+        if (other !is Ident) return false
+        return this.str.equals(other.str)
+    }
+
+    override fun hashCode(): Int {
+        return str.hashCode()
+    }
+
+    /** For usages where only the print-out appearance of Defnid is needed.
+     *  These might persist long-term.
+     *  wVG-TODO: Maybe make this the toString override. */
+    fun toDisplayString(): String = str
+
+    /** A bridge hack, for usages where the legacy implementation used a string,
+     *  but we should eventually transition to using an identifier. */
+    fun underlyingString(): String = str
+
+    /** The difference between Defnid creation methods is primarily in intent
+     *  (to mark usages with different purposes, as opposed to invoke different implementations):
+     *  - [createRegular] performs implementation-defined case normalization;
+     *          with legacy identifiers, this is primarily used for the names of built-in functions and such;
+     *          with SQL-conforming identifiers, this will be used with user-defined things as well.
+     *  - [createDelimited] is for a Defnid that corresponds to a lexical delimited identifier;
+     *          probably will be used only with SQL-conforming identifiers.
+     *  - [createAsIs] is meant to indicate that the lexical provenance of the identifier is not important;
+     *          this corresponds to the semantics of user-introduced legacy identifiers
+     *          and should get phased out during transition to SQL-conforming identifiers.
+     */
+    companion object {
+        fun createRegular(str: String): Ident =
+            Ident(normalize(str))
+
+        // wVG This is intended to be the one place to hold the design choice of whether
+        // regular identifiers normalize to lower or upper case.
+        private fun normalize(str: String): String =
+            str.lowercase()
+
+        // wVG-TODO: Decide whether this method should deal with quotes within the identifier,
+        //  or the argument [str] should come properly pre-processed.
+        //  Note: in legacy, this is done in PartiqlPigVisitor.visitIdentifier()
+        fun createDelimited(str: String): Ident =
+            Ident(str)
+
+        fun createAsIs(str: String): Ident =
+            Ident(str)
+    }
+
+    /** This marks lowercasing that is essential for implementing "case-sensitive lookup" of legacy identifiers.  */
+    fun essentialLowercase(): Ident =
+        Ident(str.lowercase())
+
+    /** wVG This method is to mark lowercasing that happened in the prior implementation,
+     *  but appeared extraneous. wVG-TODO: switch to no-op and see if tests pass. */
+    fun extraLowercase(): Ident =
+        Ident(str.lowercase())
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/domains/util.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/domains/util.kt
@@ -5,6 +5,7 @@ import com.amazon.ionelement.api.emptyMetaContainer
 import com.amazon.ionelement.api.metaContainerOf
 import org.partiql.errors.Property
 import org.partiql.errors.PropertyValueMap
+import org.partiql.lang.Ident
 import org.partiql.lang.ast.Meta
 import org.partiql.lang.ast.SourceLocationMeta
 import org.partiql.lang.ast.StaticTypeMeta
@@ -82,3 +83,25 @@ fun PartiqlPhysical.CaseSensitivity.toBindingCase(): BindingCase = when (this) {
     is PartiqlPhysical.CaseSensitivity.CaseInsensitive -> BindingCase.INSENSITIVE
     is PartiqlPhysical.CaseSensitivity.CaseSensitive -> BindingCase.SENSITIVE
 }
+
+fun PartiqlAst.Defnid.toIdent(): Ident =
+    Ident.createAsIs(this.symb.text)
+
+/** wVG This is a bridge method, indicating places from which introduction of semantic identifiers should spread further.
+ *  Given e: SymbolPrimitive (formerly) or e: PartiqlAst.Defnid (currently),
+ *  the former usage pattern was
+ *      e.text         // results in a String
+ *  which now, with this bridge method, became
+ *      e.string()     // results is a String
+ *  and should, in the future, transition to something like
+ *      e.ident()      // results in an identifier
+ *  with the downstream code using identifiers rather than strings.
+ */
+fun PartiqlAst.Defnid.string(): String =
+    this.symb.text
+
+fun PartiqlLogicalResolved.Defnid.string(): String =
+    this.symb.text
+
+fun PartiqlPhysical.Defnid.string(): String =
+    this.symb.text

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/domains/util.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/domains/util.kt
@@ -86,22 +86,3 @@ fun PartiqlPhysical.CaseSensitivity.toBindingCase(): BindingCase = when (this) {
 
 fun PartiqlAst.Defnid.toIdent(): Ident =
     Ident.createAsIs(this.symb.text)
-
-/** wVG This is a bridge method, indicating places from which introduction of semantic identifiers should spread further.
- *  Given e: SymbolPrimitive (formerly) or e: PartiqlAst.Defnid (currently),
- *  the former usage pattern was
- *      e.text         // results in a String
- *  which now, with this bridge method, became
- *      e.string()     // results is a String
- *  and should, in the future, transition to something like
- *      e.ident()      // results in an identifier
- *  with the downstream code using identifiers rather than strings.
- */
-fun PartiqlAst.Defnid.string(): String =
-    this.symb.text
-
-fun PartiqlLogicalResolved.Defnid.string(): String =
-    this.symb.text
-
-fun PartiqlPhysical.Defnid.string(): String =
-    this.symb.text

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/Bindings.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/Bindings.kt
@@ -146,7 +146,7 @@ interface Bindings<T> {
         fun addBinding(name: String, getter: () -> T): LazyBindingBuilder<T> =
             this.apply { bindings[name] = lazy(getter) }
 
-        /** wVG-TODO: switch to HashMap<Defnid, _>, so that this addBinding is primary. */
+        /** TODO: switch to HashMap<Defnid, _>, so that this addBinding is primary. */
         fun addBinding(name: Ident, getter: () -> T): LazyBindingBuilder<T> =
             addBinding(name.underlyingString(), getter)
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/Bindings.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/Bindings.kt
@@ -17,6 +17,7 @@ import com.amazon.ion.IonStruct
 import com.amazon.ion.IonSystem
 import com.amazon.ion.IonValue
 import org.partiql.errors.ErrorCode
+import org.partiql.lang.Ident
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.util.errAmbiguousBinding
 import org.partiql.lang.util.isBindingNameEquivalent
@@ -144,6 +145,10 @@ interface Bindings<T> {
 
         fun addBinding(name: String, getter: () -> T): LazyBindingBuilder<T> =
             this.apply { bindings[name] = lazy(getter) }
+
+        /** wVG-TODO: switch to HashMap<Defnid, _>, so that this addBinding is primary. */
+        fun addBinding(name: Ident, getter: () -> T): LazyBindingBuilder<T> =
+            addBinding(name.underlyingString(), getter)
 
         fun build(): Bindings<T> =
             LazyBindings<T>(bindings)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/EvaluatingCompiler.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/EvaluatingCompiler.kt
@@ -343,7 +343,7 @@ internal class EvaluatingCompiler(
                 Pair("some", PartiqlAst.SetQuantifier.Distinct()) to ExprAggregatorFactory.over {
                     Accumulator(null, anySomeAccFunc, createUniqueExprValueFilter())
                 },
-            ).map { (p, a) -> Pair(Ident.createRegular(p.first), p.second) to a }.toMap()
+            ).map { (p, a) -> Pair(Ident.createFromRegular(p.first), p.second) to a }.toMap()
         }
 
     /**
@@ -3172,11 +3172,6 @@ private sealed class ProjectionElement
  * - `name` is "value"
  * - `thunk` is compiled expression, i.e. `a + b`
  */
-// wVG Why is this complication with name: ExprValue (i.e., `x` in `AS x` being "computable"),
-//   while x can only be an identifier, both in the grammar and in the AST (i.e. a thing fully known at lexing)?
-//   Best guess [see the only usage of SingleProjectionElement.name], this is because of the Named facet,
-//   as used for "named" ExprValues representing key/value pairs in struct construction.
-//   This is another reason Named facet is to be considered harmful.
 private class SingleProjectionElement(val name: ExprValue, val thunk: ThunkEnv) : ProjectionElement()
 
 /**

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/binding/LocalsBinder.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/binding/LocalsBinder.kt
@@ -112,9 +112,7 @@ fun List<Alias>.localsBinder(missingValue: ExprValue): LocalsBinder {
         val caseInsensitiveBindings = compileBindings { it.essentialLowercase() }
         override fun binderForName(bindingName: BindingName): (List<ExprValue>) -> ExprValue? {
             return when (bindingName.bindingCase) {
-// wVG               BindingCase.INSENSITIVE -> caseInsensitiveBindings[bindingName.name.lowercase()]
-                BindingCase.INSENSITIVE -> caseInsensitiveBindings[Ident.createRegular(bindingName.name)]
-// wVG               BindingCase.SENSITIVE -> caseSensitiveBindings[bindingName.name]
+                BindingCase.INSENSITIVE -> caseInsensitiveBindings[Ident.createFromRegular(bindingName.name)]
                 BindingCase.SENSITIVE -> caseSensitiveBindings[Ident.createAsIs(bindingName.name)]
             } ?: dynamicLocalsBinder(bindingName)
         }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/DefinitionalBuiltins.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/DefinitionalBuiltins.kt
@@ -40,7 +40,7 @@ internal fun definitionalBuiltins(typingMode: TypingMode): List<ExprFunction> =
  */
 internal class ExprFunctionCollToScalar(typingMode: TypingMode) : ExprFunction {
     override val signature = FunctionSignature(
-        name = "coll_to_scalar", // wVG-TODO: FunctionSignature.name should be an identifier rather than String
+        name = "coll_to_scalar", // TODO: FunctionSignature.name should be an identifier rather than String
         requiredParameters = listOf(StaticType.ANY),
         returnType = StaticType.ANY
     )

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/DefinitionalBuiltins.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/builtins/DefinitionalBuiltins.kt
@@ -40,7 +40,7 @@ internal fun definitionalBuiltins(typingMode: TypingMode): List<ExprFunction> =
  */
 internal class ExprFunctionCollToScalar(typingMode: TypingMode) : ExprFunction {
     override val signature = FunctionSignature(
-        name = "coll_to_scalar",
+        name = "coll_to_scalar", // wVG-TODO: FunctionSignature.name should be an identifier rather than String
         requiredParameters = listOf(StaticType.ANY),
         returnType = StaticType.ANY
     )

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
@@ -30,6 +30,7 @@ import org.partiql.lang.ast.UNKNOWN_SOURCE_LOCATION
 import org.partiql.lang.ast.sourceLocation
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.domains.staticType
+import org.partiql.lang.domains.string
 import org.partiql.lang.domains.toBindingCase
 import org.partiql.lang.eval.AnyOfCastTable
 import org.partiql.lang.eval.Arguments
@@ -816,11 +817,11 @@ internal class PhysicalPlanCompilerImpl(
 
     private fun compileCall(expr: PartiqlPhysical.Expr.Call, metas: MetaContainer): PhysicalPlanThunk {
         val funcArgThunks = compileAstExprs(expr.args)
-        val func = functions[expr.funcName.text] ?: err(
-            "No such function: ${expr.funcName.text}",
+        val func = functions[expr.funcName.string()] ?: err(
+            "No such function: ${expr.funcName.string()}",
             ErrorCode.EVALUATOR_NO_SUCH_FUNCTION,
             errorContextFrom(metas).also {
-                it[Property.FUNCTION_NAME] = expr.funcName.text
+                it[Property.FUNCTION_NAME] = expr.funcName.string()
             },
             internal = false
         )

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransform.kt
@@ -41,7 +41,7 @@ class AggregateSupportVisitorTransform : VisitorTransformBase() {
 
     override fun transformExprCallAgg(node: PartiqlAst.Expr.CallAgg): PartiqlAst.Expr {
         val transformedCallAgg = PartiqlAst.build {
-            callAgg_(
+            callAgg(
                 setq = node.setq,
                 funcName = node.funcName,
                 arg = transformExpr(node.arg),

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/FromSourceAliasVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/FromSourceAliasVisitorTransform.kt
@@ -42,14 +42,12 @@ class FromSourceAliasVisitorTransform : VisitorTransformBase() {
             val thisFromSourceIndex = fromSourceCounter++
             return node.asAlias
                 ?: PartiqlAst.build { defnid(node.expr.extractColumnAlias(thisFromSourceIndex)) }
-            // wVG: No longer adding node.extractSourceLocation() to the synthesized id, because that's bogus.
         }
 
         override fun transformFromSourceUnpivot_asAlias(node: PartiqlAst.FromSource.Unpivot): PartiqlAst.Defnid {
             val thisFromSourceIndex = fromSourceCounter++
             return node.asAlias
                 ?: PartiqlAst.build { defnid(node.expr.extractColumnAlias(thisFromSourceIndex)) }
-            // wVG: No longer adding node.extractSourceLocation() to the synthesized id, because that's bogus.
         }
 
         // Do not traverse into subexpressions of a [FromSource].

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/FromSourceAliasVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/FromSourceAliasVisitorTransform.kt
@@ -1,9 +1,7 @@
 package org.partiql.lang.eval.visitors
 
 import org.partiql.lang.domains.PartiqlAst
-import org.partiql.lang.domains.extractSourceLocation
 import org.partiql.lang.eval.extractColumnAlias
-import org.partiql.pig.runtime.SymbolPrimitive
 
 /**
  * Assigns aliases to any unspecified [PartiqlAst.FromSource.Scan]/[PartiqlAst.FromSource.Unpivot] that does not
@@ -40,16 +38,18 @@ class FromSourceAliasVisitorTransform : VisitorTransformBase() {
     private class InnerFromSourceAliasVisitorTransform : VisitorTransformBase() {
         private var fromSourceCounter = 0
 
-        override fun transformFromSourceScan_asAlias(node: PartiqlAst.FromSource.Scan): SymbolPrimitive {
+        override fun transformFromSourceScan_asAlias(node: PartiqlAst.FromSource.Scan): PartiqlAst.Defnid {
             val thisFromSourceIndex = fromSourceCounter++
             return node.asAlias
-                ?: SymbolPrimitive(node.expr.extractColumnAlias(thisFromSourceIndex), node.extractSourceLocation())
+                ?: PartiqlAst.build { defnid(node.expr.extractColumnAlias(thisFromSourceIndex)) }
+            // wVG: No longer adding node.extractSourceLocation() to the synthesized id, because that's bogus.
         }
 
-        override fun transformFromSourceUnpivot_asAlias(node: PartiqlAst.FromSource.Unpivot): SymbolPrimitive {
+        override fun transformFromSourceUnpivot_asAlias(node: PartiqlAst.FromSource.Unpivot): PartiqlAst.Defnid {
             val thisFromSourceIndex = fromSourceCounter++
             return node.asAlias
-                ?: SymbolPrimitive(node.expr.extractColumnAlias(thisFromSourceIndex), node.extractSourceLocation())
+                ?: PartiqlAst.build { defnid(node.expr.extractColumnAlias(thisFromSourceIndex)) }
+            // wVG: No longer adding node.extractSourceLocation() to the synthesized id, because that's bogus.
         }
 
         // Do not traverse into subexpressions of a [FromSource].

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/GroupByItemAliasVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/GroupByItemAliasVisitorTransform.kt
@@ -48,7 +48,7 @@ class GroupByItemAliasVisitorTransform(var nestLevel: Int = 0) : VisitorTransfor
                         if (it.asAlias == null) {
                             metas = metas + metaContainerOf(IsSyntheticNameMeta.TAG to IsSyntheticNameMeta.instance)
                         }
-                        val alias = defnid(aliasText)
+                        val alias = defnid(aliasText, metas)
 
                         groupKey(transformExpr(it.expr), alias, alias.metas)
                     },

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/GroupByPathExpressionVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/GroupByPathExpressionVisitorTransform.kt
@@ -19,6 +19,7 @@ import org.partiql.errors.ErrorCode
 import org.partiql.lang.ast.IsSyntheticNameMeta
 import org.partiql.lang.ast.UniqueNameMeta
 import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.string
 import org.partiql.lang.eval.errNoContext
 
 /**
@@ -63,7 +64,8 @@ class GroupByPathExpressionVisitorTransform(
             when (fromSource) {
                 is PartiqlAst.FromSource.Scan ->
                     listOf(
-                        fromSource.asAlias?.text
+                        // wVG brute-forced it in this file -- there is interaction with Expr.Id and it's better to deal with this then
+                        fromSource.asAlias?.string()
                             ?: errNoContext(
                                 "FromSource.asAlias.text must be specified for this transform to work",
                                 errorCode = ErrorCode.SEMANTIC_MISSING_AS_NAME,
@@ -75,7 +77,7 @@ class GroupByPathExpressionVisitorTransform(
                     collectAliases(fromSource.left) + collectAliases(fromSource.right)
 
                 is PartiqlAst.FromSource.Unpivot ->
-                    listOfNotNull(fromSource.asAlias?.text, fromSource.atAlias?.text)
+                    listOfNotNull(fromSource.asAlias?.string(), fromSource.atAlias?.string())
             }
     }
 
@@ -139,7 +141,7 @@ class GroupByPathExpressionVisitorTransform(
                     groupKey.expr,
                     PartiqlAst.build {
                         id(
-                            name = groupKey.asAlias!!.text,
+                            name = groupKey.asAlias!!.string(),
                             case = caseSensitive(),
                             qualifier = unqualified(),
                             metas = groupKey.expr.metas + metaContainerOf(UniqueNameMeta.TAG to uniqueIdentifierMeta)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/GroupByPathExpressionVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/GroupByPathExpressionVisitorTransform.kt
@@ -64,7 +64,6 @@ class GroupByPathExpressionVisitorTransform(
             when (fromSource) {
                 is PartiqlAst.FromSource.Scan ->
                     listOf(
-                        // wVG brute-forced it in this file -- there is interaction with Expr.Id and it's better to deal with this then
                         fromSource.asAlias?.string()
                             ?: errNoContext(
                                 "FromSource.asAlias.text must be specified for this transform to work",

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/OrderBySortSpecVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/OrderBySortSpecVisitorTransform.kt
@@ -48,7 +48,6 @@ internal class OrderBySortSpecVisitorTransform : VisitorTransformBase() {
      */
     override fun transformProjectItemProjectExpr_asAlias(node: PartiqlAst.ProjectItem.ProjectExpr): PartiqlAst.Defnid? {
         val transformedAlias = super.transformProjectItemProjectExpr_asAlias(node)
-        // wVG Brute-forced, since there is an interaction with Expr.Id. Eventually, projectionAliases should be keyed on identifiers, not strings.
         if (node.asAlias != null) { projectionAliases[node.asAlias!!.string()] = node.expr }
         return transformedAlias
     }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/OrderBySortSpecVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/OrderBySortSpecVisitorTransform.kt
@@ -17,7 +17,7 @@ package org.partiql.lang.eval.visitors
 import org.partiql.lang.ast.IsTransformedOrderByAliasMeta
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.domains.metaContainerOf
-import org.partiql.pig.runtime.SymbolPrimitive
+import org.partiql.lang.domains.string
 
 /**
  * A [PartiqlAst.VisitorTransform] to replace the [PartiqlAst.SortSpec] of a [PartiqlAst.OrderBy] with a reference to
@@ -46,9 +46,10 @@ internal class OrderBySortSpecVisitorTransform : VisitorTransformBase() {
     /**
      * Uses default transform and adds the alias to the [projectionAliases] map
      */
-    override fun transformProjectItemProjectExpr_asAlias(node: PartiqlAst.ProjectItem.ProjectExpr): SymbolPrimitive? {
+    override fun transformProjectItemProjectExpr_asAlias(node: PartiqlAst.ProjectItem.ProjectExpr): PartiqlAst.Defnid? {
         val transformedAlias = super.transformProjectItemProjectExpr_asAlias(node)
-        if (node.asAlias != null) { projectionAliases[node.asAlias!!.text] = node.expr }
+        // wVG Brute-forced, since there is an interaction with Expr.Id. Eventually, projectionAliases should be keyed on identifiers, not strings.
+        if (node.asAlias != null) { projectionAliases[node.asAlias!!.string()] = node.expr }
         return transformedAlias
     }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SelectListItemAliasVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SelectListItemAliasVisitorTransform.kt
@@ -1,9 +1,7 @@
 package org.partiql.lang.eval.visitors
 
 import org.partiql.lang.domains.PartiqlAst
-import org.partiql.lang.domains.extractSourceLocation
 import org.partiql.lang.eval.extractColumnAlias
-import org.partiql.pig.runtime.SymbolPrimitive
 
 /**
  * Specifies any previously unspecified select list item aliases.
@@ -44,14 +42,11 @@ class SelectListItemAliasVisitorTransform : VisitorTransformBase() {
                         is PartiqlAst.ProjectItem.ProjectExpr ->
                             when (it.asAlias) {
                                 //  Synthesize a column name if one was not specified in the query.
-                                null -> projectExpr_(
+                                null -> projectExpr(
                                     expr = transformExpr(it.expr),
-                                    asAlias = SymbolPrimitive(
-                                        text = it.expr.extractColumnAlias(idx),
-                                        metas = node.extractSourceLocation()
-                                    )
+                                    asAlias = defnid(it.expr.extractColumnAlias(idx)),
                                 )
-                                else -> projectExpr_(
+                                else -> projectExpr(
                                     expr = transformExpr(it.expr),
                                     asAlias = it.asAlias
                                 )

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SelectStarVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SelectStarVisitorTransform.kt
@@ -20,6 +20,7 @@ import org.partiql.lang.ast.IsGroupAttributeReferenceMeta
 import org.partiql.lang.ast.UniqueNameMeta
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.domains.metaContainerOf
+import org.partiql.lang.domains.string
 import org.partiql.lang.eval.errNoContext
 
 /** Desugars `SELECT *` by, for example,
@@ -73,13 +74,13 @@ class SelectStarVisitorTransform : VisitorTransformBase() {
                             ?: error("UniqueNameMeta not found--normally, this is added by GroupByItemAliasVisitorTransform")
 
                         val metas = it.metas + metaContainerOf(IsGroupAttributeReferenceMeta.instance)
-                        createProjectExpr(uniqueNameMeta.uniqueName, asName.text, metas)
+                        createProjectExpr(uniqueNameMeta.uniqueName, asName.string(), metas)
                     }
 
                     val groupNameItem = transformedExpr.group!!.groupAsAlias.let {
                         if (it != null) {
                             val metas = it.metas + metaContainerOf(IsGroupAttributeReferenceMeta.instance)
-                            listOf(createProjectExpr(it.text, metas = metas))
+                            listOf(createProjectExpr(it.string(), metas = metas))
                         } else emptyList()
                     }
 
@@ -99,7 +100,7 @@ class SelectStarVisitorTransform : VisitorTransformBase() {
 
     private fun createProjectExpr(variableName: String, asAlias: String = variableName, metas: MetaContainer = emptyMetaContainer()) =
         PartiqlAst.build {
-            projectExpr(id(variableName, caseSensitive(), unqualified(), metas), asAlias)
+            projectExpr(id(variableName, caseSensitive(), unqualified(), metas), defnid(asAlias))
         }
 
     private class FromSourceAliases(val asAlias: String, val atAlias: String?, val byAlias: String?)
@@ -111,10 +112,10 @@ class SelectStarVisitorTransform : VisitorTransformBase() {
             override fun visitFromSourceScan(node: PartiqlAst.FromSource.Scan) {
                 aliases.add(
                     FromSourceAliases(
-                        node.asAlias?.text
+                        node.asAlias?.string()
                             ?: error("FromSourceAliasVisitorTransform must be executed before SelectStarVisitorTransform"),
-                        node.atAlias?.text,
-                        node.byAlias?.text
+                        node.atAlias?.string(),
+                        node.byAlias?.string()
                     )
                 )
             }
@@ -122,10 +123,10 @@ class SelectStarVisitorTransform : VisitorTransformBase() {
             override fun visitFromSourceUnpivot(node: PartiqlAst.FromSource.Unpivot) {
                 aliases.add(
                     FromSourceAliases(
-                        node.asAlias?.text
+                        node.asAlias?.string()
                             ?: error("FromSourceAliasVisitorTransform must be executed before SelectStarVisitorTransform"),
-                        node.atAlias?.text,
-                        node.byAlias?.text
+                        node.atAlias?.string(),
+                        node.byAlias?.string()
                     )
                 )
             }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/StaticTypeVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/StaticTypeVisitorTransform.kt
@@ -15,6 +15,7 @@ import org.partiql.lang.ast.passes.SemanticException
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.domains.addSourceLocation
 import org.partiql.lang.domains.extractSourceLocation
+import org.partiql.lang.domains.string
 import org.partiql.lang.domains.toBindingCase
 import org.partiql.lang.eval.BindingCase
 import org.partiql.lang.eval.BindingName
@@ -211,7 +212,7 @@ class StaticTypeVisitorTransform(
 
         override fun transformExprCallAgg(node: PartiqlAst.Expr.CallAgg): PartiqlAst.Expr {
             return PartiqlAst.build {
-                callAgg_(
+                callAgg(
                     // do not transform the funcExpr--as this is a symbolic name in another namespace (AST is over generalized here)
                     node.setq,
                     node.funcName,
@@ -355,11 +356,11 @@ class StaticTypeVisitorTransform(
             val from = super.transformFromSourceScan(node)
 
             node.atAlias?.let {
-                addLocal(it.text, StaticType.ANY, it.metas)
+                addLocal(it.string(), StaticType.ANY, it.metas)
             }
 
             node.byAlias?.let {
-                addLocal(it.text, StaticType.ANY, it.metas)
+                addLocal(it.string(), StaticType.ANY, it.metas)
             }
 
             val asSymbolicName = node.asAlias
@@ -368,12 +369,12 @@ class StaticTypeVisitorTransform(
                         "FromSourceAliasVisitorTransform was executed first."
                 )
 
-            addLocal(asSymbolicName.text, StaticType.ANY, asSymbolicName.metas)
+            addLocal(asSymbolicName.string(), StaticType.ANY, asSymbolicName.metas)
 
             if (!containsJoin) {
                 fromVisited = true
                 if (currentScopeDepth == 1) {
-                    singleFromSourceName = asSymbolicName.text
+                    singleFromSourceName = asSymbolicName.string()
                 }
             }
             return from
@@ -384,11 +385,11 @@ class StaticTypeVisitorTransform(
             val from = super.transformFromSourceUnpivot(node)
 
             node.atAlias?.let {
-                addLocal(it.text, StaticType.ANY, it.metas)
+                addLocal(it.string(), StaticType.ANY, it.metas)
             }
 
             node.byAlias?.let {
-                addLocal(it.text, StaticType.ANY, it.metas)
+                addLocal(it.string(), StaticType.ANY, it.metas)
             }
 
             val asSymbolicName = node.asAlias
@@ -397,12 +398,12 @@ class StaticTypeVisitorTransform(
                         "FromSourceAliasVisitorTransform was executed first."
                 )
 
-            addLocal(asSymbolicName.text, StaticType.ANY, asSymbolicName.metas)
+            addLocal(asSymbolicName.string(), StaticType.ANY, asSymbolicName.metas)
 
             if (!containsJoin) {
                 fromVisited = true
                 if (currentScopeDepth == 1) {
-                    singleFromSourceName = asSymbolicName.text
+                    singleFromSourceName = asSymbolicName.string()
                 }
             }
             return from
@@ -410,7 +411,7 @@ class StaticTypeVisitorTransform(
 
         override fun transformLetBinding(node: PartiqlAst.LetBinding): PartiqlAst.LetBinding {
             val binding = super.transformLetBinding(node)
-            addLocal(binding.name.text, StaticType.ANY, binding.name.metas)
+            addLocal(binding.name.string(), StaticType.ANY, binding.name.metas)
             return binding
         }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/SubqueryCoercionVisitorTransform.kt
@@ -110,7 +110,7 @@ class SubqueryCoercionVisitorTransform : VisitorTransformBase() {
         when (e) {
             is PartiqlAst.Expr.Select ->
                 if ((e.project is PartiqlAst.Projection.ProjectStar) || (e.project is PartiqlAst.Projection.ProjectList)) {
-                    PartiqlAst.build { call("coll_to_scalar", e) }
+                    PartiqlAst.build { call(defnid("coll_to_scalar"), e) }
                 } else e
             else -> e
         }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/graph/GpmlTranslator.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/graph/GpmlTranslator.kt
@@ -1,6 +1,7 @@
 package org.partiql.lang.graph
 
 import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.string
 import org.partiql.lang.graph.GpmlTranslator.normalizeElemList
 
 /** Translate an AST graph pattern into a "plan spec" to be executed by the graph engine.
@@ -36,7 +37,7 @@ object GpmlTranslator {
     fun translateNodePat(node: PartiqlAst.GraphMatchPatternPart.Node): NodeSpec {
         if (node.prefilter != null) TODO("Not yet supported in evaluating a GPML node pattern: prefilter.")
         return NodeSpec(
-            binder = node.variable?.text,
+            binder = node.variable?.string(),
             label = translateLabels(node.label)
         )
     }
@@ -45,7 +46,7 @@ object GpmlTranslator {
         if (edge.prefilter != null || edge.quantifier != null)
             TODO("Not yet supported in evaluating a GPML edge pattern: prefilter, quantifier.")
         return EdgeSpec(
-            binder = edge.variable?.text,
+            binder = edge.variable?.string(),
             label = translateLabels(edge.label),
             dir = translateDirection(edge.direction)
         )
@@ -54,7 +55,7 @@ object GpmlTranslator {
     fun translateLabels(labelSpec: PartiqlAst.GraphLabelSpec?): LabelSpec {
         return when (labelSpec) {
             null -> LabelSpec.Wildcard
-            is PartiqlAst.GraphLabelSpec.GraphLabelName -> LabelSpec.Name(labelSpec.name.text)
+            is PartiqlAst.GraphLabelSpec.GraphLabelName -> LabelSpec.Name(labelSpec.name.string())
             is PartiqlAst.GraphLabelSpec.GraphLabelWildcard -> LabelSpec.Wildcard
             else -> TODO("Not yet supported graph label pattern: $labelSpec")
         }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/AstToLogicalVisitorTransform.kt
@@ -529,7 +529,7 @@ internal class AstToLogicalVisitorTransform(
                         is PartiqlAst.ProjectItem.ProjectExpr ->
                             structField(
                                 lit(
-                                    projectItem.asAlias?.toIonElement()
+                                    projectItem.asAlias?.string()?.toIonElement()
                                         ?: errAstNotNormalized("SELECT-list item alias not specified")
                                 ),
                                 transformExpr(projectItem.expr),

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransform.kt
@@ -578,7 +578,7 @@ internal data class LogicalToLogicalResolvedVisitorTransform(
         }.toString().lowercase()
         return PartiqlLogicalResolved.build {
             call(
-                funcName = DYNAMIC_LOOKUP_FUNCTION_NAME,
+                funcName = defnid(DYNAMIC_LOOKUP_FUNCTION_NAME),
                 args = listOf(
                     lit(name.toIonElement()),
                     lit(ionSymbol(caseSensitivityString)),

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/RelConverter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/RelConverter.kt
@@ -3,6 +3,7 @@ package org.partiql.lang.planner.transforms.plan
 import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.ionString
 import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.string
 import org.partiql.lang.eval.visitors.VisitorTransformBase
 import org.partiql.plan.Binding
 import org.partiql.plan.Case
@@ -139,9 +140,9 @@ internal class RelConverter {
             is PartiqlAst.Expr.Select -> convert(expr)
             else -> RexConverter.convert(scan.expr)
         },
-        alias = scan.asAlias?.text,
-        at = scan.atAlias?.text,
-        by = scan.byAlias?.text
+        alias = scan.asAlias?.string(),
+        at = scan.atAlias?.string(),
+        by = scan.byAlias?.string()
     )
 
     /**
@@ -150,9 +151,9 @@ internal class RelConverter {
     private fun convertUnpivot(scan: PartiqlAst.FromSource.Unpivot) = Plan.relUnpivot(
         common = empty,
         value = RexConverter.convert(scan.expr),
-        alias = scan.asAlias?.text,
-        at = scan.atAlias?.text,
-        by = scan.byAlias?.text
+        alias = scan.asAlias?.string(),
+        at = scan.atAlias?.string(),
+        by = scan.byAlias?.string()
     )
 
     /**
@@ -198,7 +199,7 @@ internal class RelConverter {
         if (groupBy != null) {
             // GROUP AS is implemented as an aggregation function
             if (groupBy.groupAsAlias != null) {
-                calls.add(convertGroupAs(groupBy.groupAsAlias!!.text, sel.from))
+                calls.add(convertGroupAs(groupBy.groupAsAlias!!.string(), sel.from))
             }
             groups = groupBy.keyList.keys.map { convertGroupByKey(it) }
             strategy = when (groupBy.strategy) {
@@ -222,7 +223,7 @@ internal class RelConverter {
      * Each GROUP BY becomes a binding available in the output tuples of [Rel.Aggregate]
      */
     private fun convertGroupByKey(groupKey: PartiqlAst.GroupKey) = binding(
-        name = groupKey.asAlias?.text ?: error("not normalized, group key $groupKey missing unique name"),
+        name = groupKey.asAlias?.string() ?: error("not normalized, group key $groupKey missing unique name"),
         expr = groupKey.expr
     )
 
@@ -346,14 +347,14 @@ internal class RelConverter {
             if (asAlias == null) {
                 error("not normalized, scan is missing an alias")
             }
-            listOf(asAlias!!.text)
+            listOf(asAlias!!.string())
         }
         is PartiqlAst.FromSource.Join -> left.bindings() + right.bindings()
         is PartiqlAst.FromSource.Unpivot -> {
             if (asAlias == null) {
                 error("not normalized, scan is missing an alias")
             }
-            listOf(asAlias!!.text)
+            listOf(asAlias!!.string())
         }
     }
 
@@ -380,7 +381,7 @@ internal class RelConverter {
                 binding(bindingName, path)
             }
             is PartiqlAst.ProjectItem.ProjectExpr -> binding(
-                name = it.asAlias?.text ?: error("not normalized"),
+                name = it.asAlias?.string() ?: error("not normalized"),
                 expr = it.expr
             )
         }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/RexConverter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/planner/transforms/plan/RexConverter.kt
@@ -4,6 +4,7 @@ import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.ionNull
 import org.partiql.errors.ErrorCode
 import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.string
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.builtins.ExprFunctionCurrentUser
 import org.partiql.lang.eval.err
@@ -385,7 +386,7 @@ internal object RexConverter : PartiqlAst.VisitorFold<RexConverter.Ctx>() {
 
     override fun walkExprCall(node: PartiqlAst.Expr.Call, ctx: Ctx) = visit(node) {
         Plan.rexCall(
-            id = node.funcName.text,
+            id = node.funcName.string(),
             args = args(*node.args.toTypedArray()),
             type = null,
         )
@@ -393,7 +394,7 @@ internal object RexConverter : PartiqlAst.VisitorFold<RexConverter.Ctx>() {
 
     override fun walkExprCallAgg(node: PartiqlAst.Expr.CallAgg, ctx: Ctx) = visit(node) {
         Plan.rexAgg(
-            id = node.funcName.text,
+            id = node.funcName.string(),
             args = listOf(convert(node.arg)),
             modifier = when (node.setq) {
                 is PartiqlAst.SetQuantifier.All -> Rex.Agg.Modifier.ALL

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
@@ -134,6 +134,13 @@ class ASTPrettyPrinter {
             attrOfParent = attrOfParent
         )
 
+    private fun toRecursionTree(node: PartiqlAst.Defnid, attrOfParent: String? = null): RecursionTree =
+        RecursionTree(
+            astType = "Defnid",
+            value = node.symb.text,
+            attrOfParent = attrOfParent
+        )
+
     // *******
     // * DML *
     // *******
@@ -481,13 +488,13 @@ class ASTPrettyPrinter {
             )
             is PartiqlAst.Expr.Call -> RecursionTree(
                 astType = "Call",
-                value = node.funcName.text,
+                value = node.funcName.symb.text,
                 attrOfParent = attrOfParent,
                 children = toRecursionTreeList(node.args, "arg")
             )
             is PartiqlAst.Expr.CallAgg -> RecursionTree(
                 astType = "CallAgg",
-                value = node.funcName.text,
+                value = node.funcName.symb.text,
                 attrOfParent = attrOfParent,
                 children = listOf(toRecursionTree(node.arg, "arg"))
             )

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinter.kt
@@ -1,6 +1,7 @@
 package org.partiql.lang.prettyprint
 
 import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.string
 import org.partiql.lang.syntax.PartiQLParserBuilder
 import org.partiql.pig.runtime.SymbolPrimitive
 
@@ -137,7 +138,7 @@ class ASTPrettyPrinter {
     private fun toRecursionTree(node: PartiqlAst.Defnid, attrOfParent: String? = null): RecursionTree =
         RecursionTree(
             astType = "Defnid",
-            value = node.symb.text,
+            value = node.string(),
             attrOfParent = attrOfParent
         )
 
@@ -488,13 +489,13 @@ class ASTPrettyPrinter {
             )
             is PartiqlAst.Expr.Call -> RecursionTree(
                 astType = "Call",
-                value = node.funcName.symb.text,
+                value = node.funcName.string(),
                 attrOfParent = attrOfParent,
                 children = toRecursionTreeList(node.args, "arg")
             )
             is PartiqlAst.Expr.CallAgg -> RecursionTree(
                 astType = "CallAgg",
-                value = node.funcName.symb.text,
+                value = node.funcName.string(),
                 attrOfParent = attrOfParent,
                 children = listOf(toRecursionTree(node.arg, "arg"))
             )

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
@@ -138,13 +138,11 @@ class QueryPrettyPrinter {
     }
 
     private fun writeAstNode(node: PartiqlAst.TableDefPart.ColumnDeclaration, sb: StringBuilder) {
-        // sb.append("${node.name.text} ")
         writeAstNode(node.name, sb); sb.append(" ")
         writeType(node.type, sb)
         for (c in node.constraints) {
             sb.append(" ")
             c.name?.let {
-                // sb.append("CONSTRAINT ${it.text} ")
                 sb.append("CONSTRAINT ")
                 writeAstNode(it, sb)
                 sb.append(" ")
@@ -493,7 +491,6 @@ class QueryPrettyPrinter {
 
     @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.Call, sb: StringBuilder, level: Int) {
-        // sb.append("${node.funcName.text}(")
         writeAstNode(node.funcName, sb)
         sb.append('(')
         node.args.forEach { arg ->
@@ -509,7 +506,6 @@ class QueryPrettyPrinter {
 
     @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.CallAgg, sb: StringBuilder, level: Int) {
-        // sb.append("${node.funcName.text}(")
         writeAstNode(node.funcName, sb)
         sb.append('(')
         if (node.setq is PartiqlAst.SetQuantifier.Distinct) {
@@ -679,7 +675,6 @@ class QueryPrettyPrinter {
         val sqLevel = getSubQueryLevel(level)
         val separator = getSeparator(sqLevel)
         group.groupAsAlias?.let {
-            // sb.append("${separator}GROUP AS ${it.text}")
             sb.append("${separator}GROUP AS ")
             writeAstNode(it, sb)
         }
@@ -688,7 +683,6 @@ class QueryPrettyPrinter {
     private fun writeGroupKey(key: PartiqlAst.GroupKey, sb: StringBuilder, level: Int) {
         writeAstNodeCheckSubQuery(key.expr, sb, level)
         key.asAlias?.let {
-            // sb.append(" AS ${it.text}")
             sb.append(" AS ")
             writeAstNode(it, sb)
         }
@@ -704,7 +698,6 @@ class QueryPrettyPrinter {
 
     private fun writeLetBinding(letBinding: PartiqlAst.LetBinding, sb: StringBuilder, level: Int) {
         writeAstNodeCheckSubQuery(letBinding.expr, sb, level)
-        // sb.append(" AS ${letBinding.name.text}")
         sb.append(" AS ")
         writeAstNode(letBinding.name, sb)
     }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
@@ -2,6 +2,7 @@ package org.partiql.lang.prettyprint
 
 import org.partiql.lang.ast.IsListParenthesizedMeta
 import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.string
 import org.partiql.lang.syntax.PartiQLParserBuilder
 import org.partiql.pig.runtime.toIonElement
 import java.time.LocalDate
@@ -116,7 +117,7 @@ class QueryPrettyPrinter {
     }
 
     private fun writeAstNode(node: PartiqlAst.Defnid, sb: StringBuilder) {
-        sb.append(node.symb.text)
+        sb.append(node.string())
     }
 
     private fun writeAstNode(node: PartiqlAst.DdlOp.CreateTable, sb: StringBuilder) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
@@ -200,10 +200,10 @@ internal class PartiQLPigVisitor(
     override fun visitByIdent(ctx: PartiQLParser.ByIdentContext) = readIdentifierAsDefnid(ctx.identifier())
 
     // TODO: Eventually, PartiqlAst.Identifier node should probably just hold the string content of an identifier as it was lexed,
-    //  while the logic for processing this string content should be encapsulated in the createRegular and createDelimited
+    //  while the logic for processing this string content should be encapsulated in the createFromRegular and createFromDelimited
     //  methods of the Ident class.
     // For now, this follows the inconsistent legacy arrangement: lower-casing of a regular identifier is done in Ident
-    // (as well as at many legacy sites), while normalization of quotes inside a delimited identifier is done here.
+    // (as well, for now, as at many legacy sites), while normalization of quotes inside a delimited identifier is done here.
     override fun visitIdentifier(ctx: PartiQLParser.IdentifierContext): PartiqlAst.Identifier = PartiqlAst.build {
         val metas = ctx.ident.getSourceMetaContainer()
         when (ctx.ident.type) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/types/PartiqlPhysicalTypeExtensions.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/types/PartiqlPhysicalTypeExtensions.kt
@@ -1,6 +1,7 @@
 package org.partiql.lang.types
 
 import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.domains.string
 import org.partiql.types.DecimalType
 import org.partiql.types.IntType
 import org.partiql.types.NumberConstraint
@@ -101,7 +102,7 @@ internal fun PartiqlPhysical.Type.toTypedOpParameter(customTypedOpParameters: Ma
         is PartiqlPhysical.Type.CustomType ->
             customTypedOpParameters.mapKeys { (k, _) ->
                 k.lowercase()
-            }[this.name.text.lowercase()] ?: error("Could not find parameter for $this")
+            }[this.name.string().lowercase()] ?: error("Could not find parameter for $this")
         is PartiqlPhysical.Type.DateType -> TypedOpParameter(StaticType.DATE)
         is PartiqlPhysical.Type.TimeType -> TypedOpParameter(
             TimeType(this.precision?.value?.toInt(), withTimeZone = false)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/util/BindingHelpers.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/util/BindingHelpers.kt
@@ -16,6 +16,7 @@ package org.partiql.lang.util
 
 import org.partiql.errors.ErrorCode
 import org.partiql.errors.Property
+import org.partiql.lang.Ident
 import org.partiql.lang.eval.BindingCase
 import org.partiql.lang.eval.err
 
@@ -29,6 +30,10 @@ internal fun errAmbiguousBinding(bindingName: String, matchingNames: List<String
         ),
         internal = false
     )
+}
+
+internal fun errAmbiguousBinding(bindingName: Ident, matchingNames: List<Ident>): Nothing {
+    errAmbiguousBinding(bindingName.toDisplayString(), matchingNames.map { it.toDisplayString() })
 }
 
 /**

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/ast/passes/StatementRedactorTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/ast/passes/StatementRedactorTest.kt
@@ -3,6 +3,7 @@ package org.partiql.lang.ast.passes
 import com.amazon.ionelement.api.StringElement
 import junitparams.Parameters
 import org.junit.Test
+import org.partiql.lang.Ident
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.PartiQLParserTestBase
 
@@ -54,7 +55,10 @@ class StatementRedactorTest : PartiQLParserTestBase() {
     @Test
     @Parameters
     fun testRedactOnPositiveCases(tc: RedactionTestCase) {
-        val testConfig = mapOf("contains" to ::validateFuncContainsAndBeginsWith, "begins_with" to ::validateFuncContainsAndBeginsWith)
+        val testConfig = mapOf(
+            Ident.createAsIs("contains") to ::validateFuncContainsAndBeginsWith,
+            Ident.createAsIs("begins_with") to ::validateFuncContainsAndBeginsWith
+        )
         val redactedStatement = redact(tc.originalStatement, testSafeFieldNames, testConfig)
 
         assertEquals(tc.redactedStatement, redactedStatement)

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransformTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/visitors/AggregateSupportVisitorTransformTests.kt
@@ -60,7 +60,7 @@ class AggregateSupportVisitorTransformTests : VisitorTransformTestBase() {
                     PartiqlAst.build {
                         callAgg(
                             setq = all(),
-                            funcName = callAgg.first,
+                            funcName = defnid(callAgg.first),
                             arg = lit(ionInt(1)),
                             metas = metaContainerOf(AggregateRegisterIdMeta.TAG to AggregateRegisterIdMeta(callAgg.second))
                         )

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransformTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/LogicalToLogicalResolvedVisitorTransformTests.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.errors.Problem
 import org.partiql.lang.domains.PartiqlLogical
 import org.partiql.lang.domains.PartiqlLogicalResolved
+import org.partiql.lang.domains.string
 import org.partiql.lang.errors.ProblemCollector
 import org.partiql.lang.eval.BindingCase
 import org.partiql.lang.eval.builtins.DYNAMIC_LOOKUP_FUNCTION_NAME
@@ -31,7 +32,7 @@ private fun PartiqlLogicalResolved.Builder.dynamicLookup(
     vararg searchTargets: PartiqlLogicalResolved.Expr
 ) =
     call(
-        DYNAMIC_LOOKUP_FUNCTION_NAME,
+        defnid(DYNAMIC_LOOKUP_FUNCTION_NAME),
         listOf(
             lit(ionSymbol(name)),
             lit(
@@ -128,7 +129,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                                 is PartiqlLogicalResolved.Expr.GlobalId,
                                 is PartiqlLogicalResolved.Expr.LocalId -> accumulator + node
                                 is PartiqlLogicalResolved.Expr.Call -> {
-                                    if (node.funcName.text == DYNAMIC_LOOKUP_FUNCTION_NAME) {
+                                    if (node.funcName.string() == DYNAMIC_LOOKUP_FUNCTION_NAME) {
                                         accumulator + node
                                     } else {
                                         accumulator
@@ -142,7 +143,7 @@ class LogicalToLogicalResolvedVisitorTransformTests {
                             node: PartiqlLogicalResolved.Expr.Call,
                             accumulator: List<PartiqlLogicalResolved.Expr>
                         ): List<PartiqlLogicalResolved.Expr> {
-                            return if (node.funcName.text == DYNAMIC_LOOKUP_FUNCTION_NAME) {
+                            return if (node.funcName.string() == DYNAMIC_LOOKUP_FUNCTION_NAME) {
                                 accumulator
                             } else {
                                 super.walkExprCall(node, accumulator)

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinterTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/prettyprint/ASTPrettyPrinterTest.kt
@@ -810,7 +810,7 @@ class ASTPrettyPrinterTest {
                     let: Let
                         letBinding1: LetBinding
                             expr: Lit 1
-                            name: Symbol a
+                            name: Defnid a
             """.trimIndent()
         )
     }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserCastTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserCastTests.kt
@@ -41,7 +41,7 @@ class PartiQLParserCastTests : PartiQLParserTestBase() {
             ),
             Case(
                 source = "CAST(`1.2e0` as ES_FLOAT)",
-                ast = PartiqlAst.build { cast(lit(ionFloat(1.2)), customType(defnid("es_floa)t"))) }
+                ast = PartiqlAst.build { cast(lit(ionFloat(1.2)), customType(defnid("es_float"))) }
             ),
             Case(
                 source = "CAST('xyz' as ES_TEXT)",

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserCastTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserCastTests.kt
@@ -33,47 +33,47 @@ class PartiQLParserCastTests : PartiQLParserTestBase() {
         private val cases = listOf(
             Case(
                 source = "CAST(true as es_boolean)",
-                ast = PartiqlAst.build { cast(lit(ionBool(true)), customType("es_boolean")) }
+                ast = PartiqlAst.build { cast(lit(ionBool(true)), customType(defnid("es_boolean"))) }
             ),
             Case(
                 source = "CAST(1 as es_integer)",
-                ast = PartiqlAst.build { cast(lit(ionInt(1)), customType("es_integer")) }
+                ast = PartiqlAst.build { cast(lit(ionInt(1)), customType(defnid("es_integer"))) }
             ),
             Case(
                 source = "CAST(`1.2e0` as ES_FLOAT)",
-                ast = PartiqlAst.build { cast(lit(ionFloat(1.2)), customType("es_float")) }
+                ast = PartiqlAst.build { cast(lit(ionFloat(1.2)), customType(defnid("es_floa)t"))) }
             ),
             Case(
                 source = "CAST('xyz' as ES_TEXT)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("es_text")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("es_text"))) }
             ),
             Case(
                 source = "CAST('xyz' as RS_VARCHAR_MAX)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("rs_varchar_max")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("rs_varchar_max"))) }
             ),
             Case(
                 source = "CAST('xyz' as RS_REAL)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("rs_real")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("rs_real"))) }
             ),
             Case(
                 source = "CAST('xyz' as RS_FLOAT4)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("rs_real")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("rs_real"))) }
             ),
             Case(
                 source = "CAST('xyz' as RS_DOUBLE_PRECISION)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("rs_double_precision")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("rs_double_precision"))) }
             ),
             Case(
                 source = "CAST('xyz' as RS_FLOAT)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("rs_double_precision")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("rs_double_precision"))) }
             ),
             Case(
                 source = "CAST('xyz' as rs_float8)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("rs_double_precision")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("rs_double_precision"))) }
             ),
             Case(
                 source = "CAST('xyz' as SPARK_FLOAT)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("spark_float")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("spark_float"))) }
             ),
             Case(
                 source = "CAST('xyz' as int4)",
@@ -109,35 +109,35 @@ class PartiQLParserCastTests : PartiQLParserTestBase() {
             ),
             Case(
                 source = "CAST('xyz' as SPARK_SHORT)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("spark_short")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("spark_short"))) }
             ),
             Case(
                 source = "CAST('xyz' as SPARK_INTEGER)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("spark_integer")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("spark_integer"))) }
             ),
             Case(
                 source = "CAST('xyz' as SPARK_LONG)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("spark_long")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("spark_long"))) }
             ),
             Case(
                 source = "CAST('xyz' as SPARK_DOUBLE)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("spark_double")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("spark_double"))) }
             ),
             Case(
                 source = "CAST('xyz' as SPARK_BOOLEAN)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("spark_boolean")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("spark_boolean"))) }
             ),
             Case(
                 source = "CAST('xyz' as RS_integer)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("rs_integer")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("rs_integer"))) }
             ),
             Case(
                 source = "CAST('xyz' as RS_BIGINT)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("rs_bigint")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("rs_bigint"))) }
             ),
             Case(
                 source = "CAST('xyz' as RS_BOOLEAN)",
-                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType("rs_boolean")) }
+                ast = PartiqlAst.build { cast(lit(ionString("xyz")), customType(defnid("rs_boolean"))) }
             )
         )
     }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserCorrelatedJoinTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserCorrelatedJoinTests.kt
@@ -9,7 +9,7 @@ class PartiQLParserCorrelatedJoinTests : PartiQLParserTestBase() {
     override val targets: Array<ParserTarget> = arrayOf(ParserTarget.DEFAULT, ParserTarget.EXPERIMENTAL)
 
     private fun PartiqlAst.Builder.callFWithS() =
-        call("f", id("s", caseInsensitive(), unqualified()))
+        call(defnid("f"), id("s", caseInsensitive(), unqualified()))
 
     private fun PartiqlAst.Builder.selectWithCorrelatedJoin(
         joinType: PartiqlAst.JoinType,
@@ -23,7 +23,7 @@ class PartiQLParserCorrelatedJoinTests : PartiQLParserTestBase() {
             ),
             from = join(
                 joinType,
-                scan(id("stuff"), "s"),
+                scan(id("stuff"), defnid("s")),
                 scan(id("s", caseInsensitive(), localsFirst())),
                 joinPredicate
             ),

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserJoinTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserJoinTest.kt
@@ -21,8 +21,8 @@ class PartiQLParserJoinTest : PartiQLParserTestBase() {
             project = projectX,
             from = join(
                 joinType,
-                scan(id("stuff"), "s"),
-                scan(id("foo"), "f"),
+                scan(id("stuff"), defnid("s")),
+                scan(id("foo"), defnid("f")),
                 joinPredicate
             ),
             where = wherePredicate

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserMatchTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserMatchTest.kt
@@ -60,7 +60,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                         parts = listOf(
                             node(
                                 prefilter = null,
-                                variable = "x",
+                                variable = defnid("x"),
                             )
                         )
                     ),
@@ -68,7 +68,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                         parts = listOf(
                             edge(
                                 direction = edgeRight(),
-                                variable = "u"
+                                variable = defnid("u")
                             )
                         )
                     )
@@ -87,7 +87,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                         parts = listOf(
                             node(
                                 prefilter = null,
-                                variable = "x",
+                                variable = defnid("x"),
                             )
                         )
                     )
@@ -271,12 +271,12 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                     )
                 )
             ),
-            where = call(funcName = "contains_value", args = listOf(lit(ionString("1"))))
+            where = call(funcName = defnid("contains_value"), args = listOf(lit(ionString("1"))))
         )
     }
 
     val bindAllNodesAST =
-        { projection: PartiqlAst.Projection, asVar: String? ->
+        { projection: PartiqlAst.Projection, asVar: PartiqlAst.Defnid? ->
             PartiqlAst.build {
                 select(
                     project = projection,
@@ -289,7 +289,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                         parts = listOf(
                                             node(
                                                 prefilter = null,
-                                                variable = "x",
+                                                variable = defnid("x"),
                                             )
                                         )
                                     )
@@ -328,7 +328,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     ) {
         bindAllNodesAST(
             projectStar(),
-            "a"
+            defnid("a")
         )
     }
 
@@ -338,7 +338,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     ) {
         bindAllNodesAST(
             projectStar(),
-            "a"
+            defnid("a")
         )
     }
 
@@ -350,7 +350,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
             project = projectList(
                 projectExpr(
                     expr = path(id("x"), pathExpr(lit(ionString("info")), caseInsensitive())),
-                    asAlias = "info"
+                    asAlias = defnid("info")
                 )
             ),
             from = scan(
@@ -362,7 +362,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                 parts = listOf(
                                     node(
                                         prefilter = null,
-                                        variable = "x",
+                                        variable = defnid("x"),
                                     )
                                 )
                             )
@@ -382,7 +382,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
         "SELECT x AS target FROM my_graph MATCH (x:Label) WHERE x.has_data = true",
     ) {
         select(
-            project = projectList(projectExpr(expr = id("x"), asAlias = "target")),
+            project = projectList(projectExpr(expr = id("x"), asAlias = defnid("target"))),
             from = scan(
                 graphMatch(
                     expr = id("my_graph"),
@@ -392,8 +392,8 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                 parts = listOf(
                                     node(
                                         prefilter = null,
-                                        variable = "x",
-                                        label = graphLabelName("Label")
+                                        variable = defnid("x"),
+                                        label = graphLabelName(defnid("Label"))
                                     )
                                 )
                             )
@@ -514,7 +514,8 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     }
 
     val simpleGraphAST =
-        { direction: PartiqlAst.GraphMatchDirection, quantifier: PartiqlAst.GraphMatchQuantifier?, variable: String?, label: String? ->
+        { direction: PartiqlAst.GraphMatchDirection, quantifier: PartiqlAst.GraphMatchQuantifier?,
+            variable: PartiqlAst.Defnid?, label: PartiqlAst.Defnid? ->
             PartiqlAst.build {
                 select(
                     project = projectList(projectExpr(id("a")), projectExpr(id("b"))),
@@ -528,8 +529,8 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                         parts = listOf(
                                             node(
                                                 prefilter = null,
-                                                variable = "a",
-                                                label = graphLabelName("A")
+                                                variable = defnid("a"),
+                                                label = graphLabelName(defnid("A"))
                                             ),
                                             edge(
                                                 direction = direction,
@@ -540,8 +541,8 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                             ),
                                             node(
                                                 prefilter = null,
-                                                variable = "b",
-                                                label = graphLabelName("B")
+                                                variable = defnid("b"),
+                                                label = graphLabelName(defnid("B"))
                                             ),
                                         )
                                     )
@@ -558,7 +559,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     fun rightDirected() = assertExpression(
         "SELECT a,b FROM g MATCH (a:A) -[e:E]-> (b:B)",
     ) {
-        simpleGraphAST(edgeRight(), null, "e", "E")
+        simpleGraphAST(edgeRight(), null, defnid("e"), defnid("E"))
     }
 
     @Test
@@ -572,7 +573,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     fun leftDirected() = assertExpression(
         "SELECT a,b FROM g MATCH (a:A) <-[e:E]- (b:B)",
     ) {
-        simpleGraphAST(edgeLeft(), null, "e", "E")
+        simpleGraphAST(edgeLeft(), null, defnid("e"), defnid("E"))
     }
 
     @Test
@@ -586,7 +587,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     fun undirected() = assertExpression(
         "SELECT a,b FROM g MATCH (a:A) ~[e:E]~ (b:B)",
     ) {
-        simpleGraphAST(edgeUndirected(), null, "e", "E")
+        simpleGraphAST(edgeUndirected(), null, defnid("e"), defnid("E"))
     }
 
     @Test
@@ -600,7 +601,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     fun rightOrUnDirected() = assertExpression(
         "SELECT a,b FROM g MATCH (a:A) ~[e:E]~> (b:B)",
     ) {
-        simpleGraphAST(edgeUndirectedOrRight(), null, "e", "E")
+        simpleGraphAST(edgeUndirectedOrRight(), null, defnid("e"), defnid("E"))
     }
 
     @Test
@@ -614,7 +615,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     fun leftOrUnDirected() = assertExpression(
         "SELECT a,b FROM g MATCH (a:A) <~[e:E]~ (b:B)",
     ) {
-        simpleGraphAST(edgeLeftOrUndirected(), null, "e", "E")
+        simpleGraphAST(edgeLeftOrUndirected(), null, defnid("e"), defnid("E"))
     }
 
     @Test
@@ -628,7 +629,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     fun leftOrRight() = assertExpression(
         "SELECT a,b FROM g MATCH (a:A) <-[e:E]-> (b:B)",
     ) {
-        simpleGraphAST(edgeLeftOrRight(), null, "e", "E")
+        simpleGraphAST(edgeLeftOrRight(), null, defnid("e"), defnid("E"))
     }
 
     @Test
@@ -642,7 +643,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     fun leftOrRightOrUndirected() = assertExpression(
         "SELECT a,b FROM g MATCH (a:A) -[e:E]- (b:B)",
     ) {
-        simpleGraphAST(edgeLeftOrUndirectedOrRight(), null, "e", "E")
+        simpleGraphAST(edgeLeftOrUndirectedOrRight(), null, defnid("e"), defnid("E"))
     }
 
     @Test
@@ -656,28 +657,28 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     fun quantifierStar() = assertExpression(
         "SELECT a,b FROM g MATCH (a:A)-[:edge]->*(b:B)",
     ) {
-        simpleGraphAST(edgeRight(), graphMatchQuantifier(lower = 0, upper = null), null, "edge")
+        simpleGraphAST(edgeRight(), graphMatchQuantifier(lower = 0, upper = null), null, defnid("edge"))
     }
 
     @Test
     fun quantifierPlus() = assertExpression(
         "SELECT a,b FROM g MATCH (a:A)<-[:edge]-+(b:B)",
     ) {
-        simpleGraphAST(edgeLeft(), graphMatchQuantifier(lower = 1, upper = null), null, "edge")
+        simpleGraphAST(edgeLeft(), graphMatchQuantifier(lower = 1, upper = null), null, defnid("edge"))
     }
 
     @Test
     fun quantifierM() = assertExpression(
         "SELECT a,b FROM g MATCH (a:A)~[:edge]~{5,}(b:B)",
     ) {
-        simpleGraphAST(edgeUndirected(), graphMatchQuantifier(lower = 5, upper = null), null, "edge")
+        simpleGraphAST(edgeUndirected(), graphMatchQuantifier(lower = 5, upper = null), null, defnid("edge"))
     }
 
     @Test
     fun quantifierMN() = assertExpression(
         "SELECT a,b FROM g MATCH (a:A)-[e:edge]-{2,6}(b:B)",
     ) {
-        simpleGraphAST(edgeLeftOrUndirectedOrRight(), graphMatchQuantifier(lower = 2, upper = 6), "e", "edge")
+        simpleGraphAST(edgeLeftOrUndirectedOrRight(), graphMatchQuantifier(lower = 2, upper = 6), defnid("e"), defnid("edge"))
     }
 
     @Test
@@ -716,11 +717,11 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
             project = projectList(
                 projectExpr(
                     expr = path(id("the_a"), pathExpr(lit(ionString("name")), caseInsensitive())),
-                    asAlias = "src"
+                    asAlias = defnid("src")
                 ),
                 projectExpr(
                     expr = path(id("the_b"), pathExpr(lit(ionString("name")), caseInsensitive())),
-                    asAlias = "dest"
+                    asAlias = defnid("dest")
                 )
             ),
             from = scan(
@@ -732,20 +733,20 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                 parts = listOf(
                                     node(
                                         prefilter = null,
-                                        variable = "the_a",
-                                        label = graphLabelName("a")
+                                        variable = defnid("the_a"),
+                                        label = graphLabelName(defnid("a"))
                                     ),
                                     edge(
                                         direction = edgeRight(),
                                         quantifier = null,
                                         prefilter = null,
-                                        variable = "the_y",
-                                        label = graphLabelName("y")
+                                        variable = defnid("the_y"),
+                                        label = graphLabelName(defnid("y"))
                                     ),
                                     node(
                                         prefilter = null,
-                                        variable = "the_b",
-                                        label = graphLabelName("b")
+                                        variable = defnid("the_b"),
+                                        label = graphLabelName(defnid("b"))
                                     ),
                                 )
                             )
@@ -780,18 +781,18 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                 parts = listOf(
                                     node(
                                         prefilter = null,
-                                        variable = "a",
+                                        variable = defnid("a"),
                                     ),
                                     edge(
                                         direction = edgeRight(),
                                         quantifier = null,
                                         prefilter = null,
                                         variable = null,
-                                        label = graphLabelName("has")
+                                        label = graphLabelName(defnid("has"))
                                     ),
                                     node(
                                         prefilter = null,
-                                        variable = "x",
+                                        variable = defnid("x"),
                                     ),
                                 )
                             ),
@@ -799,18 +800,18 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                 parts = listOf(
                                     node(
                                         prefilter = null,
-                                        variable = "x",
+                                        variable = defnid("x"),
                                     ),
                                     edge(
                                         direction = edgeRight(),
                                         quantifier = null,
                                         prefilter = null,
                                         variable = null,
-                                        label = graphLabelName("contains")
+                                        label = graphLabelName(defnid("contains"))
                                     ),
                                     node(
                                         prefilter = null,
-                                        variable = "b",
+                                        variable = defnid("b"),
                                     ),
                                 )
                             )
@@ -839,14 +840,14 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                 parts = listOf(
                                     node(
                                         prefilter = null,
-                                        variable = "a",
+                                        variable = defnid("a"),
                                     ),
                                     edge(
                                         direction = edgeRight(),
                                         quantifier = null,
                                         prefilter = null,
                                         variable = null,
-                                        label = graphLabelName("has")
+                                        label = graphLabelName(defnid("has"))
                                     ),
                                     node(
                                         prefilter = null,
@@ -857,11 +858,11 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                         quantifier = null,
                                         prefilter = null,
                                         variable = null,
-                                        label = graphLabelName("contains")
+                                        label = graphLabelName(defnid("contains"))
                                     ),
                                     node(
                                         prefilter = null,
-                                        variable = "b",
+                                        variable = defnid("b"),
                                     ),
                                 )
                             )
@@ -885,20 +886,20 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                         gpmlPattern = gpmlPattern(
                             patterns = listOf(
                                 graphMatchPattern(
-                                    variable = "p",
+                                    variable = defnid("p"),
                                     parts = listOf(
                                         node(
-                                            variable = "a",
-                                            label = graphLabelName("A")
+                                            variable = defnid("a"),
+                                            label = graphLabelName(defnid("A"))
                                         ),
                                         edge(
                                             direction = edgeRight(),
-                                            variable = "e",
-                                            label = graphLabelName("E")
+                                            variable = defnid("e"),
+                                            label = graphLabelName(defnid("E"))
                                         ),
                                         node(
-                                            variable = "b",
-                                            label = graphLabelName("B")
+                                            variable = defnid("b"),
+                                            label = graphLabelName(defnid("B"))
                                         ),
                                     )
                                 )
@@ -934,17 +935,17 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                                 quantifier = graphMatchQuantifier(lower = 2, upper = 5),
                                                 parts = listOf(
                                                     node(
-                                                        variable = "a",
-                                                        label = graphLabelName("A")
+                                                        variable = defnid("a"),
+                                                        label = graphLabelName(defnid("A"))
                                                     ),
                                                     edge(
                                                         direction = edgeRight(),
-                                                        variable = "e",
-                                                        label = graphLabelName("Edge")
+                                                        variable = defnid("e"),
+                                                        label = graphLabelName(defnid("Edge"))
                                                     ),
                                                     node(
-                                                        variable = "b",
-                                                        label = graphLabelName("A")
+                                                        variable = defnid("b"),
+                                                        label = graphLabelName(defnid("A"))
                                                     ),
                                                 ),
                                             )
@@ -973,11 +974,11 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                         gpmlPattern = gpmlPattern(
                             patterns = listOf(
                                 graphMatchPattern(
-                                    variable = "pathVar",
+                                    variable = defnid("pathVar"),
                                     parts = listOf(
                                         node(
-                                            variable = "a",
-                                            label = graphLabelName("A")
+                                            variable = defnid("a"),
+                                            label = graphLabelName(defnid("A"))
                                         ),
                                         pattern(
                                             graphMatchPattern(
@@ -986,16 +987,16 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                                     node(),
                                                     edge(
                                                         direction = edgeRight(),
-                                                        variable = "e",
-                                                        label = graphLabelName("Edge")
+                                                        variable = defnid("e"),
+                                                        label = graphLabelName(defnid("Edge"))
                                                     ),
                                                     node(),
                                                 )
                                             )
                                         ),
                                         node(
-                                            variable = "b",
-                                            label = graphLabelName("B")
+                                            variable = defnid("b"),
+                                            label = graphLabelName(defnid("B"))
                                         ),
                                     )
                                 )
@@ -1018,11 +1019,11 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                         gpmlPattern = gpmlPattern(
                             patterns = listOf(
                                 graphMatchPattern(
-                                    variable = "pathVar",
+                                    variable = defnid("pathVar"),
                                     parts = listOf(
                                         node(
-                                            variable = "a",
-                                            label = graphLabelName("A")
+                                            variable = defnid("a"),
+                                            label = graphLabelName(defnid("A"))
                                         ),
                                         pattern(
                                             graphMatchPattern(
@@ -1030,15 +1031,15 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                                 parts = listOf(
                                                     edge(
                                                         direction = edgeRight(),
-                                                        variable = "e",
-                                                        label = graphLabelName("Edge")
+                                                        variable = defnid("e"),
+                                                        label = graphLabelName(defnid("Edge"))
                                                     ),
                                                 )
                                             )
                                         ),
                                         node(
-                                            variable = "b",
-                                            label = graphLabelName("B")
+                                            variable = defnid("b"),
+                                            label = graphLabelName(defnid("B"))
                                         ),
                                     )
                                 )
@@ -1071,7 +1072,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     ) {
         PartiqlAst.build {
             select(
-                project = projectList(projectExpr(id("u"), asAlias = "banCandidate")),
+                project = projectList(projectExpr(id("u"), asAlias = defnid("banCandidate"))),
                 from = scan(
                     graphMatch(
                         expr = id("g"),
@@ -1080,8 +1081,8 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                 graphMatchPattern(
                                     parts = listOf(
                                         node(
-                                            variable = "p",
-                                            label = graphLabelName("Post"),
+                                            variable = defnid("p"),
+                                            label = graphLabelName(defnid("Post")),
                                             prefilter = eq(
                                                 path(id("p"), pathExpr(lit(ionString("isFlagged")), caseInsensitive())),
                                                 lit(ionBool(true))
@@ -1089,11 +1090,11 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                         ),
                                         edge(
                                             direction = edgeLeft(),
-                                            label = graphLabelName("createdPost")
+                                            label = graphLabelName(defnid("createdPost"))
                                         ),
                                         node(
-                                            variable = "u",
-                                            label = graphLabelName("Usr"),
+                                            variable = defnid("u"),
+                                            label = graphLabelName(defnid("Usr")),
                                             prefilter = and(
                                                 eq(
                                                     path(
@@ -1110,11 +1111,11 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                         ),
                                         edge(
                                             direction = edgeRight(),
-                                            label = graphLabelName("createdComment")
+                                            label = graphLabelName(defnid("createdComment"))
                                         ),
                                         node(
-                                            variable = "c",
-                                            label = graphLabelName("Comment"),
+                                            variable = defnid("c"),
+                                            label = graphLabelName(defnid("Comment")),
                                             prefilter =
                                             eq(
                                                 path(id("c"), pathExpr(lit(ionString("isFlagged")), caseInsensitive())),
@@ -1146,10 +1147,10 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                             patterns = listOf(
                                 graphMatchPattern(
                                     restrictor = restrictor,
-                                    variable = "p",
+                                    variable = defnid("p"),
                                     parts = listOf(
                                         node(
-                                            variable = "a",
+                                            variable = defnid("a"),
                                             prefilter =
                                             eq(
                                                 path(id("a"), pathExpr(lit(ionString("owner")), caseInsensitive())),
@@ -1158,12 +1159,12 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                         ),
                                         edge(
                                             direction = edgeRight(),
-                                            variable = "t",
-                                            label = graphLabelName("Transfer"),
+                                            variable = defnid("t"),
+                                            label = graphLabelName(defnid("Transfer")),
                                             quantifier = graphMatchQuantifier(0)
                                         ),
                                         node(
-                                            variable = "b",
+                                            variable = defnid("b"),
                                             prefilter =
                                             eq(
                                                 path(id("b"), pathExpr(lit(ionString("owner")), caseInsensitive())),
@@ -1213,10 +1214,10 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                             selector = selector,
                             patterns = listOf(
                                 graphMatchPattern(
-                                    variable = "p",
+                                    variable = defnid("p"),
                                     parts = listOf(
                                         node(
-                                            variable = "a",
+                                            variable = defnid("a"),
                                             prefilter =
                                             eq(
                                                 path(id("a"), pathExpr(lit(ionString("owner")), caseInsensitive())),
@@ -1225,12 +1226,12 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                         ),
                                         edge(
                                             direction = edgeRight(),
-                                            variable = "t",
-                                            label = graphLabelName("Transfer"),
+                                            variable = defnid("t"),
+                                            label = graphLabelName(defnid("Transfer")),
                                             quantifier = graphMatchQuantifier(0)
                                         ),
                                         node(
-                                            variable = "b",
+                                            variable = defnid("b"),
                                             prefilter =
                                             eq(
                                                 path(id("b"), pathExpr(lit(ionString("owner")), caseInsensitive())),
@@ -1299,16 +1300,16 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                         patterns = listOf(
                             graphMatchPattern(
                                 parts = listOf(
-                                    node(variable = "a"),
+                                    node(variable = defnid("a")),
                                     edge(direction = edgeRight()),
-                                    node(variable = "b"),
+                                    node(variable = defnid("b")),
                                 )
                             ),
                             graphMatchPattern(
                                 parts = listOf(
-                                    node(variable = "a"),
+                                    node(variable = defnid("a")),
                                     edge(direction = edgeRight()),
-                                    node(variable = "c"),
+                                    node(variable = defnid("c")),
                                 )
                             )
                         )
@@ -1318,11 +1319,11 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
         }
 
         val t1 = PartiqlAst.build {
-            scan(expr = id("table1"), asAlias = "t1")
+            scan(expr = id("table1"), asAlias = defnid("t1"))
         }
 
         val t2 = PartiqlAst.build {
-            scan(expr = id("table2"), asAlias = "t2")
+            scan(expr = id("table2"), asAlias = defnid("t2"))
         }
 
         PartiqlAst.build {
@@ -1331,8 +1332,8 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                     projectExpr(id("a")),
                     projectExpr(id("b")),
                     projectExpr(id("c")),
-                    projectExpr(path(id("t1"), pathExpr(lit(ionString("x")), caseInsensitive())), "x"),
-                    projectExpr(path(id("t2"), pathExpr(lit(ionString("y")), caseInsensitive())), "y")
+                    projectExpr(path(id("t1"), pathExpr(lit(ionString("x")), caseInsensitive())), defnid("x")),
+                    projectExpr(path(id("t2"), pathExpr(lit(ionString("y")), caseInsensitive())), defnid("y"))
                 ),
                 from = join(
                     type = inner(),
@@ -1406,7 +1407,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
                                 parts = listOf(
                                     node(
                                         prefilter = null,
-                                        variable = "x",
+                                        variable = defnid("x"),
                                         label = spec,
                                     )
                                 )
@@ -1422,7 +1423,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     fun labelSimpleNamed() = assertExpression(
         "SELECT x FROM g MATCH (x:A)"
     ) {
-        astSelectNodeWithLabelSpec(spec = graphLabelName("A"))
+        astSelectNodeWithLabelSpec(spec = graphLabelName(defnid("A")))
     }
 
     @Test
@@ -1430,7 +1431,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
         "SELECT x FROM g MATCH (x:Label|OtherLabel)",
     ) {
         astSelectNodeWithLabelSpec(
-            spec = graphLabelDisj(graphLabelName("Label"), graphLabelName("OtherLabel"))
+            spec = graphLabelDisj(graphLabelName(defnid("Label")), graphLabelName(defnid("OtherLabel")))
         )
     }
 
@@ -1439,7 +1440,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
         "SELECT x FROM g MATCH (x:Label&OtherLabel)",
     ) {
         astSelectNodeWithLabelSpec(
-            spec = graphLabelConj(graphLabelName("Label"), graphLabelName("OtherLabel"))
+            spec = graphLabelConj(graphLabelName(defnid("Label")), graphLabelName(defnid("OtherLabel")))
         )
     }
 
@@ -1447,7 +1448,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     fun labelNegation() = assertExpression(
         "SELECT x FROM g MATCH (x:!Label)",
     ) {
-        astSelectNodeWithLabelSpec(spec = graphLabelNegation(graphLabelName("Label")))
+        astSelectNodeWithLabelSpec(spec = graphLabelNegation(graphLabelName(defnid("Label"))))
     }
 
     @Test
@@ -1462,12 +1463,12 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
             spec = graphLabelDisj(
                 graphLabelDisj(
                     graphLabelDisj(
-                        graphLabelName("L1"),
-                        graphLabelConj(graphLabelName("L2"), graphLabelName("L3"))
+                        graphLabelName(defnid("L1")),
+                        graphLabelConj(graphLabelName(defnid("L2")), graphLabelName(defnid("L3")))
                     ),
-                    graphLabelNegation(graphLabelName("L4"))
+                    graphLabelNegation(graphLabelName(defnid("L4")))
                 ),
-                graphLabelConj(graphLabelName("L5"), graphLabelWildcard())
+                graphLabelConj(graphLabelName(defnid("L5")), graphLabelWildcard())
             )
         )
     }
@@ -1506,7 +1507,7 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     fun edgeLabelSimpleNamed() = assertExpression(
         "(g MATCH <-[:City]->)"
     ) {
-        astMatchEdgeWithLabelSpec(graphLabelName("City"))
+        astMatchEdgeWithLabelSpec(graphLabelName(defnid("City")))
     }
 
     @Test
@@ -1515,8 +1516,8 @@ class PartiQLParserMatchTest : PartiQLParserTestBase() {
     ) {
         astMatchEdgeWithLabelSpec(
             graphLabelDisj(
-                graphLabelName("Country"),
-                graphLabelConj(graphLabelName("City"), graphLabelName("Sovereign"))
+                graphLabelName(defnid("Country")),
+                graphLabelConj(graphLabelName(defnid("City")), graphLabelName(defnid("Sovereign")))
             )
         )
     }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -195,73 +195,73 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun callEmpty() = assertExpression(
         "foobar()",
-        "(call foobar)"
+        "(call (defnid foobar))"
     )
 
     @Test
     fun callOneArgument() = assertExpression(
         "foobar(1)",
-        "(call foobar (lit 1))"
+        "(call (defnid foobar) (lit 1))"
     )
 
     @Test
     fun callTwoArgument() = assertExpression(
         "foobar(1, 2)",
-        "(call foobar (lit 1) (lit 2))"
+        "(call (defnid foobar) (lit 1) (lit 2))"
     )
 
     @Test
     fun callSubstringSql92Syntax() = assertExpression(
         "substring('test' from 100)",
-        "(call substring (lit \"test\") (lit 100))"
+        "(call (defnid substring) (lit \"test\") (lit 100))"
     )
 
     @Test
     fun callSubstringSql92SyntaxWithLength() = assertExpression(
         "substring('test' from 100 for 50)",
-        "(call substring (lit \"test\") (lit 100) (lit 50))"
+        "(call (defnid substring) (lit \"test\") (lit 100) (lit 50))"
     )
 
     @Test
     fun callSubstringNormalSyntax() = assertExpression(
         "substring('test', 100)",
-        "(call substring (lit \"test\") (lit 100))"
+        "(call (defnid substring) (lit \"test\") (lit 100))"
     )
 
     @Test
     fun callSubstringNormalSyntaxWithLength() = assertExpression(
         "substring('test', 100, 50)",
-        "(call substring (lit \"test\") (lit 100) (lit 50))"
+        "(call (defnid substring) (lit \"test\") (lit 100) (lit 50))"
     )
 
     @Test
     fun callTrimSingleArgument() = assertExpression(
         "trim('test')",
-        "(call trim (lit \"test\"))"
+        "(call (defnid trim) (lit \"test\"))"
     )
 
     @Test
     fun callTrimTwoArgumentsDefaultSpecification() = assertExpression(
         "trim(' ' from 'test')",
-        "(call trim (lit \" \") (lit \"test\"))"
+        "(call (defnid trim) (lit \" \") (lit \"test\"))"
     )
 
     @Test
     fun callTrimTwoArgumentsUsingBoth() = assertExpression(
         "trim(both from 'test')",
-        "(call trim (lit both) (lit \"test\"))"
+        "(call (defnid trim) (lit both) (lit \"test\"))"
     )
 
     @Test
     fun callTrimTwoArgumentsUsingLeading() = assertExpression(
         "trim(leading from 'test')",
-        "(call trim (lit leading) (lit \"test\"))"
+        "(call (defnid trim) (lit leading) (lit \"test\"))"
     )
 
     @Test
     fun callTrimTwoArgumentsUsingTrailing() = assertExpression(
         "trim(trailing from 'test')",
-        "(call trim (lit trailing) (lit \"test\"))"
+        """(call (defnid trim) (lit trailing) (lit "test"))"""
     )
 
     // ****************************************
@@ -271,19 +271,19 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun negCall() = assertExpression(
         "-baz()",
-        "(neg (call baz))"
+        "(neg (call (defnid baz)))"
     )
 
     @Test
     fun posNegIdent() = assertExpression(
         "+(-baz())",
-        "(pos (neg (call baz)))"
+        "(pos (neg (call (defnid baz))))"
     )
 
     @Test
     fun posNegIdentNoSpaces() = assertExpression(
         "+-baz()",
-        "(pos (neg (call baz)))"
+        "(pos (neg (call (defnid baz))))"
     )
 
     @Test
@@ -362,7 +362,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun callIsVarchar() = assertExpression(
         "f() IS VARCHAR(200)",
-        "(is_type (call f) (character_varying_type 200))"
+        "(is_type (call (defnid f)) (character_varying_type 200))"
     )
 
     @Test
@@ -380,43 +380,43 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun callIsNotVarchar() = assertExpression(
         "f() IS NOT VARCHAR(200)",
-        "(not (is_type (call f) (character_varying_type 200)))"
+        "(not (is_type (call (defnid f)) (character_varying_type 200)))"
     )
 
     @Test
     fun callWithMultiple() = assertExpression(
         "foobar(5, 6, a)",
-        "(call foobar (lit 5) (lit 6) (id a (case_insensitive) (unqualified)))"
+        "(call (defnid foobar) (lit 5) (lit 6) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun aggregateFunctionCall() = assertExpression(
         "COUNT(a)",
-        """(call_agg (all) count (id a (case_insensitive) (unqualified)))"""
+        """(call_agg (all) (defnid count) (id a (case_insensitive) (unqualified)))"""
     )
 
     @Test
     fun aggregateDistinctFunctionCall() = assertExpression(
         "SUM(DISTINCT a)",
-        "(call_agg (distinct) sum (id a (case_insensitive) (unqualified)))"
+        "(call_agg (distinct) (defnid sum) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun countStarFunctionCall() = assertExpression(
         "COUNT(*)",
-        "(call_agg (all) count (lit 1))"
+        "(call_agg (all) (defnid count) (lit 1))"
     )
 
     @Test
     fun countFunctionCall() = assertExpression(
         "COUNT(a)",
-        "(call_agg (all) count (id a (case_insensitive) (unqualified)))"
+        "(call_agg (all) (defnid count) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun countDistinctFunctionCall() = assertExpression(
         "COUNT(DISTINCT a)",
-        "(call_agg (distinct) count (id a (case_insensitive) (unqualified)))"
+        "(call_agg (distinct) (defnid count) (id a (case_insensitive) (unqualified)))"
     )
 
     // ****************************************
@@ -513,7 +513,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun pathWithCallAndDotStar() = assertExpression(
         "foo(x, y).a.*.b",
-        """(path (call foo (id x (case_insensitive) (unqualified)) (id y (case_insensitive) (unqualified)))
+        """(path (call (defnid foo) (id x (case_insensitive) (unqualified)) (id y (case_insensitive) (unqualified)))
            (path_expr (lit "a") (case_insensitive))
            (path_unpivot)
            (path_expr (lit "b") (case_insensitive)))""".trimMargin()
@@ -589,13 +589,13 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun castAsEsBoolean() = assertExpression(
         "CAST(TRUE AS ES_BOOLEAN)",
-        "(cast (lit true) (custom_type es_boolean))"
+        "(cast (lit true) (custom_type (defnid es_boolean)))"
     )
 
     @Test
     fun castAsRsInteger() = assertExpression(
         "CAST(1.123 AS RS_INTEGER)",
-        "(cast (lit 1.123) (custom_type rs_integer))"
+        "(cast (lit 1.123) (custom_type (defnid rs_integer)))"
     )
 
     // ****************************************
@@ -828,49 +828,49 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun callDateArithYear() = assertDateArithmetic(
         "date_<op>(year, a, b)",
-        "(call date_<op> (lit YEAR) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call (defnid date_<op>) (lit YEAR) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithMonth() = assertDateArithmetic(
         "date_<op>(month, a, b)",
-        "(call date_<op> (lit MONTH) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call (defnid date_<op>) (lit MONTH) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithDay() = assertDateArithmetic(
         "date_<op>(day, a, b)",
-        "(call date_<op> (lit DAY) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call (defnid date_<op>) (lit DAY) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithHour() = assertDateArithmetic(
         "date_<op>(hour, a, b)",
-        "(call date_<op> (lit HOUR) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call (defnid date_<op>) (lit HOUR) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithMinute() = assertDateArithmetic(
         "date_<op>(minute, a, b)",
-        "(call date_<op> (lit MINUTE) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call (defnid date_<op>) (lit MINUTE) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callDateArithSecond() = assertDateArithmetic(
         "date_<op>(second, a, b)",
-        "(call date_<op> (lit SECOND) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call (defnid date_<op>) (lit SECOND) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test // invalid evaluation, but valid parsing
     fun callDateArithTimezoneHour() = assertDateArithmetic(
         "date_<op>(timezone_hour, a, b)",
-        "(call date_<op> (lit TIMEZONE_HOUR) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call (defnid date_<op>) (lit TIMEZONE_HOUR) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     @Test // invalid evaluation, but valid parsing
     fun callDateArithTimezoneMinute() = assertDateArithmetic(
         "date_<op>(timezone_minute, a, b)",
-        "(call date_<op> (lit TIMEZONE_MINUTE) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
+        "(call (defnid date_<op>) (lit TIMEZONE_MINUTE) (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified)))"
     )
 
     // ****************************************
@@ -879,55 +879,55 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun callExtractYear() = assertExpression(
         "extract(year from a)",
-        "(call extract (lit YEAR) (id a (case_insensitive) (unqualified)))"
+        "(call (defnid extract) (lit YEAR) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractMonth() = assertExpression(
         "extract(month from a)",
-        "(call extract (lit MONTH) (id a (case_insensitive) (unqualified)))"
+        "(call (defnid extract) (lit MONTH) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractDay() = assertExpression(
         "extract(day from a)",
-        "(call extract (lit DAY) (id a (case_insensitive) (unqualified)))"
+        "(call (defnid extract) (lit DAY) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractHour() = assertExpression(
         "extract(hour from a)",
-        "(call extract (lit HOUR) (id a (case_insensitive) (unqualified)))"
+        "(call (defnid extract) (lit HOUR) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractMinute() = assertExpression(
         "extract(minute from a)",
-        "(call extract (lit MINUTE) (id a (case_insensitive) (unqualified)))"
+        "(call (defnid extract) (lit MINUTE) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractSecond() = assertExpression(
         "extract(second from a)",
-        "(call extract (lit SECOND) (id a (case_insensitive) (unqualified)))"
+        "(call (defnid extract) (lit SECOND) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractTimezoneHour() = assertExpression(
         "extract(timezone_hour from a)",
-        "(call extract (lit TIMEZONE_HOUR) (id a (case_insensitive) (unqualified)))"
+        "(call (defnid extract) (lit TIMEZONE_HOUR) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun callExtractTimezoneMinute() = assertExpression(
         "extract(timezone_minute from a)",
-        "(call extract (lit TIMEZONE_MINUTE) (id a (case_insensitive) (unqualified)))"
+        "(call (defnid extract) (lit TIMEZONE_MINUTE) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
     fun caseInsensitiveFunctionName() = assertExpression(
         "mY_fUnCtIoN(a)",
-        "(call my_function (id a (case_insensitive) (unqualified)))"
+        "(call (defnid my_function) (id a (case_insensitive) (unqualified)))"
     )
 
     @Test
@@ -996,49 +996,53 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun selectAliasDotStar() = assertExpression(
         "SELECT t.* FROM table1 AS t",
-        "(select (project (project_list (project_all (id t (case_insensitive) (unqualified))))) (from (scan (id table1 (case_insensitive) (unqualified)) t null null)))"
+        "(select (project (project_list (project_all (id t (case_insensitive) (unqualified))))) (from (scan (id table1 (case_insensitive) (unqualified)) (defnid t) null null)))"
     )
 
     @Test
     fun selectPathAliasDotStar() = assertExpression(
         "SELECT a.b.* FROM table1 AS t",
-        "(select (project (project_list (project_all (path (id a (case_insensitive) (unqualified)) (path_expr (lit \"b\") (case_insensitive)))))) (from (scan (id table1 (case_insensitive) (unqualified)) t null null)))"
+        """
+            (select 
+               (project (project_list (project_all (path (id a (case_insensitive) (unqualified)) (path_expr (lit "b") (case_insensitive)))))) 
+               (from (scan (id table1 (case_insensitive) (unqualified)) (defnid t) null null)))
+                      """
     )
 
     @Test
     fun selectWithFromAt() = assertExpression(
         "SELECT ord FROM table1 AT ord",
-        "(select (project (project_list (project_expr (id ord (case_insensitive) (unqualified)) null))) (from (scan (id table1 (case_insensitive) (unqualified)) null ord null)))"
+        "(select (project (project_list (project_expr (id ord (case_insensitive) (unqualified)) null))) (from (scan (id table1 (case_insensitive) (unqualified)) null (defnid ord) null)))"
     )
 
     @Test
     fun selectWithFromAsAndAt() = assertExpression(
         "SELECT ord, val FROM table1 AS val AT ord",
-        "(select (project (project_list (project_expr (id ord (case_insensitive) (unqualified)) null) (project_expr (id val (case_insensitive) (unqualified)) null))) (from (scan (id table1 (case_insensitive) (unqualified)) val ord null)))"
+        "(select (project (project_list (project_expr (id ord (case_insensitive) (unqualified)) null) (project_expr (id val (case_insensitive) (unqualified)) null))) (from (scan (id table1 (case_insensitive) (unqualified)) (defnid val) (defnid ord) null)))"
     )
 
     @Test
     fun selectWithFromIdBy() = assertExpression(
         "SELECT * FROM table1 BY uid",
-        "(select (project (project_star)) (from (scan (id table1 (case_insensitive) (unqualified)) null null uid)))"
+        "(select (project (project_star)) (from (scan (id table1 (case_insensitive) (unqualified)) null null (defnid uid))))"
     )
 
     @Test
     fun selectWithFromAtIdBy() = assertExpression(
         "SELECT * FROM table1 AT ord BY uid",
-        "(select (project (project_star)) (from (scan (id table1 (case_insensitive) (unqualified)) null ord uid)))"
+        "(select (project (project_star)) (from (scan (id table1 (case_insensitive) (unqualified)) null (defnid ord) (defnid uid))))"
     )
 
     @Test
     fun selectWithFromAsIdBy() = assertExpression(
         "SELECT * FROM table1 AS t BY uid",
-        "(select (project (project_star)) (from (scan (id table1 (case_insensitive) (unqualified)) t null uid)))"
+        "(select (project (project_star)) (from (scan (id table1 (case_insensitive) (unqualified)) (defnid t) null (defnid uid))))"
     )
 
     @Test
     fun selectWithFromAsAndAtIdBy() = assertExpression(
         "SELECT * FROM table1 AS val AT ord BY uid",
-        "(select (project (project_star)) (from (scan (id table1 (case_insensitive) (unqualified)) val ord uid)))"
+        "(select (project (project_star)) (from (scan (id table1 (case_insensitive) (unqualified)) (defnid val) (defnid ord) (defnid uid))))"
     )
 
     @Test
@@ -1058,7 +1062,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         """
         (select
           (project (project_list (project_expr (id ord (case_insensitive) (unqualified)) null)))
-          (from (unpivot (id item (case_insensitive) (unqualified)) null name null))
+          (from (unpivot (id item (case_insensitive) (unqualified)) null (defnid name) null))
         )
         """
     )
@@ -1069,7 +1073,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         """
         (select
           (project (project_list (project_expr (id ord (case_insensitive) (unqualified)) null)))
-          (from (unpivot (id item (case_insensitive) (unqualified)) val null null))
+          (from (unpivot (id item (case_insensitive) (unqualified)) (defnid val) null null))
         )
         """
     )
@@ -1080,7 +1084,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         """
         (select
           (project (project_list (project_expr (id ord (case_insensitive) (unqualified)) null)))
-          (from (unpivot (id item (case_insensitive) (unqualified)) val name null))
+          (from (unpivot (id item (case_insensitive) (unqualified)) (defnid val) (defnid name) null))
         )
         """
     )
@@ -1159,10 +1163,10 @@ class PartiQLParserTest : PartiQLParserTestBase() {
              (from 
                 (join
                     (inner)
-                    (scan (id table1 (case_insensitive) (unqualified)) t1 null null) 
+                    (scan (id table1 (case_insensitive) (unqualified)) (defnid t1) null null) 
                     (scan (id table2 (case_insensitive) (unqualified)) null null null)
                     null))
-             (where (call f (id t1 (case_insensitive) (unqualified))))
+             (where (call (defnid f) (id t1 (case_insensitive) (unqualified))))
            )
         """
     )
@@ -1172,14 +1176,15 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         "SELECT a a1, b b1 FROM table1 t1, table2 WHERE f(t1)",
         """
         (select
-            (project (project_list (project_expr (id a (case_insensitive) (unqualified)) a1) (project_expr (id b (case_insensitive) (unqualified)) b1)))
+            (project (project_list (project_expr (id a (case_insensitive) (unqualified)) (defnid a1)) 
+                                   (project_expr (id b (case_insensitive) (unqualified)) (defnid b1))))
             (from 
                 (join 
                     (inner) 
-                    (scan (id table1 (case_insensitive) (unqualified)) t1 null null) 
+                    (scan (id table1 (case_insensitive) (unqualified)) (defnid t1) null null) 
                     (scan (id table2 (case_insensitive) (unqualified)) null null null) 
                     null))
-            (where (call f (id t1 (case_insensitive) (unqualified))))
+            (where (call (defnid f) (id t1 (case_insensitive) (unqualified))))
         )
         """
     )
@@ -1191,10 +1196,10 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         (select
           (project
             (project_list
-              (project_expr (plus (call_agg (all) sum (id a (case_insensitive) (unqualified))) (call_agg (all) count (lit 1))) null)
-              (project_expr (call_agg (all) avg (id b (case_insensitive) (unqualified))) null)
-              (project_expr (call_agg (all) min (id c (case_insensitive) (unqualified))) null)
-              (project_expr (call_agg (all) max (plus (id d (case_insensitive) (unqualified)) (id e (case_insensitive) (unqualified)))) null)
+              (project_expr (plus (call_agg (all) (defnid sum) (id a (case_insensitive) (unqualified))) (call_agg (all) (defnid count) (lit 1))) null)
+              (project_expr (call_agg (all) (defnid avg) (id b (case_insensitive) (unqualified))) null)
+              (project_expr (call_agg (all) (defnid min) (id c (case_insensitive) (unqualified))) null)
+              (project_expr (call_agg (all) (defnid max) (plus (id d (case_insensitive) (unqualified)) (id e (case_insensitive) (unqualified)))) null)
             )
           )
           (from (scan (id foo (case_insensitive) (unqualified)) null null null))
@@ -1211,21 +1216,23 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         """(select
              (project
                (project_list
-                 (project_expr (path (call process (id t (case_insensitive) (unqualified))) (path_expr (lit "a") (case_insensitive)) (path_expr (lit 0) (case_sensitive))) a)
-                 (project_expr (path (id t2 (case_insensitive) (unqualified)) (path_expr (lit "b") (case_insensitive))) b)
+                 (project_expr (path (call (defnid process) (id t (case_insensitive) (unqualified))) (path_expr (lit "a") (case_insensitive)) (path_expr (lit 0) (case_sensitive))) 
+                               (defnid a))
+                 (project_expr (path (id t2 (case_insensitive) (unqualified)) (path_expr (lit "b") (case_insensitive))) 
+                               (defnid b))
                )
              )
              (from
                (join 
                  (inner) 
-                 (scan (path (id t1 (case_insensitive) (unqualified)) (path_expr (lit "a") (case_insensitive))) t null null) 
+                 (scan (path (id t1 (case_insensitive) (unqualified)) (path_expr (lit "a") (case_insensitive))) (defnid t) null null) 
                  (scan (path (id t2 (case_insensitive) (unqualified)) (path_expr (lit "x") (case_insensitive)) (path_unpivot) (path_expr (lit "b") (case_insensitive))) null null null)
                  null
                )
              )
              (where
                (and
-                 (call test (path (id t2 (case_insensitive) (unqualified)) (path_expr (lit "name") (case_insensitive))) (path (id t1 (case_insensitive) (unqualified)) (path_expr (lit "name") (case_insensitive))))
+                 (call (defnid test) (path (id t2 (case_insensitive) (unqualified)) (path_expr (lit "name") (case_insensitive))) (path (id t1 (case_insensitive) (unqualified)) (path_expr (lit "name") (case_insensitive))))
                  (eq (path (id t1 (case_insensitive) (unqualified)) (path_expr (lit "id") (case_insensitive))) (path (id t2 (case_insensitive) (unqualified)) (path_expr (lit "id") (case_insensitive))))
                )
              )
@@ -1242,19 +1249,22 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun selectValueWithSingleAliasedFrom() = assertExpression(
         "SELECT VALUE v FROM table1 AS v",
-        "(select (project (project_value (id v (case_insensitive) (unqualified)))) (from (scan (id table1 (case_insensitive) (unqualified)) v null null)))"
+        "(select (project (project_value (id v (case_insensitive) (unqualified)))) (from (scan (id table1 (case_insensitive) (unqualified)) (defnid v) null null)))"
     )
 
     @Test
     fun selectAllValues() = assertExpression(
         "SELECT ALL VALUE v FROM table1 AS v",
-        "(select (project (project_value (id v (case_insensitive) (unqualified)))) (from (scan (id table1 (case_insensitive) (unqualified)) v null null)))"
+        "(select (project (project_value (id v (case_insensitive) (unqualified)))) (from (scan (id table1 (case_insensitive) (unqualified)) (defnid v) null null)))"
     )
 
     @Test
     fun selectDistinctValues() = assertExpression(
         "SELECT DISTINCT VALUE v FROM table1 AS v",
-        "(select (setq (distinct)) (project (project_value (id v (case_insensitive) (unqualified)))) (from (scan (id table1 (case_insensitive) (unqualified)) v null null)))"
+        """
+            (select (setq (distinct)) 
+                    (project (project_value (id v (case_insensitive) (unqualified)))) 
+                    (from (scan (id table1 (case_insensitive) (unqualified)) (defnid v) null null)))"""
     )
 
     @Test
@@ -1335,7 +1345,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
             (from
                 (scan 
                     (id foo (case_insensitive) (unqualified))
-                    f
+                    (defnid f)
                     null
                     null))
             (where
@@ -1662,19 +1672,19 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (group_key_list
                         (group_key
                             (id a (case_insensitive) (unqualified))
-                            x)
+                            (defnid x))
                         (group_key
                             (plus
                                 (id b (case_insensitive) (unqualified))
                                 (id c (case_insensitive) (unqualified)))
-                            y)
+                            (defnid y))
                         (group_key
                             (call
-                                foo
+                                (defnid foo)
                                 (id d (case_insensitive) (unqualified)))
-                            z)
+                            (defnid z))
                         )
-                    g
+                    (defnid g)
                 )
              )
            )
@@ -1717,7 +1727,10 @@ class PartiQLParserTest : PartiQLParserTestBase() {
             (project (project_list (project_expr (id g (case_insensitive) (unqualified)) null)))
             (from (scan (id data (case_insensitive) (unqualified)) null null null))
             (where (eq (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified))))
-            (group (group_by (group_full) (group_key_list (group_key (id c (case_insensitive) (unqualified)) null) (group_key (id d (case_insensitive) (unqualified)) null)) g))
+            (group (group_by (group_full) 
+                             (group_key_list (group_key (id c (case_insensitive) (unqualified)) null) 
+                                             (group_key (id d (case_insensitive) (unqualified)) null)) 
+                             (defnid g)))
             (having (gt (id d (case_insensitive) (unqualified)) (lit 6)))
           )
         """
@@ -1751,7 +1764,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (id g (case_insensitive) (unqualified))))
             (from (scan (id data (case_insensitive) (unqualified)) null null null))
             (where (eq (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified))))
-            (group (group_by (group_full) (group_key_list (group_key (id c (case_insensitive) (unqualified)) null) (group_key (id d (case_insensitive) (unqualified)) null)) g))
+            (group (group_by (group_full) (group_key_list (group_key (id c (case_insensitive) (unqualified)) null) (group_key (id d (case_insensitive) (unqualified)) null)) (defnid g)))
             (having (gt (id d (case_insensitive) (unqualified)) (lit 6)))
           )
         """
@@ -2186,7 +2199,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (lit 1)
                 null
                 (on_conflict
-                    (call attribute_exists (id hk (case_insensitive) (unqualified)))
+                    (call (defnid attribute_exists) (id hk (case_insensitive) (unqualified)))
                     (do_nothing)
                 )
               )
@@ -2206,7 +2219,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 (lit 1)
                 null
                 (on_conflict
-                    (not (call attribute_exists (id hk (case_insensitive) (unqualified))))
+                    (not (call (defnid attribute_exists) (id hk (case_insensitive) (unqualified))))
                     (do_nothing)
                 )
               )
@@ -2336,7 +2349,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
-                            f
+                            (defnid f)
                             (bag
                                 (struct
                                     (expr_pair
@@ -2361,7 +2374,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
-                            f
+                            (defnid f)
                             (bag
                                 (struct
                                     (expr_pair
@@ -2393,7 +2406,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
-                            f
+                            (defnid f)
                             (bag
                                 (struct
                                     (expr_pair
@@ -2551,7 +2564,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
-                            f
+                            (defnid f)
                             (bag
                                 (struct
                                     (expr_pair
@@ -2576,7 +2589,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
-                            f
+                            (defnid f)
                             (bag
                                 (struct
                                     (expr_pair
@@ -2608,7 +2621,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
-                            f
+                            (defnid f)
                             (bag
                                 (struct
                                     (expr_pair
@@ -2738,7 +2751,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
-                            f
+                            (defnid f)
                             (bag
                                 (struct
                                     (expr_pair
@@ -2822,7 +2835,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
-                            f
+                            (defnid f)
                             (bag
                                 (struct
                                     (expr_pair
@@ -2872,7 +2885,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (dml_op_list
                         (insert
                             (id foo (case_insensitive) (unqualified))
-                            f
+                            (defnid f)
                             (bag
                                 (struct
                                     (expr_pair
@@ -3465,7 +3478,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                 )
               )
             )
-            (from (scan (id x (case_insensitive) (unqualified)) y null null))
+            (from (scan (id x (case_insensitive) (unqualified)) (defnid y) null null))
             (where (eq (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified))))
           )
         """
@@ -3492,7 +3505,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
             )
           )
         )
-        (from (scan (id x (case_insensitive) (unqualified)) y null null))
+        (from (scan (id x (case_insensitive) (unqualified)) (defnid y) null null))
         (where (eq (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified))))
         (returning 
             (returning_expr 
@@ -3518,7 +3531,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
             (from
                 (scan
                     (id x (case_insensitive) (unqualified))
-                    y
+                    (defnid y)
                     null
                     null))
             (where
@@ -3544,7 +3557,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
             (from
                 (scan
                     (id x (case_insensitive) (unqualified))
-                    y
+                    (defnid y)
                     null
                     null))
             (where
@@ -3576,7 +3589,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
               )
             )    
             (from
-              (scan (id x (case_insensitive) (unqualified)) y null null))
+              (scan (id x (case_insensitive) (unqualified)) (defnid y) null null))
             (where
               (eq
                 (id a (case_insensitive) (unqualified))
@@ -3595,7 +3608,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                   (path
                     (id y (case_insensitive) (unqualified))
                     (path_expr (lit "a") (case_insensitive))))))
-            (from (scan (id x (case_insensitive) (unqualified)) y null null))
+            (from (scan (id x (case_insensitive) (unqualified)) (defnid y) null null))
             (where (eq (id a (case_insensitive) (unqualified)) (id b (case_insensitive) (unqualified))))
           )
         """
@@ -3613,7 +3626,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (path (id z (case_insensitive) (unqualified)) (path_expr (lit "kingdom") (case_insensitive)))
                     (lit "Fungi")))))
             (from
-              (scan (id zoo (case_insensitive) (unqualified)) z null null)))
+              (scan (id zoo (case_insensitive) (unqualified)) (defnid z) null null)))
         """
     )
 
@@ -3629,7 +3642,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (path (id z (case_insensitive) (unqualified)) (path_expr (lit "kingdom") (case_insensitive)))
                     (lit "Fungi")))))
             (from
-              (scan (id zoo (case_insensitive) (unqualified)) null z_ord null)))
+              (scan (id zoo (case_insensitive) (unqualified)) null (defnid z_ord) null)))
         """
     )
 
@@ -3645,7 +3658,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (path (id z (case_insensitive) (unqualified)) (path_expr (lit "kingdom") (case_insensitive)))
                     (lit "Fungi")))))
             (from
-              (scan (id zoo (case_insensitive) (unqualified)) null null z_id)))
+              (scan (id zoo (case_insensitive) (unqualified)) null null (defnid z_id))))
         """
     )
 
@@ -3661,7 +3674,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                     (path (id z (case_insensitive) (unqualified)) (path_expr (lit "kingdom") (case_insensitive)))
                     (lit "Fungi")))))
             (from
-              (scan (id zoo (case_insensitive) (unqualified)) null z_ord z_id)))
+              (scan (id zoo (case_insensitive) (unqualified)) null (defnid z_ord) (defnid z_id))))
         """
     )
 
@@ -3829,7 +3842,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         """
           (dml
             (operations (dml_op_list (delete)))
-            (from (scan (id x (case_insensitive) (unqualified)) y null null))
+            (from (scan (id x (case_insensitive) (unqualified)) (defnid y) null null))
           )
         """
     )
@@ -3840,7 +3853,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         """
             (dml
               (operations ( dml_op_list (delete)))
-              (from (scan (id x (case_insensitive) (unqualified)) null y null)))
+              (from (scan (id x (case_insensitive) (unqualified)) null (defnid y) null)))
         """
     )
 
@@ -3850,7 +3863,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         """
             (dml
                (operations (dml_op_list (delete)))
-               (from (scan (id x (case_insensitive) (unqualified)) y z null)))
+               (from (scan (id x (case_insensitive) (unqualified)) (defnid y) (defnid z) null)))
         """
     )
 
@@ -3899,7 +3912,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                             (id x (case_insensitive) (unqualified))
                             (path_expr (lit "n") (case_insensitive))
                             (path_expr (lit "m") (case_insensitive)))
-                        y
+                        (defnid y)
                         null    
                         null)))
         """
@@ -3917,8 +3930,8 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                             (id x (case_insensitive) (unqualified))
                             (path_expr (lit "n") (case_insensitive))
                             (path_expr (lit "m") (case_insensitive)))
-                        y
-                        z
+                        (defnid y)
+                        (defnid z)
                         null)))
         """
     )
@@ -3937,7 +3950,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         """
             (ddl (create_table (identifier foo (case_insensitive))  
               (table_def
-                (column_declaration boo (string_type)))))
+                (column_declaration (defnid boo) (string_type)))))
         """.trimIndent()
     )
 
@@ -3947,7 +3960,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         """
             (ddl (create_table (identifier user (case_sensitive)) 
               (table_def
-                (column_declaration lastname (string_type)))))
+                (column_declaration (defnid lastname) (string_type)))))
         """.trimIndent()
     )
 
@@ -3968,12 +3981,12 @@ class PartiQLParserTest : PartiQLParserTestBase() {
                         Customer
                         (case_insensitive)) 
                     (table_def
-                        (column_declaration name (string_type)
-                            (column_constraint name_is_present (column_notnull)))
-                        (column_declaration age (integer_type))
-                        (column_declaration city (string_type)
+                        (column_declaration (defnid name) (string_type)
+                            (column_constraint (defnid name_is_present) (column_notnull)))
+                        (column_declaration (defnid age) (integer_type))
+                        (column_declaration (defnid city) (string_type)
                             (column_constraint null (column_null)))
-                        (column_declaration state (string_type)
+                        (column_declaration (defnid state) (string_type)
                             (column_constraint null (column_null))))))
         """.trimIndent()
     )

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -4361,7 +4361,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         select(
             project = projectX,
             from = scan(id("table1")),
-            fromLet = let(letBinding(lit(ionInt(1)), "A"))
+            fromLet = let(letBinding(lit(ionInt(1)), defnid("A")))
         )
     }
 
@@ -4370,7 +4370,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         select(
             project = projectX,
             from = scan(id("table1")),
-            fromLet = let(letBinding(lit(ionInt(1)), "A"), letBinding(lit(ionInt(2)), "B"))
+            fromLet = let(letBinding(lit(ionInt(1)), defnid("A")), letBinding(lit(ionInt(2)), defnid("B")))
         )
     }
 
@@ -4379,7 +4379,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         select(
             project = projectX,
             from = scan(id("table1")),
-            fromLet = let(letBinding(id("table1"), "A"))
+            fromLet = let(letBinding(id("table1"), defnid("A")))
         )
     }
 
@@ -4388,7 +4388,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         select(
             project = projectX,
             from = scan(id("table1")),
-            fromLet = let(letBinding(call("foo", emptyList()), "A"))
+            fromLet = let(letBinding(call(defnid("foo"), emptyList()), defnid("A")))
         )
     }
 
@@ -4399,7 +4399,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         select(
             project = projectX,
             from = scan(id("table1")),
-            fromLet = let(letBinding(call("foo", listOf(lit(ionInt(42)), lit(ionString("bar")))), "A"))
+            fromLet = let(letBinding(call(defnid("foo"), listOf(lit(ionInt(42)), lit(ionString("bar")))), defnid("A")))
         )
     }
 
@@ -4410,7 +4410,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
         select(
             project = projectX,
             from = scan(id("table1")),
-            fromLet = let(letBinding(call("foo", listOf(id("table1"))), "A"))
+            fromLet = let(letBinding(call(defnid("foo"), listOf(id("table1"))), defnid("A")))
         )
     }
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserWindowTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserWindowTests.kt
@@ -20,7 +20,7 @@ class PartiQLParserWindowTests : PartiQLParserTestBase() {
                 (project_list
                     (project_expr
                         (call_window
-                            lag
+                            (defnid lag)
                             (over
                                 (window_partition_list
                                     (id b (case_insensitive) (unqualified))
@@ -57,7 +57,7 @@ class PartiQLParserWindowTests : PartiQLParserTestBase() {
                 (project_list
                     (project_expr
                         (call_window
-                            lead
+                            (defnid lead)
                             (over
                                 (window_partition_list
                                     (id b (case_insensitive) (unqualified))
@@ -94,7 +94,7 @@ class PartiQLParserWindowTests : PartiQLParserTestBase() {
                 (project_list
                     (project_expr
                         (call_window
-                            lag
+                            (defnid lag)
                             (over
                                 (window_partition_list
                                     (id b (case_insensitive) (unqualified))
@@ -133,7 +133,7 @@ class PartiQLParserWindowTests : PartiQLParserTestBase() {
                 (project_list
                     (project_expr
                         (call_window
-                            lead
+                            (defnid lead)
                             (over
                                 (window_partition_list
                                     (id b (case_insensitive) (unqualified))
@@ -171,7 +171,7 @@ class PartiQLParserWindowTests : PartiQLParserTestBase() {
                 (project_list
                     (project_expr
                         (call_window
-                            lag
+                            (defnid lag)
                             (over
                                 (window_partition_list
                                     (id b (case_insensitive) (unqualified))
@@ -209,7 +209,7 @@ class PartiQLParserWindowTests : PartiQLParserTestBase() {
                 (project_list
                     (project_expr
                         (call_window
-                            lead
+                            (defnid lead)
                             (over
                                 (window_partition_list
                                     (id b (case_insensitive) (unqualified))


### PR DESCRIPTION
## Relevant Issues
This is the 2nd preliminary PR towards #1122, on top of PR #1178. 

## Description

While PR#1178 focused on the grammar, this one changes the AST.  But as with PR#1178, there are no semantic changes visible to a query user. 

The primary change is in partiql.ion, adding the node 
```
        (product defnid symb::symbol)
```
as a complement to the existing node 
```
	(product identifier name::symbol case::case_sensitivity)
```
The name is a short for "definitional identifier" since `defnid`s (primarily, and by intent) are used at sites that introduce an identifier by binding it to something (e.g., an `AS` alias in `FROM`).  This is in contrast to `identifier`s, which are used as references.  With this introduction, `defnid` replaces most direct uses of `symbol` in the AST. 
Note that a `defnid` does not keep track of "case sensitivity": this reflects the current design of identifiers and case-sensitive identifier lookup, where lexical appearance (delimited or not) of a definitional identifier in a query does not matter, but the exact appearance of its string content does (even when it is a regular/non-delimited identifier). 

The "primarily" caveat above alludes to the use of defnids as function names in function calls. Before this PR, those were `symbol` as well, and should similarly become identifier nodes. However, the uses in function calls are referential, not definitional. Handling rules for function references in the implementation are yet again different from both `identifier` and `defnid` (e.g., they normalize to lower case). In principle, this would be addressed with a third category of an AST node for identifiers. However, function identifiers being treated differently from other identifiers appears to be a mistake; there is no discernible reason for it.  So, this PR cuts some corners and uses `defnid` for identifiers that refer to functions.  (Besides, the distinction between `identifier` and `defnid` is to go away upon transition to SQL-conformant identifiers.)
There are comments in this PR elaborating on this matter where appropriate.  (See, in particular, `funDefnid` method in `PartiQLPigVisitor`.)

Also introduces class `Ident` -- beginning of an ADT for identifiers, to be used internally instead of `String`.
For now, `Ident` values started replacing `String` as keys in just a few internal lookup data structures used by `EvaluatingCompiler`.  This can/should grow over time. 

In the remaining places, there are now calls to the extension method string() in org.partiql.lang.domains.
This is a "bridge" method that converts `PartiqlAst.Defnid`s to `String`s, until those are transitioned to `Ident`s.


## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]** 
- Any backward-incompatible changes? **[YES]**
- Any new external dependencies? **[NO]**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.