### PR TITLE
Adds support for dynamic dispatch of functions

### DIFF
--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
@@ -480,7 +480,7 @@ class PartiQLSchemaInferencerTests {
                         )
                     )
                 }
-            ).toIgnored("Plus op will be resolved to PLUS__ANY_ANY__ANY"),
+            ),
         )
 
         @JvmStatic
@@ -498,7 +498,7 @@ class PartiQLSchemaInferencerTests {
             SuccessTestCase(
                 name = "BITWISE_AND_3",
                 query = "1 & 2",
-                expected = StaticType.INT4
+                expected = INT4
             ),
             SuccessTestCase(
                 name = "BITWISE_AND_4",
@@ -561,7 +561,7 @@ class PartiQLSchemaInferencerTests {
                         PlanningProblemDetails.UnknownFunction("bitwise_and", listOf(INT4, STRING))
                     )
                 }
-            ).toIgnored("Bitwise And opearator will be resolved to BITWISE_AND__ANY_ANY__ANY"),
+            ),
         )
 
         @JvmStatic
@@ -2964,7 +2964,7 @@ class PartiQLSchemaInferencerTests {
                         )
                     )
                 }
-            ).toIgnored("Between will be resolved to BETWEEN__ANY_ANY_ANY__BOOL"),
+            ),
             SuccessTestCase(
                 name = "LIKE",
                 catalog = CATALOG_DB,
@@ -2987,7 +2987,7 @@ class PartiQLSchemaInferencerTests {
                         )
                     )
                 }
-            ).toIgnored("Like Op will be resolved to LIKE__ANY_ANY__BOOL"),
+            ),
             SuccessTestCase(
                 name = "Case Insensitive success",
                 catalog = CATALOG_DB,
@@ -3058,7 +3058,7 @@ class PartiQLSchemaInferencerTests {
                         )
                     )
                 }
-            ).toIgnored("And Op will be resolved to AND__ANY_ANY__BOOL"),
+            ),
             ErrorTestCase(
                 name = "Bad comparison",
                 catalog = CATALOG_DB,
@@ -3074,7 +3074,7 @@ class PartiQLSchemaInferencerTests {
                         )
                     )
                 }
-            ).toIgnored("And Op will be resolved to AND__ANY_ANY__BOOL"),
+            ),
             ErrorTestCase(
                 name = "Unknown column",
                 catalog = CATALOG_DB,
@@ -3311,8 +3311,7 @@ class PartiQLSchemaInferencerTests {
                         )
                     )
                 }
-            ).toIgnored("Currently this will be resolved to TRIM_CHARS__ANY_ANY__ANY."),
-
+            ),
         )
     }
 

--- a/partiql-plan/src/main/resources/partiql_plan_0_1.ion
+++ b/partiql-plan/src/main/resources/partiql_plan_0_1.ion
@@ -118,20 +118,15 @@ rex::{
       ],
     },
 
-    call::{
-       fn:    fn,
-       args:  list::[rex],
-    },
-
-    call_dynamic::{
-      candidates: list::[candidate],
-      _: [
-        candidate::{
-          fn: fn,
-          args: list::[rex]
-        }
-      ]
-    },
+    call::[
+      static::{
+        fn: fn,
+        args: list::[rex]
+      },
+      dynamic::{
+        candidates: list::[static]
+      }
+    ],
 
     case::{
       branches: list::[branch],

--- a/partiql-plan/src/main/resources/partiql_plan_0_1.ion
+++ b/partiql-plan/src/main/resources/partiql_plan_0_1.ion
@@ -123,8 +123,19 @@ rex::{
         fn: fn,
         args: list::[rex]
       },
+      // fn: is this needed?
+      // args: represent the original arguments.
+      // candidates:
       dynamic::{
-        candidates: list::[static]
+        fn: fn,
+        args: list::[rex],
+        candidates: list::[static],
+        _: [
+          candidate::{
+            fn: fn,
+            coercions: list::[nullable::fn]
+          }
+        ]
       }
     ],
 

--- a/partiql-plan/src/main/resources/partiql_plan_0_1.ion
+++ b/partiql-plan/src/main/resources/partiql_plan_0_1.ion
@@ -141,7 +141,7 @@ rex::{
           //  over the first argument of dynamic.args and so on.
           candidate::{
             fn: '.fn.resolved',
-            coercions: list::[optional::fn]
+            coercions: list::[optional::'.fn.resolved']
           }
         ]
       }

