### PR TITLE
Adds toString() override to Sprout generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Adds overridden `toString()` method for Sprout-generated code.
 
 ### Changed
 

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
@@ -539,7 +539,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
     override fun visitExprTrim(node: Expr.Trim, ctx: Ctx) = translate(node) { metas ->
         val operands = mutableListOf<PartiqlAst.Expr>()
         // Legacy AST requires adding the spec as an argument
-        val spec = node.spec?.toString()?.lowercase()
+        val spec = node.spec?.name?.lowercase()
         val chars = node.chars?.let { visitExpr(it, ctx) }
         val value = visitExpr(node.value, ctx)
         if (spec != null) operands.add(lit(ionSymbol(spec)))
@@ -1334,7 +1334,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
     }
 
     private fun DatetimeField.toLegacyDatetimePart(): PartiqlAst.Expr.Lit {
-        val symbol = this.toString().lowercase()
+        val symbol = this.name.lowercase()
         return pig.lit(ionSymbol(symbol))
     }
 

--- a/test/sprout-tests/src/test/kotlin/org/partiql/sprout/tests/example/ToStringTests.kt
+++ b/test/sprout-tests/src/test/kotlin/org/partiql/sprout/tests/example/ToStringTests.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.sprout.tests.example
+
+import com.amazon.ionelement.api.createIonElementLoader
+import org.junit.jupiter.api.Test
+import org.partiql.sprout.tests.example.builder.ExampleFactoryImpl
+import kotlin.test.assertEquals
+
+/**
+ * While toString isn't a contract, here are some tests for making sure at least some things work.
+ *
+ * Notably, the following definitely won't get properly converted to Ion:
+ * - Maps
+ * - Imported Types
+ * - Escape Characters
+ */
+class ToStringTests {
+    private val factory = ExampleFactoryImpl()
+    private val loader = createIonElementLoader()
+
+    @Test
+    fun simpleProductAndEnum() {
+        val product = factory.identifierSymbol(
+            symbol = "helloworld!",
+            caseSensitivity = Identifier.CaseSensitivity.SENSITIVE
+        )
+        val expected = loader.loadSingleElement("IdentifierSymbol::{ symbol: \"helloworld!\", caseSensitivity: IdentifierCaseSensitivity::SENSITIVE }")
+        val actual = loader.loadSingleElement(product.toString())
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun emptyProduct() {
+        val product = factory.exprEmpty()
+        val expected = loader.loadSingleElement("ExprEmpty::{ }")
+        val actual = loader.loadSingleElement(product.toString())
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun list() {
+        val product = factory.identifierQualified(
+            root = factory.identifierSymbol(
+                symbol = "hello",
+                caseSensitivity = Identifier.CaseSensitivity.INSENSITIVE
+            ),
+            steps = listOf(
+                factory.identifierSymbol(
+                    symbol = "world",
+                    caseSensitivity = Identifier.CaseSensitivity.SENSITIVE
+                ),
+            )
+        )
+        val expectedString = """
+            IdentifierQualified::{
+                root: IdentifierSymbol::{ symbol: "hello", caseSensitivity: IdentifierCaseSensitivity::INSENSITIVE },
+                steps: [
+                    IdentifierSymbol::{ symbol: "world", caseSensitivity: IdentifierCaseSensitivity::SENSITIVE },
+                ]
+            }
+        """.trimIndent()
+        val expected = loader.loadSingleElement(expectedString)
+        val actual = loader.loadSingleElement(product.toString())
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds toString() override to Sprout generation
- Ion format -- yet, we shouldn't rely on it. See the comments. It's more for readability. We don't format to Ion for:
  - Maps
  - Imported Types
  - Escaped strings

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**

- Any backward-incompatible changes? **NO**
  - `toString` isn't a contract.

- Any new external dependencies? **NO**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.