### PR TITLE
Support ANY type in Header functions And Planning of Control Flow Functions. 

### DIFF
--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -85,5 +85,6 @@ tasks.processTestResources {
 
 tasks.shadowJar {
     archiveBaseName.set("shadow")
+    exclude("**/*.kotlin_metadata")
     archiveClassifier.set("")
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/Header.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/Header.kt
@@ -43,7 +43,7 @@ public abstract class Header {
      * For functions, output CREATE FUNCTION statements.
      */
     override fun toString(): String = buildString {
-        functions.groupBy { it.name }.forEach {
+        (functions + operators + aggregations).groupBy { it.name }.forEach {
             appendLine("-- [${it.key}] ---------")
             appendLine()
             it.value.forEach { fn -> appendLine(fn) }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/Header.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/Header.kt
@@ -58,13 +58,14 @@ public abstract class Header {
     companion object {
 
         @JvmStatic
-        internal fun unary(name: String, returns: PartiQLValueType, value: PartiQLValueType) =
+        internal fun unary(name: String, returns: PartiQLValueType, value: PartiQLValueType, isMissable: Boolean = false) =
             FunctionSignature.Scalar(
                 name = name,
                 returns = returns,
                 parameters = listOf(FunctionParameter("value", value)),
                 isNullCall = true,
                 isNullable = false,
+                isMissable = isMissable
             )
 
         @JvmStatic

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/Header.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/Header.kt
@@ -68,13 +68,14 @@ public abstract class Header {
             )
 
         @JvmStatic
-        internal fun binary(name: String, returns: PartiQLValueType, lhs: PartiQLValueType, rhs: PartiQLValueType) =
+        internal fun binary(name: String, returns: PartiQLValueType, lhs: PartiQLValueType, rhs: PartiQLValueType, isMissable: Boolean = false) =
             FunctionSignature.Scalar(
                 name = name,
                 returns = returns,
                 parameters = listOf(FunctionParameter("lhs", lhs), FunctionParameter("rhs", rhs)),
                 isNullCall = true,
                 isNullable = false,
+                isMissable = isMissable
             )
     }
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
@@ -4,14 +4,23 @@ import org.partiql.ast.DatetimeField
 import org.partiql.types.function.FunctionParameter
 import org.partiql.types.function.FunctionSignature
 import org.partiql.value.PartiQLValueExperimental
-import org.partiql.value.PartiQLValueType.*
+import org.partiql.value.PartiQLValueType.ANY
+import org.partiql.value.PartiQLValueType.BOOL
+import org.partiql.value.PartiQLValueType.CHAR
+import org.partiql.value.PartiQLValueType.DATE
+import org.partiql.value.PartiQLValueType.DECIMAL
+import org.partiql.value.PartiQLValueType.INT
+import org.partiql.value.PartiQLValueType.INT32
+import org.partiql.value.PartiQLValueType.INT64
+import org.partiql.value.PartiQLValueType.STRING
+import org.partiql.value.PartiQLValueType.TIME
+import org.partiql.value.PartiQLValueType.TIMESTAMP
 
 /**
  * A header which uses the PartiQL Lang Kotlin default standard library. All functions exist in a global namespace.
  * Once we have catalogs with information_schema, the PartiQL Header will be fixed on a specification version and
  * user defined functions will be defined within their own schema.
  *
- * TODO: The model of ANY type in function signature is less than ideal. If we have
  */
 @OptIn(PartiQLValueExperimental::class)
 object PartiQLHeader : Header() {
@@ -105,7 +114,7 @@ object PartiQLHeader : Header() {
 
     // OPERATORS
 
-    private fun not(): List<FunctionSignature.Scalar> = listOf(unary("not", BOOL, BOOL), unary("not", ANY, ANY))
+    private fun not(): List<FunctionSignature.Scalar> = listOf(unary("not", BOOL, BOOL), unary("not", BOOL, ANY, true))
 
     private fun pos(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         unary("pos", t, t)
@@ -113,7 +122,7 @@ object PartiQLHeader : Header() {
 
     private fun neg(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         unary("neg", t, t)
-    } + listOf(unary("pos", ANY, ANY))
+    } + listOf(unary("neg", ANY, ANY))
 
     private fun eq(): List<FunctionSignature.Scalar> = types.all.map { t ->
         FunctionSignature.Scalar(
@@ -411,7 +420,7 @@ object PartiQLHeader : Header() {
             ),
             isNullCall = true,
             isNullable = false,
-            isMissable = false,
+            isMissable = true,
         ),
         FunctionSignature.Scalar(
             name = "substring",
@@ -423,7 +432,7 @@ object PartiQLHeader : Header() {
             ),
             isNullCall = true,
             isNullable = false,
-            isMissable = false
+            isMissable = true
         )
     )
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
@@ -166,7 +166,7 @@ object PartiQLHeader : Header() {
 
     private fun plus(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("plus", t, t, t)
-    } + listOf(binary("plus", BOOL, ANY, ANY, true))
+    } + listOf(binary("plus", ANY, ANY, ANY, true))
 
     private fun minus(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("minus", t, t, t)

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
@@ -105,15 +105,15 @@ object PartiQLHeader : Header() {
 
     // OPERATORS
 
-    private fun not(): List<FunctionSignature.Scalar> = listOf(unary("not", BOOL, BOOL))
+    private fun not(): List<FunctionSignature.Scalar> = listOf(unary("not", BOOL, BOOL), unary("not", ANY, ANY))
 
     private fun pos(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         unary("pos", t, t)
-    }
+    } + listOf(unary("pos", ANY, ANY))
 
     private fun neg(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         unary("neg", t, t)
-    }
+    } + listOf(unary("pos", ANY, ANY))
 
     private fun eq(): List<FunctionSignature.Scalar> = types.all.map { t ->
         FunctionSignature.Scalar(
@@ -127,55 +127,55 @@ object PartiQLHeader : Header() {
 
     private fun ne(): List<FunctionSignature.Scalar> = types.all.map { t ->
         binary("ne", BOOL, t, t)
-    }
+    } + listOf(binary("ne", ANY, ANY, ANY))
 
-    private fun and(): List<FunctionSignature.Scalar> = listOf(binary("and", BOOL, BOOL, BOOL))
+    private fun and(): List<FunctionSignature.Scalar> = listOf(binary("and", BOOL, BOOL, BOOL), binary("and", ANY, ANY, ANY))
 
-    private fun or(): List<FunctionSignature.Scalar> = listOf(binary("or", BOOL, BOOL, BOOL))
+    private fun or(): List<FunctionSignature.Scalar> = listOf(binary("or", BOOL, BOOL, BOOL), binary("or", ANY, ANY, ANY))
 
     private fun lt(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("lt", BOOL, t, t)
-    }
+    } + listOf(binary("lt", ANY, ANY, ANY))
 
     private fun lte(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("lte", BOOL, t, t)
-    }
+    } + listOf(binary("lte", ANY, ANY, ANY))
 
     private fun gt(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("gt", BOOL, t, t)
-    }
+    } + listOf(binary("gt", ANY, ANY, ANY))
 
     private fun gte(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("gte", BOOL, t, t)
-    }
+    } + listOf(binary("gte", ANY, ANY, ANY))
 
     private fun plus(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("plus", t, t, t)
-    }
+    } + listOf(binary("plus", ANY, ANY, ANY))
 
     private fun minus(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("minus", t, t, t)
-    }
+    } + listOf(binary("minus", ANY, ANY, ANY))
 
     private fun times(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("times", t, t, t)
-    }
+    } + listOf(binary("times", ANY, ANY, ANY))
 
     private fun div(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("divide", t, t, t)
-    }
+    } + listOf(binary("divide", ANY, ANY, ANY))
 
     private fun mod(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("modulo", t, t, t)
-    }
+    } + listOf(binary("modulo", ANY, ANY, ANY))
 
     private fun concat(): List<FunctionSignature.Scalar> = types.text.map { t ->
         binary("concat", t, t, t)
-    }
+    } + listOf(binary("concat", ANY, ANY, ANY))
 
     private fun bitwiseAnd(): List<FunctionSignature.Scalar> = types.integer.map { t ->
         binary("bitwise_and", t, t, t)
-    }
+    } + listOf(binary("bitwise_and", ANY, ANY, ANY))
 
     // BUILT INTS
 
@@ -219,6 +219,27 @@ object PartiQLHeader : Header() {
                 FunctionParameter("value", STRING),
                 FunctionParameter("pattern", STRING),
                 FunctionParameter("escape", STRING),
+            ),
+            isNullCall = true,
+            isNullable = false,
+        ),
+        FunctionSignature.Scalar(
+            name = "like",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("value", ANY),
+                FunctionParameter("pattern", ANY),
+            ),
+            isNullCall = true,
+            isNullable = false,
+        ),
+        FunctionSignature.Scalar(
+            name = "like_escape",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("value", ANY),
+                FunctionParameter("pattern", ANY),
+                FunctionParameter("escape", ANY),
             ),
             isNullCall = true,
             isNullable = false,
