### PR TITLE
add support of text and bool type to comparison

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
@@ -254,19 +254,19 @@ public object PartiQLHeader : Header() {
         ),
     )
 
-    private fun lt(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
+    private fun lt(): List<FunctionSignature.Scalar> = (types.numeric + types.text + BOOL).map { t ->
         binary("lt", BOOL, t, t)
     }
 
-    private fun lte(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
+    private fun lte(): List<FunctionSignature.Scalar> = (types.numeric + types.text + BOOL).map { t ->
         binary("lte", BOOL, t, t)
     }
 
-    private fun gt(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
+    private fun gt(): List<FunctionSignature.Scalar> = (types.numeric + types.text + BOOL).map { t ->
         binary("gt", BOOL, t, t)
     }
 
-    private fun gte(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
+    private fun gte(): List<FunctionSignature.Scalar> = (types.numeric + types.text + BOOL).map { t ->
         binary("gte", BOOL, t, t)
     }
 
@@ -347,7 +347,7 @@ public object PartiQLHeader : Header() {
         )
     }
 
-    private fun between(): List<FunctionSignature.Scalar> = types.numeric.map { t ->
+    private fun between(): List<FunctionSignature.Scalar> = (types.numeric + types.text).map { t ->
         FunctionSignature.Scalar(
             name = "between",
             returns = BOOL,

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpBetweenTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpBetweenTest.kt
@@ -24,6 +24,10 @@ class OpBetweenTest : PartiQLTyperTestBase() {
                     allNumberType + listOf(StaticType.NULL),
                     allNumberType + listOf(StaticType.NULL),
                     allNumberType + listOf(StaticType.NULL),
+                ) + cartesianProduct(
+                    StaticType.TEXT.allTypes + listOf(StaticType.CLOB, StaticType.NULL),
+                    StaticType.TEXT.allTypes + listOf(StaticType.CLOB, StaticType.NULL),
+                    StaticType.TEXT.allTypes + listOf(StaticType.CLOB, StaticType.NULL)
                 )
 
             val failureArgs = cartesianProduct(

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpComparisonTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpComparisonTest.kt
@@ -3,10 +3,8 @@ package org.partiql.planner.internal.typer.predicate
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
-import org.partiql.planner.util.CastType
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.cartesianProduct
-import org.partiql.planner.util.castTable
 import org.partiql.types.StaticType
 import java.util.stream.Stream
 
@@ -59,6 +57,12 @@ class OpComparisonTest : PartiQLTyperTestBase() {
                 cartesianProduct(
                     StaticType.NUMERIC.allTypes + listOf(StaticType.NULL),
                     StaticType.NUMERIC.allTypes + listOf(StaticType.NULL)
+                ) + cartesianProduct(
+                    StaticType.TEXT.allTypes + listOf(StaticType.CLOB, StaticType.NULL),
+                    StaticType.TEXT.allTypes + listOf(StaticType.CLOB, StaticType.NULL)
+                ) + cartesianProduct(
+                    listOf(StaticType.BOOL, StaticType.NULL),
+                    listOf(StaticType.BOOL, StaticType.NULL)
                 )
             val failureArgs = cartesianProduct(
                 allSupportedType,
@@ -68,23 +72,9 @@ class OpComparisonTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                val arg0 = args.first()
-                val arg1 = args[1]
-                if (args.contains(StaticType.MISSING)) {
-                    (this[TestResult.Success(StaticType.MISSING)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.MISSING), it + setOf(args))
-                    }
-                } else if (args.contains(StaticType.NULL)) {
+                if (args.contains(StaticType.NULL)) {
                     (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
                         put(TestResult.Success(StaticType.NULL), it + setOf(args))
-                    }
-                } else if (arg0 == arg1) {
-                    (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.BOOL), it + setOf(args))
-                    }
-                } else if (castTable(arg1, arg0) == CastType.COERCION) {
-                    (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.BOOL), it + setOf(args))
                     }
                 } else {
                     (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] N/A

## Description
- Add support of Boolean Type and Text Type (Symbol, String, Clob) to comparison predicate (greater than, greater than or equal, less than, less than or equal.)
- Add support for Text type in Between predicate. 
- SQL spec permits comparison between: 
    - Number
    - Character String
    - Binary String
    - datetime
    - Interval
    - Boolean 


## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No. 

- Any backward-incompatible changes? **[YES/NO]**
  -  No. 

- Any new external dependencies? **[YES/NO]**
  -  No. 

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
- Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.