### PR TITLE
In-memory Connector

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
 
       - name: Use Java ${{ matrix.java }}

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation(Deps.kotlinReflect)
 
     testImplementation(testFixtures(project(":partiql-planner")))
-    testImplementation(project(":plugins:partiql-local"))
+    testImplementation(project(":plugins:partiql-memory"))
     testImplementation(project(":lib:isl"))
     testImplementation(Deps.assertj)
     testImplementation(Deps.junit4)
@@ -80,6 +80,7 @@ tasks.processResources {
 }
 
 tasks.processTestResources {
+    dependsOn(":partiql-planner:generateResourcePath")
     from("${project(":partiql-planner").buildDir}/resources/testFixtures")
 }
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/SchemaLoader.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/SchemaLoader.kt
@@ -1,0 +1,229 @@
+package org.partiql.lang.planner
+
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.ListElement
+import com.amazon.ionelement.api.StringElement
+import com.amazon.ionelement.api.StructElement
+import com.amazon.ionelement.api.SymbolElement
+import com.amazon.ionelement.api.ionListOf
+import com.amazon.ionelement.api.ionString
+import com.amazon.ionelement.api.ionStructOf
+import com.amazon.ionelement.api.ionSymbol
+import org.partiql.types.AnyOfType
+import org.partiql.types.AnyType
+import org.partiql.types.BagType
+import org.partiql.types.BlobType
+import org.partiql.types.BoolType
+import org.partiql.types.ClobType
+import org.partiql.types.DateType
+import org.partiql.types.DecimalType
+import org.partiql.types.FloatType
+import org.partiql.types.GraphType
+import org.partiql.types.IntType
+import org.partiql.types.ListType
+import org.partiql.types.MissingType
+import org.partiql.types.NullType
+import org.partiql.types.SexpType
+import org.partiql.types.StaticType
+import org.partiql.types.StringType
+import org.partiql.types.StructType
+import org.partiql.types.SymbolType
+import org.partiql.types.TimeType
+import org.partiql.types.TimestampType
+import org.partiql.types.TupleConstraint
+
+// TODO: This code is ported from plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/LocalSchema.kt
+//  In my opinion, the in-memory connector should be independent of schema file format,
+//  hence making it inappropriate to leave the code in plugins/partiql-memory
+//  We need to figure out where to put the code.
+object SchemaLoader {
+// Use some generated serde eventually
+
+    public inline fun <reified T : IonElement> StructElement.getAngry(name: String): T {
+        val f = getOptional(name) ?: error("Expected field `$name`")
+        if (f !is T) {
+            error("Expected field `name` to be of type ${T::class.simpleName}")
+        }
+        return f
+    }
+
+    /**
+     * Parses an IonElement to a StaticType.
+     *
+     * The format used is effectively Avro JSON, but with PartiQL type names.
+     */
+    public fun IonElement.toStaticType(): StaticType {
+        return when (this) {
+            is StringElement -> this.toStaticType()
+            is ListElement -> this.toStaticType()
+            is StructElement -> this.toStaticType()
+            else -> error("Invalid element, expected string, list, or struct")
+        }
+    }
+
+    // Atomic type
+    public fun StringElement.toStaticType(): StaticType = when (textValue) {
+        "any" -> StaticType.ANY
+        "bool" -> StaticType.BOOL
+        "int8" -> error("`int8` is currently not supported")
+        "int16" -> StaticType.INT2
+        "int32" -> StaticType.INT4
+        "int64" -> StaticType.INT8
+        "int" -> StaticType.INT
+        "decimal" -> StaticType.DECIMAL
+        "float32" -> StaticType.FLOAT
+        "float64" -> StaticType.FLOAT
+        "string" -> StaticType.STRING
+        "symbol" -> StaticType.SYMBOL
+        "binary" -> error("`binary` is currently not supported")
+        "byte" -> error("`byte` is currently not supported")
+        "blob" -> StaticType.BLOB
+        "clob" -> StaticType.CLOB
+        "date" -> StaticType.DATE
+        "time" -> StaticType.TIME
+        "timestamp" -> StaticType.TIMESTAMP
+        "interval" -> error("`interval` is currently not supported")
+        "bag" -> error("`bag` is not an atomic type")
+        "list" -> error("`list` is not an atomic type")
+        "sexp" -> error("`sexp` is not an atomic type")
+        "struct" -> error("`struct` is not an atomic type")
+        "null" -> StaticType.NULL
+        "missing" -> StaticType.MISSING
+        else -> error("Invalid type `$textValue`")
+    }
+
+    // Union type
+    public fun ListElement.toStaticType(): StaticType {
+        val types = values.map { it.toStaticType() }.toSet()
+        return StaticType.unionOf(types)
+    }
+
+    // Complex type
+    public fun StructElement.toStaticType(): StaticType {
+        val type = getAngry<StringElement>("type").textValue
+        return when (type) {
+            "bag" -> toBagType()
+            "list" -> toListType()
+            "sexp" -> toSexpType()
+            "struct" -> toStructType()
+            else -> error("Unknown complex type $type")
+        }
+    }
+
+    public fun StructElement.toBagType(): StaticType {
+        val items = getAngry<IonElement>("items").toStaticType()
+        return BagType(items)
+    }
+
+    public fun StructElement.toListType(): StaticType {
+        val items = getAngry<IonElement>("items").toStaticType()
+        return ListType(items)
+    }
+
+    public fun StructElement.toSexpType(): StaticType {
+        val items = getAngry<IonElement>("items").toStaticType()
+        return SexpType(items)
+    }
+
+    public fun StructElement.toStructType(): StaticType {
+        // Constraints
+        var contentClosed = false
+        val constraintsE = getOptional("constraints") ?: ionListOf()
+        val constraints = (constraintsE as ListElement).values.map {
+            assert(it is SymbolElement)
+            it as SymbolElement
+            when (it.textValue) {
+                "ordered" -> TupleConstraint.Ordered
+                "unique" -> TupleConstraint.UniqueAttrs(true)
+                "closed" -> {
+                    contentClosed = true
+                    TupleConstraint.Open(false)
+                }
+                else -> error("unknown tuple constraint `${it.textValue}`")
+            }
+        }.toSet()
+        // Fields
+        val fieldsE = getAngry<ListElement>("fields")
+        val fields = fieldsE.values.map {
+            assert(it is StructElement) { "field definition must be as struct" }
+            it as StructElement
+            val name = it.getAngry<StringElement>("name").textValue
+            val type = it.getAngry<IonElement>("type").toStaticType()
+            StructType.Field(name, type)
+        }
+        return StructType(fields, contentClosed, constraints = constraints)
+    }
+
+    public fun StaticType.toIon(): IonElement = when (this) {
+        is AnyOfType -> this.toIon()
+        is AnyType -> ionString("any")
+        is BlobType -> ionString("blob")
+        is BoolType -> ionString("bool")
+        is ClobType -> ionString("clob")
+        is BagType -> this.toIon()
+        is ListType -> this.toIon()
+        is SexpType -> this.toIon()
+        is DateType -> ionString("date")
+        is DecimalType -> ionString("decimal")
+        is FloatType -> ionString("float64")
+        is GraphType -> ionString("graph")
+        is IntType -> when (this.rangeConstraint) {
+            IntType.IntRangeConstraint.SHORT -> ionString("int16")
+            IntType.IntRangeConstraint.INT4 -> ionString("int32")
+            IntType.IntRangeConstraint.LONG -> ionString("int64")
+            IntType.IntRangeConstraint.UNCONSTRAINED -> ionString("int")
+        }
+        MissingType -> ionString("missing")
+        is NullType -> ionString("null")
+        is StringType -> ionString("string") // TODO char
+        is StructType -> this.toIon()
+        is SymbolType -> ionString("symbol")
+        is TimeType -> ionString("time")
+        is TimestampType -> ionString("timestamp")
+    }
+
+    private fun AnyOfType.toIon(): IonElement {
+        // create some predictable ordering
+        val sorted = this.types.sortedWith { t1, t2 -> t1::class.java.simpleName.compareTo(t2::class.java.simpleName) }
+        val elements = sorted.map { it.toIon() }
+        return ionListOf(elements)
+    }
+
+    private fun BagType.toIon(): IonElement = ionStructOf(
+        "type" to ionString("bag"),
+        "items" to elementType.toIon()
+    )
+
+    private fun ListType.toIon(): IonElement = ionStructOf(
+        "type" to ionString("list"),
+        "items" to elementType.toIon()
+    )
+
+    private fun SexpType.toIon(): IonElement = ionStructOf(
+        "type" to ionString("sexp"),
+        "items" to elementType.toIon()
+    )
+
+    private fun StructType.toIon(): IonElement {
+        val constraintSymbols = mutableListOf<SymbolElement>()
+        for (constraint in constraints) {
+            val c = when (constraint) {
+                is TupleConstraint.Open -> if (constraint.value) null else ionSymbol("closed")
+                TupleConstraint.Ordered -> ionSymbol("ordered")
+                is TupleConstraint.UniqueAttrs -> ionSymbol("unique")
+            }
+            if (c != null) constraintSymbols.add(c)
+        }
+        val fieldTypes = this.fields.map {
+            ionStructOf(
+                "name" to ionString(it.key),
+                "type" to it.value.toIon(),
+            )
+        }
+        return ionStructOf(
+            "type" to ionString("struct"),
+            "fields" to ionListOf(fieldTypes),
+            "constraints" to ionListOf(constraintSymbols),
+        )
+    }
+}

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/impl/PartiQLParserSessionAttributeTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/impl/PartiQLParserSessionAttributeTests.kt
@@ -8,7 +8,7 @@ import org.partiql.ast.exprLit
 import org.partiql.ast.exprSessionAttribute
 import org.partiql.ast.statementQuery
 import org.partiql.value.PartiQLValueExperimental
