### PR TITLE
fix typer/transfomrer

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -49,7 +49,7 @@ internal object PlanTransform : PlanBaseVisitor<PlanNode, ProblemCallback>() {
     override fun visitFnResolved(node: Fn.Resolved, ctx: ProblemCallback) = org.partiql.plan.fn(node.signature)
 
     override fun visitFnUnresolved(node: Fn.Unresolved, ctx: ProblemCallback): org.partiql.plan.Rex.Op {
-        return org.partiql.plan.Rex.Op.Err("Unresolved function")
+        error("Unresolved function ${node.identifier}")
     }
 
     override fun visitAgg(node: Agg, ctx: ProblemCallback) = super.visitAgg(node, ctx) as org.partiql.plan.Agg
@@ -57,7 +57,7 @@ internal object PlanTransform : PlanBaseVisitor<PlanNode, ProblemCallback>() {
     override fun visitAggResolved(node: Agg.Resolved, ctx: ProblemCallback) = org.partiql.plan.Agg(node.signature)
 
     override fun visitAggUnresolved(node: Agg.Unresolved, ctx: ProblemCallback): org.partiql.plan.Rex.Op {
-        return org.partiql.plan.Rex.Op.Err("Unresolved aggregation")
+        error("Unresolved aggregation ${node.identifier}")
     }
 
     override fun visitStatement(node: Statement, ctx: ProblemCallback) =

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -503,6 +503,17 @@ internal class PlanTyper(
             return rex(type, rexOpPath(root, newSteps))
         }
 
+        // Default returns the original node, in some case we need the resolved node.
+        // i.e., the path step is a call node
+        override fun visitRexOpPathStep(node: Rex.Op.Path.Step, ctx: StaticType?): Rex.Op.Path.Step =
+            when (node) {
+                is Rex.Op.Path.Step.Index -> Rex.Op.Path.Step.Index(visitRex(node.key, ctx))
+                is Rex.Op.Path.Step.Key -> Rex.Op.Path.Step.Key(visitRex(node.key, ctx))
+                is Rex.Op.Path.Step.Symbol -> Rex.Op.Path.Step.Symbol(node.identifier)
+                is Rex.Op.Path.Step.Unpivot -> Rex.Op.Path.Step.Unpivot()
+                is Rex.Op.Path.Step.Wildcard -> Rex.Op.Path.Step.Wildcard()
+            }
+
         /**
          * Resolve and type scalar function calls.
          *

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/path/SanityTests.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/path/SanityTests.kt
@@ -1,0 +1,28 @@
+package org.partiql.planner.internal.typer.path
+
+import org.junit.jupiter.api.DynamicContainer
+import org.junit.jupiter.api.TestFactory
+import org.partiql.planner.internal.typer.PartiQLTyperTestBase
+import org.partiql.types.StaticType
+import java.util.stream.Stream
+
+/**
+ * This test makes sure that the planner can resolve various path expression
+ */
+class SanityTests : PartiQLTyperTestBase() {
+    @TestFactory
+    fun path(): Stream<DynamicContainer> {
+        val tests = buildList {
+            (0..14).forEach {
+                this.add("paths-${it.toString().padStart(2,'0')}")
+            }
+        }.map { inputs.get("basics", it)!! }
+
+        val argsMap: Map<TestResult, Set<List<StaticType>>> = buildMap {
+            put(TestResult.Success(StaticType.ANY), setOf(listOf(StaticType.ANY, StaticType.ANY)))
+            put(TestResult.Failure, emptySet<List<StaticType>>())
+        }
+
+        return super.testGen("path", tests, argsMap)
+    }
+}

--- a/partiql-planner/src/testFixtures/resources/inputs/basics/paths.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/basics/paths.sql
@@ -4,67 +4,67 @@
 
 --#[paths-00]
 -- tuple navigation
-x.y;
+t1.y;
 
 --#[paths-01]
 -- array navigation with literal
-x[0];
+t1[0];
     
 --#[paths-02]
 -- tuple navigation with array notation
-x['y'];
+t1['y'];
 
 --#[paths-03]
 -- tuple navigation (2)
-x."y";
+t1."y";
 
 --#[paths-04]
 -- tuple navigation with explicit cast as string
-x[CAST(z AS STRING)];
+t1[CAST(t2 AS STRING)];
 
 -- ----------------------------------------
 --  Composition of Navigation (5 choose 3)
 -- ----------------------------------------
 
 --#[paths-05]
-x.y[0]['y'];
+t1.y[0]['y'];
 
 --#[paths-06]
-x.y[0]."y";
+t1.y[0]."y";
 
 --#[paths-07]
-x.y[0][CAST(z AS STRING)];
+t1.y[0][CAST(t2 AS STRING)];
 
 --#[paths-08]
-x.y['y']."y";
+t1.y['y']."y";
 
 --#[paths-09]
-x.y['y'][CAST(z AS STRING)];
+t1.y['y'][CAST(t2 AS STRING)];
 
 --#[paths-10]
-x.y."y"[CAST(z AS STRING)];
+t1.y."y"[CAST(t2 AS STRING)];
 
 --#[paths-11]
-x[0]['y']."y";
+t1[0]['y']."y";
 
 --#[paths-12]
-x[0]['y'][CAST(z AS STRING)];
+t1[0]['y'][CAST(t2 AS STRING)];
 
 --#[paths-13]
-x[0]."y"[CAST(z AS STRING)];
+t1[0]."y"[CAST(t2 AS STRING)];
 
 --#[paths-14]
-x['y']."y"[CAST(z AS STRING)];
+t1['y']."y"[CAST(t2 AS STRING)];
 
 -- ----------------------------------------
 --  Array Navigation with Expressions
 -- ----------------------------------------
 
 --#[paths-15]
-x[0+1];
+t1[0+1];
 
 --#[paths-16]
-x[ABS(1)];
+t1[ABS(1)];
 
 -- ----------------------------------------
 --  PartiQL Path Navigation (+SFW)


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
- We need explicitly override the `visitRexOpPathStep` in the typer as in some case we need the resolved node as the step. i.e., the path step is a call node
- The Typer should throw an problem code upon encounter an unresolved function. Hence in `PlanTransform` we can just error out. 
    - I am not sure what is the purpose of the error node in the resolved plan. If we don't need this, I can have a follow up PR to remove it. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No.

- Any backward-incompatible changes? **[YES/NO]**
  -  No.
  
- Any new external dependencies? **[YES/NO]**
  - No.
  
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
No. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.