### PR TITLE
Disambiguates references to struct attributes

### DIFF
--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
@@ -2334,6 +2334,27 @@ class PartiQLSchemaInferencerTests {
                     )
                 )
             ),
+            SuccessTestCase(
+                name = "Pathing into resolved local variable without qualification",
+                query = """
+                    SELECT address.street AS s FROM employer;
+                """,
+                catalog = "pql",
+                catalogPath = listOf("main"),
+                expected = BagType(
+                    StructType(
+                        fields = mapOf(
+                            "s" to STRING,
+                        ),
+                        contentClosed = true,
+                        constraints = setOf(
+                            TupleConstraint.Open(false),
+                            TupleConstraint.UniqueAttrs(true),
+                            TupleConstraint.Ordered
+                        )
+                    )
+                )
+            ),
         )
 
         @JvmStatic
@@ -3303,7 +3324,11 @@ class PartiQLSchemaInferencerTests {
 
         val result = PartiQLSchemaInferencer.inferInternal(input, ctx)
         assert(collector.problems.isEmpty()) {
-            collector.problems.toString()
+            buildString {
+                appendLine(collector.problems.toString())
+                appendLine()
+                PlanPrinter.append(this, result.first)
+            }
         }
         val actual = result.second
         assert(tc.expected == actual) {

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/typer/PlanTyper.kt
@@ -969,6 +969,7 @@ internal class PlanTyper(
                             val results = prevTypes.map { inferPathStep(it, step) }
                             val types = results.map { it.first }
                             val firstResultStep = results.first().second
+                            // replace step only if all are disambiguated
                             val replacementStep = when (results.map { it.second }.all { it == firstResultStep }) {
                                 true -> firstResultStep
                                 false -> step

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/typer/PlanTyperTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/typer/PlanTyperTest.kt
@@ -1,0 +1,572 @@
+package org.partiql.planner.typer
+
+import com.amazon.ionelement.api.field
+import com.amazon.ionelement.api.ionString
+import com.amazon.ionelement.api.ionStructOf
+import org.junit.jupiter.api.Test
+import org.partiql.errors.Problem
+import org.partiql.errors.ProblemCallback
+import org.partiql.errors.ProblemHandler
+import org.partiql.errors.ProblemSeverity
+import org.partiql.plan.Identifier
+import org.partiql.plan.Rex
+import org.partiql.plan.identifierSymbol
+import org.partiql.plan.rex
+import org.partiql.plan.rexOpGlobal
+import org.partiql.plan.rexOpLit
+import org.partiql.plan.rexOpPath
+import org.partiql.plan.rexOpPathStepSymbol
+import org.partiql.plan.rexOpStruct
+import org.partiql.plan.rexOpStructField
+import org.partiql.plan.rexOpVarUnresolved
+import org.partiql.plan.statementQuery
+import org.partiql.planner.Env
+import org.partiql.planner.PartiQLHeader
+import org.partiql.planner.PartiQLPlanner
+import org.partiql.plugins.local.LocalPlugin
+import org.partiql.types.StaticType
+import org.partiql.types.StructType
+import org.partiql.types.TupleConstraint
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.int32Value
+import org.partiql.value.stringValue
+import java.util.Random
+import kotlin.io.path.pathString
+import kotlin.io.path.toPath
+import kotlin.test.assertEquals
+
+class PlanTyperTest {
+
+    companion object {
+        private val root = this::class.java.getResource("/catalogs/default")!!.toURI().toPath().pathString
+
+        private val catalogConfig = mapOf(
+            "pql" to ionStructOf(
+                field("connector_name", ionString("local")),
+                field("root", ionString("$root/pql")),
+            )
+        )
+
+        private val ORDERED_DUPLICATES_STRUCT = StructType(
+            fields = listOf(
+                StructType.Field("definition", StaticType.STRING),
+                StructType.Field("definition", StaticType.FLOAT),
+                StructType.Field("DEFINITION", StaticType.DECIMAL),
+            ),
+            contentClosed = true,
+            constraints = setOf(
+                TupleConstraint.Open(false),
+                TupleConstraint.Ordered
+            )
+        )
+
+        private val DUPLICATES_STRUCT = StructType(
+            fields = listOf(
+                StructType.Field("definition", StaticType.STRING),
+                StructType.Field("definition", StaticType.FLOAT),
+                StructType.Field("DEFINITION", StaticType.DECIMAL),
+            ),
+            contentClosed = true,
+            constraints = setOf(
+                TupleConstraint.Open(false)
+            )
+        )
+
+        private val CLOSED_UNION_DUPLICATES_STRUCT = StaticType.unionOf(
+            StructType(
+                fields = listOf(
+                    StructType.Field("definition", StaticType.STRING),
+                    StructType.Field("definition", StaticType.FLOAT),
+                    StructType.Field("DEFINITION", StaticType.DECIMAL),
+                ),
+                contentClosed = true,
+                constraints = setOf(
+                    TupleConstraint.Open(false)
+                )
+            ),
+            StructType(
+                fields = listOf(
+                    StructType.Field("definition", StaticType.INT2),
+                    StructType.Field("definition", StaticType.INT4),
+                    StructType.Field("DEFINITION", StaticType.INT8),
+                ),
+                contentClosed = true,
+                constraints = setOf(
+                    TupleConstraint.Open(false),
+                    TupleConstraint.Ordered
+                )
+            ),
+        )
+
+        private val OPEN_DUPLICATES_STRUCT = StructType(
+            fields = listOf(
+                StructType.Field("definition", StaticType.STRING),
+                StructType.Field("definition", StaticType.FLOAT),
+                StructType.Field("DEFINITION", StaticType.DECIMAL),
+            ),
+            contentClosed = false
+        )
+
+        private fun getTyper(): PlanTyperWrapper {
+            val collector = ProblemCollector()
+            val env = Env(
+                listOf(PartiQLHeader),
+                listOf(LocalPlugin()),
+                PartiQLPlanner.Session(
+                    queryId = Random().nextInt().toString(),
+                    userId = "test-user",
+                    currentCatalog = "pql",
+                    currentDirectory = listOf("main"),
+                    catalogConfig = catalogConfig
+                )
+            )
+            return PlanTyperWrapper(PlanTyper(env, collector), collector)
+        }
+    }
+
+    private class PlanTyperWrapper(
+        internal val typer: PlanTyper,
+        internal val collector: ProblemCollector
+    )
+
+    /**
+     * This is a test to show that we convert:
+     * ```
+     * { 'FiRsT_KeY': { 'sEcoNd_KEY': 5 } }.first_key."sEcoNd_KEY"
+     * ```
+     * to
+     * ```
+     * { 'FiRsT_KeY': { 'sEcoNd_KEY': 5 } }."FiRsT_KeY"."sEcoNd_KEY"
+     * ```
+     *
+     * It also checks that we type it all correctly as well.
+     */
+    @Test
+    @OptIn(PartiQLValueExperimental::class)
+    fun testReplacingStructs() {
+        val wrapper = getTyper()
+        val typer = wrapper.typer
+        val input = statementQuery(
+            root = rex(
+                type = StaticType.ANY,
+                op = rexOpPath(
+                    root = rex(
+                        StaticType.ANY,
+                        rexOpStruct(
+                            fields = listOf(
+                                rexOpStructField(
+                                    k = rex(StaticType.STRING, rexOpLit(stringValue("FiRsT_KeY"))),
+                                    v = rex(
+                                        StaticType.ANY,
+                                        rexOpStruct(
+                                            fields = listOf(
+                                                rexOpStructField(
+                                                    k = rex(StaticType.STRING, rexOpLit(stringValue("sEcoNd_KEY"))),
+                                                    v = rex(StaticType.INT4, rexOpLit(int32Value(5)))
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("first_key", Identifier.CaseSensitivity.INSENSITIVE)),
+                        rexOpPathStepSymbol(identifierSymbol("sEcoNd_KEY", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val firstKeyStruct = StructType(
+            fields = mapOf(
+                "sEcoNd_KEY" to StaticType.INT4
+            ),
+            contentClosed = true,
+            constraints = setOf(
+                TupleConstraint.UniqueAttrs(true),
+                TupleConstraint.Open(false)
+            )
+        )
+        val topLevelStruct = StructType(
+            fields = mapOf(
+                "FiRsT_KeY" to firstKeyStruct
+            ),
+            contentClosed = true,
+            constraints = setOf(
+                TupleConstraint.UniqueAttrs(true),
+                TupleConstraint.Open(false)
+            )
+        )
+        val expected = statementQuery(
+            root = rex(
+                type = StaticType.INT4,
+                op = rexOpPath(
+                    root = rex(
+                        type = topLevelStruct,
+                        rexOpStruct(
+                            fields = listOf(
+                                rexOpStructField(
+                                    k = rex(StaticType.STRING, rexOpLit(stringValue("FiRsT_KeY"))),
+                                    v = rex(
+                                        type = firstKeyStruct,
+                                        rexOpStruct(
+                                            fields = listOf(
+                                                rexOpStructField(
+                                                    k = rex(StaticType.STRING, rexOpLit(stringValue("sEcoNd_KEY"))),
+                                                    v = rex(StaticType.INT4, rexOpLit(int32Value(5)))
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("FiRsT_KeY", Identifier.CaseSensitivity.SENSITIVE)),
+                        rexOpPathStepSymbol(identifierSymbol("sEcoNd_KEY", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val actual = typer.resolve(input)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOrderedDuplicates() {
+        val wrapper = getTyper()
+        val typer = wrapper.typer
+        val input = statementQuery(
+            root = rex(
+                type = StaticType.ANY,
+                op = rexOpPath(
+                    root = rex(
+                        StaticType.ANY,
+                        rexOpVarUnresolved(
+                            identifierSymbol("closed_ordered_duplicates_struct", Identifier.CaseSensitivity.SENSITIVE),
+                            Rex.Op.Var.Scope.DEFAULT
+                        )
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("DEFINITION", Identifier.CaseSensitivity.INSENSITIVE)),
+                    )
+                )
+            )
+        )
+        val expected = statementQuery(
+            root = rex(
+                type = StaticType.STRING,
+                op = rexOpPath(
+                    root = rex(
+                        ORDERED_DUPLICATES_STRUCT,
+                        rexOpGlobal(0)
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("definition", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val actual = typer.resolve(input)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOrderedDuplicatesWithSensitivity() {
+        val wrapper = getTyper()
+        val typer = wrapper.typer
+        val input = statementQuery(
+            root = rex(
+                type = StaticType.ANY,
+                op = rexOpPath(
+                    root = rex(
+                        StaticType.ANY,
+                        rexOpVarUnresolved(
+                            identifierSymbol("closed_ordered_duplicates_struct", Identifier.CaseSensitivity.SENSITIVE),
+                            Rex.Op.Var.Scope.DEFAULT
+                        )
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("DEFINITION", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val expected = statementQuery(
+            root = rex(
+                type = StaticType.DECIMAL,
+                op = rexOpPath(
+                    root = rex(
+                        ORDERED_DUPLICATES_STRUCT,
+                        rexOpGlobal(0)
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("DEFINITION", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val actual = typer.resolve(input)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testUnorderedDuplicates() {
+        val wrapper = getTyper()
+        val typer = wrapper.typer
+        val input = statementQuery(
+            root = rex(
+                type = StaticType.ANY,
+                op = rexOpPath(
+                    root = rex(
+                        StaticType.ANY,
+                        rexOpVarUnresolved(
+                            identifierSymbol("closed_duplicates_struct", Identifier.CaseSensitivity.SENSITIVE),
+                            Rex.Op.Var.Scope.DEFAULT
+                        )
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("DEFINITION", Identifier.CaseSensitivity.INSENSITIVE)),
+                    )
+                )
+            )
+        )
+        val expected = statementQuery(
+            root = rex(
+                type = StaticType.unionOf(StaticType.STRING, StaticType.FLOAT, StaticType.DECIMAL),
+                op = rexOpPath(
+                    root = rex(
+                        DUPLICATES_STRUCT,
+                        rexOpGlobal(0)
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("DEFINITION", Identifier.CaseSensitivity.INSENSITIVE)),
+                    )
+                )
+            )
+        )
+        val actual = typer.resolve(input)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testUnorderedDuplicatesWithSensitivity() {
+        val wrapper = getTyper()
+        val typer = wrapper.typer
+        val input = statementQuery(
+            root = rex(
+                type = StaticType.ANY,
+                op = rexOpPath(
+                    root = rex(
+                        StaticType.ANY,
+                        rexOpVarUnresolved(
+                            identifierSymbol("closed_duplicates_struct", Identifier.CaseSensitivity.SENSITIVE),
+                            Rex.Op.Var.Scope.DEFAULT
+                        )
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("DEFINITION", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val expected = statementQuery(
+            root = rex(
+                type = StaticType.DECIMAL,
+                op = rexOpPath(
+                    root = rex(
+                        DUPLICATES_STRUCT,
+                        rexOpGlobal(0)
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("DEFINITION", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val actual = typer.resolve(input)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testUnorderedDuplicatesWithSensitivityAndDuplicateResults() {
+        val wrapper = getTyper()
+        val typer = wrapper.typer
+        val input = statementQuery(
+            root = rex(
+                type = StaticType.ANY,
+                op = rexOpPath(
+                    root = rex(
+                        StaticType.ANY,
+                        rexOpVarUnresolved(
+                            identifierSymbol("closed_duplicates_struct", Identifier.CaseSensitivity.SENSITIVE),
+                            Rex.Op.Var.Scope.DEFAULT
+                        )
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("definition", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val expected = statementQuery(
+            root = rex(
+                type = StaticType.unionOf(StaticType.STRING, StaticType.FLOAT),
+                op = rexOpPath(
+                    root = rex(
+                        DUPLICATES_STRUCT,
+                        rexOpGlobal(0)
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("definition", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val actual = typer.resolve(input)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testOpenDuplicates() {
+        val wrapper = getTyper()
+        val typer = wrapper.typer
+        val input = statementQuery(
+            root = rex(
+                type = StaticType.ANY,
+                op = rexOpPath(
+                    root = rex(
+                        StaticType.ANY,
+                        rexOpVarUnresolved(
+                            identifierSymbol("open_duplicates_struct", Identifier.CaseSensitivity.SENSITIVE),
+                            Rex.Op.Var.Scope.DEFAULT
+                        )
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("definition", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val expected = statementQuery(
+            root = rex(
+                type = StaticType.ANY,
+                op = rexOpPath(
+                    root = rex(
+                        OPEN_DUPLICATES_STRUCT,
+                        rexOpGlobal(0)
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("definition", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val actual = typer.resolve(input)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testUnionClosedDuplicates() {
+        val wrapper = getTyper()
+        val typer = wrapper.typer
+        val input = statementQuery(
+            root = rex(
+                type = StaticType.ANY,
+                op = rexOpPath(
+                    root = rex(
+                        StaticType.ANY,
+                        rexOpVarUnresolved(
+                            identifierSymbol("closed_union_duplicates_struct", Identifier.CaseSensitivity.SENSITIVE),
+                            Rex.Op.Var.Scope.DEFAULT
+                        )
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("definition", Identifier.CaseSensitivity.INSENSITIVE)),
+                    )
+                )
+            )
+        )
+        val expected = statementQuery(
+            root = rex(
+                type = StaticType.unionOf(StaticType.STRING, StaticType.FLOAT, StaticType.DECIMAL, StaticType.INT2),
+                op = rexOpPath(
+                    root = rex(
+                        CLOSED_UNION_DUPLICATES_STRUCT,
+                        rexOpGlobal(0)
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("definition", Identifier.CaseSensitivity.INSENSITIVE)),
+                    )
+                )
+            )
+        )
+        val actual = typer.resolve(input)
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testUnionClosedDuplicatesWithSensitivity() {
+        val wrapper = getTyper()
+        val typer = wrapper.typer
+        val input = statementQuery(
+            root = rex(
+                type = StaticType.ANY,
+                op = rexOpPath(
+                    root = rex(
+                        StaticType.ANY,
+                        rexOpVarUnresolved(
+                            identifierSymbol("closed_union_duplicates_struct", Identifier.CaseSensitivity.SENSITIVE),
+                            Rex.Op.Var.Scope.DEFAULT
+                        )
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("definition", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val expected = statementQuery(
+            root = rex(
+                type = StaticType.unionOf(StaticType.STRING, StaticType.FLOAT, StaticType.INT2),
+                op = rexOpPath(
+                    root = rex(
+                        CLOSED_UNION_DUPLICATES_STRUCT,
+                        rexOpGlobal(0)
+                    ),
+                    steps = listOf(
+                        rexOpPathStepSymbol(identifierSymbol("definition", Identifier.CaseSensitivity.SENSITIVE)),
+                    )
+                )
+            )
+        )
+        val actual = typer.resolve(input)
+        assertEquals(expected, actual)
+    }
+
+    /**
+     * A [ProblemHandler] that collects all the encountered [Problem]s without throwing.
+     *
+     * This is intended to be used when wanting to collect multiple problems that may be encountered (e.g. a static type
+     * inference pass that can result in multiple errors and/or warnings). This handler does not collect other exceptions
+     * that may be thrown.
+     */
+    internal class ProblemCollector : ProblemCallback {
+        private val problemList = mutableListOf<Problem>()
+
+        val problems: List<Problem>
+            get() = problemList
+
+        val hasErrors: Boolean
+            get() = problemList.any { it.details.severity == ProblemSeverity.ERROR }
+
+        val hasWarnings: Boolean
+            get() = problemList.any { it.details.severity == ProblemSeverity.WARNING }
+
+        override fun invoke(problem: Problem) {
+            problemList.add(problem)
+        }
+    }
+}

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/b/b/d.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/b/b/d.ion
@@ -1,6 +1,6 @@
 {
   type: "struct",
-  constraints: [ ordered ],
+  constraints: [ closed, ordered ],
   fields: [
     {
       name: "e",

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/T.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/T.ion
@@ -1,0 +1,48 @@
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed, ordered, unique ],
+    fields: [
+      {
+        name: "a",
+        type: "bool",
+      },
+      {
+        name: "b",
+        type: "int32",
+      },
+      {
+        name: "c",
+        type: "string",
+      },
+      {
+        name: "d",
+        type: {
+          type: "struct",
+          constraints: [ closed, ordered, unique ],
+          fields: [
+            {
+              name: "e",
+              type: "string"
+            }
+          ]
+        },
+      },
+      // path expression tests
+      {
+        name: "x",
+        type: "any",
+      },
+      {
+        name: "z",
+        type: "string",
+      },
+      // split
+      {
+        name: "v",
+        type: "string",
+      }
+    ]
+  }
+}

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/closed_duplicates_struct.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/closed_duplicates_struct.ion
@@ -1,0 +1,20 @@
+{
+  type: "struct",
+  constraints: [
+    closed
+  ],
+  fields: [
+    {
+      name: "definition",
+      type: "string",
+    },
+    {
+      name: "definition",
+      type: "float32",
+    },
+    {
+      name: "DEFINITION",
+      type: "decimal"
+    }
+  ]
+}

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/closed_ordered_duplicates_struct.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/closed_ordered_duplicates_struct.ion
@@ -1,0 +1,21 @@
+{
+  type: "struct",
+  constraints: [
+    closed,
+    ordered
+  ],
+  fields: [
+    {
+      name: "definition",
+      type: "string",
+    },
+    {
+      name: "definition",
+      type: "float32",
+    },
+    {
+      name: "DEFINITION",
+      type: "decimal"
+    }
+  ]
+}

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/closed_union_duplicates_struct.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/closed_union_duplicates_struct.ion
@@ -1,0 +1,43 @@
+[
+  {
+    type: "struct",
+    constraints: [
+      closed
+    ],
+    fields: [
+      {
+        name: "definition",
+        type: "string",
+      },
+      {
+        name: "definition",
+        type: "float32",
+      },
+      {
+        name: "DEFINITION",
+        type: "decimal"
+      }
+    ]
+  },
+  {
+    type: "struct",
+    constraints: [
+      closed,
+      ordered
+    ],
+    fields: [
+      {
+        name: "definition",
+        type: "int16",
+      },
+      {
+        name: "definition",
+        type: "int32",
+      },
+      {
+        name: "DEFINITION",
+        type: "int64"
+      }
+    ]
+  },
+]

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/open_duplicates_struct.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/pql/main/open_duplicates_struct.ion
@@ -1,0 +1,17 @@
+{
+  type: "struct",
+  fields: [
+    {
+      name: "definition",
+      type: "string",
+    },
+    {
+      name: "definition",
+      type: "float32",
+    },
+    {
+      name: "DEFINITION",
+      type: "decimal"
+    }
+  ]
+}


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Disambiguates references to struct attributes
- Before, when someone were to type `{ 'aBc': { 'DeF': 1 } }.abc.def` it would return a plan representing `{ 'aBc': { 'DeF': 1 } }.abc.def`. This PR disambiguates the plan by instead returning `{ 'aBc': { 'DeF': 1 } }."aBc"."DeF"`. This will help with transpilation.
- This PR handles union types, closed content structs, ordered structs, and open structs. Please see the tests for more information. The tests are lengthy, however, they are written to avoid any potential breaks in the future.
  - Please see the kdoc for `PlanTyper.inferStructLookup` for information on how we handle the above.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.