-import org.partiql.value.int64Value
+import org.partiql.value.int32Value
 import kotlin.test.assertEquals
 
 @OptIn(PartiQLValueExperimental::class)
@@ -48,7 +48,7 @@ class PartiQLParserSessionAttributeTests {
         query {
             exprBinary(
                 op = Expr.Binary.Op.EQ,
-                lhs = exprLit(int64Value(1)),
+                lhs = exprLit(int32Value(1)),
                 rhs = exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_USER)
             )
         }

--- a/plugins/partiql-memory/README.md
+++ b/plugins/partiql-memory/README.md
@@ -1,0 +1,36 @@
+# PartiQL In-Memory Plugin
+
+This is a PartiQL plugin for in-memory DB. The primary purpose of this plugin is for testing. 
+
+## Provider
+
+The plugin is backed by a catalog provider. This enables use to easily modify a catalog for testing. 
+
+```kotlin
+val provider = MemoryCatalog.Provider()
+provider[catalogName] = MemoryCatalog.of(
+    t1 to StaticType.INT2,
+    ...
+)
+```
+
+## Catalog path
+
+The in-memory connector can handle arbitrary depth catalog path: 
+
+```kotlin
+val provider = MemoryCatalog.Provider()
+provider[catalogName] = MemoryCatalog.of(
+    "schema.tbl" to StaticType.INT2,
+)
+```
+
+The full path is `catalogName.schema.tbl`
+
+The lookup logic is identical to localPlugin. 
+
+```
+|_ catalogName
+   |_ schema 
+     |_ tbl.ion
+```