--- a/partiql-plan/src/main/resources/partiql_plan_0_1.ion
+++ b/partiql-plan/src/main/resources/partiql_plan_0_1.ion
@@ -123,17 +123,25 @@ rex::{
         fn: fn,
         args: list::[rex]
       },
-      // fn: is this needed?
-      // args: represent the original arguments.
-      // candidates:
+
+      // Represents a dynamic function call. If all candidates are exhausted, dynamic calls will return MISSING.
+      //
+      // args: represent the original typed arguments. These will eventually be wrapped by coercions from [candidates].
+      // candidates: represent the potentially applicable resolved functions with coercions. Each of these candidates
+      //  should be overloaded functions of the same name and number of arguments.
       dynamic::{
-        fn: fn,
         args: list::[rex],
-        candidates: list::[static],
+        candidates: list::[candidate],
         _: [
+
+          // Represents a viable candidate.
+          //
+          // fn: The resolved function
+          // coercions: Represents the coercion that should take place -- if not null. The first item is to be wrapped
+          //  over the first argument of dynamic.args and so on.
           candidate::{
-            fn: fn,
-            coercions: list::[nullable::fn]
+            fn: '.fn.resolved',
+            coercions: list::[optional::fn]
           }
         ]
       }

--- a/partiql-plan/src/main/resources/partiql_plan_0_1.ion
+++ b/partiql-plan/src/main/resources/partiql_plan_0_1.ion
@@ -35,6 +35,9 @@ fn::[
     identifier: identifier,
     isHidden: bool,
   },
+  dynamic::{
+    signatures: list::[scalar_signature],
+  }
 ]
 
 agg::[
@@ -118,6 +121,16 @@ rex::{
     call::{
        fn:    fn,
        args:  list::[rex],
+    },
+
+    call_dynamic::{
+      candidates: list::[candidate],
+      _: [
+        candidate::{
+          fn: fn,
+          args: list::[rex]
+        }
+      ]
     },
 
     case::{

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/Header.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/Header.kt
@@ -58,25 +58,23 @@ public abstract class Header {
     companion object {
 
         @JvmStatic
-        internal fun unary(name: String, returns: PartiQLValueType, value: PartiQLValueType, isMissable: Boolean = false) =
+        internal fun unary(name: String, returns: PartiQLValueType, value: PartiQLValueType) =
             FunctionSignature.Scalar(
                 name = name,
                 returns = returns,
                 parameters = listOf(FunctionParameter("value", value)),
-                isNullCall = true,
                 isNullable = false,
-                isMissable = isMissable
+                isNullCall = true
             )
 
         @JvmStatic
-        internal fun binary(name: String, returns: PartiQLValueType, lhs: PartiQLValueType, rhs: PartiQLValueType, isMissable: Boolean = false) =
+        internal fun binary(name: String, returns: PartiQLValueType, lhs: PartiQLValueType, rhs: PartiQLValueType) =
             FunctionSignature.Scalar(
                 name = name,
                 returns = returns,
                 parameters = listOf(FunctionParameter("lhs", lhs), FunctionParameter("rhs", rhs)),
-                isNullCall = true,
                 isNullable = false,
-                isMissable = isMissable
+                isNullCall = true
             )
     }
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
@@ -128,9 +128,9 @@ object PartiQLHeader : Header() {
         FunctionSignature.Scalar(
             name = "eq",
             returns = BOOL,
-            isNullCall = false,
-            isNullable = false,
             parameters = listOf(FunctionParameter("lhs", t), FunctionParameter("rhs", t)),
+            isNullable = false,
+            isNullCall = false,
         )
     }
 
@@ -196,8 +196,8 @@ object PartiQLHeader : Header() {
             name = "upper",
             returns = t,
             parameters = listOf(FunctionParameter("value", t)),
-            isNullCall = true,
             isNullable = false,
+            isNullCall = true,
         )
     }
 
@@ -206,8 +206,8 @@ object PartiQLHeader : Header() {
             name = "lower",
             returns = t,
             parameters = listOf(FunctionParameter("value", t)),
-            isNullCall = true,
             isNullable = false,
+            isNullCall = true,
         )
     }
 
@@ -221,8 +221,8 @@ object PartiQLHeader : Header() {
                 FunctionParameter("value", STRING),
                 FunctionParameter("pattern", STRING),
             ),
-            isNullCall = true,
             isNullable = false,
+            isNullCall = true,
         ),
         FunctionSignature.Scalar(
             name = "like_escape",
@@ -232,8 +232,8 @@ object PartiQLHeader : Header() {
                 FunctionParameter("pattern", STRING),
                 FunctionParameter("escape", STRING),
             ),
-            isNullCall = true,
             isNullable = false,
+            isNullCall = true,
         ),
     )
 
