### PR TITLE
Fixes scan_indexed and adds PIVOT

### DIFF
--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
@@ -418,6 +418,36 @@ class PartiQLSchemaInferencerTests {
                     )
                 )
             ),
+            SuccessTestCase(
+                name = "Scan indexed",
+                key = key("sanity-07"),
+                catalog = "pql",
+                expected = BagType(
+                    StructType(
+                        fields = listOf(
+                            StructType.Field("first", STRING),
+                            StructType.Field("i", INT),
+                        ),
+                        contentClosed = true,
+                        constraints = setOf(
+                            TupleConstraint.Open(false),
+                            TupleConstraint.UniqueAttrs(true),
+                            TupleConstraint.Ordered
+                        )
+                    )
+                )
+            ),
+            SuccessTestCase(
+                name = "Scan indexed",
+                key = key("pivot-00"),
+                catalog = "pql",
+                expected = StructType(
+                    contentClosed = false,
+                    constraints = setOf(
+                        TupleConstraint.Open(true),
+                    )
+                )
+            ),
         )
 
         @JvmStatic

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
@@ -79,6 +79,16 @@ class PartiQLSchemaInferencerTests {
     fun testSelectStar(tc: TestCase) = runTest(tc)
 
     @ParameterizedTest
+    @MethodSource("scanCases")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun testScan(tc: TestCase) = runTest(tc)
+
+    @ParameterizedTest
+    @MethodSource("pivotCases")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun testPivot(tc: TestCase) = runTest(tc)
+
+    @ParameterizedTest
     @MethodSource("sessionVariables")
     @Execution(ExecutionMode.CONCURRENT)
     fun testSessionVariables(tc: TestCase) = runTest(tc)
@@ -418,15 +428,19 @@ class PartiQLSchemaInferencerTests {
                     )
                 )
             ),
+        )
+
+        @JvmStatic
+        fun scanCases() = listOf(
             SuccessTestCase(
-                name = "Scan indexed",
+                name = "Basic Scan Indexed",
                 key = key("sanity-07"),
                 catalog = "pql",
                 expected = BagType(
                     StructType(
                         fields = listOf(
                             StructType.Field("first", STRING),
-                            StructType.Field("i", INT),
+                            StructType.Field("i", INT8),
                         ),
                         contentClosed = true,
                         constraints = setOf(
@@ -437,8 +451,12 @@ class PartiQLSchemaInferencerTests {
                     )
                 )
             ),
+        )
+
+        @JvmStatic
+        fun pivotCases() = listOf(
             SuccessTestCase(
-                name = "Scan indexed",
+                name = "Basic PIVOT",
                 key = key("pivot-00"),
                 catalog = "pql",
                 expected = StructType(

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
@@ -54,6 +54,7 @@ import org.partiql.planner.internal.ir.relOpLimit
 import org.partiql.planner.internal.ir.relOpOffset
 import org.partiql.planner.internal.ir.relOpProject
 import org.partiql.planner.internal.ir.relOpScan
+import org.partiql.planner.internal.ir.relOpScanIndexed
 import org.partiql.planner.internal.ir.relOpSort
 import org.partiql.planner.internal.ir.relOpSortSpec
 import org.partiql.planner.internal.ir.relOpUnion
@@ -271,9 +272,9 @@ internal object RelConverter {
 
         private fun convertScanIndexed(rex: Rex, binding: Rel.Binding, index: Rel.Binding): Rel {
             val schema = listOf(binding, index)
-            val props = setOf(Rel.Prop.ORDERED)
+            val props = emptySet<Rel.Prop>()
             val type = relType(schema, props)
-            val op = relOpScan(rex)
+            val op = relOpScanIndexed(rex)
             return rel(type, op)
         }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -161,7 +161,7 @@ internal class PlanTyper(
             val rex = node.rex.type(outer.global())
             // compute rel type
             val valueT = getElementTypeForFromSource(rex.type)
-            val indexT = StaticType.INT
+            val indexT = StaticType.INT8
             val type = ctx!!.copyWithSchema(listOf(valueT, indexT))
             // rewrite
             val op = relOpScanIndexed(rex)

--- a/partiql-planner/src/testFixtures/resources/inputs/schema_inferencer/pivot.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/schema_inferencer/pivot.sql
@@ -1,0 +1,2 @@
+--#[pivot-00]
+PIVOT t.a AT t.c FROM main.T AS t;

--- a/partiql-planner/src/testFixtures/resources/inputs/schema_inferencer/sanity.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/schema_inferencer/sanity.sql
@@ -45,3 +45,6 @@ SELECT
        p.name.*,
        (p.name."first" || ' ' || p.name."last") AS full_name
 FROM main.person AS p;
+
+--#[sanity-07]
+SELECT p.name."first", i FROM main.person AS p AT i;


### PR DESCRIPTION
## Description
- Fixes typo which was using scan instead of scan_indexed
- Adds static typing of the PIVOT projection

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.