--- a/plugins/partiql-memory/build.gradle.kts
+++ b/plugins/partiql-memory/build.gradle.kts
@@ -1,0 +1,26 @@
+import org.gradle.kotlin.dsl.distribution
+
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+plugins {
+    id(Plugins.conventions)
+    distribution
+}
+
+dependencies {
+    implementation(project(":partiql-spi"))
+    implementation(project(":partiql-types"))
+}

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryCatalog.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryCatalog.kt
@@ -1,0 +1,76 @@
+package org.partiql.plugins.memory
+
+import org.partiql.spi.BindingCase
+import org.partiql.spi.BindingPath
+import org.partiql.spi.connector.ConnectorObjectPath
+import org.partiql.types.StaticType
+
+class MemoryCatalog(
+    private val map: Map<String, StaticType>
+) {
+    operator fun get(key: String): StaticType? = map[key]
+
+    public fun lookup(path: BindingPath): MemoryObject? {
+        val kPath = ConnectorObjectPath(
+            path.steps.map {
+                when (it.bindingCase) {
+                    BindingCase.SENSITIVE -> it.name
+                    BindingCase.INSENSITIVE -> it.loweredName
+                }
+            }
+        )
+        val k = kPath.steps.joinToString(".")
+        if (this[k] != null) {
+            return this[k]?.let { MemoryObject(kPath.steps, it) }
+        } else {
+            val candidatePath = this.map.keys.map { it.split(".") }
+            val kPathIter = kPath.steps.listIterator()
+            while (kPathIter.hasNext()) {
+                val currKPath = kPathIter.next()
+                candidatePath.forEach {
+                    val match = mutableListOf<String>()
+                    val candidateIterator = it.iterator()
+                    while (candidateIterator.hasNext()) {
+                        if (candidateIterator.next() == currKPath) {
+                            match.add(currKPath)
+                            val pathIteratorCopy = kPath.steps.listIterator(kPathIter.nextIndex())
+                            candidateIterator.forEachRemaining {
+                                val nextPath = pathIteratorCopy.next()
+                                if (it != nextPath) {
+                                    match.clear()
+                                    return@forEachRemaining
+                                }
+                                match.add(it)
+                            }
+                        } else {
+                            return@forEach
+                        }
+                    }
+                    if (match.isNotEmpty()) {
+                        return this[match.joinToString(".")]?.let { it1 ->
+                            MemoryObject(
+                                match,
+                                it1
+                            )
+                        }
+                    }
+                }
+            }
+            return null
+        }
+    }
+
+    companion object {
+        fun of(vararg entities: Pair<String, StaticType>) = MemoryCatalog(mapOf(*entities))
+    }
+
+    class Provider {
+        private val catalogs = mutableMapOf<String, MemoryCatalog>()
+
+        operator fun get(path: String): MemoryCatalog = catalogs[path] ?: error("invalid catalog path")
+
+        operator fun set(path: String, catalog: MemoryCatalog) {
+            catalogs[path] = catalog
+        }
+    }
+}

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryConnector.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryConnector.kt
@@ -1,0 +1,46 @@
+package org.partiql.plugins.memory
+
+import com.amazon.ionelement.api.StructElement
+import org.partiql.spi.BindingPath
+import org.partiql.spi.connector.Connector
+import org.partiql.spi.connector.ConnectorMetadata
+import org.partiql.spi.connector.ConnectorObjectHandle
+import org.partiql.spi.connector.ConnectorObjectPath
+import org.partiql.spi.connector.ConnectorSession
+import org.partiql.types.StaticType
+
+class MemoryConnector(
+    val catalog: MemoryCatalog
+) : Connector {
+
+    companion object {
+        const val CONNECTOR_NAME = "memory"
+    }
+
+    override fun getMetadata(session: ConnectorSession): ConnectorMetadata = Metadata()
+
+    class Factory(private val provider: MemoryCatalog.Provider) : Connector.Factory {
+        override fun getName(): String = CONNECTOR_NAME
+
+        override fun create(catalogName: String, config: StructElement): Connector {
+            val catalog = provider[catalogName]
+            return MemoryConnector(catalog)
+        }
+    }
+
+    inner class Metadata : ConnectorMetadata {
+
+        override fun getObjectType(session: ConnectorSession, handle: ConnectorObjectHandle): StaticType? {
+            val obj = handle.value as MemoryObject
+            return obj.type
+        }
+
+        override fun getObjectHandle(session: ConnectorSession, path: BindingPath): ConnectorObjectHandle? {
+            val value = catalog.lookup(path) ?: return null
+            return ConnectorObjectHandle(
+                absolutePath = ConnectorObjectPath(value.path),
+                value = value,
+            )
+        }
+    }
+}

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryObject.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryObject.kt
@@ -1,0 +1,9 @@
+package org.partiql.plugins.memory
+
+import org.partiql.spi.connector.ConnectorObject
+import org.partiql.types.StaticType
+
+class MemoryObject(
+    val path: List<String>,
+    val type: StaticType
+) : ConnectorObject

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryPlugin.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryPlugin.kt
@@ -1,0 +1,13 @@
+package org.partiql.plugins.memory
+
+import org.partiql.spi.Plugin
+import org.partiql.spi.connector.Connector
+import org.partiql.spi.function.PartiQLFunction
+import org.partiql.spi.function.PartiQLFunctionExperimental
+
+class MemoryPlugin(val provider: MemoryCatalog.Provider) : Plugin {
+    override fun getConnectorFactories(): List<Connector.Factory> = listOf(MemoryConnector.Factory(provider))
+
+    @PartiQLFunctionExperimental
+    override fun getFunctions(): List<PartiQLFunction> = emptyList()
+}