@@ -246,8 +246,8 @@ object PartiQLHeader : Header() {
                 FunctionParameter("lower", t),
                 FunctionParameter("upper", t),
             ),
-            isNullCall = true,
             isNullable = false,
+            isNullCall = true,
         )
     }
 
@@ -260,8 +260,8 @@ object PartiQLHeader : Header() {
                     FunctionParameter("value", element),
                     FunctionParameter("collection", collection),
                 ),
-                isNullCall = true,
                 isNullable = false,
+                isNullCall = true,
             )
         }
     }.flatten()
@@ -279,8 +279,8 @@ object PartiQLHeader : Header() {
             parameters = listOf(
                 FunctionParameter("value", ANY) // TODO: Decide if we need to further segment this
             ),
-            isNullCall = false,
-            isNullable = false
+            isNullable = false,
+            isNullCall = false
         )
     }
 
@@ -295,8 +295,8 @@ object PartiQLHeader : Header() {
                 FunctionParameter("type_parameter_1", INT32),
                 FunctionParameter("value", ANY) // TODO: Decide if we need to further segment this
             ),
-            isNullCall = false,
-            isNullable = false
+            isNullable = false,
+            isNullCall = false
         )
     }
 
@@ -309,8 +309,8 @@ object PartiQLHeader : Header() {
                 FunctionParameter("type_parameter_2", INT32),
                 FunctionParameter("value", ANY) // TODO: Decide if we need to further segment this
             ),
-            isNullCall = false,
-            isNullable = false
+            isNullable = false,
+            isNullCall = false
         )
     }
 
@@ -323,8 +323,8 @@ object PartiQLHeader : Header() {
                 FunctionParameter("type_parameter_2", INT32),
                 FunctionParameter("value", ANY) // TODO: Decide if we need to further segment this
             ),
-            isNullCall = false,
-            isNullable = false
+            isNullable = false,
+            isNullCall = false
         )
     }
 
@@ -339,8 +339,8 @@ object PartiQLHeader : Header() {
                     FunctionParameter("value", t),
                     FunctionParameter("start", INT64),
                 ),
-                isNullCall = true,
                 isNullable = false,
+                isNullCall = true,
             ),
             FunctionSignature.Scalar(
                 name = "substring",
@@ -350,8 +350,8 @@ object PartiQLHeader : Header() {
                     FunctionParameter("start", INT64),
                     FunctionParameter("end", INT64),
                 ),
-                isNullCall = true,
                 isNullable = false,
+                isNullCall = true,
             )
         )
     }.flatten()
@@ -366,8 +366,8 @@ object PartiQLHeader : Header() {
                 FunctionParameter("probe", t),
                 FunctionParameter("value", t),
             ),
-            isNullCall = true,
             isNullable = false,
+            isNullCall = true,
         )
     }
 
@@ -379,8 +379,8 @@ object PartiQLHeader : Header() {
             parameters = listOf(
                 FunctionParameter("value", t),
             ),
-            isNullCall = true,
             isNullable = false,
+            isNullCall = true,
         )
     }
 
@@ -396,8 +396,8 @@ object PartiQLHeader : Header() {
                     FunctionParameter("value", t),
                     FunctionParameter("chars", t),
                 ),
-                isNullCall = true,
                 isNullable = false,
