### PR TITLE
Prepare v0.13.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Adds overridden `toString()` method for Sprout-generated code.
-- Adds CURRENT_DATE session variable to PartiQL.g4 and PartiQLParser
-- Adds configurable AST to SQL pretty printer. Usage in Java `AstKt.sql(ast)` or in Kotlin `ast.sql()`.
 
 ### Changed
 
@@ -28,9 +25,12 @@ Thank you to all who have contributed!
 
 -->
 
-## [Unreleased]
+## [0.13.2]
 
 ### Added
+- Adds overridden `toString()` method for Sprout-generated code.
+- Adds CURRENT_DATE session variable to PartiQL.g4 and PartiQLParser
+- Adds configurable AST to SQL pretty printer. Usage in Java `AstKt.sql(ast)` or in Kotlin `ast.sql()`.
 - Support parsing, planning, and evaluation of Bitwise AND operator (&).
   - The Bitwise And Operator only works for integer operands.
   - The operator precedence may change based on the pending operator precedence [RFC](https://github.com/partiql/partiql-docs/issues/50).
@@ -54,6 +54,9 @@ Thank you to all who have contributed!
 ### Contributors
 Thank you to all who have contributed!
 - @johnedquinn
+- @RCHowell
+- @yliuuuu
+- @alanca98
 
 ## [0.13.1] - 2023-09-19
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID      | Artifact ID           | Recommended Version |
 |---------------|-----------------------|---------------------|
-| `org.partiql` | `partiql-lang-kotlin` | `0.13.1`            |
+| `org.partiql` | `partiql-lang-kotlin` | `0.13.2`            |
 
 
 For Maven builds, add the following to your `pom.xml`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=0.13.2-SNAPSHOT
+version=0.13.2
 
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY


### PR DESCRIPTION
## Description
Prepare v0.13.2 release.

## Other Information
- Updated Unreleased Section in CHANGELOG: No -- release.

- Any backward-incompatible changes? No

- Any new external dependencies? No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.