### PR TITLE
Revert "Prepares v0.12.1 release (#1200)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,25 +25,8 @@ Thank you to all who have contributed!
 
 -->
 
+
 ## [Unreleased]
-
-### Added
-
-### Changed
-
-### Deprecated
-
-### Fixed
-
-### Removed
-
-### Security
-
-### Contributors
-Thank you to all who have contributed!
-- @<your-username>
-
-## [0.12.1] - 2023-09-07
 
 ### Added
 - Adds `org.partiql.value` (experimental) package for reading/writing PartiQL values

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID      | Artifact ID           | Recommended Version |
 |---------------|-----------------------|---------------------|
-| `org.partiql` | `partiql-lang-kotlin` | `0.12.1`            | 
+| `org.partiql` | `partiql-lang-kotlin` | `0.12.0`            | 
 
 
 For Maven builds, add the following to your `pom.xml`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=0.12.1
+version=0.12.1-SNAPSHOT
 
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY


### PR DESCRIPTION
This reverts commit a2ce4d517207ad5a6ff04ca1f947e11529dcadf7.

## Relevant Issues
- [Closes/Related To] N/A

## Description
- PR #1200  overlooked breaking changing. The next release version should be `0.13.0`. 
- Reverting to make commit history clean. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - Yes. Reverting. 

- Any backward-incompatible changes? **[YES/NO]**
  -  No

- Any new external dependencies? **[YES/NO]**
  - No. 

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
  - No. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.