+                isNullCall = true,
             ),
             // TRIM(LEADING FROM value)
             FunctionSignature.Scalar(
@@ -406,8 +406,8 @@ object PartiQLHeader : Header() {
                 parameters = listOf(
                     FunctionParameter("value", t),
                 ),
-                isNullCall = true,
                 isNullable = false,
+                isNullCall = true,
             ),
             // TRIM(LEADING chars FROM value)
             FunctionSignature.Scalar(
@@ -417,8 +417,8 @@ object PartiQLHeader : Header() {
                     FunctionParameter("value", t),
                     FunctionParameter("chars", t),
                 ),
-                isNullCall = true,
                 isNullable = false,
+                isNullCall = true,
             ),
             // TRIM(TRAILING FROM value)
             FunctionSignature.Scalar(
@@ -427,8 +427,8 @@ object PartiQLHeader : Header() {
                 parameters = listOf(
                     FunctionParameter("value", t),
                 ),
-                isNullCall = true,
                 isNullable = false,
+                isNullCall = true,
             ),
             // TRIM(TRAILING chars FROM value)
             FunctionSignature.Scalar(
@@ -438,8 +438,8 @@ object PartiQLHeader : Header() {
                     FunctionParameter("value", t),
                     FunctionParameter("chars", t),
                 ),
-                isNullCall = true,
                 isNullable = false,
+                isNullCall = true,
             ),
         )
     }.flatten()
@@ -464,8 +464,8 @@ object PartiQLHeader : Header() {
                         FunctionParameter("interval", INT),
                         FunctionParameter("datetime", type),
                     ),
-                    isNullCall = true,
                     isNullable = false,
+                    isNullCall = true,
                 )
                 operators.add(signature)
             }
@@ -487,8 +487,8 @@ object PartiQLHeader : Header() {
                         FunctionParameter("datetime1", type),
                         FunctionParameter("datetime2", type),
                     ),
-                    isNullCall = true,
                     isNullable = false,
+                    isNullCall = true,
                 )
                 operators.add(signature)
             }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
@@ -114,15 +114,15 @@ object PartiQLHeader : Header() {
 
     // OPERATORS
 
-    private fun not(): List<FunctionSignature.Scalar> = listOf(unary("not", BOOL, BOOL), unary("not", BOOL, ANY, true))
+    private fun not(): List<FunctionSignature.Scalar> = listOf(unary("not", BOOL, BOOL))
 
     private fun pos(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         unary("pos", t, t)
-    } + listOf(unary("pos", ANY, ANY))
+    }
 
     private fun neg(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         unary("neg", t, t)
-    } + listOf(unary("neg", ANY, ANY))
+    }
 
     private fun eq(): List<FunctionSignature.Scalar> = types.all.map { t ->
         FunctionSignature.Scalar(
@@ -140,57 +140,55 @@ object PartiQLHeader : Header() {
 
     private fun and(): List<FunctionSignature.Scalar> = listOf(
         binary("and", BOOL, BOOL, BOOL),
-        binary("and", BOOL, ANY, ANY, true)
     )
 
     private fun or(): List<FunctionSignature.Scalar> = listOf(
         binary("or", BOOL, BOOL, BOOL),
-        binary("or", BOOL, ANY, ANY, true)
     )
 
     private fun lt(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("lt", BOOL, t, t)
-    } + listOf(binary("lt", BOOL, ANY, ANY, true))
+    }
 
     private fun lte(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("lte", BOOL, t, t)
-    } + listOf(binary("lte", BOOL, ANY, ANY, true))
+    }
 
     private fun gt(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("gt", BOOL, t, t)
-    } + listOf(binary("gt", BOOL, ANY, ANY, true))
+    }
 
     private fun gte(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("gte", BOOL, t, t)
-    } + listOf(binary("gte", BOOL, ANY, ANY, true))
+    }
 
     private fun plus(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("plus", t, t, t)
-    } + listOf(binary("plus", ANY, ANY, ANY, true))
+    }
 
     private fun minus(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("minus", t, t, t)
-    } + listOf(binary("minus", ANY, ANY, ANY, true))
+    }
 
     private fun times(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("times", t, t, t)
-    } + listOf(binary("times", ANY, ANY, ANY, true))
+    }
 
     private fun div(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("divide", t, t, t)
-    } + listOf(binary("divide", ANY, ANY, ANY, true))
+    }
 
     private fun mod(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
         binary("modulo", t, t, t)
-    } + listOf(binary("modulo", ANY, ANY, ANY, true))
+    }
 
     private fun concat(): List<FunctionSignature.Scalar> = types.text.map { t ->
         binary("concat", t, t, t)
-    } + listOf(binary("concat", ANY, ANY, ANY, true))
+    }
 
     private fun bitwiseAnd(): List<FunctionSignature.Scalar> = types.integer.map { t ->
         binary("bitwise_and", t, t, t)
-    } + listOf(binary("bitwise_and", ANY, ANY, ANY, true))
+    }
 
     // BUILT INS
     private fun upper(): List<FunctionSignature.Scalar> = types.text.map { t ->
@@ -201,16 +199,7 @@ object PartiQLHeader : Header() {
             isNullCall = true,
             isNullable = false,
         )
-    } + listOf(
-        FunctionSignature.Scalar(
-            name = "upper",
-            returns = ANY,
-            parameters = listOf(FunctionParameter("value", ANY)),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true
-        )
-    )
+    }
 
     private fun lower(): List<FunctionSignature.Scalar> = types.text.map { t ->
         FunctionSignature.Scalar(
@@ -220,16 +209,7 @@ object PartiQLHeader : Header() {
             isNullCall = true,
             isNullable = false,
         )
-    } + listOf(
-        FunctionSignature.Scalar(
-            name = "lower",
-            returns = ANY,
-            parameters = listOf(FunctionParameter("value", ANY)),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true
-        )
-    )
+    }
 
     // SPECIAL FORMS
 
