### PR TITLE
Make Collection pretty printing compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Thank you to all who have contributed!
 ## [Unreleased]
 
 ### Added
+- **Breaking**: Compacts query pretty printing for `List`, `Bag`, and `Sexp`. E.g.: before `[ 1, 2, 3 ]` after `[1,2,3]`.
 
 ### Changed
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
@@ -407,16 +407,16 @@ class QueryPrettyPrinter {
 
     @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.Bag, sb: StringBuilder, level: Int) {
-        sb.append("<< ")
+        sb.append("<<")
         node.values.forEach {
             // Print anything as one line inside a bag
             writeAstNodeCheckSubQuery(it, sb, -1)
-            sb.append(", ")
+            sb.append(",")
         }
         if (node.values.isNotEmpty()) {
-            sb.removeLast(2)
+            sb.removeLast(1)
         }
-        sb.append(" >>")
+        sb.append(">>")
     }
 
     @Suppress("UNUSED_PARAMETER")
@@ -425,10 +425,10 @@ class QueryPrettyPrinter {
         node.values.forEach {
             // Print anything as one line inside a sexp
             writeAstNodeCheckSubQuery(it, sb, -1)
-            sb.append(", ")
+            sb.append(",")
         }
         if (node.values.isNotEmpty()) {
-            sb.removeLast(2)
+            sb.removeLast(1)
         }
         sb.append(")")
     }
@@ -436,17 +436,17 @@ class QueryPrettyPrinter {
     @Suppress("UNUSED_PARAMETER")
     private fun writeAstNode(node: PartiqlAst.Expr.List, sb: StringBuilder, level: Int) {
         val (open, close) = when (node.metas.containsKey(IsListParenthesizedMeta.tag)) {
-            true -> "( " to " )"
-            else -> "[ " to " ]"
+            true -> "(" to ")"
+            else -> "[" to "]"
         }
         sb.append(open)
         node.values.forEach {
             // Print anything as one line inside a list
             writeAstNodeCheckSubQuery(it, sb, -1)
-            sb.append(", ")
+            sb.append(",")
         }
         if (node.values.isNotEmpty()) {
-            sb.removeLast(2)
+            sb.removeLast(1)
         }
         sb.append(close)
     }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinterTest.kt
@@ -22,7 +22,7 @@ class QueryPrettyPrinterTest {
     @Test
     fun exec() {
         checkPrettyPrintQuery(
-            "EXEC foo 'bar0', 1, 2, [3]", "EXEC foo 'bar0', 1, 2, [ 3 ]"
+            "EXEC foo 'bar0', 1, 2, [3]", "EXEC foo 'bar0', 1, 2, [3]"
         )
     }
 
@@ -96,7 +96,7 @@ class QueryPrettyPrinterTest {
     @Test
     fun insertValue() {
         checkPrettyPrintQuery(
-            "INSERT INTO foo VALUE (1, 2)", "INSERT INTO foo VALUE ( 1, 2 )"
+            "INSERT INTO foo VALUE (1, 2)", "INSERT INTO foo VALUE (1,2)"
         )
     }
 
@@ -171,7 +171,7 @@ class QueryPrettyPrinterTest {
                 FROM x
                 WHERE a = b
                 SET k = 5, m = 6
-                INSERT INTO c VALUE << 1 >>
+                INSERT INTO c VALUE <<1>>
                 REMOVE a
                 SET l = 3
                 REMOVE b
@@ -320,17 +320,17 @@ class QueryPrettyPrinterTest {
 
     @Test
     fun bag() {
-        checkPrettyPrintQuery("<<1,2,3>>", "<< 1, 2, 3 >>")
+        checkPrettyPrintQuery("<<1,2,3>>", "<<1,2,3>>")
     }
 
     @Test
     fun list() {
-        checkPrettyPrintQuery("[1,2,3]", "[ 1, 2, 3 ]")
+        checkPrettyPrintQuery("[1,2,3]", "[1,2,3]")
     }
 
     @Test
     fun sexp() {
-        checkPrettyPrintQuery("sexp(1,2,3)", "sexp(1, 2, 3)")
+        checkPrettyPrintQuery("sexp(1,2,3)", "sexp(1,2,3)")
     }
 
     @Test
@@ -455,12 +455,12 @@ class QueryPrettyPrinterTest {
 
     @Test
     fun inCollectionBrackets() {
-        checkPrettyPrintQuery("1 IN [1, 2, 3]", "1 IN [ 1, 2, 3 ]")
+        checkPrettyPrintQuery("1 IN [1, 2, 3]", "1 IN [1,2,3]")
     }
 
     @Test
     fun inCollectionParens() {
-        checkPrettyPrintQuery("1 IN (1, 2, 3)", "1 IN ( 1, 2, 3 )")
+        checkPrettyPrintQuery("1 IN (1, 2, 3)", "1 IN (1,2,3)")
     }
 
     @Test
@@ -802,7 +802,7 @@ class QueryPrettyPrinterTest {
         checkPrettyPrintQuery(
             "<< (SELECT a FROM b), c >>",
             """
-                << (SELECT a FROM b), c >>
+                <<(SELECT a FROM b),c>>
             """.trimIndent()
         )
     }
@@ -812,7 +812,7 @@ class QueryPrettyPrinterTest {
         checkPrettyPrintQuery(
             "<< (CASE name WHEN 'jack' THEN 1 WHEN 'joe' THEN 2 END), c >>",
             """
-                << (CASE name WHEN 'jack' THEN 1 WHEN 'joe' THEN 2 END), c >>
+                <<(CASE name WHEN 'jack' THEN 1 WHEN 'joe' THEN 2 END),c>>
             """.trimIndent()
         )
     }
@@ -899,7 +899,7 @@ class QueryPrettyPrinterTest {
     @Test
     fun selectInExec() {
         checkPrettyPrintQuery(
-            "EXEC foo 'bar0', 1, 2, [3], SELECT a FROM b", "EXEC foo 'bar0', 1, 2, [ 3 ], (SELECT a FROM b)"
+            "EXEC foo 'bar0', 1, 2, [3], SELECT a FROM b", "EXEC foo 'bar0', 1, 2, [3], (SELECT a FROM b)"
         )
     }
 
@@ -925,7 +925,7 @@ class QueryPrettyPrinterTest {
             query = "SELECT * FROM [ CURRENT_user ]",
             expected = """
                 SELECT *
-                FROM [ CURRENT_USER ]
+                FROM [CURRENT_USER]
             """.trimIndent()
         )
     }


### PR DESCRIPTION
## Relevant Issues
- N/A

## Description
- Makes collection pretty printing compact so that pretty printing of queries with large number of collection elements becomes more compact.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - Yes.

- Any backward-incompatible changes? **[YES/NO]**
  - Yes. This is a backward incompatible changes becomes the query texts resulting from `QueryPrettyPrinter` are now different because the blank spaces for list components are now being elided.

Example: 
```SQL
-- Before
1 IN [1,2 ,3] -> 1 IN [ 1, 2, 3 ]
1 IN <<1, 2 , 3>> -> 1 IN << 1, 2, 3 >>
1 IN ( 1,2,3 ) >> -> 1 IN  ( 1, 2, 3 )

-- After
1 IN [1,2 ,3] -> 1 IN [1,2,3]
1 IN <<1, 2 , 3>> -> 1 IN <<1,2,3>>
1 IN ( 1,2,3 ) >> -> 1 IN  (1,2,3)
```

- Any new external dependencies? **[YES/NO]**
  - No.

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)?
 - Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.