### PR TITLE
Adds int32 and int64 variants of date_add

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
@@ -590,23 +590,26 @@ public object PartiQLHeader : Header() {
     private fun extract(): List<FunctionSignature.Scalar> = emptyList()
 
     private fun dateAdd(): List<FunctionSignature.Scalar> {
+        val intervals = listOf(INT32, INT64, INT)
         val operators = mutableListOf<FunctionSignature.Scalar>()
         for (field in DatetimeField.values()) {
             for (type in types.datetime) {
                 if (field == DatetimeField.TIMEZONE_HOUR || field == DatetimeField.TIMEZONE_MINUTE) {
                     continue
                 }
-                val signature = FunctionSignature.Scalar(
-                    name = "date_add_${field.name.lowercase()}",
-                    returns = type,
-                    parameters = listOf(
-                        FunctionParameter("interval", INT),
-                        FunctionParameter("datetime", type),
-                    ),
-                    isNullable = false,
-                    isNullCall = true,
-                )
-                operators.add(signature)
+                for (interval in intervals) {
+                    val signature = FunctionSignature.Scalar(
+                        name = "date_add_${field.name.lowercase()}",
+                        returns = type,
+                        parameters = listOf(
+                            FunctionParameter("interval", interval),
+                            FunctionParameter("datetime", type),
+                        ),
+                        isNullable = false,
+                        isNullCall = true,
+                    )
+                    operators.add(signature)
+                }
             }
         }
         return operators


### PR DESCRIPTION
## Relevant Issues
N/A

## Description

Adds int32 and int64 operators to the date_add function. Before we only had the arbitrary-sized integer which we don't want as default.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.