@@ -255,29 +235,6 @@ object PartiQLHeader : Header() {
             isNullCall = true,
             isNullable = false,
         ),
-        FunctionSignature.Scalar(
-            name = "like",
-            returns = BOOL,
-            parameters = listOf(
-                FunctionParameter("value", ANY),
-                FunctionParameter("pattern", ANY),
-            ),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true
-        ),
-        FunctionSignature.Scalar(
-            name = "like_escape",
-            returns = BOOL,
-            parameters = listOf(
-                FunctionParameter("value", ANY),
-                FunctionParameter("pattern", ANY),
-                FunctionParameter("escape", ANY),
-            ),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true
-        ),
     )
 
     private fun between(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
@@ -292,20 +249,7 @@ object PartiQLHeader : Header() {
             isNullCall = true,
             isNullable = false,
         )
-    } + listOf(
-        FunctionSignature.Scalar(
-            name = "between",
-            returns = BOOL,
-            parameters = listOf(
-                FunctionParameter("value", ANY),
-                FunctionParameter("lower", ANY),
-                FunctionParameter("upper", ANY),
-            ),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true
-        )
-    )
+    }
 
     private fun inCollection(): List<FunctionSignature.Scalar> = types.all.map { element ->
         types.collections.map { collection ->
@@ -410,31 +354,7 @@ object PartiQLHeader : Header() {
                 isNullable = false,
             )
         )
-    }.flatten() + listOf(
-        FunctionSignature.Scalar(
-            name = "substring",
-            returns = ANY,
-            parameters = listOf(
-                FunctionParameter("value", ANY),
-                FunctionParameter("start", ANY),
-            ),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true,
-        ),
-        FunctionSignature.Scalar(
-            name = "substring",
-            returns = ANY,
-            parameters = listOf(
-                FunctionParameter("value", ANY),
-                FunctionParameter("start", ANY),
-                FunctionParameter("end", ANY),
-            ),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true
-        )
-    )
+    }.flatten()
 
     // position (str1, str2)
     // position (str1 in str2)
@@ -449,19 +369,7 @@ object PartiQLHeader : Header() {
             isNullCall = true,
             isNullable = false,
         )
-    } + listOf(
-        FunctionSignature.Scalar(
-            name = "position",
-            returns = ANY,
-            parameters = listOf(
-                FunctionParameter("probe", ANY),
-                FunctionParameter("value", ANY),
-            ),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true,
-        )
-    )
+    }
 
     // trim(str)
     private fun trim(): List<FunctionSignature.Scalar> = types.text.map { t ->
@@ -474,18 +382,7 @@ object PartiQLHeader : Header() {
             isNullCall = true,
             isNullable = false,
         )
-    } + listOf(
-        FunctionSignature.Scalar(
-            name = "trim",
-            returns = ANY,
-            parameters = listOf(
-                FunctionParameter("value", ANY),
-            ),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true,
-        )
-    )
+    }
 
     // TODO: We need to add a special form function for TRIM(BOTH FROM value)
     private fun trimSpecial(): List<FunctionSignature.Scalar> = types.text.map { t ->
@@ -545,67 +442,7 @@ object PartiQLHeader : Header() {
                 isNullable = false,
             ),
         )
