### PR TITLE
Adds PIVOT and SCAN_INDEXED to evaluation engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Thank you to all who have contributed!
 ### Fixed
 - Fixes the CLI hanging on invalid queries. See issue #1230.
 - Fixes Timestamp Type parsing issue. Previously Timestamp Type would get parsed to a Time type.
+- Fixes PIVOT parsing to assign the key and value as defined by spec section 14.
 - Fixes the physical plan compiler to return list when `DISTINCT` used with `ORDER BY`
 
 ### Removed

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
@@ -708,9 +708,12 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
             projectExpr(expr, alias, metas)
         }
 
+    // !!
+    // Legacy AST mislabels key and value in PIVOT, swapping the order here to recreate bug for compatibility.
+    // !!
     override fun visitSelectPivot(node: Select.Pivot, ctx: Ctx) = translate(node) { metas ->
-        val value = visitExpr(node.value, ctx)
-        val key = visitExpr(node.key, ctx)
+        val key = visitExpr(node.value, ctx) // SWAP val -> key
+        val value = visitExpr(node.key, ctx) // SWAP key -> val
         projectPivot(value, key, metas)
     }
 

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
@@ -536,10 +536,14 @@ class ToLegacyAstTest {
                     }
                 }
             },
-            expect("(project_pivot (lit 1) (lit 2))") {
+            expect("(project_pivot (lit 2) (lit 1))") {
                 selectPivot {
-                    value = exprLit(int32Value(1))
+                    // PIVOT 1 AT 2
+                    //  - 1 is the VALUE
+                    //  - 2 is the KEY
+                    // In the legacy implementation these were accidentally flipped
                     key = exprLit(int32Value(2))
+                    value = exprLit(int32Value(1))
                 }
             },
             expect("(project_value (lit null))") {

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/utils/ServiceLoaderUtil.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/utils/ServiceLoaderUtil.kt
@@ -480,13 +480,13 @@ class ServiceLoaderUtil {
                     )
                 }
                 PartiQLValueType.STRUCT -> when (exprValue.type) {
-                    ExprValueType.NULL -> structValue(null)
+                    ExprValueType.NULL -> structValue(null as Iterable<Pair<String, PartiQLValue>>?)
                     ExprValueType.STRUCT -> structValue(
                         exprValue.map {
                             Pair(
                                 it.name?.stringValue() ?: "", ExprToPartiQLValue(it, ExprToPartiQLValueType(it))
                             )
-                        }.asSequence()
+                        }
                     )
                     else -> throw ExprToPartiQLValueTypeMismatchException(
                         PartiQLValueType.STRUCT, ExprToPartiQLValueType(exprValue)

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -6,9 +6,11 @@ import org.partiql.eval.internal.operator.rel.RelJoinInner
 import org.partiql.eval.internal.operator.rel.RelJoinLeft
 import org.partiql.eval.internal.operator.rel.RelProject
 import org.partiql.eval.internal.operator.rel.RelScan
+import org.partiql.eval.internal.operator.rel.RelScanIndexed
 import org.partiql.eval.internal.operator.rex.ExprCollection
 import org.partiql.eval.internal.operator.rex.ExprLiteral
 import org.partiql.eval.internal.operator.rex.ExprPathKey
+import org.partiql.eval.internal.operator.rex.ExprPivot
 import org.partiql.eval.internal.operator.rex.ExprSelect
 import org.partiql.eval.internal.operator.rex.ExprStruct
 import org.partiql.eval.internal.operator.rex.ExprVar
@@ -47,21 +49,33 @@ internal object Compiler {
             return ExprCollection(values)
         }
 
-        override fun visitRelOpProject(node: Rel.Op.Project, ctx: Unit): Operator {
-            val input = visitRel(node.input, ctx)
-            val projections = node.projections.map { visitRex(it, ctx) }
-            return RelProject(input, projections)
-        }
-
         override fun visitRexOpSelect(node: Rex.Op.Select, ctx: Unit): Operator {
             val rel = visitRel(node.rel, ctx)
             val constructor = visitRex(node.constructor, ctx)
             return ExprSelect(rel, constructor)
         }
 
+        override fun visitRexOpPivot(node: Rex.Op.Pivot, ctx: Unit): Operator {
+            val rel = visitRel(node.rel, ctx)
+            val key = visitRex(node.key, ctx)
+            val value = visitRex(node.value, ctx)
+            return ExprPivot(rel, key, value)
+        }
+
+        override fun visitRelOpProject(node: Rel.Op.Project, ctx: Unit): Operator {
+            val input = visitRel(node.input, ctx)
+            val projections = node.projections.map { visitRex(it, ctx) }
+            return RelProject(input, projections)
+        }
+
         override fun visitRelOpScan(node: Rel.Op.Scan, ctx: Unit): Operator {
             val rex = visitRex(node.rex, ctx)
             return RelScan(rex)
+        }
+
+        override fun visitRelOpScanIndexed(node: Rel.Op.ScanIndexed, ctx: Unit): Operator {
+            val rex = visitRex(node.rex, ctx)
+            return RelScanIndexed(rex)
         }
 
         @OptIn(PartiQLValueExperimental::class)

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/ToNull.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/ToNull.kt
@@ -108,7 +108,7 @@ internal fun PartiQLValueType.toNull(): () -> PartiQLValue = when (this) {
         { sexpValue<PartiQLValue>(null) }
     }
     PartiQLValueType.STRUCT -> {
-        { structValue<PartiQLValue>(null) }
+        { structValue<PartiQLValue>() }
     }
     PartiQLValueType.NULL -> {
         { nullValue() }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelScanIndexed.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelScanIndexed.kt
@@ -1,0 +1,38 @@
+package org.partiql.eval.internal.operator.rel
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.CollectionValue
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.int64Value
+
+@OptIn(PartiQLValueExperimental::class)
+internal class RelScanIndexed(
+    private val expr: Operator.Expr
+) : Operator.Relation {
+
+    private lateinit var iterator: Iterator<PartiQLValue>
+    private var index: Long = 0
+
+    override fun open() {
+        val r = expr.eval(Record.empty)
+        index = 0
+        iterator = when (r) {
+            is CollectionValue<*> -> r.elements!!.iterator()
+            else -> iterator { yield(r) }
+        }
+    }
+
+    override fun next(): Record? {
+        if (!iterator.hasNext()) {
+            return null
+        }
+        val i = index
+        val v = iterator.next()
+        index += 1
+        return Record.of(v, int64Value(i))
+    }
+
+    override fun close() {}
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPivot.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPivot.kt
@@ -1,0 +1,29 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.StringValue
+import org.partiql.value.structValue
+
+@OptIn(PartiQLValueExperimental::class)
+internal class ExprPivot(
+    private val input: Operator.Relation,
+    private val key: Operator.Expr,
+    private val value: Operator.Expr,
+) : Operator.Expr {
+
+    override fun eval(record: Record): PartiQLValue {
+        input.open()
+        val fields = mutableListOf<Pair<String, PartiQLValue>>()
+        while (true) {
+            val row = input.next() ?: break
+            val k = key.eval(row) as? StringValue ?: error("PIVOT key must be a StringValue")
+            val v = value.eval(row)
+            fields.add(k.value!! to v)
+        }
+        input.close()
+        return structValue(fields)
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprStruct.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprStruct.kt
@@ -16,7 +16,7 @@ internal class ExprStruct(val fields: List<Field>) : Operator.Expr {
             val value = it.value.eval(record)
             key.value!! to value
         }
-        return structValue(fields.asSequence())
+        return structValue(fields)
     }
 
     internal class Field(val key: Operator.Expr, val value: Operator.Expr)

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -1,5 +1,6 @@
 package org.partiql.eval.internal
 
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.partiql.eval.PartiQLEngine
 import org.partiql.eval.PartiQLResult
@@ -8,23 +9,26 @@ import org.partiql.planner.PartiQLPlanner
 import org.partiql.planner.PartiQLPlannerBuilder
 import org.partiql.value.BagValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.StructValue
 import org.partiql.value.bagValue
 import org.partiql.value.boolValue
 import org.partiql.value.int32Value
+import org.partiql.value.int64Value
 import org.partiql.value.nullValue
+import org.partiql.value.stringValue
 import org.partiql.value.structValue
 import kotlin.test.assertEquals
 
 /**
  * This holds sanity tests during the development of the [PartiQLEngine.default] implementation.
  */
+@OptIn(PartiQLValueExperimental::class)
 class PartiQLEngineDefaultTest {
 
     private val engine = PartiQLEngine.default()
     private val planner = PartiQLPlannerBuilder().build()
     private val parser = PartiQLParserBuilder.standard().build()
 
-    @OptIn(PartiQLValueExperimental::class)
     @Test
     fun testLiterals() {
         val statement = parser.parse("SELECT VALUE 1 FROM <<0, 1>>;").root
@@ -39,7 +43,6 @@ class PartiQLEngineDefaultTest {
         assertEquals(expected, output)
     }
 
-    @OptIn(PartiQLValueExperimental::class)
     @Test
     fun testReference() {
         val statement = parser.parse("SELECT VALUE t FROM <<10, 20, 30>> AS t;").root
@@ -54,10 +57,10 @@ class PartiQLEngineDefaultTest {
         assertEquals(expected, output)
     }
 
-    @OptIn(PartiQLValueExperimental::class)
     @Test
     fun testFilter() {
-        val statement = parser.parse("SELECT VALUE t FROM <<true, false, true, false, false, false>> AS t WHERE t;").root
+        val statement =
+            parser.parse("SELECT VALUE t FROM <<true, false, true, false, false, false>> AS t WHERE t;").root
         val session = PartiQLPlanner.Session("q", "u")
         val plan = planner.plan(statement, session)
 
@@ -69,7 +72,6 @@ class PartiQLEngineDefaultTest {
         assertEquals(expected, output)
     }
 
-    @OptIn(PartiQLValueExperimental::class)
     @Test
     fun testJoinInner() {
         val statement = parser.parse("SELECT a, b FROM << { 'a': 1 } >> t, << { 'b': 2 } >> s;").root
@@ -80,11 +82,17 @@ class PartiQLEngineDefaultTest {
         val result = engine.execute(prepared) as PartiQLResult.Value
         val output = result.value as BagValue<*>
 
-        val expected = bagValue(sequenceOf(structValue(sequenceOf("a" to int32Value(1), "b" to int32Value(2)))))
+        val expected = bagValue(
+            sequenceOf(
+                structValue(
+                    "a" to int32Value(1),
+                    "b" to int32Value(2),
+                )
+            )
+        )
         assertEquals(expected, output)
     }
 
-    @OptIn(PartiQLValueExperimental::class)
     @Test
     fun testJoinLeft() {
         val statement = parser.parse("SELECT a, b FROM << { 'a': 1 } >> t LEFT JOIN << { 'b': 2 } >> s ON false;").root
@@ -95,7 +103,63 @@ class PartiQLEngineDefaultTest {
         val result = engine.execute(prepared) as PartiQLResult.Value
         val output = result.value as BagValue<*>
 
-        val expected = bagValue(sequenceOf(structValue(sequenceOf("a" to int32Value(1), "b" to nullValue()))))
+        val expected = bagValue(
+            sequenceOf(
+                structValue(
+                    "a" to int32Value(1),
+                    "b" to nullValue(),
+                )
+            )
+        )
+        assertEquals(expected, output)
+    }
+
+    @Test
+    @Disabled
+    fun testScanIndexed() {
+        val statement = parser.parse("SELECT v, i FROM << 'a', 'b', 'c' >> AS v AT i").root
+        val session = PartiQLPlanner.Session("q", "u")
+        val plan = planner.plan(statement, session)
+
+        val prepared = engine.prepare(plan.plan)
+        val result = engine.execute(prepared) as PartiQLResult.Value
+        val output = result.value as BagValue<*>
+
+        val expected = bagValue(
+            sequenceOf(
+                structValue(
+                    "a" to int64Value(0),
+                    "b" to int64Value(1),
+                    "c" to int64Value(2),
+                )
+            )
+        )
+        assertEquals(expected, output)
+    }
+
+    @Test
+    fun testPivot() {
+        val statement = parser.parse(
+            """
+           PIVOT x.v AT x.k FROM << 
+                { 'k': 'a', 'v': 'x' },
+                { 'k': 'b', 'v': 'y' },
+                { 'k': 'c', 'v': 'z' }
+           >> AS x
+            """.trimIndent()
+        ).root
+        val session = PartiQLPlanner.Session("q", "u")
+        val plan = planner.plan(statement, session)
+
+        val prepared = engine.prepare(plan.plan)
+        val result = engine.execute(prepared) as PartiQLResult.Value
+        val output = result.value as StructValue<*>
+
+        val expected = structValue(
+            "a" to stringValue("x"),
+            "b" to stringValue("y"),
+            "c" to stringValue("z"),
+        )
         assertEquals(expected, output)
     }
 }

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
@@ -939,8 +939,8 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitSelectPivot(ctx: GeneratedParser.SelectPivotContext) = translate(ctx) {
-            val key = visitExpr(ctx.pivot)
-            val value = visitExpr(ctx.at)
+            val key = visitExpr(ctx.at)
+            val value = visitExpr(ctx.pivot)
             selectPivot(key, value)
         }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -84,10 +84,7 @@ import org.partiql.types.NullType
 import org.partiql.types.SexpType
 import org.partiql.types.StaticType
 import org.partiql.types.StaticType.Companion.ANY
-import org.partiql.types.StaticType.Companion.BOOL
 import org.partiql.types.StaticType.Companion.MISSING
-import org.partiql.types.StaticType.Companion.NULL
-import org.partiql.types.StaticType.Companion.STRING
 import org.partiql.types.StringType
 import org.partiql.types.StructType
 import org.partiql.types.TupleConstraint
@@ -96,7 +93,6 @@ import org.partiql.value.BoolValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.TextValue
 import org.partiql.value.boolValue
-import java.sql.Struct
 
 /**
  * Rewrites an untyped algebraic translation of the query to be both typed and have resolved variables.

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -96,6 +96,7 @@ import org.partiql.value.BoolValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.TextValue
 import org.partiql.value.boolValue
+import java.sql.Struct
 
 /**
  * Rewrites an untyped algebraic translation of the query to be both typed and have resolved variables.

--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQL.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQL.kt
@@ -38,12 +38,12 @@ import org.partiql.value.impl.Int64ValueImpl
 import org.partiql.value.impl.Int8ValueImpl
 import org.partiql.value.impl.IntValueImpl
 import org.partiql.value.impl.IntervalValueImpl
+import org.partiql.value.impl.IterableStructValueImpl
 import org.partiql.value.impl.ListValueImpl
 import org.partiql.value.impl.MapStructValueImpl
 import org.partiql.value.impl.MissingValueImpl
 import org.partiql.value.impl.MultiMapStructValueImpl
 import org.partiql.value.impl.NullValueImpl
-import org.partiql.value.impl.SequenceStructValueImpl
 import org.partiql.value.impl.SexpValueImpl
 import org.partiql.value.impl.StringValueImpl
 import org.partiql.value.impl.SymbolValueImpl
@@ -379,7 +379,7 @@ public fun <T : PartiQLValue> sexpValue(
 ): SexpValue<T> = SexpValueImpl(elements, annotations.toPersistentList())
 
 /**
- * STRUCT type value.
+ * Create a PartiQL struct value backed by an iterable of key-value field pairs.
  *
  * @param T
  * @param fields
@@ -389,12 +389,12 @@ public fun <T : PartiQLValue> sexpValue(
 @JvmOverloads
 @PartiQLValueExperimental
 public fun <T : PartiQLValue> structValue(
-    fields: Sequence<Pair<String, T>>?,
+    fields: Iterable<Pair<String, T>>?,
     annotations: Annotations = emptyList(),
-): StructValue<T> = SequenceStructValueImpl(fields, annotations.toPersistentList())
+): StructValue<T> = IterableStructValueImpl(fields, annotations.toPersistentList())
 
 /**
- * STRUCT type value.
+ * Create a PartiQL struct value backed by an iterable of key-value field pairs.
  *
  * @param T
  * @param fields
@@ -403,13 +403,30 @@ public fun <T : PartiQLValue> structValue(
  */
 @JvmOverloads
 @PartiQLValueExperimental
-public fun <T : PartiQLValue> structValueWithDuplicates(
+public fun <T : PartiQLValue> structValue(
+    vararg fields: Pair<String, T>,
+    annotations: Annotations = emptyList(),
+): StructValue<T> = IterableStructValueImpl(fields.toList(), annotations.toPersistentList())
+
+/**
+ * Create a PartiQL struct value backed by a multimap of keys with a list of values. This supports having multiple
+ * values per key, while improving lookup performance compared to using an iterable.
+ *
+ * @param T
+ * @param fields
+ * @param annotations
+ * @return
+ */
+@JvmOverloads
+@PartiQLValueExperimental
+public fun <T : PartiQLValue> structValue(
     fields: Map<String, Iterable<T>>?,
     annotations: Annotations = emptyList(),
 ): StructValue<T> = MultiMapStructValueImpl(fields, annotations.toPersistentList())
 
 /**
- * STRUCT type value.
+ * Create a PartiQL struct value backed by a map of keys with a list of values. This does not support having multiple
+ * values per key, but uses a Java HashMap for quicker lookup than an iterable backed StructValue.
  *
  * @param T
  * @param fields
@@ -418,7 +435,7 @@ public fun <T : PartiQLValue> structValueWithDuplicates(
  */
 @JvmOverloads
 @PartiQLValueExperimental
-public fun <T : PartiQLValue> structValueNoDuplicates(
+public fun <T : PartiQLValue> structValueMap(
     fields: Map<String, T>?,
     annotations: Annotations = emptyList(),
 ): StructValue<T> = MapStructValueImpl(fields, annotations.toPersistentList())

--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
@@ -465,11 +465,11 @@ public abstract class SexpValue<T : PartiQLValue> : CollectionValue<T> {
 }
 
 @PartiQLValueExperimental
-public abstract class StructValue<T : PartiQLValue> : PartiQLValue, Sequence<Pair<String, T>> {
+public abstract class StructValue<T : PartiQLValue> : PartiQLValue, Iterable<Pair<String, T>> {
 
     override val type: PartiQLValueType = PartiQLValueType.STRUCT
 
-    public abstract val fields: Sequence<Pair<String, T>>?
+    public abstract val fields: Collection<Pair<String, T>>?
 
     override val isNull: Boolean
         get() = fields == null

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/StructValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/StructValueImpl.kt
@@ -23,19 +23,19 @@ import org.partiql.value.StructValue
 import org.partiql.value.util.PartiQLValueVisitor
 
 /**
- * Implementation of a [StructValue<T>] backed by a Sequence.
+ * Implementation of a [StructValue<T>] backed by an iterator.
  *
  * @param T
  * @property delegate
  * @property annotations
  */
 @OptIn(PartiQLValueExperimental::class)
-internal class SequenceStructValueImpl<T : PartiQLValue>(
-    private val delegate: Sequence<Pair<String, T>>?,
+internal class IterableStructValueImpl<T : PartiQLValue>(
+    private val delegate: Iterable<Pair<String, T>>?,
     override val annotations: PersistentList<String>,
 ) : StructValue<T>() {
 
-    override val fields: Sequence<Pair<String, T>>? = delegate
+    override val fields: Collection<Pair<String, T>>? = delegate?.toList()
 
     override operator fun get(key: String): T? {
         if (delegate == null) {
@@ -51,7 +51,7 @@ internal class SequenceStructValueImpl<T : PartiQLValue>(
         return delegate.filter { it.first == key }.map { it.second }.asIterable()
     }
 
-    override fun copy(annotations: Annotations) = SequenceStructValueImpl(delegate, annotations.toPersistentList())
+    override fun copy(annotations: Annotations) = IterableStructValueImpl(delegate, annotations.toPersistentList())
 
     override fun withAnnotations(annotations: Annotations): StructValue<T> = _withAnnotations(annotations)
 
@@ -73,12 +73,12 @@ internal class MultiMapStructValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : StructValue<T>() {
 
-    override val fields: Sequence<Pair<String, T>>?
+    override val fields: Collection<Pair<String, T>>?
         get() {
             if (delegate == null) {
                 return null
             }
-            return delegate.asSequence().map { f -> f.value.map { v -> f.key to v } }.flatten()
+            return delegate.entries.map { f -> f.value.map { v -> f.key to v } }.flatten()
         }
 
     override operator fun get(key: String): T? = getAll(key).firstOrNull()
@@ -112,12 +112,12 @@ internal class MapStructValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : StructValue<T>() {
 
-    override val fields: Sequence<Pair<String, T>>?
+    override val fields: Collection<Pair<String, T>>?
         get() {
             if (delegate == null) {
                 return null
             }
-            return delegate.asSequence().map { f -> f.key to f.value }
+            return delegate.entries.map { f -> f.key to f.value }
         }
 
     override operator fun get(key: String): T? {

--- a/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
@@ -192,7 +192,7 @@ internal class PartiQLValueIonReader(
                     }
                 }
                 reader.stepOut()
-                structValue(elements.asSequence(), annotations)
+                structValue(elements, annotations)
             }
 
             IonType.DATAGRAM -> throw IllegalArgumentException("Datagram not supported")
@@ -525,7 +525,7 @@ internal class PartiQLValueIonReader(
                     PARTIQL_ANNOTATION.GRAPH_ANNOTATION -> TODO("Not yet implemented")
                     null -> {
                         if (reader.isNullValue) {
-                            val nullSequence: Sequence<Pair<String, PartiQLValue>>? = null
+                            val nullSequence: List<Pair<String, PartiQLValue>>? = null
                             structValue<PartiQLValue>(nullSequence, annotations)
                         } else {
                             reader.stepIn()
@@ -536,7 +536,7 @@ internal class PartiQLValueIonReader(
                                 }
                             }
                             reader.stepOut()
-                            structValue(elements.asSequence(), annotations)
+                            structValue(elements, annotations)
                         }
                     }
                 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueTextWriter.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueTextWriter.kt
@@ -200,7 +200,7 @@ public class PartiQLValueTextWriter(
 
         override fun visitStruct(v: StructValue<*>, format: Format?): String = buildString {
             // null.struct
-            val fields = v.fields?.toList() ?: return "null"
+            val fields = v.fields?.asSequence()?.toList() ?: return "null"
             // {}
             if (fields.isEmpty() || format == null) {
                 format?.let { append(it.prefix) }

--- a/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueIonSerdeTest.kt
+++ b/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueIonSerdeTest.kt
@@ -147,7 +147,7 @@ class PartiQLValueIonSerdeTest {
             ),
             // struct.null
             roundTrip(
-                structValue<PartiQLValue>(null),
+                structValue(null as Iterable<Pair<String, PartiQLValue>>?),
                 ION.newNullStruct()
             ),
             // $bag::list.null
@@ -429,10 +429,8 @@ class PartiQLValueIonSerdeTest {
             ),
             oneWayTrip(
                 structValue(
-                    sequenceOf(
-                        "a" to int32Value(1),
-                        "b" to stringValue("x"),
-                    )
+                    "a" to int32Value(1),
+                    "b" to stringValue("x"),
                 ),
                 ION.newEmptyStruct()
                     .apply {
@@ -440,10 +438,8 @@ class PartiQLValueIonSerdeTest {
                         add("b", ION.newString("x"))
                     },
                 structValue(
-                    sequenceOf(
-                        "a" to intValue(BigInteger.ONE),
-                        "b" to stringValue("x"),
-                    )
+                    "a" to intValue(BigInteger.ONE),
+                    "b" to stringValue("x"),
                 ),
             )
         )

--- a/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueTextWriterTest.kt
+++ b/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueTextWriterTest.kt
@@ -377,7 +377,7 @@ class PartiQLValueTextWriterTest {
                 expected = "null",
             ),
             case(
-                value = structValue<PartiQLValue>(null),
+                value = structValue(null as Iterable<Pair<String, PartiQLValue>>?),
                 expected = "null",
             ),
         )
@@ -385,15 +385,13 @@ class PartiQLValueTextWriterTest {
         @JvmStatic
         fun struct() = listOf(
             case(
-                value = structValue<PartiQLValue>(emptySequence()),
+                value = structValue<PartiQLValue>(),
                 expected = "{}",
             ),
             case(
                 value = structValue(
-                    sequenceOf(
-                        "a" to int32Value(1),
-                        "b" to stringValue("x"),
-                    )
+                    "a" to int32Value(1),
+                    "b" to stringValue("x"),
                 ),
                 expected = "{a:1,b:'x'}",
             ),
@@ -454,15 +452,13 @@ class PartiQLValueTextWriterTest {
         @JvmStatic
         fun structFormatted() = listOf(
             formatted(
-                value = structValue<PartiQLValue>(emptySequence()),
+                value = structValue<PartiQLValue>(),
                 expected = "{}",
             ),
             formatted(
                 value = structValue(
-                    sequenceOf(
-                        "a" to int32Value(1),
-                        "b" to stringValue("x"),
-                    )
+                    "a" to int32Value(1),
+                    "b" to stringValue("x"),
                 ),
                 expected = """
                     |{
@@ -477,29 +473,27 @@ class PartiQLValueTextWriterTest {
         fun nestedCollectionsFormatted() = listOf(
             formatted(
                 value = structValue(
-                    sequenceOf(
-                        "bag" to bagValue(
-                            sequenceOf(
-                                int32Value(1),
-                                int32Value(2),
-                                int32Value(3),
-                            )
-                        ),
-                        "list" to listValue(
-                            sequenceOf(
-                                stringValue("a"),
-                                stringValue("b"),
-                                stringValue("c"),
-                            )
-                        ),
-                        "sexp" to sexpValue(
-                            sequenceOf(
-                                int32Value(1),
-                                int32Value(2),
-                                int32Value(3),
-                            )
-                        ),
-                    )
+                    "bag" to bagValue(
+                        sequenceOf(
+                            int32Value(1),
+                            int32Value(2),
+                            int32Value(3),
+                        )
+                    ),
+                    "list" to listValue(
+                        sequenceOf(
+                            stringValue("a"),
+                            stringValue("b"),
+                            stringValue("c"),
+                        )
+                    ),
+                    "sexp" to sexpValue(
+                        sequenceOf(
+                            int32Value(1),
+                            int32Value(2),
+                            int32Value(3),
+                        )
+                    ),
                 ),
                 expected = """
                     |{
@@ -539,10 +533,8 @@ class PartiQLValueTextWriterTest {
                             )
                         ),
                         structValue(
-                            sequenceOf(
-                                "a" to int32Value(1),
-                                "b" to stringValue("x"),
-                            )
+                            "a" to int32Value(1),
+                            "b" to stringValue("x"),
                         ),
                     )
                 ),
@@ -567,11 +559,9 @@ class PartiQLValueTextWriterTest {
             ),
             formatted(
                 value = structValue(
-                    sequenceOf(
-                        "bag" to bagValue<PartiQLValue>(emptySequence()),
-                        "list" to listValue<PartiQLValue>(emptySequence()),
-                        "sexp" to sexpValue<PartiQLValue>(emptySequence()),
-                    )
+                    "bag" to bagValue(emptySequence()),
+                    "list" to listValue(emptySequence()),
+                    "sexp" to sexpValue(emptySequence()),
                 ),
                 expected = """
                     |{
@@ -584,9 +574,9 @@ class PartiQLValueTextWriterTest {
             formatted(
                 value = bagValue(
                     sequenceOf(
-                        listValue<PartiQLValue>(emptySequence()),
-                        sexpValue<PartiQLValue>(emptySequence()),
-                        structValue<PartiQLValue>(emptySequence()),
+                        listValue(emptySequence()),
+                        sexpValue(emptySequence()),
+                        structValue<PartiQLValue>(),
                     )
                 ),
                 expected = """
@@ -717,10 +707,8 @@ class PartiQLValueTextWriterTest {
                             listOf("sexp")
                         ),
                         structValue(
-                            sequenceOf(
-                                "a" to int32Value(1, listOf("z")),
-                            ),
-                            listOf("struct")
+                            "a" to int32Value(1, listOf("z")),
+                            annotations = listOf("struct")
                         ),
                     )
                 ),


### PR DESCRIPTION

## Description

- Fixes scan_indexed in the PlanTyper
- Adds PIVOT expression to engine
- Adds SCAN_INDEXED relation operator to engine

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.