### PR TITLE
Fix `PlanCompiler` output type for `DISTINCT` + `ORDER BY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,13 +46,14 @@ Thank you to all who have contributed!
 - **BREAKING** In the produced plan: 
   - The new plan is fully resolved and typed.
   - Operators will be converted to function call. 
-
+- Changes the return type of `filter_distinct` to a list if input collection is list
 
 ### Deprecated
 
 ### Fixed
 - Fixes the CLI hanging on invalid queries. See issue #1230.
 - Fixes Timestamp Type parsing issue. Previously Timestamp Type would get parsed to a Time type.
+- Fixes the physical plan compiler to return list when `DISTINCT` used with `ORDER BY`
 
 ### Removed
 - **Breaking** Removed IR factory in favor of static top-level functions. Change `Ast.foo()`

--- a/docs/wiki/documentation/Functions.md
+++ b/docs/wiki/documentation/Functions.md
@@ -477,20 +477,20 @@ EXTRACT(TIMEZONE_MINUTE FROM TIME WITH TIME ZONE '23:12:59-08:30')  -- -30
 ### `FILTER_DISTINCT` -- since v0.7.0
 
 Signature
-: `FILTER_DISTINCT: Container -> Bag`
+: `FILTER_DISTINCT: Container -> Bag|List`
 
 Header
 : `FILTER_DISTINCT(c)`
 
 Purpose
-: Returns a bag of distinct values contained within a bag, list, sexp, or struct.  If the container is a struct,
-the field names are not considered.
+: Returns a bag or list of distinct values contained within a bag, list, sexp, or struct.  If the container is a struct,
+the field names are not considered. A list will be returned if and only if the input is a list.
 
 Examples
 :
 
 ```sql
-FILTER_DISTINCT([0, 0, 1])                  -- <<0, 1>>
+FILTER_DISTINCT([0, 0, 1])                  -- [0, 1]
 FILTER_DISTINCT(<<0, 0, 1>>)                -- <<0, 1>>
 FILTER_DISTINCT(SEXP(0, 0, 1))              -- <<0, 1>>
 FILTER_DISTINCT({'a': 0, 'b': 0, 'c': 1})   -- <<0, 1>>

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/FilterDistinctEvaluationTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/FilterDistinctEvaluationTest.kt
@@ -26,15 +26,36 @@ class FilterDistinctEvaluationTest : EvaluatorTestBase() {
         override fun getParameters(): List<Any> = listOf(
 
             // These three tests ensure we can accept lists, bags, s-expressions and structs
-            ExprFunctionTestCase("filter_distinct([0, 0, 1])", "$BAG_ANNOTATION::[0, 1]"), // list
-            ExprFunctionTestCase("filter_distinct(<<0, 0, 1>>)", "$BAG_ANNOTATION::[0, 1]"), // bag
-            ExprFunctionTestCase("filter_distinct(SEXP(0, 0, 1))", "$BAG_ANNOTATION::[0, 1]"), // s-exp
-            ExprFunctionTestCase("filter_distinct({'a': 0, 'b': 0, 'c': 1})", "$BAG_ANNOTATION::[0, 1]"), // struct
+            ExprFunctionTestCase(
+                "filter_distinct([0, 0, 1])",
+                "[0, 1]"
+            ), // list
+            ExprFunctionTestCase(
+                "filter_distinct(<<0, 0, 1>>)",
+                "$BAG_ANNOTATION::[0, 1]"
+            ), // bag
+            ExprFunctionTestCase(
+                "filter_distinct(SEXP(0, 0, 1))",
+                "$BAG_ANNOTATION::[0, 1]"
+            ), // s-exp
+            ExprFunctionTestCase(
+                "filter_distinct({'a': 0, 'b': 0, 'c': 1})",
+                "$BAG_ANNOTATION::[0, 1]"
+            ), // struct
 
             // Some "smoke tests" to ensure the basic plumbing is working right.
-            ExprFunctionTestCase("filter_distinct(['foo', 'foo', 1, 1, `symbol`, `symbol`])", "$BAG_ANNOTATION::[\"foo\", 1, symbol]"),
-            ExprFunctionTestCase("filter_distinct([{ 'a': 1 }, { 'a': 1 }, { 'a': 1 }])", "$BAG_ANNOTATION::[{ 'a': 1 }]"),
-            ExprFunctionTestCase("filter_distinct([[1, 1], [1, 1], [2, 2]])", "$BAG_ANNOTATION::[[1,1], [2, 2]]"),
+            ExprFunctionTestCase(
+                "filter_distinct(['foo', 'foo', 1, 1, `symbol`, `symbol`])",
+                "[\"foo\", 1, symbol]"
+            ),
+            ExprFunctionTestCase(
+                "filter_distinct([{ 'a': 1 }, { 'a': 1 }, { 'a': 1 }])",
+                "[{ 'a': 1 }]"
+            ),
+            ExprFunctionTestCase(
+                "filter_distinct([[1, 1], [1, 1], [2, 2]])",
+                "[[1,1], [2, 2]]"
+            ),
         )
     }
 
@@ -70,5 +91,9 @@ class FilterDistinctEvaluationTest : EvaluatorTestBase() {
     }
 
     @Test
-    fun invalidArityTest() = checkInvalidArity(funcName = "filter_distinct", maxArity = 1, minArity = 1)
+    fun invalidArityTest() = checkInvalidArity(
+        funcName = "filter_distinct",
+        maxArity = 1,
+        minArity = 1
+    )
 }


### PR DESCRIPTION
## Relevant Issues
- Fixes https://github.com/partiql/partiql-lang-kotlin/issues/1277

## Description
The `PlanCompiler` was outputting a bag when `DISTINCT` and `ORDER BY` were present in a query. A list should have been outputted as `EvaluatingCompiler` outputs. `PlanCompiler` rewrites the `DISTINCT` to use the `ExprFunction` `filter_distinct` to preserve a collection's distinct elements. This PR changes that function to return a list when the input is a list.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.