### PR TITLE
Prepare v0.13.1 release and add partiql-planner Maven publishing plugin v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Thank you to all who have contributed!
 ### Fixed
 - Fix a bug in `FilterScanToKeyLookup` pass wherein it was rewriting primary key equality expressions with references
   to the candidate row on both sides.  Now it will correctly ignore such expressions.
-- Fixes build failure for version `0.13.0` by publishing `partiql-plan` and `partiql-parser` as an independent artifact. Please note that `partiql-plan` is experimental.
+- Fixes build failure for version `0.13.0` by publishing `partiql-plan` as an independent artifact. Please note that `partiql-plan` is experimental.
 
 
 ### Contributors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ Thank you to all who have contributed!
 
 -->
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
+### Contributors
+Thank you to all who have contributed!
+- @<your-username>
 
 ## [0.13.1] - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,11 +50,12 @@ Thank you to all who have contributed!
 - Adds support for thread interruption in compilation and execution. If you'd like to opt-in to this addition, please see
   the `isInterruptible` addition above for more information.
 - Adds support for CLI users to use CTRL-C to cancel long-running compilation/execution of queries
-- Added Maven publishing plugin for partiql-planner
 
 ### Fixed
 - Fix a bug in `FilterScanToKeyLookup` pass wherein it was rewriting primary key equality expressions with references
   to the candidate row on both sides.  Now it will correctly ignore such expressions.
+- Fixes build failure for version `0.13.0` by publishing `partiql-plan` and `partiql-parser` as an independent artifact. Please note that `partiql-plan` is experimental.
+
 
 ### Contributors
 Thank you to all who have contributed!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,29 +26,26 @@ Thank you to all who have contributed!
 -->
 
 
-## [Unreleased]
+## [0.13.1] - 2023-09-19
 
 ### Added
 - Adds `isInterruptible` property to `CompileOptions`. The default value is `false`. Please see the KDocs for more information.
 - Adds support for thread interruption in compilation and execution. If you'd like to opt-in to this addition, please see
   the `isInterruptible` addition above for more information.
 - Adds support for CLI users to use CTRL-C to cancel long-running compilation/execution of queries
-
-### Changed
-
-### Deprecated
+- Added Maven publishing plugin for partiql-planner
 
 ### Fixed
 - Fix a bug in `FilterScanToKeyLookup` pass wherein it was rewriting primary key equality expressions with references
   to the candidate row on both sides.  Now it will correctly ignore such expressions.
 
-### Removed
-
-### Security
-
 ### Contributors
 Thank you to all who have contributed!
-- @<your-username>
+- @dlurton
+- @yliuuuu
+- @am357
+- @johnedquinn
+- @alancai98
 
 ## [0.13.0] - 2023-09-07
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID      | Artifact ID           | Recommended Version |
 |---------------|-----------------------|---------------------|
-| `org.partiql` | `partiql-lang-kotlin` | `0.13.0`            |
+| `org.partiql` | `partiql-lang-kotlin` | `0.13.1`            |
 
 
 For Maven builds, add the following to your `pom.xml`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=0.13.1-SNAPSHOT
+version=0.13.1
 
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -36,11 +36,10 @@ dependencies {
     api(project(":partiql-parser"))
     api(project(":partiql-spi"))
     api(project(":partiql-types"))
+    api(project(":partiql-plan"))
     api(Deps.ionElement)
     api(Deps.ionJava)
     api(Deps.ionSchema)
-    // libs are included in partiql-lang-kotlin JAR, but are not published independently yet.
-    libs(project(":partiql-plan"))
     implementation(Deps.antlrRuntime)
     implementation(Deps.csv)
     implementation(Deps.kotlinReflect)

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -20,12 +20,6 @@ plugins {
     id(Plugins.publish)
 }
 
-val libs: Configuration by configurations.creating
-
-configurations {
-    api.get().extendsFrom(libs)
-}
-
 // Disabled for partiql-lang project.
 kotlin {
     explicitApi = null
@@ -77,14 +71,4 @@ tasks.processResources {
     from("$rootDir/partiql-ast/src/main/pig") {
         include("partiql.ion")
     }
-}
-
-tasks.jar {
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    // adds all `libs(project(...))` to the partiql-lang-kotlin jar
-    from(
-        libs.dependencies.filterIsInstance<ProjectDependency>().map {
-            it.dependencyProject.sourceSets.main.get().output.classesDirs
-        }
-    )
 }

--- a/partiql-parser/build.gradle.kts
+++ b/partiql-parser/build.gradle.kts
@@ -55,5 +55,5 @@ tasks.processResources {
 publish {
     artifactId = "partiql-parser"
     name = "PartiQL Parser"
-    description = "PartiQL's Parser"
+    description = "PartiQL's experimental Parser"
 }

--- a/partiql-plan/build.gradle.kts
+++ b/partiql-plan/build.gradle.kts
@@ -16,6 +16,7 @@
 
 plugins {
     id(Plugins.conventions)
+    id(Plugins.publish)
     id(Plugins.library)
 }
 
@@ -23,6 +24,17 @@ dependencies {
     implementation(project(":partiql-types"))
     implementation(Deps.ionElement)
     implementation(Deps.kotlinReflect)
+}
+
+// Disabled for partiql-plan project.
+kotlin {
+    explicitApi = null
+}
+
+publish {
+    artifactId = "partiql-plan"
+    name = "PartiQL Plan"
+    description = "PartiQL Plan experimental data structures"
 }
 
 val generate = tasks.register<Exec>("generate") {


### PR DESCRIPTION
## Description
Adds a Maven publishing step to `partiql-planner` and changes partiql-lang-kotlin's dependency on `partiql-planner` to be `api`.

## Other Information
- Updated Unreleased Section in CHANGELOG: Yes

- Any backward-incompatible changes? No

- Any new external dependencies? No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.