### PR TITLE
Start on propagating the changes in identifier normalization into the planner pipeline

### DIFF
--- a/partiql-lang/src/main/kotlin/org/partiql/lang/domains/util.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/domains/util.kt
@@ -91,6 +91,12 @@ fun PartiqlAst.Id.toBindingName(): BindingName =
 fun PartiqlLogical.Id.toBindingName(): BindingName =
     BindingName(this.symb.text, this.kind.toBindingCase())
 
+fun PartiqlLogical.Id.toIdent(): Ident =
+    when (this.kind) {
+        is PartiqlLogical.IdKind.Regular -> Ident.createFromRegular(this.symb.text)
+        is PartiqlLogical.IdKind.Delimited -> Ident.createFromDelimited(this.symb.text)
+    }
+
 fun PartiqlAst.Defnid.toIdent(): Ident =
     when (this.kind) {
         is PartiqlAst.IdKind.Regular -> Ident.createFromRegular(this.symb.text)

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatorTestBase.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatorTestBase.kt
@@ -29,7 +29,7 @@ import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestCase
 import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestTarget
 import org.partiql.lang.eval.evaluatortestframework.ExpectedResultFormat
 import org.partiql.lang.eval.evaluatortestframework.MultipleTestAdapter
-// import org.partiql.lang.eval.evaluatortestframework.PartiQLCompilerPipelineFactory
+import org.partiql.lang.eval.evaluatortestframework.PartiQLCompilerPipelineFactory
 import org.partiql.lang.eval.evaluatortestframework.PipelineEvaluatorTestAdapter
 import org.partiql.lang.eval.evaluatortestframework.VisitorTransformBaseTestAdapter
 import org.partiql.lang.graph.ExternalGraphReader
@@ -45,7 +45,7 @@ abstract class EvaluatorTestBase : TestBase() {
         listOf(
             // wVG-BAD
             PipelineEvaluatorTestAdapter(CompilerPipelineFactory()),
-            // PipelineEvaluatorTestAdapter(PartiQLCompilerPipelineFactory()),
+            PipelineEvaluatorTestAdapter(PartiQLCompilerPipelineFactory()),
             VisitorTransformBaseTestAdapter()
         )
     )


### PR DESCRIPTION
This is a spur off #1203, containing a start on unfinished work that should be done in the latter to make it complete. (Though, it might get resolved on other branches coincidentally.)

This commit tweaks enough in AstToLogicalVisitorTransform to make tests in EvaluatingCompilerFromLetTests pass,
but there are further failures. It might be possible to fix them through similar tweaks in the subsequent transforms,
past the Logical AST.

A digression for later:

These tweaks are also fairly ugly, which might provide motivation to revise somewhat the design of transitioning to
SQL-conformant identifiers, but this might be best after the transition is complete and more polished for the EvaluatingCompiler pipeline.
The revision might amount to abandoning the idea that PartiqlAst.Id/Defnid carries the precise text of the identifier
(how it was written at a given occurrence in a query). (The motivation for that was supporting textual round-tripping better, but that is not achievable for keywords already, so perhaps was a fool's errand to start with.)
Instead, the PartiqlAst.Id would carry just the normalized text of the identifier, without even the info whether it
originated as regular or delimited. (Note that this simplification is made possible by transitioning
to SQL-conformant identifiers. Keeping the internal Ident class would be advisable even in this case.)


