### PR TITLE
Adds support for EXCLUDE in the default SqlDialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Thank you to all who have contributed!
 - **EXPERIMENTAL** Evaluation of `EXCLUDE` in the `EvaluatingCompiler`
   - This is currently marked as experimental until the RFC is approved https://github.com/partiql/partiql-lang/issues/27
   - This will be added to the `PhysicalPlanCompiler` in an upcoming release
+- **EXPERIMENTAL**: Adds support for EXCLUDE in the default SqlDialect.
 
 ### Changed
 - StaticTypeInferencer and PlanTyper will not raise an error when an expression is inferred to `NULL` or `unionOf(NULL, MISSING)`. In these cases the StaticTypeInferencer and PlanTyper will still raise the Problem Code `ExpressionAlwaysReturnsNullOrMissing` but the severity of the problem has been changed to warning. In the case an expression always returns `MISSING`, problem code `ExpressionAlwaysReturnsMissing` will be raised, which will have problem severity of error.


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds support for EXCLUDE in the default SqlDialect

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.