### PR TITLE
Adds CURRENT_DATE special form to parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Adds overridden `toString()` method for Sprout-generated code.
+- Adds CURRENT_DATE session variable to PartiQL.g4 and PartiQLParser
 
 ### Changed
 

--- a/buildSrc/src/main/kotlin/partiql.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/partiql.conventions.gradle.kts
@@ -77,6 +77,10 @@ configure<KtlintExtension> {
     }
 }
 
+tasks.named("build") {
+    dependsOn("ktlintFormat")
+}
+
 sourceSets {
     main {
         java.srcDir(generatedSrc)

--- a/buildSrc/src/main/kotlin/partiql.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/partiql.conventions.gradle.kts
@@ -77,10 +77,6 @@ configure<KtlintExtension> {
     }
 }
 
-tasks.named("build") {
-    dependsOn("ktlintFormat")
-}
-
 sourceSets {
     main {
         java.srcDir(generatedSrc)

--- a/buildSrc/src/main/kotlin/partiql.versions.kt
+++ b/buildSrc/src/main/kotlin/partiql.versions.kt
@@ -42,7 +42,7 @@ object Versions {
     const val kotlinxCollections = "0.3.5"
     const val picoCli = "4.7.0"
     const val kasechange = "1.3.0"
-    const val ktlint = "11.5.0"
+    const val ktlint = "11.6.0"
     const val pig = "0.6.2"
 
     // Testing

--- a/partiql-ast/src/main/resources/partiql_ast.ion
+++ b/partiql-ast/src/main/resources/partiql_ast.ion
@@ -277,6 +277,7 @@ expr::[
   session_attribute::{
     attribute: [
       CURRENT_USER,
+      CURRENT_DATE,
     ],
   },
 

--- a/partiql-parser/src/main/antlr/PartiQL.g4
+++ b/partiql-parser/src/main/antlr/PartiQL.g4
@@ -602,6 +602,7 @@ exprPrimary
 exprTerm
     : PAREN_LEFT expr PAREN_RIGHT    # ExprTermWrappedQuery
     | CURRENT_USER                   # ExprTermCurrentUser
+    | CURRENT_DATE                   # ExprTermCurrentDate
     | parameter                      # ExprTermBase
     | varRefExpr                     # ExprTermBase
     | literal                        # ExprTermBase

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
@@ -1475,6 +1475,10 @@ internal class PartiQLParserDefault : PartiQLParser {
             exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_USER)
         }
 
+        override fun visitExprTermCurrentDate(ctx: org.partiql.parser.antlr.PartiQLParser.ExprTermCurrentDateContext) = translate(ctx) {
+            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_DATE)
+        }
+
         /**
          *
          * FUNCTIONS

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/impl/PartiQLParserSessionAttributeTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/impl/PartiQLParserSessionAttributeTests.kt
@@ -1,0 +1,85 @@
+package org.partiql.parser.impl
+
+import org.junit.jupiter.api.Test
+import org.partiql.ast.AstNode
+import org.partiql.ast.Expr
+import org.partiql.ast.builder.AstFactory
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.int64Value
+import kotlin.test.assertEquals
+
+@OptIn(PartiQLValueExperimental::class)
+class PartiQLParserSessionAttributeTests {
+
+    private val parser = PartiQLParserDefault()
+
+    private fun query(body: AstFactory.() -> Expr) = AstFactory.create {
+        statementQuery(this.body())
+    }
+
+    @Test
+    fun currentUserUpperCase() = assertExpression(
+        "CURRENT_USER",
+        query {
+            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_USER)
+        }
+    )
+
+    @Test
+    fun currentUserMixedCase() = assertExpression(
+        "CURRENT_user",
+        query {
+            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_USER)
+        }
+    )
+
+    @Test
+    fun currentUserLowerCase() = assertExpression(
+        "current_user",
+        query {
+            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_USER)
+        }
+    )
+
+    @Test
+    fun currentUserEquals() = assertExpression(
+        "1 = current_user",
+        query {
+            exprBinary(
+                op = Expr.Binary.Op.EQ,
+                lhs = exprLit(int64Value(1)),
+                rhs = exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_USER)
+            )
+        }
+    )
+
+    @Test
+    fun currentDateUpperCase() = assertExpression(
+        "CURRENT_DATE",
+        query {
+            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_DATE)
+        }
+    )
+
+    @Test
+    fun currentDateMixedCase() = assertExpression(
+        "CURRENT_date",
+        query {
+            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_DATE)
+        }
+    )
+
+    @Test
+    fun currentDateLowerCase() = assertExpression(
+        "current_date",
+        query {
+            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_DATE)
+        }
+    )
+
+    private fun assertExpression(input: String, expected: AstNode) {
+        val result = parser.parse(input)
+        val actual = result.root
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
## Relevant Issues

Needed for transpiler. Similar to https://github.com/partiql/partiql-lang-kotlin/pull/1049

## Description

Adds the CURRENT_DATE special form to the parser.

**SQL-99 6.19**
```ebnf
<current date value function> ::= CURRENT_DATE
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
YES

- Any backward-incompatible changes? **[YES/NO]**
NO

- Any new external dependencies? **[YES/NO]**
NO

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
YES

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.