### PR TITLE
Timestamp staticType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ classes in `:partiql-ast` and `:partiql-plan`.
 - **Breaking** the `sourceLocation` field of `org.partiql.errors.Problem` was changed from `org.partiql.lang.ast.SoureceLocationMeta` to `org.partiql.errors.ProblemLocation`.
 - Removed `Nullable...Value` implementations of PartiQLValue and made the standard implementations nullable.
 - Using PartiQLValueType requires optin; this was a miss from an earlier commit.
+- Modified timestamp static type to model precision and time zone. 
 
 ### Deprecated
 - **Breaking**: Deprecates the `Arguments`, `RequiredArgs`, `RequiredWithOptional`, and `RequiredWithVariadic` classes, 

--- a/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
@@ -373,11 +373,13 @@ public class TimestampType internal constructor(internal val timestampType: Part
     @PartiQLTimestampExperimental
     public val withTimeZone: Boolean = timestampType.withTimeZone
 
-    // Preserve the original semantics. An arbitrary timestamp type without time zone
+    // Preserve the original semantics (ion timestamp). An arbitrary timestamp type with time zone.
     public constructor(metas: Map<String, Any> = mapOf()) : this(PartiQLTimestampType(null, true, metas))
 
     /**
-     * @param precision specifies the number of digits in the fractional seconds. If omitted, the default value is 6.
+     * @param precision specifies the number of digits in the fractional seconds.
+     *  If omitted, the default value is 6 as specified in the SQL spec.
+     *  If null, then the timestamp can have arbitrary constraint.
      * @param withTimeZone If true, then the underlying data must be associated with either unknown timezone(-00:00) or an UTC offset.
      * @param metas Metadata associated with the timestamp type.
      */

--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValueExperimental.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValueExperimental.kt
@@ -19,3 +19,12 @@ package org.partiql.value
     level = RequiresOptIn.Level.ERROR,
 )
 public annotation class PartiQLValueExperimental
+
+@RequiresOptIn(
+    message = """
+        PartiQL Timestamp Type requires explicit opt-in, 
+        See https://github.com/partiql/partiql-docs/blob/datetime/RFCs/0047-datetime-data-type.md
+    """,
+    level = RequiresOptIn.Level.ERROR,
+)
+public annotation class PartiQLTimestampExperimental


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] N/A

## Description
- Add Timestamp StaticType. 
- The idea is to introduce minimal backward incompatible change. 
- Customer should not need to opt-in for timestamp class, or modify their existing codebase if they wish to continue use the ion timestamp. 
- However, if customer want to specify added feature such as precision, with/without timezone, then an explicit opt-in is required. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - Yes. 

- Any backward-incompatible changes? **[YES/NO]**
 - Should not be. But would appreciate a second option on this. 
 

- Any new external dependencies? **[YES/NO]**
  - No. 

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.