### PR TITLE
Fixes references to globals

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/Env.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/Env.kt
@@ -227,8 +227,11 @@ internal class Env(
             getObjectHandle(cat, catalogPath)?.let { handle ->
                 getObjectDescriptor(handle).let { type ->
                     val depth = calculateMatched(originalPath, catalogPath, handle.second.absolutePath)
-                    val match = BindingPath(originalPath.steps.subList(0, depth)).toCaseSensitive()
-                    val global = global(match.toIdentifier(), type)
+                    val qualifiedPath = identifierQualified(
+                        root = handle.first.toIdentifier(),
+                        steps = handle.second.absolutePath.steps.map { it.toIdentifier() }
+                    )
+                    val global = global(qualifiedPath, type)
                     globals.add(global)
                     // Return resolution metadata
                     ResolvedVar.Global(type, globals.size - 1, depth)
@@ -378,9 +381,9 @@ internal class Env(
         return originalPath.steps.size + outputCatalogPath.steps.size - inputCatalogPath.steps.size
     }
 
-    private fun BindingPath.toIdentifier() = identifierQualified(
-        root = steps[0].toIdentifier(),
-        steps = steps.subList(1, steps.size).map { it.toIdentifier() }
+    private fun String.toIdentifier() = identifierSymbol(
+        symbol = this,
+        caseSensitivity = Identifier.CaseSensitivity.SENSITIVE
     )
 
     private fun BindingName.toIdentifier() = identifierSymbol(

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/EnvTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/EnvTest.kt
@@ -1,0 +1,97 @@
+package org.partiql.planner
+
+import com.amazon.ionelement.api.field
+import com.amazon.ionelement.api.ionString
+import com.amazon.ionelement.api.ionStructOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.partiql.plan.Global
+import org.partiql.plan.Identifier
+import org.partiql.plan.Rex
+import org.partiql.plan.identifierQualified
+import org.partiql.plan.identifierSymbol
+import org.partiql.plugins.local.LocalPlugin
+import org.partiql.spi.BindingCase
+import org.partiql.spi.BindingName
+import org.partiql.spi.BindingPath
+import org.partiql.types.StaticType
+import java.util.Random
+import kotlin.io.path.pathString
+import kotlin.io.path.toPath
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class EnvTest {
+
+    companion object {
+        private val root = this::class.java.getResource("/catalogs/default")!!.toURI().toPath().pathString
+
+        val catalogConfig = mapOf(
+            "pql" to ionStructOf(
+                field("connector_name", ionString("local")),
+                field("root", ionString("$root/pql")),
+            )
+        )
+
+        private val EMPTY_TYPE_ENV = TypeEnv(schema = emptyList(), ResolutionStrategy.GLOBAL)
+
+        private val GLOBAL_OS = Global(
+            path = identifierQualified(
+                root = identifierSymbol("pql", Identifier.CaseSensitivity.SENSITIVE),
+                steps = listOf(
+                    identifierSymbol("main", Identifier.CaseSensitivity.SENSITIVE),
+                    identifierSymbol("os", Identifier.CaseSensitivity.SENSITIVE)
+                )
+            ),
+            type = StaticType.STRING
+        )
+    }
+
+    private lateinit var env: Env
+
+    @BeforeEach
+    fun init() {
+        env = Env(
+            listOf(PartiQLHeader),
+            listOf(LocalPlugin()),
+            PartiQLPlanner.Session(
+                queryId = Random().nextInt().toString(),
+                userId = "test-user",
+                currentCatalog = "pql",
+                currentDirectory = listOf("main"),
+                catalogConfig = catalogConfig
+            )
+        )
+    }
+
+    @Test
+    fun testGlobalMatchingSensitiveName() {
+        val path = BindingPath(listOf(BindingName("os", BindingCase.SENSITIVE)))
+        assertNotNull(env.resolve(path, EMPTY_TYPE_ENV, Rex.Op.Var.Scope.DEFAULT))
+        assertEquals(1, env.globals.size)
+        assert(env.globals.contains(GLOBAL_OS))
+    }
+
+    @Test
+    fun testGlobalMatchingInsensitiveName() {
+        val path = BindingPath(listOf(BindingName("oS", BindingCase.INSENSITIVE)))
+        assertNotNull(env.resolve(path, EMPTY_TYPE_ENV, Rex.Op.Var.Scope.DEFAULT))
+        assertEquals(1, env.globals.size)
+        assert(env.globals.contains(GLOBAL_OS))
+    }
+
+    @Test
+    fun testGlobalNotMatchingSensitiveName() {
+        val path = BindingPath(listOf(BindingName("oS", BindingCase.SENSITIVE)))
+        assertNull(env.resolve(path, EMPTY_TYPE_ENV, Rex.Op.Var.Scope.DEFAULT))
+        assert(env.globals.isEmpty())
+    }
+
+    @Test
+    fun testGlobalNotMatchingInsensitiveName() {
+        val path = BindingPath(listOf(BindingName("nonexistent", BindingCase.INSENSITIVE)))
+        assertNull(env.resolve(path, EMPTY_TYPE_ENV, Rex.Op.Var.Scope.DEFAULT))
+        assert(env.globals.isEmpty())
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- This fixes references to globals
- Previously, when a user typed a query like `SELECT * FROM DoGs`, we would add a qualified identifier `"DoGs" (case-sensitive)` to the `globals` in the `TypeEnv`. This was wrong. The actual global should've been called `"dogs"` to match the filesystem. On top of that, we should've put the **entire** path as a global. AKA: `"default"."pql"."dogs"`. This PR fixes that.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.