### PR TITLE
Support Datetime Types in comparison functions

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
@@ -254,19 +254,19 @@ public object PartiQLHeader : Header() {
         ),
     )
 
-    private fun lt(): List<FunctionSignature.Scalar> = (types.numeric + types.text + BOOL).map { t ->
+    private fun lt(): List<FunctionSignature.Scalar> = (types.numeric + types.text + types.datetime + BOOL).map { t ->
         binary("lt", BOOL, t, t)
     }
 
-    private fun lte(): List<FunctionSignature.Scalar> = (types.numeric + types.text + BOOL).map { t ->
+    private fun lte(): List<FunctionSignature.Scalar> = (types.numeric + types.text + types.datetime + BOOL).map { t ->
         binary("lte", BOOL, t, t)
     }
 
-    private fun gt(): List<FunctionSignature.Scalar> = (types.numeric + types.text + BOOL).map { t ->
+    private fun gt(): List<FunctionSignature.Scalar> = (types.numeric + types.text + types.datetime + BOOL).map { t ->
         binary("gt", BOOL, t, t)
     }
 
-    private fun gte(): List<FunctionSignature.Scalar> = (types.numeric + types.text + BOOL).map { t ->
+    private fun gte(): List<FunctionSignature.Scalar> = (types.numeric + types.text + types.datetime + BOOL).map { t ->
         binary("gte", BOOL, t, t)
     }
 
@@ -347,7 +347,7 @@ public object PartiQLHeader : Header() {
         )
     }
 
-    private fun between(): List<FunctionSignature.Scalar> = (types.numeric + types.text).map { t ->
+    private fun between(): List<FunctionSignature.Scalar> = (types.numeric + types.text + types.datetime).map { t ->
         FunctionSignature.Scalar(
             name = "between",
             returns = BOOL,

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
@@ -51,6 +51,7 @@ import org.partiql.value.StringValue
 import org.partiql.value.boolValue
 import org.partiql.value.int32Value
 import org.partiql.value.int64Value
+import org.partiql.value.io.PartiQLValueIonReaderBuilder
 import org.partiql.value.nullValue
 
 /**
@@ -74,6 +75,17 @@ internal object RexConverter {
             }
             val op = rexOpLit(node.value)
             return rex(type, op)
+        }
+
+        override fun visitExprIon(node: Expr.Ion, ctx: Env): Rex {
+            val value =
+                PartiQLValueIonReaderBuilder
+                    .standard().build(node.value).read()
+            val type = when (value.isNull) {
+                true -> value.type.toStaticType()
+                else -> value.type.toNonNullStaticType()
+            }
+            return rex(type, rexOpLit(value))
         }
 
         /**

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpBetweenTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpBetweenTest.kt
@@ -28,6 +28,18 @@ class OpBetweenTest : PartiQLTyperTestBase() {
                     StaticType.TEXT.allTypes + listOf(StaticType.CLOB, StaticType.NULL),
                     StaticType.TEXT.allTypes + listOf(StaticType.CLOB, StaticType.NULL),
                     StaticType.TEXT.allTypes + listOf(StaticType.CLOB, StaticType.NULL)
+                ) + cartesianProduct(
+                    listOf(StaticType.DATE, StaticType.NULL),
+                    listOf(StaticType.DATE, StaticType.NULL),
+                    listOf(StaticType.DATE, StaticType.NULL)
+                ) + cartesianProduct(
+                    listOf(StaticType.TIME, StaticType.NULL),
+                    listOf(StaticType.TIME, StaticType.NULL),
+                    listOf(StaticType.TIME, StaticType.NULL)
+                ) + cartesianProduct(
+                    listOf(StaticType.TIMESTAMP, StaticType.NULL),
+                    listOf(StaticType.TIMESTAMP, StaticType.NULL),
+                    listOf(StaticType.TIMESTAMP, StaticType.NULL)
                 )
 
             val failureArgs = cartesianProduct(

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpComparisonTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpComparisonTest.kt
@@ -63,7 +63,17 @@ class OpComparisonTest : PartiQLTyperTestBase() {
                 ) + cartesianProduct(
                     listOf(StaticType.BOOL, StaticType.NULL),
                     listOf(StaticType.BOOL, StaticType.NULL)
+                ) + cartesianProduct(
+                    listOf(StaticType.DATE, StaticType.NULL),
+                    listOf(StaticType.DATE, StaticType.NULL)
+                ) + cartesianProduct(
+                    listOf(StaticType.TIME, StaticType.NULL),
+                    listOf(StaticType.TIME, StaticType.NULL)
+                ) + cartesianProduct(
+                    listOf(StaticType.TIMESTAMP, StaticType.NULL),
+                    listOf(StaticType.TIMESTAMP, StaticType.NULL)
                 )
+
             val failureArgs = cartesianProduct(
                 allSupportedType,
                 allSupportedType,

--- a/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
@@ -3,6 +3,10 @@ package org.partiql.value.io
 import com.amazon.ion.IonReader
 import com.amazon.ion.IonType
 import com.amazon.ion.system.IonReaderBuilder
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ion.system.IonTextWriterBuilder
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.toIonValue
 import org.partiql.value.DecimalValue
 import org.partiql.value.IntValue
 import org.partiql.value.PartiQLValue
@@ -27,6 +31,8 @@ import org.partiql.value.structValue
 import org.partiql.value.symbolValue
 import org.partiql.value.timeValue
 import org.partiql.value.timestampValue
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.math.BigDecimal
@@ -618,6 +624,15 @@ public class PartiQLValueIonReaderBuilder private constructor(
             ionReader = ionReaderBuilder.build(inputStream),
             sourceDataFormat = sourceDataFormat
         )
+
+    public fun build(ionElement: IonElement): PartiQLValueReader {
+        val out = ByteArrayOutputStream()
+        val reader = IonReaderBuilder.standard().build(ionElement.toIonValue(IonSystemBuilder.standard().build()))
+        val writer = IonTextWriterBuilder.standard().build(out)
+        writer.writeValues(reader)
+        val input = ByteArrayInputStream(out.toByteArray())
+        return build(input)
+    }
 
     public fun sourceDataFormat(sourceDataFormat: SourceDataFormat): PartiQLValueIonReaderBuilder = this.apply {
         this.sourceDataFormat = sourceDataFormat


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] N/A

## Description
1. Adds support for using datetime types in comparison function in the Function header.
2. Convert Ion Value to PartiQL value in Rex Converter.
3. Adds a convenient API in PartiQLValueIonReader for easier loading of ionElement to PartiQLValue.

Note that as of today we don't support implicit casting between date time types. i.e., Timestamp to Date, Timestamp to time etc. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No. 

- Any backward-incompatible changes? **[YES/NO]**
  -  No. 

- Any new external dependencies? **[YES/NO]**
  -  No. 
  
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
- No. 


## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.