### PR TITLE
Adds support for DISTINCT in the Planner

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -38,6 +38,7 @@ import org.partiql.planner.internal.ir.rel
 import org.partiql.planner.internal.ir.relBinding
 import org.partiql.planner.internal.ir.relOpAggregate
 import org.partiql.planner.internal.ir.relOpAggregateCall
+import org.partiql.planner.internal.ir.relOpDistinct
 import org.partiql.planner.internal.ir.relOpErr
 import org.partiql.planner.internal.ir.relOpFilter
 import org.partiql.planner.internal.ir.relOpJoin
@@ -197,7 +198,8 @@ internal class PlanTyper(
         }
 
         override fun visitRelOpDistinct(node: Rel.Op.Distinct, ctx: Rel.Type?): Rel {
-            TODO("Type RelOp Distinct")
+            val input = visitRel(node.input, ctx)
+            return rel(input.type, relOpDistinct(input))
         }
 
         override fun visitRelOpFilter(node: Rel.Op.Filter, ctx: Rel.Type?): Rel {


### PR DESCRIPTION
## Relevant Issues
- See #1292 

## Description
- I was adding DISTINCT to the evaluator, and I noticed it was missing in the plan.
- This PR adds support for DISTINCT in the Planner

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.