### PR TITLE
Adds support for DISTINCT in Eval

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -1,6 +1,7 @@
 package org.partiql.eval.internal
 
 import org.partiql.eval.internal.operator.Operator
+import org.partiql.eval.internal.operator.rel.RelDistinct
 import org.partiql.eval.internal.operator.rel.RelFilter
 import org.partiql.eval.internal.operator.rel.RelJoinInner
 import org.partiql.eval.internal.operator.rel.RelJoinLeft
@@ -172,6 +173,11 @@ internal class Compiler(
     @OptIn(PartiQLValueExperimental::class)
     override fun visitRexOpLit(node: Rex.Op.Lit, ctx: Unit): Operator {
         return ExprLiteral(node.value)
+    }
+
+    override fun visitRelOpDistinct(node: Rel.Op.Distinct, ctx: Unit): Operator {
+        val input = visitRel(node.input, ctx)
+        return RelDistinct(input)
     }
 
     override fun visitRelOpFilter(node: Rel.Op.Filter, ctx: Unit): Operator {

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelDistinct.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelDistinct.kt
@@ -1,0 +1,31 @@
+package org.partiql.eval.internal.operator.rel
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+
+internal class RelDistinct(
+    val input: Operator.Relation
+) : Operator.Relation {
+
+    private val seen = mutableSetOf<Record>()
+
+    override fun open() {
+        input.open()
+    }
+
+    override fun next(): Record? {
+        var next = input.next()
+        while (next != null) {
+            if (seen.contains(next).not()) {
+                seen.add(next)
+                return next
+            }
+            next = input.next()
+        }
+        return null
+    }
+
+    override fun close() {
+        input.close()
+    }
+}

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -2,15 +2,17 @@ package org.partiql.eval.internal
 
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.partiql.eval.PartiQLEngine
 import org.partiql.eval.PartiQLResult
 import org.partiql.parser.PartiQLParser
 import org.partiql.planner.PartiQLPlanner
 import org.partiql.planner.PartiQLPlannerBuilder
-import org.partiql.value.BagValue
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
-import org.partiql.value.StructValue
 import org.partiql.value.bagValue
 import org.partiql.value.boolValue
 import org.partiql.value.int32Value
@@ -25,286 +27,249 @@ import kotlin.test.assertEquals
 
 /**
  * This holds sanity tests during the development of the [PartiQLEngine.default] implementation.
-<<<<<<< HEAD
-=======
- *
->>>>>>> 1772f0ed (Updates JOIN tests)
  */
+@OptIn(PartiQLValueExperimental::class)
 class PartiQLEngineDefaultTest {
 
-    private val engine = PartiQLEngine.default()
-    private val planner = PartiQLPlannerBuilder().build()
-    private val parser = PartiQLParser.default()
+    @ParameterizedTest
+    @MethodSource("sanityTestsCases")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun sanityTests(tc: SuccessTestCase) = tc.assert()
 
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testLiterals() {
-        val statement = parser.parse("SELECT VALUE 1 FROM <<0, 1>>;").root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
+    companion object {
 
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value as BagValue<*>
-
-        val expected = bagValue(int32Value(1), int32Value(1))
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testReference() {
-        val statement = parser.parse("SELECT VALUE t FROM <<10, 20, 30>> AS t;").root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value as BagValue<*>
-
-        val expected = bagValue(int32Value(10), int32Value(20), int32Value(30))
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testFilter() {
-        val statement =
-            parser.parse("SELECT VALUE t FROM <<true, false, true, false, false, false>> AS t WHERE t;").root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value as BagValue<*>
-
-        val expected = bagValue(boolValue(true), boolValue(true))
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testJoinInner() {
-        val statement = parser.parse("SELECT t.a, s.b FROM << { 'a': 1 } >> t, << { 'b': 2 } >> s;").root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value as BagValue<*>
-
-        val expected = bagValue(structValue("a" to int32Value(1), "b" to int32Value(2)))
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testJoinLeft() {
-        val statement = parser.parse("SELECT t.a, s.b FROM << { 'a': 1 } >> t LEFT JOIN << { 'b': 2 } >> s ON false;").root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value as BagValue<*>
-
-        val expected = bagValue(structValue("a" to int32Value(1), "b" to nullValue()))
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testJoinOuterFull() {
-        val statement =
-            parser.parse("SELECT t.a, s.b FROM << { 'a': 1 } >> t FULL OUTER JOIN << { 'b': 2 } >> s ON false;").root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-
-        val result = engine.execute(prepared)
-        if (result is PartiQLResult.Error) {
-            throw result.cause
-        }
-        result as PartiQLResult.Value
-        val output = result.value as BagValue<*>
-
-        val expected = bagValue(
-            structValue(
-                "a" to nullValue(),
-                "b" to int32Value(2)
+        @JvmStatic
+        fun sanityTestsCases() = listOf(
+            SuccessTestCase(
+                input = "SELECT VALUE 1 FROM <<0, 1>>;",
+                expected = bagValue(int32Value(1), int32Value(1))
             ),
-            structValue(
-                "a" to int32Value(1),
-                "b" to nullValue()
+            SuccessTestCase(
+                input = "SELECT VALUE t FROM <<10, 20, 30>> AS t;",
+                expected = bagValue(int32Value(10), int32Value(20), int32Value(30))
+            ),
+            SuccessTestCase(
+                input = "SELECT VALUE t FROM <<true, false, true, false, false, false>> AS t WHERE t;",
+                expected = bagValue(boolValue(true), boolValue(true))
+            ),
+            SuccessTestCase(
+                input = "SELECT t.a, s.b FROM << { 'a': 1 } >> t, << { 'b': 2 } >> s;",
+                expected = bagValue(structValue("a" to int32Value(1), "b" to int32Value(2)))
+            ),
+            SuccessTestCase(
+                input = "SELECT t.a, s.b FROM << { 'a': 1 } >> t LEFT JOIN << { 'b': 2 } >> s ON false;",
+                expected = bagValue(structValue("a" to int32Value(1), "b" to nullValue()))
+            ),
+            SuccessTestCase(
+                input = "SELECT t.a, s.b FROM << { 'a': 1 } >> t FULL OUTER JOIN << { 'b': 2 } >> s ON false;",
+                expected = bagValue(
+                    structValue(
+                        "a" to nullValue(),
+                        "b" to int32Value(2)
+                    ),
+                    structValue(
+                        "a" to int32Value(1),
+                        "b" to nullValue()
+                    ),
+                )
+            ),
+            SuccessTestCase(
+                input = """
+                    TUPLEUNION(
+                        { 'a': 1 },
+                        { 'b': TRUE },
+                        { 'c': 'hello' }
+                    );
+                """.trimIndent(),
+                expected = structValue(
+                    "a" to int32Value(1),
+                    "b" to boolValue(true),
+                    "c" to stringValue("hello")
+                )
+            ),
+            SuccessTestCase(
+                input = """
+                    CASE
+                        WHEN NULL THEN 'isNull'
+                        WHEN MISSING THEN 'isMissing'
+                        WHEN FALSE THEN 'isFalse'
+                        WHEN TRUE THEN 'isTrue'
+                    END
+                    ;
+                """.trimIndent(),
+                expected = stringValue("isTrue")
+            ),
+            SuccessTestCase(
+                input = "SELECT t.a, s.b FROM << { 'a': 1 } >> t FULL OUTER JOIN << { 'b': 2 } >> s ON TRUE;",
+                expected = bagValue(
+                    structValue(
+                        "a" to int32Value(1),
+                        "b" to int32Value(2)
+                    ),
+                )
+            ),
+            SuccessTestCase(
+                input = """
+                    TUPLEUNION(
+                        { 'a': 1 },
+                        NULL,
+                        { 'c': 'hello' }
+                    );
+                """.trimIndent(),
+                expected = structValue<PartiQLValue>(null)
+            ),
+            SuccessTestCase(
+                input = """
+                    CASE
+                        WHEN NULL THEN 'isNull'
+                        WHEN MISSING THEN 'isMissing'
+                        WHEN FALSE THEN 'isFalse'
+                    END
+                    ;
+                """.trimIndent(),
+                expected = nullValue()
+            ),
+            SuccessTestCase(
+                input = """
+                    TUPLEUNION(
+                        { 'a': 1 },
+                        5,
+                        { 'c': 'hello' }
+                    );
+                """.trimIndent(),
+                expected = missingValue()
+            ),
+            SuccessTestCase(
+                input = """
+                    TUPLEUNION(
+                        { 'a': 1, 'b': FALSE },
+                        { 'b': TRUE },
+                        { 'c': 'hello' }
+                    );
+                """.trimIndent(),
+                expected = structValue(
+                    "a" to int32Value(1),
+                    "b" to boolValue(false),
+                    "b" to boolValue(true),
+                    "c" to stringValue("hello")
+                )
+            ),
+            SuccessTestCase(
+                input = """
+                    SELECT * FROM
+                    <<
+                        { 'a': 1, 'b': FALSE }
+                    >> AS t,
+                    <<
+                        { 'b': TRUE }
+                    >> AS s
+                """.trimIndent(),
+                expected = bagValue(
+                    structValue(
+                        "a" to int32Value(1),
+                        "b" to boolValue(false),
+                        "b" to boolValue(true)
+                    )
+                )
+            ),
+            SuccessTestCase(
+                input = """
+                    SELECT VALUE {
+                        'a': 1,
+                        'b': NULL,
+                        t.c : t.d
+                    }
+                    FROM <<
+                        { 'c': 'hello', 'd': 'world' }
+                    >> AS t
+                """.trimIndent(),
+                expected = bagValue(
+                    structValue(
+                        "a" to int32Value(1),
+                        "b" to nullValue(),
+                        "hello" to stringValue("world")
+                    )
+                )
+            ),
+            SuccessTestCase(
+                input = "SELECT v, i FROM << 'a', 'b', 'c' >> AS v AT i",
+                expected = bagValue(
+                    structValue(
+                        "v" to stringValue("a"),
+                        "i" to int64Value(0),
+                    ),
+                    structValue(
+                        "v" to stringValue("b"),
+                        "i" to int64Value(1),
+                    ),
+                    structValue(
+                        "v" to stringValue("c"),
+                        "i" to int64Value(2),
+                    ),
+                )
+            ),
+            SuccessTestCase(
+                input = "SELECT DISTINCT VALUE t FROM <<true, false, true, false, false, false>> AS t;",
+                expected = bagValue(boolValue(true), boolValue(false))
+            ),
+            SuccessTestCase(
+                input = """
+                    PIVOT x.v AT x.k FROM << 
+                        { 'k': 'a', 'v': 'x' },
+                        { 'k': 'b', 'v': 'y' },
+                        { 'k': 'c', 'v': 'z' }
+                    >> AS x
+                """.trimIndent(),
+                expected = structValue(
+                    "a" to stringValue("x"),
+                    "b" to stringValue("y"),
+                    "c" to stringValue("z"),
+                )
             ),
         )
-        assertEquals(expected, output, comparisonString(expected, output))
     }
+    public class SuccessTestCase @OptIn(PartiQLValueExperimental::class) constructor(
+        val input: String,
+        val expected: PartiQLValue
+    ) {
 
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testTupleUnion() {
-        val source = """
-            TUPLEUNION(
-                { 'a': 1 },
-                { 'b': TRUE },
-                { 'c': 'hello' }
-            );
-        """.trimIndent()
-        val statement = parser.parse(source).root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
+        private val engine = PartiQLEngine.default()
+        private val planner = PartiQLPlannerBuilder().build()
+        private val parser = PartiQLParser.default()
 
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value
-
-        val expected = structValue(
-            "a" to int32Value(1),
-            "b" to boolValue(true),
-            "c" to stringValue("hello")
-        )
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testCaseLiteral00() {
-        val source = """
-            CASE
-                WHEN NULL THEN 'isNull'
-                WHEN MISSING THEN 'isMissing'
-                WHEN FALSE THEN 'isFalse'
-                WHEN TRUE THEN 'isTrue'
-            END
-            ;
-        """.trimIndent()
-        val statement = parser.parse(source).root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value
-
-        val expected = stringValue("isTrue")
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testJoinOuterFullOnTrue() {
-        val statement =
-            parser.parse("SELECT t.a, s.b FROM << { 'a': 1 } >> t FULL OUTER JOIN << { 'b': 2 } >> s ON TRUE;").root
-
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-
-        val result = engine.execute(prepared)
-        if (result is PartiQLResult.Error) {
-            throw result.cause
+        @OptIn(PartiQLValueExperimental::class)
+        internal fun assert() {
+            val statement = parser.parse(input).root
+            val session = PartiQLPlanner.Session("q", "u")
+            val plan = planner.plan(statement, session)
+            val prepared = engine.prepare(plan.plan)
+            val result = engine.execute(prepared) as PartiQLResult.Value
+            val output = result.value
+            assertEquals(expected, output, comparisonString(expected, output))
         }
-        result as PartiQLResult.Value
-        val output = result.value as BagValue<*>
 
-        val expected = bagValue(
-            structValue(
-                "a" to int32Value(1),
-                "b" to int32Value(2)
-            ),
-        )
-        assertEquals(expected, output, comparisonString(expected, output))
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testTupleUnionNullInput() {
-        val source = """
-            TUPLEUNION(
-                { 'a': 1 },
-                NULL,
-                { 'c': 'hello' }
-            );
-        """.trimIndent()
-        val statement = parser.parse(source).root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value
-
-        val expected = structValue<PartiQLValue>(null)
-
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testCaseLiteral01() {
-        val source = """
-            CASE
-                WHEN NULL THEN 'isNull'
-                WHEN MISSING THEN 'isMissing'
-                WHEN FALSE THEN 'isFalse'
-            END
-            ;
-        """.trimIndent()
-        val statement = parser.parse(source).root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value
-
-        val expected = nullValue()
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    private fun comparisonString(expected: PartiQLValue, actual: PartiQLValue): String {
-        val expectedBuffer = ByteArrayOutputStream()
-        val expectedWriter = PartiQLValueIonWriterBuilder.standardIonTextBuilder().build(expectedBuffer)
-        expectedWriter.append(expected)
-        return buildString {
-            appendLine("Expected : $expectedBuffer")
-            expectedBuffer.reset()
-            expectedWriter.append(actual)
-            appendLine("Actual   : $expectedBuffer")
+        @OptIn(PartiQLValueExperimental::class)
+        private fun comparisonString(expected: PartiQLValue, actual: PartiQLValue): String {
+            val expectedBuffer = ByteArrayOutputStream()
+            val expectedWriter = PartiQLValueIonWriterBuilder.standardIonTextBuilder().build(expectedBuffer)
+            expectedWriter.append(expected)
+            return buildString {
+                appendLine("Expected : $expectedBuffer")
+                expectedBuffer.reset()
+                expectedWriter.append(actual)
+                appendLine("Actual   : $expectedBuffer")
+            }
         }
-    }
 
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testTupleUnionBadInput() {
-        val source = """
-            TUPLEUNION(
-                { 'a': 1 },
-                5,
-                { 'c': 'hello' }
-            );
-        """.trimIndent()
-        val statement = parser.parse(source).root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value
-        val expected = missingValue()
-        assertEquals(expected, output)
+        override fun toString(): String {
+            return input
+        }
     }
 
     @Disabled("This is disabled because FN EQUALS is not yet implemented.")
-    @OptIn(PartiQLValueExperimental::class)
     @Test
-    fun testCaseLiteral02() {
-        val source = """
+    fun testCaseLiteral02() = SuccessTestCase(
+        input = """
             CASE (1)
                 WHEN NULL THEN 'isNull'
                 WHEN MISSING THEN 'isMissing'
@@ -312,191 +277,21 @@ class PartiQLEngineDefaultTest {
                 WHEN 1 THEN 'isOne'
             END
             ;
-        """.trimIndent()
-        val statement = parser.parse(source).root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value
-
-        val expected = stringValue("isOne")
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testTupleUnionDuplicates() {
-        val source = """
-            TUPLEUNION(
-                { 'a': 1, 'b': FALSE },
-                { 'b': TRUE },
-                { 'c': 'hello' }
-            );
-            
-        """.trimIndent()
-        val statement = parser.parse(source).root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value
-
-        val expected = structValue(
-            "a" to int32Value(1),
-            "b" to boolValue(false),
-            "b" to boolValue(true),
-            "c" to stringValue("hello")
-        )
-        assertEquals(expected, output)
-    }
+        """.trimIndent(),
+        expected = stringValue("isOne")
+    ).assert()
 
     @Disabled("This is disabled because FN EQUALS is not yet implemented.")
-    @OptIn(PartiQLValueExperimental::class)
     @Test
-    fun testCaseLiteral03() {
-        val source = """
+    fun testCaseLiteral03() = SuccessTestCase(
+        input = """
             CASE (1)
                 WHEN NULL THEN 'isNull'
                 WHEN MISSING THEN 'isMissing'
                 WHEN 2 THEN 'isTwo'
             END
             ;
-        """.trimIndent()
-        val statement = parser.parse(source).root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value
-        val expected = nullValue()
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testSelectStarTupleUnion() {
-        // As SELECT * gets converted to TUPLEUNION, this is a sanity check
-        val source = """
-            SELECT * FROM
-            <<
-                { 'a': 1, 'b': FALSE }
-            >> AS t,
-            <<
-                { 'b': TRUE }
-            >> AS s
-        """.trimIndent()
-        val statement = parser.parse(source).root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value
-
-        val expected = bagValue(
-            structValue(
-                "a" to int32Value(1),
-                "b" to boolValue(false),
-                "b" to boolValue(true)
-            )
-        )
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testStruct() {
-        val source = """
-            SELECT VALUE {
-                'a': 1,
-                'b': NULL,
-                t.c : t.d
-            }
-            FROM <<
-                { 'c': 'hello', 'd': 'world' }
-            >> AS t
-        """.trimIndent()
-        val statement = parser.parse(source).root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared)
-        if (result is PartiQLResult.Error) {
-            throw result.cause
-        }
-        val output = (result as PartiQLResult.Value).value
-
-        val expected: PartiQLValue = bagValue(
-            structValue(
-                "a" to int32Value(1),
-                "b" to nullValue(),
-                "hello" to stringValue("world")
-            )
-        )
-        assertEquals(expected, output)
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testScanIndexed() {
-        val statement = parser.parse("SELECT v, i FROM << 'a', 'b', 'c' >> AS v AT i").root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared) as PartiQLResult.Value
-        val output = result.value
-
-        val expected = bagValue(
-            structValue(
-                "v" to stringValue("a"),
-                "i" to int64Value(0),
-            ),
-            structValue(
-                "v" to stringValue("b"),
-                "i" to int64Value(1),
-            ),
-            structValue(
-                "v" to stringValue("c"),
-                "i" to int64Value(2),
-            ),
-        )
-        assertEquals(expected, output, comparisonString(expected, output))
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    @Test
-    fun testPivot() {
-        val statement = parser.parse(
-            """
-           PIVOT x.v AT x.k FROM << 
-                { 'k': 'a', 'v': 'x' },
-                { 'k': 'b', 'v': 'y' },
-                { 'k': 'c', 'v': 'z' }
-           >> AS x
-            """.trimIndent()
-        ).root
-        val session = PartiQLPlanner.Session("q", "u")
-        val plan = planner.plan(statement, session)
-
-        val prepared = engine.prepare(plan.plan)
-        val result = engine.execute(prepared)
-        if (result is PartiQLResult.Error) {
-            throw result.cause
-        }
-        result as PartiQLResult.Value
-        val output = result.value as StructValue<*>
-
-        val expected = structValue(
-            "a" to stringValue("x"),
-            "b" to stringValue("y"),
-            "c" to stringValue("z"),
-        )
-        assertEquals(expected, output, comparisonString(expected, output))
-    }
+        """.trimIndent(),
+        expected = nullValue()
+    ).assert()
 }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -372,6 +372,98 @@ class PlanTyperTestsPorted {
         )
 
         @JvmStatic
+        fun distinctClauseCases() = listOf<TestCase>(
+            SuccessTestCase(
+                name = "Distinct SQL Select",
+                catalog = CATALOG_AWS,
+                query = "SELECT DISTINCT a, b FROM << { 'a': 1, 'b': 'Hello, world!' } >>;",
+                expected = BagType(
+                    StructType(
+                        fields = listOf(
+                            StructType.Field("a", StaticType.INT4),
+                            StructType.Field("b", StaticType.STRING),
+                        ),
+                        contentClosed = true,
+                        constraints = setOf(
+                            TupleConstraint.Open(false),
+                            TupleConstraint.UniqueAttrs(true),
+                            TupleConstraint.Ordered
+                        )
+                    )
+                )
+            ),
+            SuccessTestCase(
+                name = "Distinct SQL Select with Ordering",
+                catalog = CATALOG_AWS,
+                query = "SELECT DISTINCT a, b FROM << { 'a': 1, 'b': 'Hello, world!' } >> ORDER BY a;",
+                expected = ListType(
+                    StructType(
+                        fields = listOf(
+                            StructType.Field("a", StaticType.INT4),
+                            StructType.Field("b", StaticType.STRING),
+                        ),
+                        contentClosed = true,
+                        constraints = setOf(
+                            TupleConstraint.Open(false),
+                            TupleConstraint.UniqueAttrs(true),
+                            TupleConstraint.Ordered
+                        )
+                    )
+                )
+            ),
+            SuccessTestCase(
+                name = "Distinct SQL Select *",
+                catalog = CATALOG_AWS,
+                query = "SELECT DISTINCT * FROM << { 'a': 1, 'b': 'Hello, world!' } >>;",
+                expected = BagType(
+                    StructType(
+                        fields = listOf(
+                            StructType.Field("a", StaticType.INT4),
+                            StructType.Field("b", StaticType.STRING),
+                        ),
+                        contentClosed = true,
+                        constraints = setOf(
+                            TupleConstraint.Open(false),
+                            TupleConstraint.UniqueAttrs(true),
+                            TupleConstraint.Ordered
+                        )
+                    )
+                )
+            ),
+            SuccessTestCase(
+                name = "Distinct SQL Select * with Ordering",
+                catalog = CATALOG_AWS,
+                query = "SELECT DISTINCT * FROM << { 'a': 1, 'b': 'Hello, world!' } >> ORDER BY a;",
+                expected = ListType(
+                    StructType(
+                        fields = listOf(
+                            StructType.Field("a", StaticType.INT4),
+                            StructType.Field("b", StaticType.STRING),
+                        ),
+                        contentClosed = true,
+                        constraints = setOf(
+                            TupleConstraint.Open(false),
+                            TupleConstraint.UniqueAttrs(true),
+                            TupleConstraint.Ordered
+                        )
+                    )
+                )
+            ),
+            SuccessTestCase(
+                name = "Distinct PartiQL Select Value *",
+                catalog = CATALOG_AWS,
+                query = "SELECT DISTINCT VALUE a FROM << { 'a': 1, 'b': 'Hello, world!' } >>;",
+                expected = BagType(StaticType.INT4)
+            ),
+            SuccessTestCase(
+                name = "Distinct PartiQL Select Value * with Ordering",
+                catalog = CATALOG_AWS,
+                query = "SELECT DISTINCT VALUE a FROM << { 'a': 1, 'b': 'Hello, world!' } >> ORDER BY a;",
+                expected = ListType(StaticType.INT4)
+            ),
+        )
+
+        @JvmStatic
         fun pivotCases() = listOf(
             SuccessTestCase(
                 name = "Basic PIVOT",
@@ -2939,6 +3031,11 @@ class PlanTyperTestsPorted {
     @MethodSource("scalarFunctions")
     @Execution(ExecutionMode.CONCURRENT)
     fun testScalarFunctions(tc: TestCase) = runTest(tc)
+
+    @ParameterizedTest
+    @MethodSource("distinctClauseCases")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun testDistinctClause(tc: TestCase) = runTest(tc)
 
     @ParameterizedTest
     @MethodSource("pathExpressions")


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds support for DISTINCT in Planner and Eval
- I also refactored the tests to make it easier to rebase and continue developing. Prior sanity tests were 17 passing and 2 disabled. There are now 18 passing and 2 disabled. The newly introduced one had to do with DISTINCT.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.