-    }.flatten() + listOf(
-        // TRIM(chars FROM value)
-        // TRIM(both chars from value)
-        FunctionSignature.Scalar(
-            name = "trim_chars",
-            returns = ANY,
-            parameters = listOf(
-                FunctionParameter("value", ANY),
-                FunctionParameter("chars", ANY),
-            ),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true,
-        ),
-        // TRIM(LEADING FROM value)
-        FunctionSignature.Scalar(
-            name = "trim_leading",
-            returns = ANY,
-            parameters = listOf(
-                FunctionParameter("value", ANY),
-            ),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true,
-        ),
-        // TRIM(LEADING chars FROM value)
-        FunctionSignature.Scalar(
-            name = "trim_leading_chars",
-            returns = ANY,
-            parameters = listOf(
-                FunctionParameter("value", ANY),
-                FunctionParameter("chars", ANY),
-            ),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true
-        ),
-        // TRIM(TRAILING FROM value)
-        FunctionSignature.Scalar(
-            name = "trim_trailing",
-            returns = ANY,
-            parameters = listOf(
-                FunctionParameter("value", ANY),
-            ),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true
-        ),
-        // TRIM(TRAILING chars FROM value)
-        FunctionSignature.Scalar(
-            name = "trim_trailing_chars",
-            returns = ANY,
-            parameters = listOf(
-                FunctionParameter("value", ANY),
-                FunctionParameter("chars", ANY),
-            ),
-            isNullCall = true,
-            isNullable = false,
-            isMissable = true
-        ),
-    )
+    }.flatten()
 
     // TODO
     private fun overlay(): List<FunctionSignature.Scalar> = emptyList()
@@ -632,18 +469,6 @@ object PartiQLHeader : Header() {
                 )
                 operators.add(signature)
             }
-            val anySignature = FunctionSignature.Scalar(
-                name = "date_diff_${field.name.lowercase()}",
-                returns = ANY,
-                parameters = listOf(
-                    FunctionParameter("interval", ANY),
-                    FunctionParameter("datetime", ANY),
-                ),
-                isNullCall = true,
-                isNullable = false,
-                isMissable = true
-            )
-            operators.add(anySignature)
         }
         return operators
     }
@@ -667,18 +492,6 @@ object PartiQLHeader : Header() {
                 )
                 operators.add(signature)
             }
-            val anySignature = FunctionSignature.Scalar(
-                name = "date_diff_${field.name.lowercase()}",
-                returns = INT64,
-                parameters = listOf(
-                    FunctionParameter("datetime1", ANY),
-                    FunctionParameter("datetime2", ANY),
-                ),
-                isNullCall = true,
-                isNullable = false,
-                isMissable = true
-            )
-            operators.add(anySignature)
         }
         return operators
     }
@@ -731,12 +544,6 @@ object PartiQLHeader : Header() {
             parameters = listOf(FunctionParameter("value", BOOL)),
             isNullable = true,
         ),
-        FunctionSignature.Aggregation(
-            name = "every",
-            returns = BOOL,
-            parameters = listOf(FunctionParameter("value", ANY)),
-            isNullable = true,
-        ),
     )
 
     private fun any() = listOf(
@@ -746,12 +553,6 @@ object PartiQLHeader : Header() {
             parameters = listOf(FunctionParameter("value", BOOL)),
             isNullable = true,
         ),
-        FunctionSignature.Aggregation(
-            name = "any",
-            returns = BOOL,
-            parameters = listOf(FunctionParameter("value", ANY)),
-            isNullable = true,
-        ),
     )
 
     private fun some() = listOf(
@@ -759,12 +560,6 @@ object PartiQLHeader : Header() {
             name = "some",
             returns = BOOL,
             parameters = listOf(FunctionParameter("value", BOOL)),
-            isNullable = true,
-        ),
-        FunctionSignature.Aggregation(
-            name = "some",
-            returns = BOOL,
-            parameters = listOf(FunctionParameter("value", ANY)),
             isNullable = true,
         ),
     )
@@ -791,12 +586,7 @@ object PartiQLHeader : Header() {
             parameters = listOf(FunctionParameter("value", it)),
             isNullable = true,
         )
