### PR TITLE
Removes the dynamic function definition

### DIFF
--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -21,14 +21,9 @@ global::{
 
 // Functions
 
-fn::[
-  static::{
-    signature: scalar_signature,
-  },
-  dynamic::{
-    signatures: list::[scalar_signature],
-  }
-]
+fn::{
+  signature: scalar_signature,
+}
 
 agg::{
   signature: aggregation_signature,

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
@@ -4,7 +4,6 @@ package org.partiql.planner.internal.ir
 
 import org.partiql.planner.internal.ir.builder.AggResolvedBuilder
 import org.partiql.planner.internal.ir.builder.AggUnresolvedBuilder
-import org.partiql.planner.internal.ir.builder.FnDynamicBuilder
 import org.partiql.planner.internal.ir.builder.FnResolvedBuilder
 import org.partiql.planner.internal.ir.builder.FnUnresolvedBuilder
 import org.partiql.planner.internal.ir.builder.GlobalBuilder
@@ -126,7 +125,6 @@ internal sealed class Fn : PlanNode() {
     internal override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R = when (this) {
         is Resolved -> visitor.visitFnResolved(this, ctx)
         is Unresolved -> visitor.visitFnUnresolved(this, ctx)
-        is Dynamic -> visitor.visitFnDynamic(this, ctx)
     }
 
     internal data class Resolved(
@@ -162,21 +160,6 @@ internal sealed class Fn : PlanNode() {
         internal companion object {
             @JvmStatic
             internal fun builder(): FnUnresolvedBuilder = FnUnresolvedBuilder()
-        }
-    }
-
-    internal data class Dynamic(
-        @JvmField
-        internal val signatures: List<FunctionSignature.Scalar>,
-    ) : Fn() {
-        internal override val children: List<PlanNode> = emptyList()
-
-        internal override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
-            visitor.visitFnDynamic(this, ctx)
-
-        internal companion object {
-            @JvmStatic
-            internal fun builder(): FnDynamicBuilder = FnDynamicBuilder()
         }
     }
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Plan.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Plan.kt
@@ -21,9 +21,6 @@ internal fun fnResolved(signature: FunctionSignature.Scalar): Fn.Resolved = Fn.R
 internal fun fnUnresolved(identifier: Identifier, isHidden: Boolean): Fn.Unresolved =
     Fn.Unresolved(identifier, isHidden)
 
-internal fun fnDynamic(signatures: List<FunctionSignature.Scalar>): Fn.Dynamic =
-    Fn.Dynamic(signatures)
-
 internal fun aggResolved(signature: FunctionSignature.Aggregation): Agg.Resolved =
     Agg.Resolved(signature)
 
@@ -39,6 +36,7 @@ internal fun identifierQualified(root: Identifier.Symbol, steps: List<Identifier
 
 internal fun rex(type: StaticType, op: Rex.Op): Rex = Rex(type, op)
 
+@OptIn(PartiQLValueExperimental::class)
 internal fun rexOpLit(`value`: PartiQLValue): Rex.Op.Lit = Rex.Op.Lit(value)
 
 internal fun rexOpVarResolved(ref: Int): Rex.Op.Var.Resolved = Rex.Op.Var.Resolved(ref)

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilder.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilder.kt
@@ -60,15 +60,6 @@ internal class PlanBuilder {
         return builder.build()
     }
 
-    internal fun fnDynamic(
-        signatures: MutableList<FunctionSignature.Scalar> = mutableListOf(),
-        block: FnDynamicBuilder.() -> Unit = {},
-    ): Fn.Dynamic {
-        val builder = FnDynamicBuilder(signatures)
-        builder.block()
-        return builder.build()
-    }
-
     internal fun aggResolved(
         signature: FunctionSignature.Aggregation? = null,
         block: AggResolvedBuilder.() -> Unit = {},

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilders.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilders.kt
@@ -84,17 +84,6 @@ internal class FnUnresolvedBuilder(
     )
 }
 
-internal class FnDynamicBuilder(
-    internal var signatures: MutableList<FunctionSignature.Scalar> = mutableListOf(),
-) {
-    internal fun signatures(signatures: MutableList<FunctionSignature.Scalar>): FnDynamicBuilder =
-        this.apply {
-            this.signatures = signatures
-        }
-
-    internal fun build(): Fn.Dynamic = Fn.Dynamic(signatures = signatures)
-}
-
 internal class AggResolvedBuilder(
     internal var signature: FunctionSignature.Aggregation? = null,
 ) {

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/util/PlanRewriter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/util/PlanRewriter.kt
@@ -121,11 +121,6 @@ internal abstract class PlanRewriter<C> : PlanBaseVisitor<PlanNode, C>() {
         }
     }
 
-    override fun visitFnDynamic(node: Fn.Dynamic, ctx: C): PlanNode {
-        val signatures = node.signatures
-        return node
-    }
-
     override fun visitAggResolved(node: Agg.Resolved, ctx: C): PlanNode {
         val signature = node.signature
         return node

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/visitor/PlanBaseVisitor.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/visitor/PlanBaseVisitor.kt
@@ -23,14 +23,11 @@ internal abstract class PlanBaseVisitor<R, C> : PlanVisitor<R, C> {
     override fun visitFn(node: Fn, ctx: C): R = when (node) {
         is Fn.Resolved -> visitFnResolved(node, ctx)
         is Fn.Unresolved -> visitFnUnresolved(node, ctx)
-        is Fn.Dynamic -> visitFnDynamic(node, ctx)
     }
 
     override fun visitFnResolved(node: Fn.Resolved, ctx: C): R = defaultVisit(node, ctx)
 
     override fun visitFnUnresolved(node: Fn.Unresolved, ctx: C): R = defaultVisit(node, ctx)
-
-    override fun visitFnDynamic(node: Fn.Dynamic, ctx: C): R = defaultVisit(node, ctx)
 
     override fun visitAgg(node: Agg, ctx: C): R = when (node) {
         is Agg.Resolved -> visitAggResolved(node, ctx)

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/visitor/PlanVisitor.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/visitor/PlanVisitor.kt
@@ -26,8 +26,6 @@ internal interface PlanVisitor<R, C> {
 
     fun visitFnUnresolved(node: Fn.Unresolved, ctx: C): R
 
-    fun visitFnDynamic(node: Fn.Dynamic, ctx: C): R
-
     fun visitAgg(node: Agg, ctx: C): R
 
     fun visitAggResolved(node: Agg.Resolved, ctx: C): R

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -40,13 +40,11 @@ internal object PlanTransform : PlanBaseVisitor<PlanNode, ProblemCallback>() {
         return org.partiql.plan.global(path, type)
     }
 
-    override fun visitFnResolved(node: Fn.Resolved, ctx: ProblemCallback) = org.partiql.plan.fnStatic(node.signature)
+    override fun visitFnResolved(node: Fn.Resolved, ctx: ProblemCallback) = org.partiql.plan.fn(node.signature)
 
     override fun visitFnUnresolved(node: Fn.Unresolved, ctx: ProblemCallback): org.partiql.plan.Rex.Op {
         return org.partiql.plan.Rex.Op.Err("Unresolved function")
     }
-
-    override fun visitFnDynamic(node: Fn.Dynamic, ctx: ProblemCallback) = org.partiql.plan.fnDynamic(node.signatures)
 
     override fun visitAgg(node: Agg, ctx: ProblemCallback) = super.visitAgg(node, ctx) as org.partiql.plan.Agg
 


### PR DESCRIPTION
## Relevant Issues
- #1267 

## Description
- I realize I left an unused plan node in my PR of dynamic dispatch of functions. In the PR above, there is both a scalar function call (of static, unresolved, and dynamic) and a scalar function definition (resolved, unresolved, dynamic). There need not be a "definition" of a dynamic function call -- as this wouldn't make much sense. Hence, it was unused.
- This PR removes the node. Since it was unused, no other code needs to be modified.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.