--- a/plugins/partiql-memory/src/test/kotlin/org/partiql/plugins/memory/InMemoryPluginTest.kt
+++ b/plugins/partiql-memory/src/test/kotlin/org/partiql/plugins/memory/InMemoryPluginTest.kt
@@ -1,0 +1,159 @@
+package org.partiql.plugins.memory
+
+import org.junit.jupiter.api.Test
+import org.partiql.spi.BindingCase
+import org.partiql.spi.BindingName
+import org.partiql.spi.BindingPath
+import org.partiql.spi.connector.ConnectorObjectPath
+import org.partiql.spi.connector.ConnectorSession
+import org.partiql.types.BagType
+import org.partiql.types.StaticType
+import org.partiql.types.StructType
+
+class InMemoryPluginTest {
+
+    private val session = object : ConnectorSession {
+        override fun getQueryId(): String = "mock_query_id"
+        override fun getUserId(): String = "mock_user"
+    }
+
+    companion object {
+        val provider = MemoryCatalog.Provider().also {
+            it["test"] = MemoryCatalog.of(
+                "a" to StaticType.INT2,
+                "struct" to StructType(
+                    fields = listOf(StructType.Field("a", StaticType.INT2))
+                ),
+                "schema.tbl" to BagType(
+                    StructType(
+                        fields = listOf(StructType.Field("a", StaticType.INT2))
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun getValue() {
+        val requested = BindingPath(
+            listOf(
+                BindingName("a", BindingCase.INSENSITIVE)
+            )
+        )
+        val expected = StaticType.INT2
+
+        val connector = MemoryConnector(provider["test"])
+
+        val metadata = connector.Metadata()
+
+        val handle = metadata.getObjectHandle(session, requested)
+
+        val descriptor = metadata.getObjectType(session, handle!!)
+
+        assert(requested.isEquivalentTo(handle.absolutePath))
+        assert(expected == descriptor)
+    }
+
+    @Test
+    fun getCaseSensitiveValueShouldFail() {
+        val requested = BindingPath(
+            listOf(
+                BindingName("A", BindingCase.SENSITIVE)
+            )
+        )
+
+        val connector = MemoryConnector(provider["test"])
+
+        val metadata = connector.Metadata()
+
+        val handle = metadata.getObjectHandle(session, requested)
+
+        assert(null == handle)
+    }
+
+    @Test
+    fun accessStruct() {
+        val requested = BindingPath(
+            listOf(
+                BindingName("struct", BindingCase.INSENSITIVE),
+                BindingName("a", BindingCase.INSENSITIVE)
+            )
+        )
+
+        val connector = MemoryConnector(provider["test"])
+
+        val metadata = connector.Metadata()
+
+        val handle = metadata.getObjectHandle(session, requested)
+
+        val descriptor = metadata.getObjectType(session, handle!!)
+
+        val expectConnectorPath = ConnectorObjectPath(listOf("struct"))
+
+        val expectedObjectType = StructType(fields = listOf(StructType.Field("a", StaticType.INT2)))
+
+        assert(expectConnectorPath == handle.absolutePath)
+        assert(expectedObjectType == descriptor)
+    }
+
+    @Test
+    fun pathNavigationSuccess() {
+        val requested = BindingPath(
+            listOf(
+                BindingName("schema", BindingCase.INSENSITIVE),
+                BindingName("tbl", BindingCase.INSENSITIVE)
+            )
+        )
+
+        val connector = MemoryConnector(provider["test"])
+
+        val metadata = connector.Metadata()
+
+        val handle = metadata.getObjectHandle(session, requested)
+
+        val descriptor = metadata.getObjectType(session, handle!!)
+
+        val expectedObjectType = BagType(StructType(fields = listOf(StructType.Field("a", StaticType.INT2))))
+
+        assert(requested.isEquivalentTo(handle.absolutePath))
+        assert(expectedObjectType == descriptor)
+    }
+
+    @Test
+    fun pathNavigationSuccess2() {
+        val requested = BindingPath(
+            listOf(
+                BindingName("schema", BindingCase.INSENSITIVE),
+                BindingName("tbl", BindingCase.INSENSITIVE),
+                BindingName("a", BindingCase.INSENSITIVE)
+            )
+        )
+
+        val connector = MemoryConnector(provider["test"])
+
+        val metadata = connector.Metadata()
+
+        val handle = metadata.getObjectHandle(session, requested)
+
+        val descriptor = metadata.getObjectType(session, handle!!)
+
+        val expectedObjectType = BagType(StructType(fields = listOf(StructType.Field("a", StaticType.INT2))))
+
+        val expectConnectorPath = ConnectorObjectPath(listOf("schema", "tbl"))
+
+        assert(expectConnectorPath == handle.absolutePath)
+        assert(expectedObjectType == descriptor)
+    }
+
+    private fun BindingPath.isEquivalentTo(other: ConnectorObjectPath): Boolean {
+        if (this.steps.size != other.steps.size) {
+            return false
+        }
+        this.steps.forEachIndexed { index, step ->
+            if (step.isEquivalentTo(other.steps[index]).not()) {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@ include(
     "partiql-spi",
     "partiql-types",
     "plugins:partiql-local",
+    "plugins:partiql-memory",
     "lib:isl",
     "lib:sprout",
     "test:coverage-tests",


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
- Adds in memory connector for testing purpose. 
- Fixes the CI builds. 

Notes on CI builds: 
1. Github actions used packaged code (JAR) for build. 
      - We can not turn folder/files in Jar to a Java File object easily, especially with the current set up in which the local plugin takes a path and we retrieve the path and turn it to `File` object later. 
      - Solution:
          -   During build process, we list out the path to each individual test resource, and store the path into a single file. 
          -   We retrieve the content of resource using path, and load the content to a in-memory connector. 
2. Github checkout action is not running against the code in the RP. Instead, it runs against some merged version that is based on top of the target branch. 
     Fix : https://github.com/actions/checkout/blob/v3.0.2/README.md#user-content-checkout-pull-request-head-commit-instead-of-merge-commit
     
Commits: 
-  [a4719e4](https://github.com/partiql/partiql-lang-kotlin/pull/1262/commits/a4719e44cd6cde889a4f3509d49776c381b4c8e3) : Implemented and tested the in-memory connector
- [130e2ab](https://github.com/partiql/partiql-lang-kotlin/pull/1262/commits/130e2abed3382650a2ff2cd2d087f3bac6fced62) : Switch the schema inferencer to use in-memory plugin. This includes the logic to generate a `resource_path.txt` file during build process, and use the file to populate the in-memory connector. Also, currently we have a couple test cases that are failing due to the `ANY` function resolution in plan. I added a `IgnoredTestCase` to workaround this issue. 
- [681c593](https://github.com/partiql/partiql-lang-kotlin/pull/1262/commits/681c59368844874c7717745b0fd2483deabfe907): This commits changes the loading logic of test case provider. 
- [a358d71](https://github.com/partiql/partiql-lang-kotlin/pull/1262/commits/a358d719ee4ef63628659d2416f06d631ee06cd3) : This commits change the checkout action to run on pull request head commit. 
     

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No. 

- Any backward-incompatible changes? **[YES/NO]**
  -  No. 
 
- Any new external dependencies? **[YES/NO]**
  - No. 
  
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.