-    } + FunctionSignature.Aggregation(
-        name = "min",
-        returns = ANY,
-        parameters = listOf(FunctionParameter("value", ANY)),
-        isNullable = true,
-    )
+    }
 
     private fun max() = types.numeric.map {
         FunctionSignature.Aggregation(
@@ -805,12 +595,7 @@ object PartiQLHeader : Header() {
             parameters = listOf(FunctionParameter("value", it)),
             isNullable = true,
         )
-    } + FunctionSignature.Aggregation(
-        name = "max",
-        returns = ANY,
-        parameters = listOf(FunctionParameter("value", ANY)),
-        isNullable = true,
-    )
+    }
 
     private fun sum() = types.numeric.map {
         FunctionSignature.Aggregation(
@@ -819,12 +604,7 @@ object PartiQLHeader : Header() {
             parameters = listOf(FunctionParameter("value", it)),
             isNullable = true,
         )
-    } + FunctionSignature.Aggregation(
-        name = "sum",
-        returns = ANY,
-        parameters = listOf(FunctionParameter("value", ANY)),
-        isNullable = true,
-    )
+    }
 
     private fun avg() = types.numeric.map {
         FunctionSignature.Aggregation(
@@ -833,10 +613,5 @@ object PartiQLHeader : Header() {
             parameters = listOf(FunctionParameter("value", it)),
             isNullable = true,
         )
-    } + FunctionSignature.Aggregation(
-        name = "avg",
-        returns = ANY,
-        parameters = listOf(FunctionParameter("value", ANY)),
-        isNullable = true,
-    )
+    }
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/typer/FnResolver.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/typer/FnResolver.kt
@@ -81,8 +81,14 @@ internal sealed class FnMatch<T : FunctionSignature> {
     ) : FnMatch<T>()
 
     /**
-     * TODO
-     * @property isMissable TRUE when the argument permutations may not definitively invoke one of the candidates.
+     * This represents dynamic dispatch.
+     *
+     * @property candidates an ordered list of potentially applicable functions to dispatch dynamically.
+     * @property isMissable TRUE when the argument permutations may not definitively invoke one of the candidates. You
+     * can think of [isMissable] as being the same as "not exhaustive". For example, if we have ABS(INT | STRING), then
+     * this function call [isMissable] because there isn't an `ABS(STRING)` function signature AKA we haven't exhausted
+     * all the arguments. On the other hand, take an "exhaustive" scenario: ABS(INT | DEC). In this case, [isMissable]
+     * is false because we have functions for each potential argument AKA we have exhausted the arguments.
      */
     public data class Dynamic<T : FunctionSignature>(
         public val candidates: List<Ok<T>>,
@@ -164,9 +170,6 @@ internal class FnResolver(private val headers: List<Header>) {
             }
         }
         val potentialFunctions = parameterPermutations.mapNotNull { parameters ->
-            if (parameters.any { it.type == MISSING }) {
-                canReturnMissing = true
-            }
             when (val match = match(candidates, parameters)) {
                 null -> {
                     canReturnMissing = true

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/typer/FnResolver.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/typer/FnResolver.kt
@@ -176,7 +176,7 @@ internal class FnResolver(private val headers: List<Header>) {
                     null
                 }
                 else -> {
-                    val isMissable = canReturnMissing || isUnsafeCast(match.signature.specific) || match.signature.isMissable
+                    val isMissable = canReturnMissing || isUnsafeCast(match.signature.specific)
                     FnMatch.Ok(match.signature, match.mapping, isMissable)
                 }
             }
@@ -371,11 +371,11 @@ internal class FnResolver(private val headers: List<Header>) {
         FunctionSignature.Scalar(
             name = castName(target),
             returns = target,
-            isNullCall = true,
-            isNullable = false,
             parameters = listOf(
                 FunctionParameter("value", operand),
-            )
+            ),
+            isNullable = false,
+            isNullCall = true
         )
 
     companion object {

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/typer/TypeUtils.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/typer/TypeUtils.kt
@@ -101,6 +101,15 @@ internal fun StaticType.toRuntimeType(): PartiQLValueType {
 }
 
 @OptIn(PartiQLValueExperimental::class)
+internal fun StaticType.toRuntimeTypeOrNull(): PartiQLValueType? {
+    return try {
+        this.toRuntimeType()
+    } catch (_: Throwable) {
+        null
+    }
+}
+
+@OptIn(PartiQLValueExperimental::class)
 private fun StaticType.asRuntimeType(): PartiQLValueType = when (this) {
     is AnyOfType -> PartiQLValueType.ANY
     is AnyType -> PartiQLValueType.ANY

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/typer/FunctionResolverTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/typer/FunctionResolverTest.kt
@@ -8,7 +8,6 @@ import org.partiql.types.function.FunctionParameter
 import org.partiql.types.function.FunctionSignature
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.PartiQLValueType
-import javax.print.DocFlavor.STRING
 
 /**
  * As far as testing is concerned, we can stub out all value related things.

--- a/partiql-types/src/main/kotlin/org/partiql/types/function/FunctionSignature.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/function/FunctionSignature.kt
@@ -55,7 +55,6 @@ public sealed class FunctionSignature(
         parameters: List<FunctionParameter>,
         description: String? = null,
         isNullable: Boolean = true,
-        @JvmField public val isMissable: Boolean = false,
         @JvmField public val isDeterministic: Boolean = true,
         @JvmField public val isNullCall: Boolean = false,
     ) : FunctionSignature(name, returns, parameters, description, isNullable) {
@@ -68,8 +67,7 @@ public sealed class FunctionSignature(
                 other.parameters.size != parameters.size ||
                 other.isDeterministic != isDeterministic ||
                 other.isNullCall != isNullCall ||
-                other.isNullable != isNullable ||
-                other.isMissable != isMissable
+                other.isNullable != isNullable
             ) {
                 return false
             }
@@ -89,7 +87,6 @@ public sealed class FunctionSignature(
             result = 31 * result + isDeterministic.hashCode()
             result = 31 * result + isNullCall.hashCode()
             result = 31 * result + isNullable.hashCode()
-            result = 31 * result + isMissable.hashCode()
             result = 31 * result + (description?.hashCode() ?: 0)
             return result
         }

--- a/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/functions/Pow.kt
+++ b/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/functions/Pow.kt
@@ -22,8 +22,8 @@ object Pow : PartiQLFunction {
             FunctionParameter(name = "base", type = PartiQLValueType.INT8),
             FunctionParameter(name = "exponent", type = PartiQLValueType.INT8)
         ),
-        isDeterministic = true,
-        description = "Power [base] with [exponent]"
+        description = "Power [base] with [exponent]",
+        isDeterministic = true
     )
 
     @OptIn(PartiQLValueExperimental::class)

--- a/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/functions/TrimLead.kt
+++ b/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/functions/TrimLead.kt
@@ -21,8 +21,8 @@ object TrimLead : PartiQLFunction {
         parameters = listOf(
             FunctionParameter(name = "str", type = PartiQLValueType.STRING)
         ),
-        isDeterministic = true,
-        description = "Trims leading whitespace of a [str]."
+        description = "Trims leading whitespace of a [str].",
+        isDeterministic = true
     )
 
     @OptIn(PartiQLValueExperimental::class)


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds support for dynamic dispatch of functions.
- I've opted to model the possible "candidates" directly within the plan under a dynamic function call. We re-use the same logic of static calls (inserting the coercions where necessary) and maintaining the order of potential functions to dynamically invoke.
  - By modeling it this way, we can remove all the `any -> any` functions from the PartiQL header.
  - We also don't need to generate a massive `CASE WHEN` -- we can let the engine handle this specifically.
  - We handle MISSING appropriately.
- In order to do this effectively, I compute the permutations of the potential types of the arguments. Consider the following invocation: `BINARY_PLUS(INT4|INT8, STRING|INT8|INT2)`. The permutations would result in the following "possible" function calls:
  - `BINARY_PLUS(INT4, STRING) -> MISSING` (doesn't exist)
  - `BINARY_PLUS(INT4, INT8)` -> `BINARY_PLUS(CAST(<INT4> AS INT8), INT8) -> INT8` (exists, but needs to coerce)
  - `BINARY_PLUS(INT4, INT2)` -> `BINARY_PLUS(INT4, CAST(<INT2> AS INT4)) -> INT4` (exists, but needs to coerce)
  - `BINARY_PLUS(INT8, STRING) -> MISSING` (doesn't exist)
  - `BINARY_PLUS(INT8, INT8) -> INT8` (exists and no coercions necessary)
  - `BINARY_PLUS(INT8, INT2)` -> `BINARY_PLUS(INT8, CAST(<INT2> AS INT8)) -> INT8` (exists, but needs to coerce)
  - So, in this scenario, we have computed that the result would be `INT8 | INT4 | MISSING`. `MISSING` when a function cannot be dynamically invoked due to incompatible types.
- NOTE: This does not deal with aggregation functions yet. That is for a subsequent PR.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO** -- planner branch
- Any backward-incompatible changes? **YES** -- no, only to planner branch
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.