### PR TITLE
Adds session binders

### DIFF
--- a/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToBinder.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToBinder.kt
@@ -22,6 +22,7 @@ public fun Expr.toBinder(index: Int): Identifier.Symbol = when (this) {
     is Expr.Var -> this.identifier.toBinder()
     is Expr.Path -> this.toBinder(index)
     is Expr.Cast -> this.value.toBinder(index)
+    is Expr.SessionAttribute -> this.attribute.name.uppercase().toBinder()
     else -> col(index).toBinder()
 }
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
@@ -33,6 +33,7 @@ import org.partiql.types.IntType
 import org.partiql.types.ListType
 import org.partiql.types.SexpType
 import org.partiql.types.StaticType
+import org.partiql.types.StaticType.Companion.DATE
 import org.partiql.types.StaticType.Companion.DECIMAL
 import org.partiql.types.StaticType.Companion.INT
 import org.partiql.types.StaticType.Companion.INT4
@@ -384,6 +385,35 @@ class PartiQLSchemaInferencerTests {
                 name = "Current User in WHERE",
                 query = "SELECT VALUE a FROM [ 0 ] AS a WHERE CURRENT_USER = 5",
                 expected = BagType(INT),
+            ),
+            SuccessTestCase(
+                name = "Testing CURRENT_USER and CURRENT_DATE Binders",
+                query = """
+                    SELECT
+                        CURRENT_USER,
+                        CURRENT_DATE,
+                        CURRENT_USER AS "curr_user",
+                        CURRENT_DATE AS "curr_date",
+                        CURRENT_USER || ' is my name.' AS name_desc
+                    FROM << 0, 1 >>;
+                """.trimIndent(),
+                expected = BagType(
+                    StructType(
+                        fields = listOf(
+                            StructType.Field("CURRENT_USER", STRING.asNullable()),
+                            StructType.Field("CURRENT_DATE", DATE),
+                            StructType.Field("curr_user", STRING.asNullable()),
+                            StructType.Field("curr_date", DATE),
+                            StructType.Field("name_desc", STRING.asNullable()),
+                        ),
+                        contentClosed = true,
+                        constraints = setOf(
+                            TupleConstraint.Open(false),
+                            TupleConstraint.UniqueAttrs(true),
+                            TupleConstraint.Ordered
+                        )
+                    )
+                )
             ),
             ErrorTestCase(
                 name = "Current User (String) PLUS String",


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Small PR to update the default binders for CURRENT_USER and CURRENT_DATE.
- Now, `SELECT CURRENT_USER` previously normalized to `SELECT CURRENT_USER AS "_1"`, but now, it normalized to: `SELECT CURRENT_USER AS "CURRENT_USER"`

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No, not to main.

- Any backward-incompatible changes? **[YES/NO]**
  - No

- Any new external dependencies? **[YES/NO]**
  - No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.