### PR TITLE
Fixes rewrite of control flow. 

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/transforms/RexConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/transforms/RexConverter.kt
@@ -345,8 +345,7 @@ internal object RexConverter {
             }.toMutableList()
 
             val defaultRex = rex(type = StaticType.NULL, op = rexOpLit(value = nullValue()))
-            branches += rexOpCaseBranch(bool(true), defaultRex)
-            val op = rexOpCase(branches)
+            val op = rexOpCase(branches, defaultRex)
             rex(type, op)
         }
 
@@ -363,9 +362,8 @@ internal object RexConverter {
             val call = rexOpCall(fn, listOf(expr1, expr2))
             val branches = listOf(
                 rexOpCaseBranch(rex(type, call), rex(type = StaticType.NULL, op = rexOpLit(value = nullValue()))),
-                rexOpCaseBranch(bool(true), expr1)
             )
-            val op = rexOpCase(branches)
+            val op = rexOpCase(branches, expr1)
             rex(type, op)
         }
 


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- <strike>Couldn't compile. The latest commit made use of `rexOpCase` which now has a default rex as an attribute. (See the 2nd latest commit).</strike>
- #1257 add a default rex as an attribute. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - < If NO, why? >

- Any backward-incompatible changes? **[YES/NO]**
  - < If YES, why? >
  - < For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base. >

- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.