### PR TITLE
Adds literal STRUCT test

### DIFF
--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -404,4 +404,35 @@ class PartiQLEngineDefaultTest {
         )
         assertEquals(expected, output)
     }
+
+    @OptIn(PartiQLValueExperimental::class)
+    @Test
+    fun testStruct() {
+        val source = """
+            SELECT VALUE {
+                'a': 1,
+                'b': NULL,
+                c : d
+            }
+            FROM <<
+                { 'c': 'hello', 'd': 'world' }
+            >>
+        """.trimIndent()
+        val statement = parser.parse(source).root
+        val session = PartiQLPlanner.Session("q", "u")
+        val plan = planner.plan(statement, session)
+
+        val prepared = engine.prepare(plan.plan)
+        val result = engine.execute(prepared) as PartiQLResult.Value
+        val output = result.value
+
+        val expected: PartiQLValue = bagValue(
+            structValue(
+                "a" to int32Value(1),
+                "b" to nullValue(),
+                "hello" to stringValue("world")
+            )
+        )
+        assertEquals(expected, output)
+    }
 }


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds literal STRUCT test just so we don't accidentally break anything in future.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **[YES/NO]**
  - No, just adding a test.

- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.