### PR TITLE
Modifies how we model paths in the plan

### DIFF
--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -83,9 +83,21 @@ rex::{
       steps:  list::[step],
       _: [
         step::[
+          // The key MUST be an integer expression. Ex: a[0], a[1 + 1]
           index::{ key: rex },
-          symbol::{ identifier: '.identifier.symbol' },
+
+          // Case-sensitive lookup. The key MUST be a string expression. Ex: a["b"], a."b", a[CAST(b AS STRING)]
+          key::{ key: rex },
+
+          // Case-insensitive lookup. The key MUST be a literal string. Ex: a.b
+          symbol::{ key: string },
+
+          // For arrays. Ex: a[*]
+          // TODO: Do we need this? According to specification: [1,2,3][*] ⇔ SELECT VALUE v FROM [1, 2, 3] AS v
           wildcard::{},
+
+          // For tuples. Ex: a.*
+          // TODO: Do we need this? According to specification: {'a':1, 'b':2}.* ⇔ SELECT VALUE v FROM UNPIVOT {'a':1, 'b':2} AS v
           unpivot::{},
         ],
       ],

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
@@ -432,6 +432,7 @@ internal data class Rex(
                     is Symbol -> visitor.visitRexOpPathStepSymbol(this, ctx)
                     is Wildcard -> visitor.visitRexOpPathStepWildcard(this, ctx)
                     is Unpivot -> visitor.visitRexOpPathStepUnpivot(this, ctx)
+                    is Key -> visitor.visitRexOpPathStepKey(this, ctx)
                 }
 
                 internal data class Index(
@@ -453,6 +454,44 @@ internal data class Rex(
                     }
                 }
 
+                /**
+                 * This represents a case-sensitive lookup on a tuple. Ex: a['b'] or a[CAST('a' || 'b' AS STRING)].
+                 * This would normally contain the dot notation for case-sensitive lookup, however, due to
+                 * limitations -- we cannot consolidate these. See [Symbol] for more information.
+                 *
+                 * The main difference is that this does NOT include `a."b"`
+                 */
+                internal data class Key(
+                    @JvmField
+                    internal val key: Rex,
+                ) : Step() {
+                    internal override val children: List<PlanNode> by lazy {
+                        val kids = mutableListOf<PlanNode?>()
+                        kids.add(key)
+                        kids.filterNotNull()
+                    }
+
+                    internal override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
+                        visitor.visitRexOpPathStepKey(this, ctx)
+
+                    internal companion object {
+                        @JvmStatic
+                        internal fun builder(): RexOpPathStepIndexBuilder = RexOpPathStepIndexBuilder()
+                    }
+                }
+
+                /**
+                 * This represents a lookup on a tuple. We differentiate a [Key] and a [Symbol] at this point in the
+                 * pipeline because we NEED to retain some syntactic knowledge for the following reason: we cannot
+                 * use the syntactic index operation on a schema -- as it is not synonymous with a tuple. In other words,
+                 * `<schema-name>."<value-name>"` is not interchangeable with `<schema-name>['<value-name>']`.
+                 *
+                 * So, in order to temporarily differentiate the `a."b"` from `a['b']` (see [Key]), we need to maintain
+                 * the syntactic difference here. Note that this would potentially be mitigated by typing during the AST to Plan
+                 * transformation.
+                 *
+                 * That being said, this represents a lookup on a tuple such as `a.b` or `a."b"`.
+                 */
                 internal data class Symbol(
                     @JvmField
                     internal val identifier: Identifier.Symbol,

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Plan.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Plan.kt
@@ -55,6 +55,8 @@ internal fun rexOpPath(root: Rex, steps: List<Rex.Op.Path.Step>): Rex.Op.Path = 
 
 internal fun rexOpPathStepIndex(key: Rex): Rex.Op.Path.Step.Index = Rex.Op.Path.Step.Index(key)
 
+internal fun rexOpPathStepKey(key: Rex): Rex.Op.Path.Step.Key = Rex.Op.Path.Step.Key(key)
+
 internal fun rexOpPathStepSymbol(identifier: Identifier.Symbol): Rex.Op.Path.Step.Symbol =
     Rex.Op.Path.Step.Symbol(identifier)
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilder.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilder.kt
@@ -174,6 +174,15 @@ internal class PlanBuilder {
         return builder.build()
     }
 
+    internal fun rexOpPathStepKey(
+        key: Rex? = null,
+        block: RexOpPathStepKeyBuilder.() -> Unit = {},
+    ): Rex.Op.Path.Step.Key {
+        val builder = RexOpPathStepKeyBuilder(key)
+        builder.block()
+        return builder.build()
+    }
+
     internal fun rexOpPathStepSymbol(
         identifier: Identifier.Symbol? = null,
         block: RexOpPathStepSymbolBuilder.() -> Unit = {},

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilders.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilders.kt
@@ -250,6 +250,16 @@ internal class RexOpPathStepIndexBuilder(
     internal fun build(): Rex.Op.Path.Step.Index = Rex.Op.Path.Step.Index(key = key!!)
 }
 
+internal class RexOpPathStepKeyBuilder(
+    internal var key: Rex? = null,
+) {
+    internal fun key(key: Rex?): RexOpPathStepKeyBuilder = this.apply {
+        this.key = key
+    }
+
+    internal fun build(): Rex.Op.Path.Step.Key = Rex.Op.Path.Step.Key(key = key!!)
+}
+
 internal class RexOpPathStepSymbolBuilder(
     internal var identifier: Identifier.Symbol? = null,
 ) {

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/visitor/PlanBaseVisitor.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/visitor/PlanBaseVisitor.kt
@@ -100,12 +100,16 @@ internal abstract class PlanBaseVisitor<R, C> : PlanVisitor<R, C> {
 
     override fun visitRexOpPathStep(node: Rex.Op.Path.Step, ctx: C): R = when (node) {
         is Rex.Op.Path.Step.Index -> visitRexOpPathStepIndex(node, ctx)
+        is Rex.Op.Path.Step.Key -> visitRexOpPathStepKey(node, ctx)
         is Rex.Op.Path.Step.Symbol -> visitRexOpPathStepSymbol(node, ctx)
         is Rex.Op.Path.Step.Wildcard -> visitRexOpPathStepWildcard(node, ctx)
         is Rex.Op.Path.Step.Unpivot -> visitRexOpPathStepUnpivot(node, ctx)
     }
 
     override fun visitRexOpPathStepIndex(node: Rex.Op.Path.Step.Index, ctx: C): R =
+        defaultVisit(node, ctx)
+
+    override fun visitRexOpPathStepKey(node: Rex.Op.Path.Step.Key, ctx: C): R =
         defaultVisit(node, ctx)
 
     override fun visitRexOpPathStepSymbol(node: Rex.Op.Path.Step.Symbol, ctx: C): R =

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/visitor/PlanVisitor.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/visitor/PlanVisitor.kt
@@ -64,6 +64,8 @@ internal interface PlanVisitor<R, C> {
 
     fun visitRexOpPathStepIndex(node: Rex.Op.Path.Step.Index, ctx: C): R
 
+    fun visitRexOpPathStepKey(node: Rex.Op.Path.Step.Key, ctx: C): R
+
     fun visitRexOpPathStepSymbol(node: Rex.Op.Path.Step.Symbol, ctx: C): R
 
     fun visitRexOpPathStepWildcard(node: Rex.Op.Path.Step.Wildcard, ctx: C): R

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -3,6 +3,10 @@ package org.partiql.planner.internal.transforms
 import org.partiql.errors.ProblemCallback
 import org.partiql.plan.PlanNode
 import org.partiql.plan.partiQLPlan
+import org.partiql.plan.rex
+import org.partiql.plan.rexOpLit
+import org.partiql.plan.rexOpPathStepKey
+import org.partiql.plan.rexOpPathStepSymbol
 import org.partiql.planner.internal.ir.Agg
 import org.partiql.planner.internal.ir.Fn
 import org.partiql.planner.internal.ir.Global
@@ -12,7 +16,9 @@ import org.partiql.planner.internal.ir.Rel
 import org.partiql.planner.internal.ir.Rex
 import org.partiql.planner.internal.ir.Statement
 import org.partiql.planner.internal.ir.visitor.PlanBaseVisitor
+import org.partiql.types.StaticType
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.stringValue
 
 /**
  * This is an internal utility to translate from the internal unresolved plan used for typing to the public plan IR.
@@ -120,10 +126,15 @@ internal object PlanTransform : PlanBaseVisitor<PlanNode, ProblemCallback>() {
             key = visitRex(node.key, ctx),
         )
 
-    override fun visitRexOpPathStepSymbol(node: Rex.Op.Path.Step.Symbol, ctx: ProblemCallback) =
-        org.partiql.plan.Rex.Op.Path.Step.Symbol(
-            identifier = visitIdentifierSymbol(node.identifier, ctx),
-        )
+    @OptIn(PartiQLValueExperimental::class)
+    override fun visitRexOpPathStepSymbol(node: Rex.Op.Path.Step.Symbol, ctx: ProblemCallback) = when (node.identifier.caseSensitivity) {
+        Identifier.CaseSensitivity.SENSITIVE -> rexOpPathStepKey(rex(StaticType.STRING, rexOpLit(stringValue(node.identifier.symbol))))
+        Identifier.CaseSensitivity.INSENSITIVE -> rexOpPathStepSymbol(node.identifier.symbol)
+    }
+
+    override fun visitRexOpPathStepKey(node: Rex.Op.Path.Step.Key, ctx: ProblemCallback): PlanNode = rexOpPathStepKey(
+        key = visitRex(node.key, ctx)
+    )
 
     override fun visitRexOpPathStepWildcard(node: Rex.Op.Path.Step.Wildcard, ctx: ProblemCallback) =
         org.partiql.plan.Rex.Op.Path.Step.Wildcard()
@@ -132,7 +143,7 @@ internal object PlanTransform : PlanBaseVisitor<PlanNode, ProblemCallback>() {
         org.partiql.plan.Rex.Op.Path.Step.Unpivot()
 
     override fun visitRexOpCall(node: Rex.Op.Call, ctx: ProblemCallback) =
-        super.visitRexOpCall(node, ctx) as org.partiql.plan.Rex.Op.Call
+        super.visitRexOpCall(node, ctx) as org.partiql.plan.Rex.Op
 
     override fun visitRexOpCallStatic(node: Rex.Op.Call.Static, ctx: ProblemCallback): org.partiql.plan.Rex.Op {
         val fn = visitFn(node.fn, ctx)


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Modifies how we model paths in the plan
- As discussed offline, when dealing with the semantics of pathing, there are 3 core operations:
  1. Indexing into an array. Ex: `a[0], a[1 + 1]`
  2. Sensitive lookup in a tuple. Ex: `a."b", a['b'], a[CAST('a' || 'b' AS STRING)]`
  3. Insensitive lookup in a tuple. Ex: `a.b`
- The above will be part of the PUBLIC API. However, in order to appropriately handle the subtle differences between `a.b`, `a."b"`, and `a['b']` when we haven't typed yet-- the internal APIs contain:
  1. Indexing into an array. Ex: `a[0], a[1 + 1]`
  2. Sensitive lookup on a tuple. Ex: `a['b'], a[CAST('a' || 'b' AS STRING)]`
  3. Dot-notation lookup on a tuple/schema. Ex: `a.b` and `a."b"`. This has a subtle difference to the public API.
- We convert the dot-notation lookup to either a sensitive or insensitive lookup after typing/resolving. In my opinion, this should happen at the AST transformation, however, that is not currently supported.
- See the added `PartiQLSchemaInferencerTests` for more information.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **YES**
  - Yes, but for the unreleased planner.
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.