@@ -328,7 +349,16 @@ object PartiQLHeader : Header() {
             ),
             isNullCall = false,
             isNullable = true,
-        )
+        ),
+        FunctionSignature.Scalar(
+            name = "coalesce",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("values", ANY)
+            ),
+            isNullCall = false,
+            isNullable = true,
+        ),
     )
 
     // NULLIF(x, y)
@@ -343,7 +373,18 @@ object PartiQLHeader : Header() {
             isNullCall = true,
             isNullable = true,
         )
-    }
+    } + listOf(
+        FunctionSignature.Scalar(
+            name = "null_if",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("value", ANY),
+                FunctionParameter("nullifier", ANY),
+            ),
+            isNullCall = true,
+            isNullable = true,
+        )
+    )
 
     // SUBSTRING (expression, start[, length]?)
     // SUBSTRINGG(expression from start [FOR length]? )
@@ -371,7 +412,29 @@ object PartiQLHeader : Header() {
                 isNullable = false,
             )
         )
-    }.flatten()
+    }.flatten() + listOf(
+        FunctionSignature.Scalar(
+            name = "substring",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("value", ANY),
+                FunctionParameter("start", ANY),
+            ),
+            isNullCall = true,
+            isNullable = false,
+        ),
+        FunctionSignature.Scalar(
+            name = "substring",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("value", ANY),
+                FunctionParameter("start", ANY),
+                FunctionParameter("end", ANY),
+            ),
+            isNullCall = true,
+            isNullable = false,
+        )
+    )
 
     // position (str1, str2)
     // position (str1 in str2)
