### PR TITLE
Add tests for Ion values with annotations

### DIFF
--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/IonAnnotationTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/IonAnnotationTests.kt
@@ -11,7 +11,7 @@ import org.partiql.lang.CompilerPipeline
  * https://github.com/partiql/partiql-spec/issues/63.
  */
 class IonAnnotationTests : EvaluatorTestBase() {
-    // Round-tripped Ion value with annotation (IonValue -> ExprValue -> IonValue) results in the elided annotation.
+    // Round-tripped Ion value with Annotation (IonValue -> ExprValue -> IonValue) results in the elided annotation.
     @Test
     fun ionValueWithAnnotationExprValueRoundTrip() {
         val ion: IonSystem = IonSystemBuilder.standard().build()
@@ -21,7 +21,7 @@ class IonAnnotationTests : EvaluatorTestBase() {
         assertEquals(ionValue, roundTripped)
     }
 
-    // Evaluated Ion Literal with annotation converted to an IonValue results in the elided annotation.
+    // Evaluated Ion Literal with Annotation converted to an IonValue results in the elided annotation.
     @Test
     fun ionLiteralWithAnnotationEvaluation() {
         val pipeline = CompilerPipeline.standard()
@@ -33,7 +33,7 @@ class IonAnnotationTests : EvaluatorTestBase() {
         assertEquals(ion.singleValue("{a: 1}"), ionValueRoundtripped)
     }
 
-    // Evaluated Ion value with annotation in an SFW projection. Converting result to an IonValue elides the annotation.
+    // Evaluated Ion value with Annotation in an SFW projection. Converting result to an IonValue elides the annotation.
     @Test
     fun ionValueWithAnnotationInSFW() {
         val pipeline = CompilerPipeline.standard()
@@ -44,7 +44,7 @@ class IonAnnotationTests : EvaluatorTestBase() {
         assertEquals(ion.singleValue("\$bag::[{a: 1}]"), ionValueRoundtripped)
     }
 
-    // Evaluated Ion values with annotations in an Arithmetic operation results to an Ion Value without annotation.
+    // Evaluated Ion values with annotations in an Arithmetic operation results in an Ion Value without Annotation.
     @Test
     fun ionValueWithAnnotationInArithmeticOperation() {
         val pipeline = CompilerPipeline.standard()

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/IonAnnotationTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/IonAnnotationTests.kt
@@ -1,0 +1,57 @@
+package org.partiql.lang.eval
+
+import com.amazon.ion.IonSystem
+import com.amazon.ion.system.IonSystemBuilder
+import org.junit.Test
+import org.partiql.lang.CompilerPipeline
+
+/**
+ * The following tests demonstrate the current IonValue annotation behavior and tracks possible regressions in future commits.
+ * This behavior is what the Kotlin implementation defines and is subject to change pending resolution of
+ * https://github.com/partiql/partiql-spec/issues/63.
+ */
+class IonAnnotationTests : EvaluatorTestBase() {
+    // Round-tripped Ion value with annotation (IonValue -> ExprValue -> IonValue) results in the elided annotation.
+    @Test
+    fun ionValueWithAnnotationExprValueRoundTrip() {
+        val ion: IonSystem = IonSystemBuilder.standard().build()
+        val ionValue = ion.singleValue("1")
+        val exprValue = ExprValue.of(ion.singleValue("annotation::1"))
+        val roundTripped = exprValue.toIonValue(ion)
+        assertEquals(ionValue, roundTripped)
+    }
+
+    // Evaluated Ion Literal with annotation converted to an IonValue results in the elided annotation.
+    @Test
+    fun ionLiteralWithAnnotationEvaluation() {
+        val pipeline = CompilerPipeline.standard()
+        val ionValueAsString = "annotation::{a: 1}"
+        val expr = pipeline.compile("`$ionValueAsString`")
+        val session = EvaluationSession.standard()
+        val result = expr.eval(session)
+        val ionValueRoundtripped = result.toIonValue(ion)
+        assertEquals(ion.singleValue("{a: 1}"), ionValueRoundtripped)
+    }
+
+    // Evaluated Ion value with annotation in an SFW projection. Converting result to an IonValue elides the annotation.
+    @Test
+    fun ionValueWithAnnotationInSFW() {
+        val pipeline = CompilerPipeline.standard()
+        val expr = pipeline.compile("SELECT t.a FROM [{'a': `annotation::1`}] AS t")
+        val session = EvaluationSession.standard()
+        val result = expr.eval(session)
+        val ionValueRoundtripped = result.toIonValue(ion)
+        assertEquals(ion.singleValue("\$bag::[{a: 1}]"), ionValueRoundtripped)
+    }
+
+    // Evaluated Ion values with annotations in an Arithmetic operation results to an Ion Value without annotation.
+    @Test
+    fun ionValueWithAnnotationInArithmeticOperation() {
+        val pipeline = CompilerPipeline.standard()
+        val expr = pipeline.compile("`value_1::1` + `value_2::2`")
+        val session = EvaluationSession.standard()
+        val result = expr.eval(session)
+        val ionValueRoundtripped = result.toIonValue(ion)
+        assertEquals(ion.singleValue("3"), ionValueRoundtripped)
+    }
+}

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/IonAnnotationTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/IonAnnotationTests.kt
@@ -15,10 +15,10 @@ class IonAnnotationTests : EvaluatorTestBase() {
     @Test
     fun ionValueWithAnnotationExprValueRoundTrip() {
         val ion: IonSystem = IonSystemBuilder.standard().build()
-        val ionValue = ion.singleValue("1")
-        val exprValue = ExprValue.of(ion.singleValue("annotation::1"))
+        val inputIonValue = ion.singleValue("annotation::1")
+        val exprValue = ExprValue.of(inputIonValue)
         val roundTripped = exprValue.toIonValue(ion)
-        assertEquals(ionValue, roundTripped)
+        assertEquals(ion.singleValue("1"), roundTripped)
     }
 
     // Evaluated Ion Literal with Annotation converted to an IonValue results in the elided annotation.


### PR DESCRIPTION
## Relevant Issues
- Related To Issue https://github.com/partiql/partiql-spec/issues/63 and https://github.com/partiql/partiql-spec/issues/61

## Description
This commits adds the tests for ensuring the correct behavior of eliding Ion annotations when evaluating Ion values in PartiQL. The intention for having such tests is to detect regression of the current behavior in future.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No, this commit does not result in a new feature release.

- Any backward-incompatible changes? **[YES/NO]**
  - No, this commit adds new tests only,

- Any new external dependencies? **[YES/NO]**
  - No.

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
 - Yes.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.