### PR TITLE
Merge `main` to `partiql-eval` (incl #1298 fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,13 +46,14 @@ Thank you to all who have contributed!
 - **BREAKING** In the produced plan: 
   - The new plan is fully resolved and typed.
   - Operators will be converted to function call. 
-
+- Changes the return type of `filter_distinct` to a list if input collection is list
 
 ### Deprecated
 
 ### Fixed
 - Fixes the CLI hanging on invalid queries. See issue #1230.
 - Fixes Timestamp Type parsing issue. Previously Timestamp Type would get parsed to a Time type.
+- Fixes the physical plan compiler to return list when `DISTINCT` used with `ORDER BY`
 
 ### Removed
 - **Breaking** Removed IR factory in favor of static top-level functions. Change `Ast.foo()`

--- a/docs/wiki/documentation/Functions.md
+++ b/docs/wiki/documentation/Functions.md
@@ -477,20 +477,20 @@ EXTRACT(TIMEZONE_MINUTE FROM TIME WITH TIME ZONE '23:12:59-08:30')  -- -30
 ### `FILTER_DISTINCT` -- since v0.7.0
 
 Signature
-: `FILTER_DISTINCT: Container -> Bag`
+: `FILTER_DISTINCT: Container -> Bag|List`
 
 Header
 : `FILTER_DISTINCT(c)`
 
 Purpose
-: Returns a bag of distinct values contained within a bag, list, sexp, or struct.  If the container is a struct,
-the field names are not considered.
+: Returns a bag or list of distinct values contained within a bag, list, sexp, or struct.  If the container is a struct,
+the field names are not considered. A list will be returned if and only if the input is a list.
 
 Examples
 :
 
 ```sql
-FILTER_DISTINCT([0, 0, 1])                  -- <<0, 1>>
+FILTER_DISTINCT([0, 0, 1])                  -- [0, 1]
 FILTER_DISTINCT(<<0, 0, 1>>)                -- <<0, 1>>
 FILTER_DISTINCT(SEXP(0, 0, 1))              -- <<0, 1>>
 FILTER_DISTINCT({'a': 0, 'b': 0, 'c': 1})   -- <<0, 1>>

--- a/partiql-eval/src/test/kotlin/org/partiql/lang/eval/internal/builtins/functions/FilterDistinctEvaluationTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/lang/eval/internal/builtins/functions/FilterDistinctEvaluationTest.kt
@@ -28,7 +28,7 @@ class FilterDistinctEvaluationTest : EvaluatorTestBase() {
             // These three tests ensure we can accept lists, bags, s-expressions and structs
             ExprFunctionTestCase(
                 "filter_distinct([0, 0, 1])",
-                "$BAG_ANNOTATION::[0, 1]"
+                "[0, 1]"
             ), // list
             ExprFunctionTestCase(
                 "filter_distinct(<<0, 0, 1>>)",
@@ -46,15 +46,15 @@ class FilterDistinctEvaluationTest : EvaluatorTestBase() {
             // Some "smoke tests" to ensure the basic plumbing is working right.
             ExprFunctionTestCase(
                 "filter_distinct(['foo', 'foo', 1, 1, `symbol`, `symbol`])",
-                "$BAG_ANNOTATION::[\"foo\", 1, symbol]"
+                "[\"foo\", 1, symbol]"
             ),
             ExprFunctionTestCase(
                 "filter_distinct([{ 'a': 1 }, { 'a': 1 }, { 'a': 1 }])",
-                "$BAG_ANNOTATION::[{ 'a': 1 }]"
+                "[{ 'a': 1 }]"
             ),
             ExprFunctionTestCase(
                 "filter_distinct([[1, 1], [1, 1], [2, 2]])",
-                "$BAG_ANNOTATION::[[1,1], [2, 2]]"
+                "[[1,1], [2, 2]]"
             ),
         )
     }

--- a/partiql-eval/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/lang/planner/transforms/PartiQLSchemaInferencerTests.kt
@@ -79,6 +79,16 @@ class PartiQLSchemaInferencerTests {
     fun testSelectStar(tc: TestCase) = runTest(tc)
 
     @ParameterizedTest
+    @MethodSource("scanCases")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun testScan(tc: TestCase) = runTest(tc)
+
+    @ParameterizedTest
+    @MethodSource("pivotCases")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun testPivot(tc: TestCase) = runTest(tc)
+
+    @ParameterizedTest
     @MethodSource("sessionVariables")
     @Execution(ExecutionMode.CONCURRENT)
     fun testSessionVariables(tc: TestCase) = runTest(tc)
@@ -415,6 +425,44 @@ class PartiQLSchemaInferencerTests {
                             TupleConstraint.UniqueAttrs(true),
                             TupleConstraint.Ordered
                         )
+                    )
+                )
+            ),
+        )
+
+        @JvmStatic
+        fun scanCases() = listOf(
+            SuccessTestCase(
+                name = "Basic Scan Indexed",
+                key = key("sanity-07"),
+                catalog = "pql",
+                expected = BagType(
+                    StructType(
+                        fields = listOf(
+                            StructType.Field("first", STRING),
+                            StructType.Field("i", INT8),
+                        ),
+                        contentClosed = true,
+                        constraints = setOf(
+                            TupleConstraint.Open(false),
+                            TupleConstraint.UniqueAttrs(true),
+                            TupleConstraint.Ordered
+                        )
+                    )
+                )
+            ),
+        )
+
+        @JvmStatic
+        fun pivotCases() = listOf(
+            SuccessTestCase(
+                name = "Basic PIVOT",
+                key = key("pivot-00"),
+                catalog = "pql",
+                expected = StructType(
+                    contentClosed = false,
+                    constraints = setOf(
+                        TupleConstraint.Open(true),
                     )
                 )
             ),

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
@@ -590,23 +590,26 @@ public object PartiQLHeader : Header() {
     private fun extract(): List<FunctionSignature.Scalar> = emptyList()
 
     private fun dateAdd(): List<FunctionSignature.Scalar> {
+        val intervals = listOf(INT32, INT64, INT)
         val operators = mutableListOf<FunctionSignature.Scalar>()
         for (field in DatetimeField.values()) {
             for (type in types.datetime) {
                 if (field == DatetimeField.TIMEZONE_HOUR || field == DatetimeField.TIMEZONE_MINUTE) {
                     continue
                 }
-                val signature = FunctionSignature.Scalar(
-                    name = "date_add_${field.name.lowercase()}",
-                    returns = type,
-                    parameters = listOf(
-                        FunctionParameter("interval", INT),
-                        FunctionParameter("datetime", type),
-                    ),
-                    isNullable = false,
-                    isNullCall = true,
-                )
-                operators.add(signature)
+                for (interval in intervals) {
+                    val signature = FunctionSignature.Scalar(
+                        name = "date_add_${field.name.lowercase()}",
+                        returns = type,
+                        parameters = listOf(
+                            FunctionParameter("interval", interval),
+                            FunctionParameter("datetime", type),
+                        ),
+                        isNullable = false,
+                        isNullCall = true,
+                    )
+                    operators.add(signature)
+                }
             }
         }
         return operators

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -38,6 +38,7 @@ import org.partiql.planner.internal.ir.rel
 import org.partiql.planner.internal.ir.relBinding
 import org.partiql.planner.internal.ir.relOpAggregate
 import org.partiql.planner.internal.ir.relOpAggregateCall
+import org.partiql.planner.internal.ir.relOpDistinct
 import org.partiql.planner.internal.ir.relOpErr
 import org.partiql.planner.internal.ir.relOpFilter
 import org.partiql.planner.internal.ir.relOpJoin
@@ -45,6 +46,7 @@ import org.partiql.planner.internal.ir.relOpLimit
 import org.partiql.planner.internal.ir.relOpOffset
 import org.partiql.planner.internal.ir.relOpProject
 import org.partiql.planner.internal.ir.relOpScan
+import org.partiql.planner.internal.ir.relOpScanIndexed
 import org.partiql.planner.internal.ir.relOpSort
 import org.partiql.planner.internal.ir.relOpUnpivot
 import org.partiql.planner.internal.ir.relType
@@ -59,6 +61,7 @@ import org.partiql.planner.internal.ir.rexOpGlobal
 import org.partiql.planner.internal.ir.rexOpLit
 import org.partiql.planner.internal.ir.rexOpPath
 import org.partiql.planner.internal.ir.rexOpPathStepSymbol
+import org.partiql.planner.internal.ir.rexOpPivot
 import org.partiql.planner.internal.ir.rexOpSelect
 import org.partiql.planner.internal.ir.rexOpStruct
 import org.partiql.planner.internal.ir.rexOpStructField
@@ -158,10 +161,10 @@ internal class PlanTyper(
             val rex = node.rex.type(outer.global())
             // compute rel type
             val valueT = getElementTypeForFromSource(rex.type)
-            val indexT = StaticType.INT
+            val indexT = StaticType.INT8
             val type = ctx!!.copyWithSchema(listOf(valueT, indexT))
             // rewrite
-            val op = relOpScan(rex)
+            val op = relOpScanIndexed(rex)
             return rel(type, op)
         }
 
@@ -197,7 +200,8 @@ internal class PlanTyper(
         }
 
         override fun visitRelOpDistinct(node: Rel.Op.Distinct, ctx: Rel.Type?): Rel {
-            TODO("Type RelOp Distinct")
+            val input = visitRel(node.input, ctx)
+            return rel(input.type, relOpDistinct(input))
         }
 
         override fun visitRelOpFilter(node: Rel.Op.Filter, ctx: Rel.Type?): Rel {
@@ -815,7 +819,16 @@ internal class PlanTyper(
         }
 
         override fun visitRexOpPivot(node: Rex.Op.Pivot, ctx: StaticType?): Rex {
-            TODO("Type RexOpPivot")
+            val rel = node.rel.type(locals)
+            val typeEnv = TypeEnv(rel.type.schema, ResolutionStrategy.LOCAL)
+            val key = node.key.type(typeEnv)
+            val value = node.value.type(typeEnv)
+            val type = StructType(
+                contentClosed = false,
+                constraints = setOf(TupleConstraint.Open(true))
+            )
+            val op = rexOpPivot(key, value, rel)
+            return rex(type, op)
         }
 
         override fun visitRexOpSubquery(node: Rex.Op.Subquery, ctx: StaticType?): Rex {

--- a/partiql-planner/src/testFixtures/resources/inputs/schema_inferencer/pivot.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/schema_inferencer/pivot.sql
@@ -1,0 +1,2 @@
+--#[pivot-00]
+PIVOT t.a AT t.c FROM main.T AS t;

--- a/partiql-planner/src/testFixtures/resources/inputs/schema_inferencer/sanity.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/schema_inferencer/sanity.sql
@@ -45,3 +45,6 @@ SELECT
        p.name.*,
        (p.name."first" || ' ' || p.name."last") AS full_name
 FROM main.person AS p;
+
+--#[sanity-07]
+SELECT p.name."first", i FROM main.person AS p AT i;


### PR DESCRIPTION
## Relevant Issues
- Port fix from #1277 to `partiql-eval` branch

## Description
Add fix to PlanCompiler for `DISTINCT` + `ORDER BY` to `partiql-eval` branch.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.