@@ -386,7 +449,18 @@ object PartiQLHeader : Header() {
             isNullCall = true,
             isNullable = false,
         )
-    }
+    } + listOf(
+        FunctionSignature.Scalar(
+            name = "position",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("probe", ANY),
+                FunctionParameter("value", ANY),
+            ),
+            isNullCall = true,
+            isNullable = false,
+        )
+    )
 
     // trim(str)
     private fun trim(): List<FunctionSignature.Scalar> = types.text.map { t ->
@@ -399,7 +473,17 @@ object PartiQLHeader : Header() {
             isNullCall = true,
             isNullable = false,
         )
-    }
+    } + listOf(
+        FunctionSignature.Scalar(
+            name = "trim",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("value", ANY),
+            ),
+            isNullCall = true,
+            isNullable = false,
+        )
+    )
 
     // TODO: We need to add a special form function for TRIM(BOTH FROM value)
     private fun trimSpecial(): List<FunctionSignature.Scalar> = types.text.map { t ->
@@ -459,7 +543,62 @@ object PartiQLHeader : Header() {
                 isNullable = false,
             ),
         )
-    }.flatten()
+    }.flatten() + listOf(
+        // TRIM(chars FROM value)
+        // TRIM(both chars from value)
+        FunctionSignature.Scalar(
+            name = "trim_chars",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("value", ANY),
+                FunctionParameter("chars", ANY),
+            ),
+            isNullCall = true,
+            isNullable = false,
+        ),
+        // TRIM(LEADING FROM value)
+        FunctionSignature.Scalar(
+            name = "trim_leading",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("value", ANY),
+            ),
+            isNullCall = true,
+            isNullable = false,
+        ),
+        // TRIM(LEADING chars FROM value)
+        FunctionSignature.Scalar(
+            name = "trim_leading_chars",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("value", ANY),
+                FunctionParameter("chars", ANY),
+            ),
+            isNullCall = true,
+            isNullable = false,
+        ),
+        // TRIM(TRAILING FROM value)
+        FunctionSignature.Scalar(
+            name = "trim_trailing",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("value", ANY),
+            ),
+            isNullCall = true,
+            isNullable = false,
+        ),
+        // TRIM(TRAILING chars FROM value)
+        FunctionSignature.Scalar(
+            name = "trim_trailing_chars",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("value", ANY),
+                FunctionParameter("chars", ANY),
+            ),
+            isNullCall = true,
+            isNullable = false,
+        ),
+    )
 
     // TODO
     private fun overlay(): List<FunctionSignature.Scalar> = emptyList()
