### PR TITLE
Fixes bug in FilterScanToKeyLookupPass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@ classes in `:partiql-ast` and `:partiql-plan`.
 
 ### Fixed
 
+- Fix a bug in `FilterScanToKeyLookup` pass wherein it was rewriting primary key equality expressions with references 
+to the candidate row on both sides.  Now it will correctly ignore such expressions.
+
 ### Removed
 - **Breaking**: Removes `optionalParameter` and `variadicParameter` from `org.partiql.lang.types.FunctionSignature`. To continue support for evaluation of `optionalParameters`, please create another same-named function. To continue support for evaluation of `variadicParameter`, please use a `StaticType.LIST` to hold all previously variadic parameters.
   As this changes coincides with the addition of function overloading, only `callWithRequired` will be invoked upon execution of an `ExprFunction`. Note: Function overloading is now allowed, which is the reason for the removal of `optionalParameter` and `variadicParameter`.

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/optimizations/FilterScanToKeyLookupTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/optimizations/FilterScanToKeyLookupTests.kt
@@ -243,6 +243,11 @@ class FilterScanToKeyLookupTests {
                 "SELECT * FROM $TABLE_WITH_1_FIELD_PK AS f WHERE to_string(f.id = 42)",
                 expectedOutputBexpr = null
             ),
+            // primary-key equality expressions that reference the candidate row must be ignored.
+            TestCase(
+                "SELECT * FROM $TABLE_WITH_1_FIELD_PK AS f WHERE f.id = f.bar",
+                expectedOutputBexpr = null
+            ),
         )
     }
 


### PR DESCRIPTION
## Relevant Issues
N/A.

## Description

`FilterScanToKeyLookupPass` will now properly ignore primary key equality expressions where both sides reference the candidate row are rewritten.  i.e.:

    SELECT * FROM foo AS f WHERE f.id = f.bar

... was previously being rewritten to:

    (bindings_to_values
        (local_id 0)
        (project
            (impl <user-impl>)
            (var_decl 0)
            (path (local_id 0) (lit bar) (case_insensitive)))
        )
    )

Which is an invalid plan because when the dynamic argument to the project operator is evaluated the local variable 0 hasn't been initialized yet.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
 See the diff.

- Any backward-incompatible changes? **[YES/NO]**
No.

- Any new external dependencies? **[YES/NO]**

No

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.