### PR TITLE
Add partiql-planner Maven publishing plugin v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.11.1] - 2023-09-19
+
+### Added
+- Added Maven publishing plugin for partiql-planner
 
 ## [0.11.0] - 2023-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.1] - 2023-09-19
 
-### Added
-- Added Maven publishing plugin for partiql-planner
+### Fixed
+- Fixes build failure for version `0.11.0` by publishing `partiql-plan` as an independent artifact. Please note that `partiql-plan` is experimental.
 
 ## [0.11.0] - 2023-05-22
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID      | Artifact ID           | Recommended Version |
 |---------------|-----------------------|---------------------|
-| `org.partiql` | `partiql-lang-kotlin` | `0.11.0`             | 
+| `org.partiql` | `partiql-lang-kotlin` | `0.11.1`            | 
 
 
 For Maven builds, add the following to your `pom.xml`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=0.11.0
+version=0.11.1
 
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -22,12 +22,6 @@ plugins {
     id(Plugins.publish)
 }
 
-val libs: Configuration by configurations.creating
-
-configurations {
-    api.get().extendsFrom(libs)
-}
-
 // Disabled for partiql-lang project.
 kotlin {
     explicitApi = null
@@ -105,14 +99,4 @@ tasks.processResources {
         include("partiql.ion")
         into("org/partiql/type-domains/")
     }
-}
-
-tasks.jar {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    // adds all `libs(project(...))` to the partiql-lang-kotlin jar
-    from(
-        libs.dependencies.filterIsInstance<ProjectDependency>().map {
-            it.dependencyProject.sourceSets.main.get().output.classesDirs
-        }
-    )
 }

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -38,11 +38,10 @@ dependencies {
     api(project(":lib:isl"))
     api(project(":partiql-spi"))
     api(project(":partiql-types"))
+    api(project(":partiql-plan"))
     api(Deps.ionElement)
     api(Deps.ionJava)
     api(Deps.pigRuntime)
-    // libs are included in partiql-lang-kotlin JAR
-    libs(project(":partiql-plan"))
     implementation(Deps.antlrRuntime)
     implementation(Deps.csv)
     implementation(Deps.kotlinReflect)

--- a/partiql-plan/build.gradle.kts
+++ b/partiql-plan/build.gradle.kts
@@ -16,6 +16,7 @@
 
 plugins {
     id(Plugins.conventions)
+    id(Plugins.publish)
     id(Plugins.library)
 }
 
@@ -23,6 +24,12 @@ dependencies {
     implementation(project(":partiql-types"))
     implementation(Deps.ionElement)
     implementation(Deps.kotlinReflect)
+}
+
+publish {
+    artifactId = "partiql-plan"
+    name = "PartiQL Plan"
+    description = "PartiQL Plan experimental data structures"
 }
 
 val generate = tasks.register<Exec>("generate") {

--- a/partiql-plan/build.gradle.kts
+++ b/partiql-plan/build.gradle.kts
@@ -26,6 +26,11 @@ dependencies {
     implementation(Deps.kotlinReflect)
 }
 
+// Disabled for partiql-plan project.
+kotlin {
+    explicitApi = null
+}
+
 publish {
     artifactId = "partiql-plan"
     name = "PartiQL Plan"


### PR DESCRIPTION
## Description
Adds a Maven publishing step to `partiql-planner` and changes partiql-lang-kotlin's dependency on `partiql-planner` to be `api`.

## Other Information
- Updated Unreleased Section in CHANGELOG: Yes

- Any backward-incompatible changes? No

- Any new external dependencies? No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.