@@ -469,8 +608,8 @@ object PartiQLHeader : Header() {
 
     private fun dateAdd(): List<FunctionSignature.Scalar> {
         val operators = mutableListOf<FunctionSignature.Scalar>()
-        for (type in types.datetime) {
-            for (field in DatetimeField.values()) {
+        for (field in DatetimeField.values()) {
+            for (type in types.datetime) {
                 if (field == DatetimeField.TIMEZONE_HOUR || field == DatetimeField.TIMEZONE_MINUTE) {
                     continue
                 }
@@ -486,14 +625,25 @@ object PartiQLHeader : Header() {
                 )
                 operators.add(signature)
             }
+            val anySignature = FunctionSignature.Scalar(
+                name = "date_diff_${field.name.lowercase()}",
+                returns = ANY,
+                parameters = listOf(
+                    FunctionParameter("datetime1", ANY),
+                    FunctionParameter("datetime2", ANY),
+                ),
+                isNullCall = true,
+                isNullable = false,
+            )
+            operators.add(anySignature)
         }
         return operators
     }
 
     private fun dateDiff(): List<FunctionSignature.Scalar> {
         val operators = mutableListOf<FunctionSignature.Scalar>()
-        for (type in types.datetime) {
-            for (field in DatetimeField.values()) {
+        for (field in DatetimeField.values()) {
+            for (type in types.datetime) {
                 if (field == DatetimeField.TIMEZONE_HOUR || field == DatetimeField.TIMEZONE_MINUTE) {
                     continue
                 }
@@ -509,6 +659,17 @@ object PartiQLHeader : Header() {
                 )
                 operators.add(signature)
             }
+            val anySignature = FunctionSignature.Scalar(
+                name = "date_diff_${field.name.lowercase()}",
+                returns = ANY,
+                parameters = listOf(
+                    FunctionParameter("datetime1", ANY),
+                    FunctionParameter("datetime2", ANY),
+                ),
+                isNullCall = true,
+                isNullable = false,
+            )
+            operators.add(anySignature)
         }
         return operators
     }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
@@ -4,17 +4,7 @@ import org.partiql.ast.DatetimeField
 import org.partiql.types.function.FunctionParameter
 import org.partiql.types.function.FunctionSignature
 import org.partiql.value.PartiQLValueExperimental
-import org.partiql.value.PartiQLValueType.ANY
-import org.partiql.value.PartiQLValueType.BOOL
-import org.partiql.value.PartiQLValueType.CHAR
-import org.partiql.value.PartiQLValueType.DATE
-import org.partiql.value.PartiQLValueType.DECIMAL
-import org.partiql.value.PartiQLValueType.INT
-import org.partiql.value.PartiQLValueType.INT32
-import org.partiql.value.PartiQLValueType.INT64
-import org.partiql.value.PartiQLValueType.STRING
-import org.partiql.value.PartiQLValueType.TIME
-import org.partiql.value.PartiQLValueType.TIMESTAMP
+import org.partiql.value.PartiQLValueType.*
 
 /**
  * A header which uses the PartiQL Lang Kotlin default standard library. All functions exist in a global namespace.
@@ -326,8 +316,20 @@ object PartiQLHeader : Header() {
         )
     }
 
-    // TODO
-    private fun coalesce(): List<FunctionSignature.Scalar> = emptyList()
+    // COALESCE(expression, expression, ... )
+    // Initial implementation of Coalesce.
+    // As the number of parameter can not be pre-determined, we wrap those into a list
+    private fun coalesce(): List<FunctionSignature.Scalar> = listOf(
+        FunctionSignature.Scalar(
+            name = "coalesce",
+            returns = ANY,
+            parameters = listOf(
+                FunctionParameter("values", LIST)
+            ),
+            isNullCall = false,
+            isNullable = true,
+        )
+    )
 
     // NULLIF(x, y)
     private fun nullIf(): List<FunctionSignature.Scalar> = types.nullable.map { t ->

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
@@ -636,7 +636,7 @@ object PartiQLHeader : Header() {
                 name = "date_diff_${field.name.lowercase()}",
                 returns = ANY,
                 parameters = listOf(
-                    FunctionParameter("interval", INT),
+                    FunctionParameter("interval", ANY),
                     FunctionParameter("datetime", ANY),
                 ),
                 isNullCall = true,

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/transforms/RexConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/transforms/RexConverter.kt
@@ -330,26 +330,47 @@ internal object RexConverter {
             return rex(type, call)
         }
 
-        override fun visitExprCoalesce(node: Expr.Coalesce, ctx: Env): Rex {
+        // coalesce(expr1, expr2, ... exprN) ->
+        //   CASE
+        //     WHEN expr1 IS NOT NULL THEN EXPR1
+        //     ...
+        //     WHEN exprn is NOT NULL THEN exprn
+        //     ELSE NULL END
+        override fun visitExprCoalesce(node: Expr.Coalesce, ctx: Env): Rex = plan {
             val type = StaticType.ANY
-            // Args
-            val arg0 = rex(StaticType.LIST, rexOpCollection(node.args.map { visitExpr(it, ctx) }))
-            // Call
-            val call = callNonHidden("coalesce", arg0)
-            return rex(type, call)
+
+            val createBranch: (Rex) -> Rex.Op.Case.Branch = { expr: Rex ->
+                val updatedCondition = rex(type, negate(call("is_null", expr)))
+                rexOpCaseBranch(updatedCondition, expr)
+            }
+
+            val branches = node.args.map {
+                createBranch(visitExpr(it, ctx))
+            }.toMutableList()
+
+            val defaultRex = rex(type = StaticType.NULL, op = rexOpLit(value = nullValue()))
+            branches += rexOpCaseBranch(bool(true), defaultRex)
+            val op = rexOpCase(branches)
+            rex(type, op)
         }
 
-        /**
-         * NULLIF(<arg0>, <arg1>)
-         */
-        override fun visitExprNullIf(node: Expr.NullIf, ctx: Env): Rex {
+        // nullIf(expr1, expr2) ->
+        //   CASE
+        //     WHEN expr1 = expr2 THEN NULL
+        //     ELSE expr1 END
+        override fun visitExprNullIf(node: Expr.NullIf, ctx: Env): Rex = plan {
             val type = StaticType.ANY
-            // Args
-            val arg0 = visitExpr(node.value, ctx)
-            val arg1 = visitExpr(node.nullifier, ctx)
-            // Call
-            val call = callNonHidden("null_if", arg0, arg1)
-            return rex(type, call)
+            val expr1 = visitExpr(node.value, ctx)
+            val expr2 = visitExpr(node.nullifier, ctx)
+            val id = identifierSymbol(Expr.Binary.Op.EQ.name.lowercase(), Identifier.CaseSensitivity.SENSITIVE)
+            val fn = fnUnresolved(id, true)
+            val call = rexOpCall(fn, listOf(expr1, expr2))
+            val branches = listOf(
+                rexOpCaseBranch(rex(type, call), rex(type = StaticType.NULL, op = rexOpLit(value = nullValue()))),
+                rexOpCaseBranch(bool(true), expr1)
+            )
+            val op = rexOpCase(branches)
+            rex(type, op)
         }
 
         /**

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/typer/FnResolver.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/typer/FnResolver.kt
@@ -153,7 +153,7 @@ internal class FnResolver(private val headers: List<Header>) {
         return when (match) {
             null -> FnMatch.Error(fn.identifier, args, candidates)
             else -> {
-                val isMissable = hadMissingArg || isUnsafeCast(match.signature.specific)
+                val isMissable = hadMissingArg || isUnsafeCast(match.signature.specific) || match.signature.isMissable
                 FnMatch.Ok(match.signature, match.mapping, isMissable)
             }
         }

--- a/partiql-types/src/main/kotlin/org/partiql/types/function/FunctionSignature.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/function/FunctionSignature.kt
@@ -55,6 +55,7 @@ public sealed class FunctionSignature(
         parameters: List<FunctionParameter>,
         description: String? = null,
         isNullable: Boolean = true,
+        @JvmField public val isMissable: Boolean = false,
         @JvmField public val isDeterministic: Boolean = true,
         @JvmField public val isNullCall: Boolean = false,
     ) : FunctionSignature(name, returns, parameters, description, isNullable) {
@@ -67,7 +68,8 @@ public sealed class FunctionSignature(
                 other.parameters.size != parameters.size ||
                 other.isDeterministic != isDeterministic ||
                 other.isNullCall != isNullCall ||
-                other.isNullable != isNullable
+                other.isNullable != isNullable ||
+                other.isMissable != isMissable
             ) {
                 return false
             }
@@ -87,6 +89,7 @@ public sealed class FunctionSignature(
             result = 31 * result + isDeterministic.hashCode()
             result = 31 * result + isNullCall.hashCode()
             result = 31 * result + isNullable.hashCode()
+            result = 31 * result + isMissable.hashCode()
             result = 31 * result + (description?.hashCode() ?: 0)
             return result
         }


### PR DESCRIPTION
## Relevant Issues
- N/A

## Description
- Control Flow functions such as `coalesce` and `nullIf` will be rewrited to a case when expression. 
- Support for ANY type in Function Header. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No, feature branch. 

- Any backward-incompatible changes? **[YES/NO]**
  -  No. 

- Any new external dependencies? **[YES/NO]**
  -  No.

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.