### PR TITLE
Remove x['y'] -> x.y printing

### DIFF
--- a/partiql-ast/src/main/kotlin/org/partiql/ast/sql/SqlDialect.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/sql/SqlDialect.kt
@@ -18,7 +18,6 @@ import org.partiql.ast.visitor.AstBaseVisitor
 import org.partiql.value.MissingValue
 import org.partiql.value.NullValue
 import org.partiql.value.PartiQLValueExperimental
-import org.partiql.value.TextValue
 import org.partiql.value.io.PartiQLValueTextWriter
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
@@ -40,7 +39,8 @@ public abstract class SqlDialect : AstBaseVisitor<SqlBlock, SqlBlock>() {
         public val PARTIQL = object : SqlDialect() {}
     }
 
-    override fun defaultReturn(node: AstNode, head: SqlBlock) = throw UnsupportedOperationException("Cannot print $node")
+    override fun defaultReturn(node: AstNode, head: SqlBlock) =
+        throw UnsupportedOperationException("Cannot print $node")
 
     // STATEMENTS
 
@@ -143,7 +143,8 @@ public abstract class SqlDialect : AstBaseVisitor<SqlBlock, SqlBlock>() {
     override fun visitTypeTimeWithTz(node: Type.TimeWithTz, head: SqlBlock) =
         head concat type("TIME WITH TIMEZONE", node.precision, gap = true)
 
-    override fun visitTypeTimestamp(node: Type.Timestamp, head: SqlBlock) = head concat type("TIMESTAMP", node.precision)
+    override fun visitTypeTimestamp(node: Type.Timestamp, head: SqlBlock) =
+        head concat type("TIMESTAMP", node.precision)
 
     override fun visitTypeTimestampWithTz(node: Type.TimestampWithTz, head: SqlBlock) =
         head concat type("TIMESTAMP WITH TIMEZONE", node.precision, gap = true)
@@ -235,20 +236,13 @@ public abstract class SqlDialect : AstBaseVisitor<SqlBlock, SqlBlock>() {
     override fun visitExprPathStepSymbol(node: Expr.Path.Step.Symbol, head: SqlBlock) =
         head concat r(".${node.symbol.sql()}")
 
-    @OptIn(PartiQLValueExperimental::class)
     override fun visitExprPathStepIndex(node: Expr.Path.Step.Index, head: SqlBlock): SqlBlock {
         var h = head
         val key = node.key
-        if (key is Expr.Lit && key.value is TextValue<*>) {
-            // use . syntax
-            h = h concat r(".")
-            h = h concat r((key.value as TextValue<*>).string!!)
-        } else {
-            // use [ ] syntax
-            h = h concat r("[")
-            h = visitExpr(node.key, h)
-            h = h concat r("]")
-        }
+        // use [ ] syntax
+        h = h concat r("[")
+        h = visitExpr(key, h)
+        h = h concat r("]")
         return h
     }
 

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
@@ -500,6 +500,15 @@ class SqlDialectTest {
                     )
                 }
             },
+            expect("x['y']") {
+                exprPath {
+                    root = exprVar {
+                        identifier = id("x")
+                        scope = Expr.Var.Scope.DEFAULT
+                    }
+                    steps += exprPathStepIndex(exprLit(stringValue("y")))
+                }
+            },
         )
 
         @JvmStatic


### PR DESCRIPTION
## Description
This printing was incorrect `x['y'] != x.y`

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.