### PR TITLE
Adds INNER JOIN, LEFT JOIN, Path Step Key & Fixes ExprStruct

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -2,10 +2,12 @@ package org.partiql.eval.internal
 
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.eval.internal.operator.rel.RelFilter
+import org.partiql.eval.internal.operator.rel.RelJoinInner
 import org.partiql.eval.internal.operator.rel.RelProject
 import org.partiql.eval.internal.operator.rel.RelScan
 import org.partiql.eval.internal.operator.rex.ExprCollection
 import org.partiql.eval.internal.operator.rex.ExprLiteral
+import org.partiql.eval.internal.operator.rex.ExprPathKey
 import org.partiql.eval.internal.operator.rex.ExprSelect
 import org.partiql.eval.internal.operator.rex.ExprStruct
 import org.partiql.eval.internal.operator.rex.ExprVar
@@ -78,6 +80,36 @@ internal object Compiler {
 
         override fun visitRex(node: Rex, ctx: Unit): Operator.Expr {
             return super.visitRexOp(node.op, ctx) as Operator.Expr
+        }
+
+        override fun visitRexOpPath(node: Rex.Op.Path, ctx: Unit): Operator {
+            val root = visitRex(node.root, ctx)
+            var path = root
+            node.steps.forEach {
+                when (it) {
+                    is Rex.Op.Path.Step.Key -> {
+                        val key = visitRex(it.key, ctx)
+                        path = ExprPathKey(path, key)
+                    }
+                    is Rex.Op.Path.Step.Index -> TODO()
+                    is Rex.Op.Path.Step.Symbol -> TODO()
+                    is Rex.Op.Path.Step.Unpivot -> TODO()
+                    is Rex.Op.Path.Step.Wildcard -> TODO()
+                }
+            }
+            return path
+        }
+
+        override fun visitRelOpJoin(node: Rel.Op.Join, ctx: Unit): Operator {
+            val lhs = visitRel(node.lhs, ctx)
+            val rhs = visitRel(node.rhs, ctx)
+            val condition = visitRex(node.rex, ctx)
+            return when (node.type) {
+                Rel.Op.Join.Type.INNER -> RelJoinInner(lhs, rhs, condition)
+                Rel.Op.Join.Type.LEFT -> TODO()
+                Rel.Op.Join.Type.RIGHT -> TODO()
+                Rel.Op.Join.Type.FULL -> TODO()
+            }
         }
 
         // TODO: Re-look at

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -3,6 +3,7 @@ package org.partiql.eval.internal
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.eval.internal.operator.rel.RelFilter
 import org.partiql.eval.internal.operator.rel.RelJoinInner
+import org.partiql.eval.internal.operator.rel.RelJoinLeft
 import org.partiql.eval.internal.operator.rel.RelProject
 import org.partiql.eval.internal.operator.rel.RelScan
 import org.partiql.eval.internal.operator.rex.ExprCollection
@@ -106,7 +107,7 @@ internal object Compiler {
             val condition = visitRex(node.rex, ctx)
             return when (node.type) {
                 Rel.Op.Join.Type.INNER -> RelJoinInner(lhs, rhs, condition)
-                Rel.Op.Join.Type.LEFT -> TODO()
+                Rel.Op.Join.Type.LEFT -> RelJoinLeft(lhs, rhs, condition)
                 Rel.Op.Join.Type.RIGHT -> TODO()
                 Rel.Op.Join.Type.FULL -> TODO()
             }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Record.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Record.kt
@@ -21,4 +21,8 @@ internal class Record(val values: Array<PartiQLValue>) {
     override fun hashCode(): Int {
         return values.contentHashCode()
     }
+
+    public operator fun plus(rhs: Record): Record {
+        return Record(this.values + rhs.values)
+    }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoin.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoin.kt
@@ -1,0 +1,45 @@
+package org.partiql.eval.internal.operator.rel
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+
+internal abstract class RelJoin : Operator.Relation {
+
+    abstract val lhs: Operator.Relation
+    abstract val rhs: Operator.Relation
+
+    private val lhsStored = mutableListOf<Record>()
+    private val rhsStored = mutableListOf<Record>()
+    private lateinit var lhsIterator: Iterator<Record>
+    private lateinit var rhsIterator: Iterator<Record>
+
+    override fun open() {
+        lhs.open()
+        rhs.open()
+
+        var x = lhs.next()
+        while (x != null) {
+            lhsStored.add(x)
+            x = lhs.next()
+        }
+
+        var rhsIter = rhs.next()
+        while (rhsIter != null) {
+            rhsStored.add(rhsIter)
+            rhsIter = rhs.next()
+        }
+        lhsIterator = lhsStored.iterator()
+        rhsIterator = rhsStored.iterator()
+    }
+
+    override fun next(): Record? {
+        TODO("Not yet implemented")
+    }
+
+    override fun close() {
+        lhs.close()
+        lhsStored.clear()
+        rhs.close()
+        rhsStored.clear()
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinInner.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinInner.kt
@@ -2,61 +2,13 @@ package org.partiql.eval.internal.operator.rel
 
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
-import org.partiql.value.BoolValue
-import org.partiql.value.PartiQLValue
-import org.partiql.value.PartiQLValueExperimental
 
 internal class RelJoinInner(
-    private val lhs: Operator.Relation,
-    private val rhs: Operator.Relation,
-    val condition: Operator.Expr
-) : Operator.Relation {
-
-    private val lhsStored = mutableListOf<Record>()
-    private val rhsStored = mutableListOf<Record>()
-    private lateinit var lhsIterator: Iterator<Record>
-    private lateinit var rhsIterator: Iterator<Record>
-
-    override fun open() {
-        lhs.open()
-        rhs.open()
-
-        var x = lhs.next()
-        while (x != null) {
-            lhsStored.add(x)
-            x = lhs.next()
-        }
-
-        var rhsIter = rhs.next()
-        while (rhsIter != null) {
-            rhsStored.add(rhsIter)
-            rhsIter = rhs.next()
-        }
-        lhsIterator = lhsStored.iterator()
-        rhsIterator = rhsStored.iterator()
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    override fun next(): Record? {
-        lhsIterator.forEach { lhsRecord ->
-            rhsIterator.forEach { rhsRecord ->
-                val input = lhsRecord + rhsRecord
-                val result = condition.eval(input)
-                if (result.isTrue()) {
-                    return input
-                }
-            }
-        }
-        return null
-    }
-
-    override fun close() {
-        lhs.close()
-        rhs.close()
-    }
-
-    @OptIn(PartiQLValueExperimental::class)
-    private fun PartiQLValue.isTrue(): Boolean {
-        return this is BoolValue && this.value == true
+    override val lhs: Operator.Relation,
+    override val rhs: Operator.Relation,
+    override val condition: Operator.Expr
+) : RelJoin() {
+    override fun getOutputRecord(result: Boolean, lhs: Record, rhs: Record): Record {
+        return lhs + rhs
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinInner.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinInner.kt
@@ -1,0 +1,62 @@
+package org.partiql.eval.internal.operator.rel
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.BoolValue
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+
+internal class RelJoinInner(
+    private val lhs: Operator.Relation,
+    private val rhs: Operator.Relation,
+    val condition: Operator.Expr
+) : Operator.Relation {
+
+    private val lhsStored = mutableListOf<Record>()
+    private val rhsStored = mutableListOf<Record>()
+    private lateinit var lhsIterator: Iterator<Record>
+    private lateinit var rhsIterator: Iterator<Record>
+
+    override fun open() {
+        lhs.open()
+        rhs.open()
+
+        var x = lhs.next()
+        while (x != null) {
+            lhsStored.add(x)
+            x = lhs.next()
+        }
+
+        var rhsIter = rhs.next()
+        while (rhsIter != null) {
+            rhsStored.add(rhsIter)
+            rhsIter = rhs.next()
+        }
+        lhsIterator = lhsStored.iterator()
+        rhsIterator = rhsStored.iterator()
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    override fun next(): Record? {
+        lhsIterator.forEach { lhsRecord ->
+            rhsIterator.forEach { rhsRecord ->
+                val input = lhsRecord + rhsRecord
+                val result = condition.eval(input)
+                if (result.isTrue()) {
+                    return input
+                }
+            }
+        }
+        return null
+    }
+
+    override fun close() {
+        lhs.close()
+        rhs.close()
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    private fun PartiQLValue.isTrue(): Boolean {
+        return this is BoolValue && this.value == true
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinLeft.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinLeft.kt
@@ -1,0 +1,41 @@
+package org.partiql.eval.internal.operator.rel
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.StructValue
+import org.partiql.value.nullValue
+import org.partiql.value.structValue
+
+internal class RelJoinLeft(
+    override val lhs: Operator.Relation,
+    override val rhs: Operator.Relation,
+    override val condition: Operator.Expr
+) : RelJoin() {
+
+    override fun getOutputRecord(result: Boolean, lhs: Record, rhs: Record): Record {
+        if (result.not()) {
+            rhs.padNull()
+        }
+        return lhs + rhs
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    private fun Record.padNull() {
+        this.values.indices.forEach { index ->
+            this.values[index] = values[index].padNull()
+        }
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    private fun PartiQLValue.padNull(): PartiQLValue {
+        return when (this) {
+            is StructValue<*> -> {
+                val newFields = this.fields?.map { it.first to nullValue() }
+                structValue(newFields)
+            }
+            else -> nullValue()
+        }
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathKey.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathKey.kt
@@ -1,0 +1,24 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.StringValue
+import org.partiql.value.StructValue
+import org.partiql.value.check
+import org.partiql.value.missingValue
+
+internal class ExprPathKey(
+    val root: Operator.Expr,
+    val key: Operator.Expr
+) : Operator.Expr {
+
+    @OptIn(PartiQLValueExperimental::class)
+    override fun eval(record: Record): PartiQLValue {
+        val rootEvaluated = root.eval(record).check<StructValue<PartiQLValue>>()
+        val keyEvaluated = key.eval(record).check<StringValue>()
+        val keyString = keyEvaluated.value ?: error("String value was null")
+        return rootEvaluated[keyString] ?: missingValue()
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprStruct.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprStruct.kt
@@ -5,14 +5,15 @@ import org.partiql.eval.internal.operator.Operator
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.StringValue
+import org.partiql.value.check
 import org.partiql.value.structValue
 
 internal class ExprStruct(val fields: List<Field>) : Operator.Expr {
     @OptIn(PartiQLValueExperimental::class)
     override fun eval(record: Record): PartiQLValue {
         val fields = fields.map {
-            val key = it.key.eval(record) as? StringValue ?: error("Expected struct key to be a STRING.")
-            val value = it.key.eval(record)
+            val key = it.key.eval(record).check<StringValue>()
+            val value = it.value.eval(record)
             key.value!! to value
         }
         return structValue(fields.asSequence())

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -11,6 +11,7 @@ import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.bagValue
 import org.partiql.value.boolValue
 import org.partiql.value.int32Value
+import org.partiql.value.structValue
 import kotlin.test.assertEquals
 
 /**
@@ -64,6 +65,21 @@ class PartiQLEngineDefaultTest {
         val output = result.value as BagValue<*>
 
         val expected = bagValue(sequenceOf(boolValue(true), boolValue(true)))
+        assertEquals(expected, output)
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    @Test
+    fun testJoinInner() {
+        val statement = parser.parse("SELECT a, b FROM << { 'a': 1 } >> t, << { 'b': 2 } >> s;").root
+        val session = PartiQLPlanner.Session("q", "u")
+        val plan = planner.plan(statement, session)
+
+        val prepared = engine.prepare(plan.plan)
+        val result = engine.execute(prepared) as PartiQLResult.Value
+        val output = result.value as BagValue<*>
+
+        val expected = bagValue(sequenceOf(structValue(sequenceOf("a" to int32Value(1), "b" to int32Value(2)))))
         assertEquals(expected, output)
     }
 }

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -11,6 +11,7 @@ import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.bagValue
 import org.partiql.value.boolValue
 import org.partiql.value.int32Value
+import org.partiql.value.nullValue
 import org.partiql.value.structValue
 import kotlin.test.assertEquals
 
@@ -80,6 +81,21 @@ class PartiQLEngineDefaultTest {
         val output = result.value as BagValue<*>
 
         val expected = bagValue(sequenceOf(structValue(sequenceOf("a" to int32Value(1), "b" to int32Value(2)))))
+        assertEquals(expected, output)
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    @Test
+    fun testJoinLeft() {
+        val statement = parser.parse("SELECT a, b FROM << { 'a': 1 } >> t LEFT JOIN << { 'b': 2 } >> s ON false;").root
+        val session = PartiQLPlanner.Session("q", "u")
+        val plan = planner.plan(statement, session)
+
+        val prepared = engine.prepare(plan.plan)
+        val result = engine.execute(prepared) as PartiQLResult.Value
+        val output = result.value as BagValue<*>
+
+        val expected = bagValue(sequenceOf(structValue(sequenceOf("a" to int32Value(1), "b" to nullValue()))))
         assertEquals(expected, output)
     }
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
@@ -399,6 +399,10 @@ public abstract class BagValue<T : PartiQLValue> : CollectionValue<T> {
         // TODO
         return type.hashCode()
     }
+
+    override fun toString(): String {
+        return this.elements!!.toList().toString()
+    }
 }
 
 @PartiQLValueExperimental
@@ -522,6 +526,22 @@ public abstract class StructValue<T : PartiQLValue> : PartiQLValue, Sequence<Pai
     override fun hashCode(): Int {
         // TODO
         return super.hashCode()
+    }
+
+    override fun toString(): String {
+        return buildString {
+            append("{ ")
+            val fieldList = fields!!.toList()
+            fieldList.forEachIndexed { index, field ->
+                append(field.first)
+                append(": ")
+                append(field.second)
+                if (index != fieldList.lastIndex) {
+                    append(", ")
+                }
+            }
+            append(" }")
+        }
     }
 }
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
@@ -399,10 +399,6 @@ public abstract class BagValue<T : PartiQLValue> : CollectionValue<T> {
         // TODO
         return type.hashCode()
     }
-
-    override fun toString(): String {
-        return this.elements!!.toList().toString()
-    }
 }
 
 @PartiQLValueExperimental
@@ -526,22 +522,6 @@ public abstract class StructValue<T : PartiQLValue> : PartiQLValue, Sequence<Pai
     override fun hashCode(): Int {
         // TODO
         return super.hashCode()
-    }
-
-    override fun toString(): String {
-        return buildString {
-            append("{ ")
-            val fieldList = fields!!.toList()
-            fieldList.forEachIndexed { index, field ->
-                append(field.first)
-                append(": ")
-                append(field.second)
-                if (index != fieldList.lastIndex) {
-                    append(", ")
-                }
-            }
-            append(" }")
-        }
     }
 }
 


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds INNER JOIN, LEFT JOIN, Path Step Key & Fixes ExprStruct
- Going to add the other JOINS after this. Wanted to get the ExprStruct and PathStepKey out.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**

- Any backward-incompatible changes? **NO**

- Any new external dependencies? **NO**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.