### PR TITLE
Fix Timestamp Type Parsing Issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Thank you to all who have contributed!
 
 ### Fixed
 - Fixes the CLI hanging on invalid queries. See issue #1230.
+- Fixes Timestamp Type parsing issue. Previously Timestamp Type would get parsed to a Time type.
 
 ### Removed
 - **Breaking** Removed IR factory in favor of static top-level functions. Change `Ast.foo()`

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
@@ -1333,7 +1333,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
         translate(node) { metas -> timestampType(node.precision?.toLong(), metas) }
 
     override fun visitTypeTimestampWithTz(node: Type.TimestampWithTz, ctx: Ctx) =
-        throw IllegalArgumentException("TIMESTAMP [WITH TIMEZONE] type not supported")
+        translate(node) { metas -> timestampWithTimeZoneType(node.precision?.toLong(), metas) }
 
     override fun visitTypeInterval(node: Type.Interval, ctx: Ctx) =
         throw IllegalArgumentException("INTERVAL type not supported")

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -378,6 +378,42 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     )
 
     @Test
+    fun callIsTimestampWithTimeZone() = assertExpression(
+        "t1 IS TIMESTAMP WITH TIME ZONE",
+        "(is_type (id t1 (case_insensitive) (unqualified)) (timestamp_with_time_zone_type null))"
+    )
+
+    @Test
+    fun callIsTimeWithTimeZone() = assertExpression(
+        "t1 IS TIME WITH TIME ZONE",
+        "(is_type (id t1 (case_insensitive) (unqualified)) (time_with_time_zone_type null))"
+    )
+
+    @Test
+    fun callIsTimestampWithPrecision() = assertExpression(
+        "t1 IS TIMESTAMP(3)",
+        "(is_type (id t1 (case_insensitive) (unqualified)) (timestamp_type 3))"
+    )
+
+    @Test
+    fun callIsTimeWithPrecision() = assertExpression(
+        "t1 IS TIME(3)",
+        "(is_type (id t1 (case_insensitive) (unqualified)) (time_type 3))"
+    )
+
+    @Test
+    fun callIsTimestampWithTimeZoneAndPrecision() = assertExpression(
+        "t1 IS TIMESTAMP(3) WITH TIME ZONE",
+        "(is_type (id t1 (case_insensitive) (unqualified)) (timestamp_with_time_zone_type 3))"
+    )
+
+    @Test
+    fun callIsTimeWithTimeZoneAndPrecision() = assertExpression(
+        "t1 IS TIME(3) WITH TIME ZONE",
+        "(is_type (id t1 (case_insensitive) (unqualified)) (time_with_time_zone_type 3))"
+    )
+
+    @Test
     fun nullIsNotNull() = assertExpression(
         "null IS NOT NULL",
         "(not (is_type (lit null) (null_type)))"

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -366,6 +366,18 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     )
 
     @Test
+    fun callIsTimestamp() = assertExpression(
+        "t1 IS TIMESTAMP",
+        "(is_type (id t1 (case_insensitive) (unqualified)) (timestamp_type null))"
+    )
+
+    @Test
+    fun callIsTime() = assertExpression(
+        "t1 IS TIME",
+        "(is_type (id t1 (case_insensitive) (unqualified)) (time_type null))"
+    )
+
+    @Test
     fun nullIsNotNull() = assertExpression(
         "null IS NOT NULL",
         "(not (is_type (lit null) (null_type)))"

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
@@ -198,6 +198,7 @@ import org.partiql.ast.typeSymbol
 import org.partiql.ast.typeTime
 import org.partiql.ast.typeTimeWithTz
 import org.partiql.ast.typeTimestamp
+import org.partiql.ast.typeTimestampWithTz
 import org.partiql.ast.typeTuple
 import org.partiql.ast.typeVarchar
 import org.partiql.parser.PartiQLLexerException
@@ -2079,9 +2080,17 @@ internal class PartiQLParserDefault : PartiQLParser {
                 if (p < 0 || 9 < p) throw error(ctx.precision, "Unsupported time precision")
                 p
             }
-            when (ctx.ZONE()) {
-                null -> typeTime(precision)
-                else -> typeTimeWithTz(precision)
+
+            when (ctx.datatype.type) {
+                GeneratedParser.TIME -> when (ctx.ZONE()) {
+                    null -> typeTime(precision)
+                    else -> typeTimeWithTz(precision)
+                }
+                GeneratedParser.TIMESTAMP -> when (ctx.ZONE()) {
+                    null -> typeTimestamp(precision)
+                    else -> typeTimestampWithTz(precision)
+                }
+                else -> throw error(ctx.datatype, "Invalid datatype")
             }
         }
 


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] N/A

## Description
- Previously the timestamp type would get parsed to a Time Type due to a bug in the parser. 
```
t1 is Timestamp
```

```
Expected:
(is_type
    (id t1 (case_insensitive) (unqualified))
    (timestamp_type
        null))
Actual:
(is_type
    (id t1 (case_insensitive) (unqualified))
    (time_type
        null))
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - Yes. 

- Any backward-incompatible changes? **[YES/NO]**
  - Yes. Bug fix. 
  
  
- Any new external dependencies? **[YES/NO]**
  -  No.
  
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.