### PR TITLE
Fixes derived binder numbering

### DIFF
--- a/partiql-ast/src/test/kotlin/org/partiql/ast/normalize/NormalizeSelectTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/normalize/NormalizeSelectTest.kt
@@ -1,0 +1,184 @@
+package org.partiql.ast.normalize
+
+import org.junit.jupiter.api.Test
+import org.partiql.ast.Expr
+import org.partiql.ast.From
+import org.partiql.ast.Identifier
+import org.partiql.ast.Select
+import org.partiql.ast.builder.ast
+import org.partiql.ast.exprLit
+import org.partiql.ast.exprVar
+import org.partiql.ast.identifierSymbol
+import org.partiql.ast.selectProjectItemExpression
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.int32Value
+import org.partiql.value.stringValue
+import kotlin.test.assertEquals
+
+class NormalizeSelectTest {
+
+    /**
+     * SELECT a, b, c FROM T
+     *
+     * SELECT VALUE {
+     *    'a': a,
+     *    'b': b,
+     *    'c': c
+     * } FROM T
+     */
+    @Test
+    fun testDerivedBinders_00() {
+        val input = select(
+            varItem("a"),
+            varItem("b"),
+            varItem("c"),
+        )
+        val expected = selectValue(
+            "a" to variable("a"),
+            "b" to variable("b"),
+            "c" to variable("c"),
+        )
+        val actual = NormalizeSelect.apply(input)
+        assertEquals(expected, actual)
+    }
+
+    /**
+     * SELECT 1, 2, 3 FROM T
+     *
+     * SELECT VALUE {
+     *      '_1': 1,
+     *      '_2': 2,
+     *      '_3': 3
+     * } FROM T
+     */
+    @Test
+    fun testDerivedBinders_01() {
+        val input = select(
+            litItem(1),
+            litItem(2),
+            litItem(3),
+        )
+        val expected = selectValue(
+            "_1" to lit(1),
+            "_2" to lit(2),
+            "_3" to lit(3),
+        )
+        val actual = NormalizeSelect.apply(input)
+        assertEquals(expected, actual)
+    }
+
+    /**
+     * SELECT a, 2, 3 FROM T
+     *
+     * SELECT VALUE {
+     *      'a': a,
+     *      '_1': 2,
+     *      '_2': 3
+     * } FROM T
+     */
+    @Test
+    fun testDerivedBinders_02() {
+        val input = select(
+            varItem("a"),
+            litItem(2),
+            litItem(3),
+        )
+        val expected = selectValue(
+            "a" to variable("a"),
+            "_1" to lit(2),
+            "_2" to lit(3),
+        )
+        val actual = NormalizeSelect.apply(input)
+        assertEquals(expected, actual)
+    }
+
+    /**
+     * SELECT a AS a, 2 AS b, 3 AS c FROM T
+     *
+     * SELECT VALUE {
+     *      'a': a,
+     *      'b': 2,
+     *      'c': 3
+     * } FROM T
+     */
+    @Test
+    fun testDerivedBinders_03() {
+        val input = select(
+            varItem("a", "a"),
+            litItem(2, "b"),
+            litItem(3, "c"),
+        )
+        val expected = selectValue(
+            "a" to variable("a"),
+            "b" to lit(2),
+            "c" to lit(3),
+        )
+        val actual = NormalizeSelect.apply(input)
+        assertEquals(expected, actual)
+    }
+
+    // ----- HELPERS -------------------------
+
+    private fun variable(name: String) = exprVar(
+        identifier = identifierSymbol(
+            symbol = name,
+            caseSensitivity = Identifier.CaseSensitivity.INSENSITIVE,
+        ),
+        scope = Expr.Var.Scope.DEFAULT,
+    )
+
+    private fun select(vararg items: Select.Project.Item) = ast {
+        statementQuery {
+            expr = exprSFW {
+                select = selectProject {
+                    this.items += items
+                }
+                from = fromValue {
+                    expr = variable("T")
+                    type = From.Value.Type.SCAN
+                }
+            }
+        }
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    private fun selectValue(vararg items: Pair<String, Expr>) = ast {
+        statementQuery {
+            expr = exprSFW {
+                select = selectValue {
+                    constructor = exprStruct {
+                        for ((k, v) in items) {
+                            fields += exprStructField {
+                                name = exprLit(stringValue(k))
+                                value = v
+                            }
+                        }
+                    }
+                }
+                from = fromValue {
+                    expr = exprVar {
+                        identifier = identifierSymbol {
+                            symbol = "T"
+                            caseSensitivity = Identifier.CaseSensitivity.INSENSITIVE
+                        }
+                        scope = Expr.Var.Scope.DEFAULT
+                    }
+                    type = From.Value.Type.SCAN
+                }
+            }
+        }
+    }
+
+    private fun varItem(symbol: String, asAlias: String? = null) = selectProjectItemExpression(
+        expr = variable(symbol),
+        asAlias = asAlias?.let { identifierSymbol(asAlias, Identifier.CaseSensitivity.INSENSITIVE) }
+    )
+
+    private fun litItem(value: Int, asAlias: String? = null) = selectProjectItemExpression(
+        expr = lit(value),
+        asAlias = asAlias?.let { identifierSymbol(asAlias, Identifier.CaseSensitivity.INSENSITIVE) }
+    )
+
+    @OptIn(PartiQLValueExperimental::class)
+    private fun lit(value: Int) = exprLit(int32Value(value))
+}

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
@@ -2474,7 +2474,27 @@ class PartiQLSchemaInferencerTests {
         @JvmStatic
         fun aggregationCases() = listOf(
             SuccessTestCase(
-                name = "AGGREGATE over INTS",
+                name = "AGGREGATE over INTS, without alias",
+                query = "SELECT a, COUNT(*), SUM(a), MIN(b) FROM << {'a': 1, 'b': 2} >> GROUP BY a",
+                expected = BagType(
+                    StructType(
+                        fields = mapOf(
+                            "a" to INT4,
+                            "_1" to INT4,
+                            "_2" to INT4.asNullable(),
+                            "_3" to INT4.asNullable(),
+                        ),
+                        contentClosed = true,
+                        constraints = setOf(
+                            TupleConstraint.Open(false),
+                            TupleConstraint.UniqueAttrs(true),
+                            TupleConstraint.Ordered
+                        )
+                    )
+                )
+            ),
+            SuccessTestCase(
+                name = "AGGREGATE over INTS, with alias",
                 query = "SELECT a, COUNT(*) AS c, SUM(a) AS s, MIN(b) AS m FROM << {'a': 1, 'b': 2} >> GROUP BY a",
                 expected = BagType(
                     StructType(
@@ -2632,7 +2652,7 @@ class PartiQLSchemaInferencerTests {
 
         class IgnoredTestCase(
             val shouldBe: TestCase,
-            reason: String
+            reason: String,
         ) : TestCase() {
             override fun toString(): String = "Disabled - $shouldBe"
         }

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/aggregations/T.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/aggregations/T.ion
@@ -1,0 +1,34 @@
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed, ordered, unique ],
+    fields: [
+      {
+        name: "a",
+        type: "bool",
+      },
+      {
+        name: "b",
+        type: "int32",
+      },
+      {
+        name: "c",
+        type: "string",
+      },
+      {
+        name: "d",
+        type: {
+          type: "struct",
+          constraints: [ closed, ordered, unique ],
+          fields: [
+            {
+              name: "e",
+              type: "string"
+            }
+          ]
+        },
+      }
+    ]
+  }
+}

--- a/partiql-planner/src/testFixtures/resources/inputs/schema_inferencer/aggregations.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/schema_inferencer/aggregations.sql
@@ -1,0 +1,50 @@
+--#[aggs-00]
+SELECT COUNT(*) FROM T;
+
+--#[aggs-01]
+SELECT COUNT(*), COUNT(1), MIN(b), MAX(b), AVG(b) FROM T;
+
+--#[aggs-02]
+SELECT COUNT(*) AS count_star FROM T;
+
+--#[aggs-03]
+SELECT COUNT(*) AS count_star,
+       COUNT(b) AS count_b,
+       MIN(b) AS min_b,
+       MAX(b) AS max_b,
+       AVG(b) AS avg_b
+FROM T;
+
+--#[aggs-04]
+SELECT a, COUNT(*) FROM T GROUP BY a;
+
+--#[aggs-05]
+SELECT COUNT(*), a FROM T GROUP BY a;
+
+--#[aggs-06]
+SELECT a, b, c, MIN(b), MAX(b) FROM T GROUP BY a, b, c;
+
+--#[aggs-07]
+SELECT MIN(b), MAX(b), a, b, c FROM T GROUP BY a, b, c;
+
+--#[aggs-08]
+SELECT a AS _a, COUNT(*) AS count_star FROM T GROUP BY a;
+
+--#[aggs-09]
+SELECT COUNT(*) AS count_star, a AS _a FROM T GROUP BY a;
+
+--#[aggs-10]
+SELECT a AS _a, b AS _b, c AS _c, MIN(b) AS min_b, MAX(b) AS max_b FROM T GROUP BY a, b, c;
+
+--#[aggs-11]
+SELECT MIN(b) AS min_b, MAX(b) AS max_b, a AS _a, b AS _b, c AS _c FROM T GROUP BY a, b, c;
+
+--#[aggs-12]
+SELECT a AS _a, AVG(b) AS avg_b FROM T
+GROUP BY a
+HAVING a = true;
+
+--#[aggs-13]
+SELECT a AS _a, AVG(b) AS avg_b FROM T
+GROUP BY a
+HAVING avg_b > 0;


### PR DESCRIPTION
## Description

We lost derived binding value in the `SELECT *` and didn't have tests on our normalization passes. This simply adds them back via slightly different mechanism. Rather than using the select item index, we increment a shared count. 

```
-- Example
SELECT a, bar(b), baz(c) FROM T

-- before used index (ie _2 and _3)
SELECT VALUE { 'a': a, '_2': bar(b), '_3': baz(c) FROM T

-- bug (always was _1)
SELECT VALUE { 'a': a,  '_1': bar(b), '_1': baz(c) } FROM T

-- bug fixed and counts up
SELECT VALUE { 'a': a, '_1': bar(b), '_2': baz(c) FROM T


```

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.