### PR TITLE
Fixes pathing of expressions

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/typer/PlanTyper.kt
@@ -453,8 +453,9 @@ internal class PlanTyper(
                     // rewrite root
                     rex(type, op) to steps
                 }
-                else -> node.root to node.steps
+                else -> visitRex(node.root, node.root.type) to node.steps
             }
+
             // short-circuit if whole path was matched
             if (steps.isEmpty()) {
                 return root

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/dogs.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/dogs.ion
@@ -1,0 +1,24 @@
+{
+  type: "list",
+  items: {
+    type: "struct",
+    constraints: [closed],
+    fields: [
+      {
+        name: "breed",
+        type: "string",
+      },
+      {
+        name: "avg_height",
+        type: "float32",
+      },
+      {
+        name: "typical_allergies",
+        type: {
+          type: "list",
+          items: "string"
+        }
+      }
+    ]
+  }
+}

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/os.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/os.ion
@@ -1,0 +1,2 @@
+// String representing the current operating system
+"string"


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Fixes pathing of expressions by visiting root.
- Adds tests for pathing
- Previously, queries would fail because we would forget to type the root of paths (unless the rex was a variable). The following used to fail:
  - `[0, 1, 2, 3][0]`
  - `SELECT typical_allergies[0] AS main_allergy FROM dogs`
  - and more
-  While this PR doesn't have anything to do with scalar functions, I was previously adding tests for scalar functions and am including them here. See `testScalarFunctions` in the schema inference tests.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.