### PR TITLE
Adds getBindings to PartiQL Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,14 @@ Thank you to all who have contributed!
   - The new plan is fully resolved and typed.
   - Operators will be converted to function call. 
 - Changes the return type of `filter_distinct` to a list if input collection is list
+- `PartiQLValue` collections are backed by iterables rather than just sequences.
 
 ### Deprecated
 
 ### Fixed
 - Fixes the CLI hanging on invalid queries. See issue #1230.
 - Fixes Timestamp Type parsing issue. Previously Timestamp Type would get parsed to a Time type.
+- Fixes PIVOT parsing to assign the key and value as defined by spec section 14.
 - Fixes the physical plan compiler to return list when `DISTINCT` used with `ORDER BY`
 
 ### Removed

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
@@ -708,9 +708,12 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
             projectExpr(expr, alias, metas)
         }
 
+    // !!
+    // Legacy AST mislabels key and value in PIVOT, swapping the order here to recreate bug for compatibility.
+    // !!
     override fun visitSelectPivot(node: Select.Pivot, ctx: Ctx) = translate(node) { metas ->
-        val value = visitExpr(node.value, ctx)
-        val key = visitExpr(node.key, ctx)
+        val key = visitExpr(node.value, ctx) // SWAP val -> key
+        val value = visitExpr(node.key, ctx) // SWAP key -> val
         projectPivot(value, key, metas)
     }
 

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
@@ -536,10 +536,14 @@ class ToLegacyAstTest {
                     }
                 }
             },
-            expect("(project_pivot (lit 1) (lit 2))") {
+            expect("(project_pivot (lit 2) (lit 1))") {
                 selectPivot {
-                    value = exprLit(int32Value(1))
+                    // PIVOT 1 AT 2
+                    //  - 1 is the VALUE
+                    //  - 2 is the KEY
+                    // In the legacy implementation these were accidentally flipped
                     key = exprLit(int32Value(2))
+                    value = exprLit(int32Value(1))
                 }
             },
             expect("(project_value (lit null))") {

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/utils/ServiceLoaderUtil.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/utils/ServiceLoaderUtil.kt
@@ -448,7 +448,7 @@ class ServiceLoaderUtil {
                 PartiQLValueType.INTERVAL -> TODO()
                 PartiQLValueType.BAG -> when (exprValue.type) {
                     ExprValueType.NULL -> bagValue(null)
-                    ExprValueType.BAG -> bagValue(exprValue.map { ExprToPartiQLValue(it, ExprToPartiQLValueType(it)) }.asSequence())
+                    ExprValueType.BAG -> bagValue(exprValue.map { ExprToPartiQLValue(it, ExprToPartiQLValueType(it)) })
                     else -> throw ExprToPartiQLValueTypeMismatchException(
                         PartiQLValueType.BAG, ExprToPartiQLValueType(exprValue)
                     )
@@ -460,7 +460,7 @@ class ServiceLoaderUtil {
                             ExprToPartiQLValue(
                                 it, ExprToPartiQLValueType(it)
                             )
-                        }.asSequence()
+                        }
                     )
                     else -> throw ExprToPartiQLValueTypeMismatchException(
                         PartiQLValueType.LIST, ExprToPartiQLValueType(exprValue)
@@ -473,7 +473,7 @@ class ServiceLoaderUtil {
                             ExprToPartiQLValue(
                                 it, ExprToPartiQLValueType(it)
                             )
-                        }.asSequence()
+                        }
                     )
                     else -> throw ExprToPartiQLValueTypeMismatchException(
                         PartiQLValueType.SEXP, ExprToPartiQLValueType(exprValue)
@@ -486,7 +486,7 @@ class ServiceLoaderUtil {
                             Pair(
                                 it.name?.stringValue() ?: "", ExprToPartiQLValue(it, ExprToPartiQLValueType(it))
                             )
-                        }.asSequence()
+                        }
                     )
                     else -> throw ExprToPartiQLValueTypeMismatchException(
                         PartiQLValueType.STRUCT, ExprToPartiQLValueType(exprValue)

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/utils/ServiceLoaderUtil.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/utils/ServiceLoaderUtil.kt
@@ -113,7 +113,7 @@ class ServiceLoaderUtil {
             } else {
                 listOf()
             }
-            return plugins.flatMap { plugin -> plugin.getFunctions() }
+            return plugins.flatMap { plugin -> plugin.functions }
                 .filterIsInstance<PartiQLFunction.Scalar>()
                 .map { partiqlFunc -> PartiQLtoExprFunction(partiqlFunc) }
         }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -31,6 +31,14 @@ internal object Compiler {
             TODO("Not yet implemented")
         }
 
+        override fun visitRexOpErr(node: Rex.Op.Err, ctx: Unit): Operator {
+            error(node.message)
+        }
+
+        override fun visitRelOpErr(node: Rel.Op.Err, ctx: Unit): Operator {
+            error(node.message)
+        }
+
         override fun visitRexOpStruct(node: Rex.Op.Struct, ctx: Unit): Operator {
             val fields = node.fields.map {
                 ExprStruct.Field(visitRex(it.k, ctx), visitRex(it.v, ctx))

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCollection.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCollection.kt
@@ -12,8 +12,6 @@ internal class ExprCollection(
 
     @PartiQLValueExperimental
     override fun eval(record: Record): PartiQLValue {
-        return bagValue(
-            values.map { it.eval(record) }.asSequence()
-        )
+        return bagValue(values.map { it.eval(record) })
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSelect.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSelect.kt
@@ -31,6 +31,6 @@ internal class ExprSelect(
             elements.add(e)
         }
         input.close()
-        return bagValue(elements.asSequence())
+        return bagValue(elements)
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprStruct.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprStruct.kt
@@ -16,7 +16,7 @@ internal class ExprStruct(val fields: List<Field>) : Operator.Expr {
             val value = it.value.eval(record)
             key.value!! to value
         }
-        return structValue(fields.asSequence())
+        return structValue(fields)
     }
 
     internal class Field(val key: Operator.Expr, val value: Operator.Expr)

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -35,7 +35,7 @@ class PartiQLEngineDefaultTest {
         val result = engine.execute(prepared) as PartiQLResult.Value
         val output = result.value as BagValue<*>
 
-        val expected = bagValue(sequenceOf(int32Value(1), int32Value(1)))
+        val expected = bagValue(int32Value(1), int32Value(1))
         assertEquals(expected, output)
     }
 
@@ -50,7 +50,7 @@ class PartiQLEngineDefaultTest {
         val result = engine.execute(prepared) as PartiQLResult.Value
         val output = result.value as BagValue<*>
 
-        val expected = bagValue(sequenceOf(int32Value(10), int32Value(20), int32Value(30)))
+        val expected = bagValue(int32Value(10), int32Value(20), int32Value(30))
         assertEquals(expected, output)
     }
 
@@ -65,7 +65,7 @@ class PartiQLEngineDefaultTest {
         val result = engine.execute(prepared) as PartiQLResult.Value
         val output = result.value as BagValue<*>
 
-        val expected = bagValue(sequenceOf(boolValue(true), boolValue(true)))
+        val expected = bagValue(boolValue(true), boolValue(true))
         assertEquals(expected, output)
     }
 
@@ -80,7 +80,7 @@ class PartiQLEngineDefaultTest {
         val result = engine.execute(prepared) as PartiQLResult.Value
         val output = result.value as BagValue<*>
 
-        val expected = bagValue(sequenceOf(structValue(sequenceOf("a" to int32Value(1), "b" to int32Value(2)))))
+        val expected = bagValue(structValue("a" to int32Value(1), "b" to int32Value(2)))
         assertEquals(expected, output)
     }
 
@@ -95,7 +95,7 @@ class PartiQLEngineDefaultTest {
         val result = engine.execute(prepared) as PartiQLResult.Value
         val output = result.value as BagValue<*>
 
-        val expected = bagValue(sequenceOf(structValue(sequenceOf("a" to int32Value(1), "b" to nullValue()))))
+        val expected = bagValue(structValue("a" to int32Value(1), "b" to nullValue()))
         assertEquals(expected, output)
     }
 }

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
@@ -939,8 +939,8 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitSelectPivot(ctx: GeneratedParser.SelectPivotContext) = translate(ctx) {
-            val key = visitExpr(ctx.pivot)
-            val value = visitExpr(ctx.at)
+            val key = visitExpr(ctx.at)
+            val value = visitExpr(ctx.pivot)
             selectPivot(key, value)
         }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Env.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Env.kt
@@ -154,12 +154,12 @@ internal class Env(
     // Initialize connectors
     init {
         val catalogs = mutableMapOf<String, Connector>()
-        val connectors = plugins.flatMap { it.getConnectorFactories() }
+        val connectors = plugins.map { it.factory }
         // map catalogs to connectors
         for ((catalog, config) in session.catalogConfig) {
             // find corresponding connector
             val connectorName = config[Constants.CONFIG_KEY_CONNECTOR_NAME].stringValue
-            val connector = connectors.first { it.getName() == connectorName }
+            val connector = connectors.first { it.name == connectorName }
             // initialize connector with given config
             catalogs[catalog] = connector.create(catalog, config)
         }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/Connector.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/Connector.kt
@@ -20,10 +20,40 @@ import com.amazon.ionelement.api.StructElement
  * A mechanism by which PartiQL can access a Catalog.
  */
 public interface Connector {
+
+    /**
+     * Returns a [ConnectorMetadata] for the given [ConnectorSession]. The [ConnectorMetadata] is responsible
+     * for accessing catalog metadata.
+     *
+     * @param session
+     * @return
+     */
     public fun getMetadata(session: ConnectorSession): ConnectorMetadata
 
+    /**
+     * Returns a [ConnectorBindings] which the engine uses to load values.
+     *
+     * @return
+     */
+    public fun getBindings(): ConnectorBindings
+
+    /**
+     * A Plugin leverages a [Factory] to produce a [Connector] which is used for catalog metadata and data access.
+     */
     public interface Factory {
-        public fun getName(): String
+
+        /**
+         * The connector name used to register the factory.
+         */
+        public val name: String
+
+        /**
+         * The connector factory method.
+         *
+         * @param catalogName
+         * @param config
+         * @return
+         */
         public fun create(catalogName: String, config: StructElement): Connector
     }
 }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/ConnectorBindings.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/ConnectorBindings.kt
@@ -12,23 +12,13 @@
  *  language governing permissions and limitations under the License.
  */
 
-package org.partiql.spi
+package org.partiql.spi.connector
 
-import org.partiql.spi.connector.Connector
-import org.partiql.spi.function.PartiQLFunction
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
 
-/**
- * A singular unit of external logic.
- */
-public interface Plugin {
+@OptIn(PartiQLValueExperimental::class)
+public interface ConnectorBindings {
 
-    /**
-     * A [Connector.Factory] is used to instantiate a connector.
-     */
-    public val factory: Connector.Factory
-
-    /**
-     * Functions defined by this plugin.
-     */
-    public val functions: List<PartiQLFunction>
+    public fun getValue(handle: ConnectorObjectHandle): PartiQLValue
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQL.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQL.kt
@@ -38,12 +38,12 @@ import org.partiql.value.impl.Int64ValueImpl
 import org.partiql.value.impl.Int8ValueImpl
 import org.partiql.value.impl.IntValueImpl
 import org.partiql.value.impl.IntervalValueImpl
+import org.partiql.value.impl.IterableStructValueImpl
 import org.partiql.value.impl.ListValueImpl
 import org.partiql.value.impl.MapStructValueImpl
 import org.partiql.value.impl.MissingValueImpl
 import org.partiql.value.impl.MultiMapStructValueImpl
 import org.partiql.value.impl.NullValueImpl
-import org.partiql.value.impl.SequenceStructValueImpl
 import org.partiql.value.impl.SexpValueImpl
 import org.partiql.value.impl.StringValueImpl
 import org.partiql.value.impl.SymbolValueImpl
@@ -344,9 +344,24 @@ public fun intervalValue(
 @JvmOverloads
 @PartiQLValueExperimental
 public fun <T : PartiQLValue> bagValue(
-    elements: Sequence<T>?,
+    elements: Iterable<T>?,
     annotations: Annotations = emptyList(),
 ): BagValue<T> = BagValueImpl(elements, annotations.toPersistentList())
+
+/**
+ * BAG type value.
+ *
+ * @param T
+ * @param elements
+ * @param annotations
+ * @return
+ */
+@JvmOverloads
+@PartiQLValueExperimental
+public fun <T : PartiQLValue> bagValue(
+    vararg elements: T,
+    annotations: Annotations = emptyList(),
+): BagValue<T> = BagValueImpl(elements.asIterable(), annotations.toPersistentList())
 
 /**
  * LIST type value.
@@ -359,9 +374,24 @@ public fun <T : PartiQLValue> bagValue(
 @JvmOverloads
 @PartiQLValueExperimental
 public fun <T : PartiQLValue> listValue(
-    elements: Sequence<T>?,
+    elements: Iterable<T>?,
     annotations: Annotations = emptyList(),
 ): ListValue<T> = ListValueImpl(elements, annotations.toPersistentList())
+
+/**
+ * LIST type value.
+ *
+ * @param T
+ * @param elements
+ * @param annotations
+ * @return
+ */
+@JvmOverloads
+@PartiQLValueExperimental
+public fun <T : PartiQLValue> listValue(
+    vararg elements: T,
+    annotations: Annotations = emptyList(),
+): ListValue<T> = ListValueImpl(elements.asIterable(), annotations.toPersistentList())
 
 /**
  * SEXP type value.
@@ -374,12 +404,27 @@ public fun <T : PartiQLValue> listValue(
 @JvmOverloads
 @PartiQLValueExperimental
 public fun <T : PartiQLValue> sexpValue(
-    elements: Sequence<T>?,
+    elements: Iterable<T>?,
     annotations: Annotations = emptyList(),
 ): SexpValue<T> = SexpValueImpl(elements, annotations.toPersistentList())
 
 /**
- * STRUCT type value.
+ * SEXP type value.
+ *
+ * @param T
+ * @param elements
+ * @param annotations
+ * @return
+ */
+@JvmOverloads
+@PartiQLValueExperimental
+public fun <T : PartiQLValue> sexpValue(
+    vararg elements: T,
+    annotations: Annotations = emptyList(),
+): SexpValue<T> = SexpValueImpl(elements.asIterable(), annotations.toPersistentList())
+
+/**
+ * Create a PartiQL struct value backed by an iterable of key-value field pairs.
  *
  * @param T
  * @param fields
@@ -389,12 +434,12 @@ public fun <T : PartiQLValue> sexpValue(
 @JvmOverloads
 @PartiQLValueExperimental
 public fun <T : PartiQLValue> structValue(
-    fields: Sequence<Pair<String, T>>?,
+    fields: Iterable<Pair<String, T>>?,
     annotations: Annotations = emptyList(),
-): StructValue<T> = SequenceStructValueImpl(fields, annotations.toPersistentList())
+): StructValue<T> = IterableStructValueImpl(fields, annotations.toPersistentList())
 
 /**
- * STRUCT type value.
+ * Create a PartiQL struct value backed by an iterable of key-value field pairs.
  *
  * @param T
  * @param fields
@@ -403,13 +448,30 @@ public fun <T : PartiQLValue> structValue(
  */
 @JvmOverloads
 @PartiQLValueExperimental
-public fun <T : PartiQLValue> structValueWithDuplicates(
+public fun <T : PartiQLValue> structValue(
+    vararg fields: Pair<String, T>,
+    annotations: Annotations = emptyList(),
+): StructValue<T> = IterableStructValueImpl(fields.toList(), annotations.toPersistentList())
+
+/**
+ * Create a PartiQL struct value backed by a multimap of keys with a list of values. This supports having multiple
+ * values per key, while improving lookup performance compared to using an iterable.
+ *
+ * @param T
+ * @param fields
+ * @param annotations
+ * @return
+ */
+@JvmOverloads
+@PartiQLValueExperimental
+public fun <T : PartiQLValue> structValueMultiMap(
     fields: Map<String, Iterable<T>>?,
     annotations: Annotations = emptyList(),
 ): StructValue<T> = MultiMapStructValueImpl(fields, annotations.toPersistentList())
 
 /**
- * STRUCT type value.
+ * Create a PartiQL struct value backed by a map of keys with a list of values. This does not support having multiple
+ * values per key, but uses a Java HashMap for quicker lookup than an iterable backed StructValue.
  *
  * @param T
  * @param fields
@@ -418,7 +480,7 @@ public fun <T : PartiQLValue> structValueWithDuplicates(
  */
 @JvmOverloads
 @PartiQLValueExperimental
-public fun <T : PartiQLValue> structValueNoDuplicates(
+public fun <T : PartiQLValue> structValueMap(
     fields: Map<String, T>?,
     annotations: Annotations = emptyList(),
 ): StructValue<T> = MapStructValueImpl(fields, annotations.toPersistentList())

--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
@@ -66,14 +66,14 @@ public sealed interface ScalarValue<T> : PartiQLValue {
 }
 
 @PartiQLValueExperimental
-public sealed interface CollectionValue<T : PartiQLValue> : PartiQLValue, Sequence<T> {
+public sealed interface CollectionValue<T : PartiQLValue> : PartiQLValue, Iterable<T> {
 
-    public val elements: Sequence<T>?
+    public val elements: Collection<T>?
 
     override val isNull: Boolean
         get() = elements == null
 
-    override fun iterator(): Iterator<T> = elements!!.iterator()
+    override fun iterator(): Iterator<T>
 
     override fun copy(annotations: Annotations): CollectionValue<T>
 
@@ -389,8 +389,8 @@ public abstract class BagValue<T : PartiQLValue> : CollectionValue<T> {
         if (this.isNull || other.isNull) return this.isNull == other.isNull
 
         // both not null, compare values
-        val lhs = this.elements!!.toList()
-        val rhs = other.elements!!.toList()
+        val lhs = this.elements!!
+        val rhs = other.elements!!
         // this is incorrect as it assumes ordered-ness, but we don't have a sort or hash yet
         return lhs == rhs
     }
@@ -422,8 +422,8 @@ public abstract class ListValue<T : PartiQLValue> : CollectionValue<T> {
         if (this.isNull || other.isNull) return this.isNull == other.isNull
 
         // both not null, compare values
-        val lhs = this.elements!!.toList()
-        val rhs = other.elements!!.toList()
+        val lhs = this.elements!!
+        val rhs = other.elements!!
         return lhs == rhs
     }
 
@@ -453,8 +453,8 @@ public abstract class SexpValue<T : PartiQLValue> : CollectionValue<T> {
         if (this.isNull || other.isNull) return this.isNull == other.isNull
 
         // both not null, compare values
-        val lhs = this.elements!!.toList()
-        val rhs = other.elements!!.toList()
+        val lhs = this.elements!!
+        val rhs = other.elements!!
         return lhs == rhs
     }
 
@@ -465,11 +465,11 @@ public abstract class SexpValue<T : PartiQLValue> : CollectionValue<T> {
 }
 
 @PartiQLValueExperimental
-public abstract class StructValue<T : PartiQLValue> : PartiQLValue, Sequence<Pair<String, T>> {
+public abstract class StructValue<T : PartiQLValue> : PartiQLValue, Iterable<Pair<String, T>> {
 
     override val type: PartiQLValueType = PartiQLValueType.STRUCT
 
-    public abstract val fields: Sequence<Pair<String, T>>?
+    public abstract val fields: Collection<Pair<String, T>>?
 
     override val isNull: Boolean
         get() = fields == null

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/BagValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/BagValueImpl.kt
@@ -24,11 +24,13 @@ import org.partiql.value.util.PartiQLValueVisitor
 
 @OptIn(PartiQLValueExperimental::class)
 internal class BagValueImpl<T : PartiQLValue>(
-    private val delegate: Sequence<T>?,
+    private val delegate: Iterable<T>?,
     override val annotations: PersistentList<String>,
 ) : BagValue<T>() {
 
-    override val elements: Sequence<T>? = delegate
+    override val elements: Collection<T>? = delegate?.toList()
+
+    override fun iterator(): Iterator<T> = delegate!!.iterator()
 
     override fun copy(annotations: Annotations) = BagValueImpl(delegate, annotations.toPersistentList())
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/ListValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/ListValueImpl.kt
@@ -24,11 +24,13 @@ import org.partiql.value.util.PartiQLValueVisitor
 
 @OptIn(PartiQLValueExperimental::class)
 internal class ListValueImpl<T : PartiQLValue>(
-    private val delegate: Sequence<T>?,
+    private val delegate: Iterable<T>?,
     override val annotations: PersistentList<String>,
 ) : ListValue<T>() {
 
-    override val elements: Sequence<T>? = delegate
+    override val elements: Collection<T>? = delegate?.toList()
+
+    override fun iterator(): Iterator<T> = delegate!!.iterator()
 
     override fun copy(annotations: Annotations) = ListValueImpl(delegate, annotations.toPersistentList())
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/SexpValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/SexpValueImpl.kt
@@ -24,11 +24,13 @@ import org.partiql.value.util.PartiQLValueVisitor
 
 @OptIn(PartiQLValueExperimental::class)
 internal class SexpValueImpl<T : PartiQLValue>(
-    private val delegate: Sequence<T>?,
+    private val delegate: Iterable<T>?,
     override val annotations: PersistentList<String>,
 ) : SexpValue<T>() {
 
-    override val elements: Sequence<T>? = delegate
+    override val elements: Collection<T>? = delegate?.toList()
+
+    override fun iterator(): Iterator<T> = delegate!!.iterator()
 
     override fun copy(annotations: Annotations) = SexpValueImpl(delegate, annotations.toPersistentList())
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/StructValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/StructValueImpl.kt
@@ -23,19 +23,19 @@ import org.partiql.value.StructValue
 import org.partiql.value.util.PartiQLValueVisitor
 
 /**
- * Implementation of a [StructValue<T>] backed by a Sequence.
+ * Implementation of a [StructValue<T>] backed by an iterator.
  *
  * @param T
  * @property delegate
  * @property annotations
  */
 @OptIn(PartiQLValueExperimental::class)
-internal class SequenceStructValueImpl<T : PartiQLValue>(
-    private val delegate: Sequence<Pair<String, T>>?,
+internal class IterableStructValueImpl<T : PartiQLValue>(
+    private val delegate: Iterable<Pair<String, T>>?,
     override val annotations: PersistentList<String>,
 ) : StructValue<T>() {
 
-    override val fields: Sequence<Pair<String, T>>? = delegate
+    override val fields: Collection<Pair<String, T>>? = delegate?.toList()
 
     override operator fun get(key: String): T? {
         if (delegate == null) {
@@ -51,7 +51,7 @@ internal class SequenceStructValueImpl<T : PartiQLValue>(
         return delegate.filter { it.first == key }.map { it.second }.asIterable()
     }
 
-    override fun copy(annotations: Annotations) = SequenceStructValueImpl(delegate, annotations.toPersistentList())
+    override fun copy(annotations: Annotations) = IterableStructValueImpl(delegate, annotations.toPersistentList())
 
     override fun withAnnotations(annotations: Annotations): StructValue<T> = _withAnnotations(annotations)
 
@@ -73,12 +73,12 @@ internal class MultiMapStructValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : StructValue<T>() {
 
-    override val fields: Sequence<Pair<String, T>>?
+    override val fields: Collection<Pair<String, T>>?
         get() {
             if (delegate == null) {
                 return null
             }
-            return delegate.asSequence().map { f -> f.value.map { v -> f.key to v } }.flatten()
+            return delegate.entries.map { f -> f.value.map { v -> f.key to v } }.flatten()
         }
 
     override operator fun get(key: String): T? = getAll(key).firstOrNull()
@@ -112,12 +112,12 @@ internal class MapStructValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : StructValue<T>() {
 
-    override val fields: Sequence<Pair<String, T>>?
+    override val fields: Collection<Pair<String, T>>?
         get() {
             if (delegate == null) {
                 return null
             }
-            return delegate.asSequence().map { f -> f.key to f.value }
+            return delegate.entries.map { f -> f.key to f.value }
         }
 
     override operator fun get(key: String): T? {

--- a/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
@@ -167,7 +167,7 @@ internal class PartiQLValueIonReader(
                     }
                 }
                 reader.stepOut()
-                listValue(elements.asSequence(), annotations)
+                listValue(elements, annotations)
             }
 
             IonType.SEXP -> {
@@ -179,7 +179,7 @@ internal class PartiQLValueIonReader(
                     }
                 }
                 reader.stepOut()
-                sexpValue(elements.asSequence(), annotation)
+                sexpValue(elements, annotation)
             }
 
             IonType.STRUCT -> {
@@ -192,7 +192,7 @@ internal class PartiQLValueIonReader(
                     }
                 }
                 reader.stepOut()
-                structValue(elements.asSequence(), annotations)
+                structValue(elements, annotations)
             }
 
             IonType.DATAGRAM -> throw IllegalArgumentException("Datagram not supported")
@@ -394,7 +394,7 @@ internal class PartiQLValueIonReader(
                                 }
                             }
                             reader.stepOut()
-                            bagValue(elements.asSequence(), annotations.dropLast(1))
+                            bagValue(elements, annotations.dropLast(1))
                         }
                     }
                     PARTIQL_ANNOTATION.DATE_ANNOTATION -> throw IllegalArgumentException("DATE_ANNOTATION with List Value")
@@ -412,7 +412,7 @@ internal class PartiQLValueIonReader(
                                 }
                             }
                             reader.stepOut()
-                            listValue(elements.asSequence(), annotations)
+                            listValue(elements, annotations)
                         }
                     }
                 }
@@ -437,7 +437,7 @@ internal class PartiQLValueIonReader(
                                 }
                             }
                             reader.stepOut()
-                            sexpValue(elements.asSequence(), annotations)
+                            sexpValue(elements, annotations)
                         }
                     }
                 }
@@ -525,8 +525,7 @@ internal class PartiQLValueIonReader(
                     PARTIQL_ANNOTATION.GRAPH_ANNOTATION -> TODO("Not yet implemented")
                     null -> {
                         if (reader.isNullValue) {
-                            val nullSequence: Sequence<Pair<String, PartiQLValue>>? = null
-                            structValue<PartiQLValue>(nullSequence, annotations)
+                            structValue(null, annotations)
                         } else {
                             reader.stepIn()
                             val elements = mutableListOf<Pair<String, PartiQLValue>>().also { elements ->
@@ -536,7 +535,7 @@ internal class PartiQLValueIonReader(
                                 }
                             }
                             reader.stepOut()
-                            structValue(elements.asSequence(), annotations)
+                            structValue(elements, annotations)
                         }
                     }
                 }

--- a/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueIonSerdeTest.kt
+++ b/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueIonSerdeTest.kt
@@ -360,24 +360,22 @@ class PartiQLValueIonSerdeTest {
         @JvmStatic
         fun collections() = listOf(
             roundTrip(
-                bagValue(emptySequence()),
+                bagValue<PartiQLValue>(),
                 ION.newEmptyList().apply { addTypeAnnotation("\$bag") },
             ),
             roundTrip(
-                listValue(emptySequence()),
+                listValue<PartiQLValue>(),
                 ION.newEmptyList()
             ),
             roundTrip(
-                sexpValue(emptySequence()),
+                sexpValue<PartiQLValue>(),
                 ION.newEmptySexp()
             ),
             oneWayTrip(
                 bagValue(
-                    sequenceOf(
-                        int32Value(1),
-                        int32Value(2),
-                        int32Value(3),
-                    )
+                    int32Value(1),
+                    int32Value(2),
+                    int32Value(3),
                 ),
                 ION.newList(
                     ION.newInt(1),
@@ -385,20 +383,16 @@ class PartiQLValueIonSerdeTest {
                     ION.newInt(3)
                 ).apply { addTypeAnnotation("\$bag") },
                 bagValue(
-                    sequenceOf(
-                        intValue(BigInteger.ONE),
-                        intValue(BigInteger.valueOf(2L)),
-                        intValue(BigInteger.valueOf(3L)),
-                    )
+                    intValue(BigInteger.ONE),
+                    intValue(BigInteger.valueOf(2L)),
+                    intValue(BigInteger.valueOf(3L)),
                 )
             ),
             roundTrip(
                 listValue(
-                    sequenceOf(
-                        stringValue("a"),
-                        stringValue("b"),
-                        stringValue("c"),
-                    )
+                    stringValue("a"),
+                    stringValue("b"),
+                    stringValue("c"),
                 ),
                 ION.newList(
                     ION.newString("a"),
@@ -408,11 +402,9 @@ class PartiQLValueIonSerdeTest {
             ),
             oneWayTrip(
                 sexpValue(
-                    sequenceOf(
-                        int32Value(1),
-                        int32Value(2),
-                        int32Value(3),
-                    )
+                    int32Value(1),
+                    int32Value(2),
+                    int32Value(3),
                 ),
                 ION.newSexp(
                     ION.newInt(1),
@@ -420,19 +412,15 @@ class PartiQLValueIonSerdeTest {
                     ION.newInt(3)
                 ),
                 sexpValue(
-                    sequenceOf(
-                        intValue(BigInteger.ONE),
-                        intValue(BigInteger.valueOf(2L)),
-                        intValue(BigInteger.valueOf(3L)),
-                    )
+                    intValue(BigInteger.ONE),
+                    intValue(BigInteger.valueOf(2L)),
+                    intValue(BigInteger.valueOf(3L)),
                 )
             ),
             oneWayTrip(
                 structValue(
-                    sequenceOf(
-                        "a" to int32Value(1),
-                        "b" to stringValue("x"),
-                    )
+                    "a" to int32Value(1),
+                    "b" to stringValue("x"),
                 ),
                 ION.newEmptyStruct()
                     .apply {
@@ -440,10 +428,8 @@ class PartiQLValueIonSerdeTest {
                         add("b", ION.newString("x"))
                     },
                 structValue(
-                    sequenceOf(
-                        "a" to intValue(BigInteger.ONE),
-                        "b" to stringValue("x"),
-                    )
+                    "a" to intValue(BigInteger.ONE),
+                    "b" to stringValue("x"),
                 ),
             )
         )

--- a/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueTextWriterTest.kt
+++ b/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueTextWriterTest.kt
@@ -322,44 +322,38 @@ class PartiQLValueTextWriterTest {
         @JvmStatic
         fun collections() = listOf(
             case(
-                value = bagValue(emptySequence()),
+                value = bagValue<PartiQLValue>(),
                 expected = "<<>>",
             ),
             case(
-                value = listValue(emptySequence()),
+                value = listValue<PartiQLValue>(),
                 expected = "[]",
             ),
             case(
-                value = sexpValue(emptySequence()),
+                value = sexpValue<PartiQLValue>(),
                 expected = "()",
             ),
             case(
                 value = bagValue(
-                    sequenceOf(
-                        int32Value(1),
-                        int32Value(2),
-                        int32Value(3),
-                    )
+                    int32Value(1),
+                    int32Value(2),
+                    int32Value(3),
                 ),
                 expected = "<<1,2,3>>",
             ),
             case(
                 value = listValue(
-                    sequenceOf(
-                        stringValue("a"),
-                        stringValue("b"),
-                        stringValue("c"),
-                    )
+                    stringValue("a"),
+                    stringValue("b"),
+                    stringValue("c"),
                 ),
                 expected = "['a','b','c']",
             ),
             case(
                 value = sexpValue(
-                    sequenceOf(
-                        int32Value(1),
-                        int32Value(2),
-                        int32Value(3),
-                    )
+                    int32Value(1),
+                    int32Value(2),
+                    int32Value(3),
                 ),
                 expected = "(1 2 3)",
             ),
@@ -385,15 +379,13 @@ class PartiQLValueTextWriterTest {
         @JvmStatic
         fun struct() = listOf(
             case(
-                value = structValue<PartiQLValue>(emptySequence()),
+                value = structValue<PartiQLValue>(),
                 expected = "{}",
             ),
             case(
                 value = structValue(
-                    sequenceOf(
-                        "a" to int32Value(1),
-                        "b" to stringValue("x"),
-                    )
+                    "a" to int32Value(1),
+                    "b" to stringValue("x"),
                 ),
                 expected = "{a:1,b:'x'}",
             ),
@@ -403,11 +395,9 @@ class PartiQLValueTextWriterTest {
         fun collectionsFormatted() = listOf(
             formatted(
                 value = bagValue(
-                    sequenceOf(
-                        int32Value(1),
-                        int32Value(2),
-                        int32Value(3),
-                    )
+                    int32Value(1),
+                    int32Value(2),
+                    int32Value(3),
                 ),
                 expected = """
                     |<<
@@ -419,11 +409,9 @@ class PartiQLValueTextWriterTest {
             ),
             formatted(
                 value = listValue(
-                    sequenceOf(
-                        stringValue("a"),
-                        stringValue("b"),
-                        stringValue("c"),
-                    )
+                    stringValue("a"),
+                    stringValue("b"),
+                    stringValue("c"),
                 ),
                 expected = """
                     |[
@@ -435,11 +423,9 @@ class PartiQLValueTextWriterTest {
             ),
             formatted(
                 value = sexpValue(
-                    sequenceOf(
-                        int32Value(1),
-                        int32Value(2),
-                        int32Value(3),
-                    )
+                    int32Value(1),
+                    int32Value(2),
+                    int32Value(3),
                 ),
                 expected = """
                     |(
@@ -454,15 +440,13 @@ class PartiQLValueTextWriterTest {
         @JvmStatic
         fun structFormatted() = listOf(
             formatted(
-                value = structValue<PartiQLValue>(emptySequence()),
+                value = structValue<PartiQLValue>(),
                 expected = "{}",
             ),
             formatted(
                 value = structValue(
-                    sequenceOf(
-                        "a" to int32Value(1),
-                        "b" to stringValue("x"),
-                    )
+                    "a" to int32Value(1),
+                    "b" to stringValue("x"),
                 ),
                 expected = """
                     |{
@@ -477,29 +461,21 @@ class PartiQLValueTextWriterTest {
         fun nestedCollectionsFormatted() = listOf(
             formatted(
                 value = structValue(
-                    sequenceOf(
-                        "bag" to bagValue(
-                            sequenceOf(
-                                int32Value(1),
-                                int32Value(2),
-                                int32Value(3),
-                            )
-                        ),
-                        "list" to listValue(
-                            sequenceOf(
-                                stringValue("a"),
-                                stringValue("b"),
-                                stringValue("c"),
-                            )
-                        ),
-                        "sexp" to sexpValue(
-                            sequenceOf(
-                                int32Value(1),
-                                int32Value(2),
-                                int32Value(3),
-                            )
-                        ),
-                    )
+                    "bag" to bagValue(
+                        int32Value(1),
+                        int32Value(2),
+                        int32Value(3),
+                    ),
+                    "list" to listValue(
+                        stringValue("a"),
+                        stringValue("b"),
+                        stringValue("c"),
+                    ),
+                    "sexp" to sexpValue(
+                        int32Value(1),
+                        int32Value(2),
+                        int32Value(3),
+                    ),
                 ),
                 expected = """
                     |{
@@ -523,28 +499,20 @@ class PartiQLValueTextWriterTest {
             ),
             formatted(
                 value = bagValue(
-                    sequenceOf(
-                        listValue(
-                            sequenceOf(
-                                stringValue("a"),
-                                stringValue("b"),
-                                stringValue("c"),
-                            )
-                        ),
-                        sexpValue(
-                            sequenceOf(
-                                int32Value(1),
-                                int32Value(2),
-                                int32Value(3),
-                            )
-                        ),
-                        structValue(
-                            sequenceOf(
-                                "a" to int32Value(1),
-                                "b" to stringValue("x"),
-                            )
-                        ),
-                    )
+                    listValue(
+                        stringValue("a"),
+                        stringValue("b"),
+                        stringValue("c"),
+                    ),
+                    sexpValue(
+                        int32Value(1),
+                        int32Value(2),
+                        int32Value(3),
+                    ),
+                    structValue(
+                        "a" to int32Value(1),
+                        "b" to stringValue("x"),
+                    ),
                 ),
                 expected = """
                     |<<
@@ -567,11 +535,9 @@ class PartiQLValueTextWriterTest {
             ),
             formatted(
                 value = structValue(
-                    sequenceOf(
-                        "bag" to bagValue<PartiQLValue>(emptySequence()),
-                        "list" to listValue<PartiQLValue>(emptySequence()),
-                        "sexp" to sexpValue<PartiQLValue>(emptySequence()),
-                    )
+                    "bag" to bagValue<PartiQLValue>(),
+                    "list" to listValue<PartiQLValue>(),
+                    "sexp" to sexpValue<PartiQLValue>(),
                 ),
                 expected = """
                     |{
@@ -583,11 +549,9 @@ class PartiQLValueTextWriterTest {
             ),
             formatted(
                 value = bagValue(
-                    sequenceOf(
-                        listValue<PartiQLValue>(emptySequence()),
-                        sexpValue<PartiQLValue>(emptySequence()),
-                        structValue<PartiQLValue>(emptySequence()),
-                    )
+                    listValue<PartiQLValue>(),
+                    sexpValue<PartiQLValue>(),
+                    structValue<PartiQLValue>(),
                 ),
                 expected = """
                     |<<
@@ -690,39 +654,31 @@ class PartiQLValueTextWriterTest {
             // TODO TIMESTAMP
             // TODO INTERVAL
             case(
-                value = bagValue(emptySequence(), annotations),
+                value = bagValue<PartiQLValue>(annotations = annotations),
                 expected = "x::y::<<>>",
             ),
             case(
-                value = listValue(emptySequence(), annotations),
+                value = listValue<PartiQLValue>(annotations = annotations),
                 expected = "x::y::[]",
             ),
             case(
-                value = sexpValue(emptySequence(), annotations),
+                value = sexpValue<PartiQLValue>(annotations = annotations),
                 expected = "x::y::()",
             ),
             formatted(
                 value = bagValue(
-                    sequenceOf(
-                        listValue(
-                            sequenceOf(
-                                stringValue("a", listOf("x")),
-                            ),
-                            listOf("list")
-                        ),
-                        sexpValue(
-                            sequenceOf(
-                                int32Value(1, listOf("y")),
-                            ),
-                            listOf("sexp")
-                        ),
-                        structValue(
-                            sequenceOf(
-                                "a" to int32Value(1, listOf("z")),
-                            ),
-                            listOf("struct")
-                        ),
-                    )
+                    listValue(
+                        stringValue("a", listOf("x")),
+                        annotations = listOf("list")
+                    ),
+                    sexpValue(
+                        int32Value(1, listOf("y")),
+                        annotations = listOf("sexp")
+                    ),
+                    structValue(
+                        "a" to int32Value(1, listOf("z")),
+                        annotations = listOf("struct")
+                    ),
                 ),
                 expected = """
                     |<<

--- a/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/LocalBindings.kt
+++ b/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/LocalBindings.kt
@@ -1,0 +1,18 @@
+package org.partiql.plugins.local
+
+import org.partiql.spi.connector.ConnectorBindings
+import org.partiql.spi.connector.ConnectorObjectHandle
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import java.nio.file.Path
+
+@OptIn(PartiQLValueExperimental::class)
+class LocalBindings(
+    private val root: Path,
+    private val format: LocalFormat,
+) : ConnectorBindings {
+
+    override fun getValue(handle: ConnectorObjectHandle): PartiQLValue {
+        TODO("Not yet implemented")
+    }
+}

--- a/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/LocalFormat.kt
+++ b/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/LocalFormat.kt
@@ -1,0 +1,14 @@
+package org.partiql.plugins.local
+
+enum class LocalFormat {
+    ION;
+
+    companion object {
+
+        fun safeValueOf(value: String): LocalFormat? = try {
+            valueOf(value.uppercase().trim())
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+    }
+}

--- a/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/LocalPlugin.kt
+++ b/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/LocalPlugin.kt
@@ -26,8 +26,8 @@ import org.partiql.spi.function.PartiQLFunctionExperimental
  */
 class LocalPlugin : Plugin {
 
-    override fun getConnectorFactories(): List<Connector.Factory> = listOf(LocalConnector.Factory())
+    override val factory: Connector.Factory = LocalConnector.Factory()
 
     @PartiQLFunctionExperimental
-    override fun getFunctions(): List<PartiQLFunction> = listOf()
+    override val functions: List<PartiQLFunction> = listOf()
 }

--- a/plugins/partiql-memory/build.gradle.kts
+++ b/plugins/partiql-memory/build.gradle.kts
@@ -24,3 +24,7 @@ dependencies {
     implementation(project(":partiql-spi"))
     implementation(project(":partiql-types"))
 }
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryBindings.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryBindings.kt
@@ -25,6 +25,11 @@ class MemoryBindings(
     companion object {
 
         /**
+         * No bindings.
+         */
+        val empty = MemoryBindings(emptyMap())
+
+        /**
          * Loads each declared global of the catalog from the data element.
          */
         fun load(catalog: MemoryCatalog, data: StructElement): MemoryBindings {

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryBindings.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryBindings.kt
@@ -1,0 +1,47 @@
+package org.partiql.plugins.memory
+
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.StructElement
+import org.partiql.spi.connector.ConnectorBindings
+import org.partiql.spi.connector.ConnectorObjectHandle
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.io.PartiQLValueIonReaderBuilder
+import org.partiql.value.missingValue
+
+@OptIn(PartiQLValueExperimental::class)
+class MemoryBindings(
+    private val bindings: Map<String, PartiQLValue>,
+) : ConnectorBindings {
+
+    @OptIn(PartiQLValueExperimental::class)
+    override fun getValue(handle: ConnectorObjectHandle): PartiQLValue {
+        val key = (handle.value as MemoryObject).path.joinToString(".")
+        return bindings[key] ?: missingValue()
+    }
+
+    internal fun iterator(): Iterator<PartiQLValue> = bindings.values.iterator()
+
+    companion object {
+
+        /**
+         * Loads each declared global of the catalog from the data element.
+         */
+        fun load(catalog: MemoryCatalog, data: StructElement): MemoryBindings {
+            val bindings = mutableMapOf<String, PartiQLValue>()
+            for (key in catalog.keys()) {
+                var ion: IonElement = data
+                val steps = key.split(".")
+                steps.forEach { s ->
+                    if (ion is StructElement) {
+                        ion = (ion as StructElement).getOptional(s) ?: error("No value for binding $key")
+                    } else {
+                        error("No value for binding $key")
+                    }
+                }
+                bindings[key] = PartiQLValueIonReaderBuilder.standard().build(ion).read()
+            }
+            return MemoryBindings(bindings)
+        }
+    }
+}

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryCatalog.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryCatalog.kt
@@ -6,9 +6,12 @@ import org.partiql.spi.connector.ConnectorObjectPath
 import org.partiql.types.StaticType
 
 class MemoryCatalog(
-    private val map: Map<String, StaticType>
+    private val map: Map<String, StaticType>,
 ) {
-    operator fun get(key: String): StaticType? = map[key]
+
+    public operator fun get(key: String): StaticType? = map[key]
+
+    public fun keys(): Iterator<String> = map.keys.iterator()
 
     public fun lookup(path: BindingPath): MemoryObject? {
         val kPath = ConnectorObjectPath(

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryCatalog.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryCatalog.kt
@@ -68,6 +68,7 @@ class MemoryCatalog(
     }
 
     class Provider {
+
         private val catalogs = mutableMapOf<String, MemoryCatalog>()
 
         operator fun get(path: String): MemoryCatalog = catalogs[path] ?: error("invalid catalog path")

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryConnector.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryConnector.kt
@@ -9,15 +9,11 @@ import org.partiql.spi.connector.ConnectorObjectHandle
 import org.partiql.spi.connector.ConnectorObjectPath
 import org.partiql.spi.connector.ConnectorSession
 import org.partiql.types.StaticType
-import org.partiql.value.PartiQLValueExperimental
 
-class MemoryConnector(
+class MemoryConnector private constructor(
     val catalog: MemoryCatalog,
-    val bindings: () -> MemoryBindings,
+    val bindings: MemoryBindings,
 ) : Connector {
-
-    @OptIn(PartiQLValueExperimental::class)
-    constructor(catalog: MemoryCatalog) : this(catalog, { MemoryBindings(emptyMap()) })
 
     companion object {
         const val CONNECTOR_NAME = "memory"
@@ -25,18 +21,18 @@ class MemoryConnector(
 
     override fun getMetadata(session: ConnectorSession): ConnectorMetadata = Metadata()
 
-    override fun getBindings(): ConnectorBindings = bindings()
+    override fun getBindings(): ConnectorBindings = bindings
 
     class Factory(
         private val provider: MemoryCatalog.Provider,
-        private val data: StructElement,
+        private val data: StructElement?,
     ) : Connector.Factory {
 
         override val name: String = CONNECTOR_NAME
 
         override fun create(catalogName: String, config: StructElement): Connector {
             val catalog = provider[catalogName]
-            val bindings = { MemoryBindings.load(catalog, data) }
+            val bindings = if (data != null) MemoryBindings.load(catalog, data) else MemoryBindings.empty
             return MemoryConnector(catalog, bindings)
         }
     }

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryPlugin.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryPlugin.kt
@@ -8,7 +8,7 @@ import org.partiql.spi.function.PartiQLFunctionExperimental
 
 class MemoryPlugin(
     val provider: MemoryCatalog.Provider,
-    val data: StructElement,
+    val data: StructElement? = null,
 ) : Plugin {
 
     override val factory: Connector.Factory = MemoryConnector.Factory(provider, data)

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryPlugin.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryPlugin.kt
@@ -1,13 +1,18 @@
 package org.partiql.plugins.memory
 
+import com.amazon.ionelement.api.StructElement
 import org.partiql.spi.Plugin
 import org.partiql.spi.connector.Connector
 import org.partiql.spi.function.PartiQLFunction
 import org.partiql.spi.function.PartiQLFunctionExperimental
 
-class MemoryPlugin(val provider: MemoryCatalog.Provider) : Plugin {
-    override fun getConnectorFactories(): List<Connector.Factory> = listOf(MemoryConnector.Factory(provider))
+class MemoryPlugin(
+    val provider: MemoryCatalog.Provider,
+    val data: StructElement,
+) : Plugin {
+
+    override val factory: Connector.Factory = MemoryConnector.Factory(provider, data)
 
     @PartiQLFunctionExperimental
-    override fun getFunctions(): List<PartiQLFunction> = emptyList()
+    override val functions: List<PartiQLFunction> = emptyList()
 }

--- a/plugins/partiql-memory/src/test/kotlin/org/partiql/plugins/memory/InMemoryPluginTest.kt
+++ b/plugins/partiql-memory/src/test/kotlin/org/partiql/plugins/memory/InMemoryPluginTest.kt
@@ -1,5 +1,6 @@
 package org.partiql.plugins.memory
 
+import com.amazon.ionelement.api.emptyIonStruct
 import org.junit.jupiter.api.Test
 import org.partiql.spi.BindingCase
 import org.partiql.spi.BindingName
@@ -18,20 +19,25 @@ class InMemoryPluginTest {
     }
 
     companion object {
-        val provider = MemoryCatalog.Provider().also {
-            it["test"] = MemoryCatalog.of(
-                "a" to StaticType.INT2,
-                "struct" to StructType(
-                    fields = listOf(StructType.Field("a", StaticType.INT2))
-                ),
-                "schema.tbl" to BagType(
-                    StructType(
+
+        val plugin = MemoryPlugin(
+            MemoryCatalog.Provider().also {
+                it["test"] = MemoryCatalog.of(
+                    "a" to StaticType.INT2,
+                    "struct" to StructType(
                         fields = listOf(StructType.Field("a", StaticType.INT2))
+                    ),
+                    "schema.tbl" to BagType(
+                        StructType(
+                            fields = listOf(StructType.Field("a", StaticType.INT2))
+                        )
                     )
                 )
-            )
-        }
+            }
+        )
     }
+
+    private fun connector(catalog: String) = plugin.factory.create(catalog, emptyIonStruct()) as MemoryConnector
 
     @Test
     fun getValue() {
@@ -42,7 +48,7 @@ class InMemoryPluginTest {
         )
         val expected = StaticType.INT2
 
-        val connector = MemoryConnector(provider["test"])
+        val connector = connector("test")
 
         val metadata = connector.Metadata()
 
@@ -62,7 +68,7 @@ class InMemoryPluginTest {
             )
         )
 
-        val connector = MemoryConnector(provider["test"])
+        val connector = connector("test")
 
         val metadata = connector.Metadata()
 
@@ -80,7 +86,7 @@ class InMemoryPluginTest {
             )
         )
 
-        val connector = MemoryConnector(provider["test"])
+        val connector = connector("test")
 
         val metadata = connector.Metadata()
 
@@ -105,7 +111,7 @@ class InMemoryPluginTest {
             )
         )
 
-        val connector = MemoryConnector(provider["test"])
+        val connector = connector("test")
 
         val metadata = connector.Metadata()
 
@@ -129,7 +135,7 @@ class InMemoryPluginTest {
             )
         )
 
-        val connector = MemoryConnector(provider["test"])
+        val connector = connector("test")
 
         val metadata = connector.Metadata()
 

--- a/plugins/partiql-memory/src/test/kotlin/org/partiql/plugins/memory/MemoryBindingsTest.kt
+++ b/plugins/partiql-memory/src/test/kotlin/org/partiql/plugins/memory/MemoryBindingsTest.kt
@@ -1,0 +1,39 @@
+package org.partiql.plugins.memory
+
+import com.amazon.ionelement.api.StructElement
+import com.amazon.ionelement.api.loadSingleElement
+import org.junit.jupiter.api.Test
+import org.partiql.types.StaticType
+import org.partiql.value.PartiQLValueExperimental
+
+@OptIn(PartiQLValueExperimental::class)
+class MemoryBindingsTest {
+
+    @Test
+    fun load() {
+        val data = loadSingleElement(
+            """
+            {
+              "x": 1,
+              "y": "hello",
+              "z": {
+                "a": true,
+                "b": 1.0
+              }
+            }
+            """.trimIndent()
+        )
+        val catalog = MemoryCatalog(
+            mapOf(
+                "x" to StaticType.INT,
+                "y" to StaticType.STRING,
+                "z.a" to StaticType.BOOL,
+                "z.b" to StaticType.FLOAT,
+            )
+        )
+        val bindings = MemoryBindings.load(catalog, data as StructElement)
+        for (v in bindings.iterator()) {
+            println(v)
+        }
+    }
+}

--- a/test/partiql-tests-runner/build.gradle.kts
+++ b/test/partiql-tests-runner/build.gradle.kts
@@ -26,6 +26,8 @@ application {
 dependencies {
     implementation(Deps.ionElement)
     testImplementation(project(":partiql-lang"))
+    testImplementation(project(":partiql-eval"))
+    testImplementation(project(":plugins:partiql-memory"))
 }
 
 val tests = System.getenv()["PARTIQL_TESTS_DATA"] ?: "../partiql-tests/partiql-tests-data"

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestEval.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestEval.kt
@@ -1,38 +1,38 @@
 package org.partiql.runner
 
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
-import org.partiql.runner.executor.LegacyExecutor
+import org.partiql.lang.eval.CompileOptions
+import org.partiql.runner.executor.EvalExecutor
+import org.partiql.runner.report.ReportGenerator
 import org.partiql.runner.schema.TestCase
 import org.partiql.runner.skip.LANG_KOTLIN_EVAL_EQUIV_FAIL_LIST
-import org.partiql.runner.skip.LANG_KOTLIN_EVAL_FAIL_LIST
 import org.partiql.runner.test.TestProvider
 import org.partiql.runner.test.TestRunner
 
-/**
- * Runs the conformance tests with an expected list of failing tests. Ensures that tests not in the failing list
- * succeed with the expected result. Ensures that tests included in the failing list fail.
- *
- * These tests are included in the normal test/building.
- * Update May 2023: Now excluded from the normal build, because the fail lists are out of date.
- * TODO: Come up with a low-burden method of maintaining fail / exclusion lists.
- */
-class ConformanceTest {
+@Disabled
+@ExtendWith(ReportGenerator::class)
+class ConformanceTestEval {
 
-    private val factory = LegacyExecutor.Factory
+    private val factory = EvalExecutor.Factory
     private val runner = TestRunner(factory)
 
     // Tests the eval tests with the Kotlin implementation
     @ParameterizedTest(name = "{arguments}")
     @ArgumentsSource(TestProvider.Eval::class)
     fun validatePartiQLEvalTestData(tc: TestCase) {
+        // val skip = LANG_KOTLIN_EVAL_FAIL_LIST
+        val skip = emptyList<Pair<String, CompileOptions>>()
         when (tc) {
-            is TestCase.Eval -> runner.test(tc, LANG_KOTLIN_EVAL_FAIL_LIST)
+            is TestCase.Eval -> runner.test(tc, skip)
             else -> error("Unsupported test case category")
         }
     }
 
     // Tests the eval equivalence tests with the Kotlin implementation
+    @Disabled
     @ParameterizedTest(name = "{arguments}")
     @ArgumentsSource(TestProvider.Equiv::class)
     fun validatePartiQLEvalEquivTestData(tc: TestCase) {

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestReport.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestReport.kt
@@ -3,11 +3,11 @@ package org.partiql.runner
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
+import org.partiql.runner.executor.LegacyExecutor
 import org.partiql.runner.report.ReportGenerator
 import org.partiql.runner.schema.TestCase
 import org.partiql.runner.test.TestProvider
 import org.partiql.runner.test.TestRunner
-import org.partiql.runner.test.executor.LegacyExecutor
 
 /**
  * Runs the conformance tests without a fail list, so we can document the passing/failing tests in the conformance

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/EvalExecutor.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/EvalExecutor.kt
@@ -1,0 +1,108 @@
+package org.partiql.runner.executor
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonValue
+import com.amazon.ionelement.api.StructElement
+import com.amazon.ionelement.api.ionString
+import com.amazon.ionelement.api.ionStructOf
+import com.amazon.ionelement.api.toIonElement
+import com.amazon.ionelement.api.toIonValue
+import org.partiql.eval.PartiQLEngine
+import org.partiql.eval.PartiQLResult
+import org.partiql.eval.PartiQLStatement
+import org.partiql.lang.eval.CompileOptions
+import org.partiql.parser.PartiQLParserBuilder
+import org.partiql.planner.PartiQLPlanner
+import org.partiql.planner.PartiQLPlannerBuilder
+import org.partiql.plugins.memory.MemoryCatalog
+import org.partiql.plugins.memory.MemoryPlugin
+import org.partiql.runner.ION
+import org.partiql.runner.test.TestExecutor
+import org.partiql.spi.Plugin
+import org.partiql.types.StaticType
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.io.PartiQLValueIonReaderBuilder
+import org.partiql.value.toIon
+
+@OptIn(PartiQLValueExperimental::class)
+class EvalExecutor(
+    private val plugin: Plugin,
+    private val session: PartiQLPlanner.Session,
+) : TestExecutor<PartiQLStatement<*>, PartiQLResult> {
+
+    private val planner = PartiQLPlannerBuilder().plugins(listOf(plugin)).build()
+
+    override fun prepare(statement: String): PartiQLStatement<*> {
+        val stmt = parser.parse(statement).root
+        val plan = planner.plan(stmt, session)
+        return engine.prepare(plan.plan)
+    }
+
+    override fun execute(statement: PartiQLStatement<*>): PartiQLResult {
+        return engine.execute(statement)
+    }
+
+    override fun fromIon(value: IonValue): PartiQLResult {
+        val partiql = PartiQLValueIonReaderBuilder.standard().build(value.toIonElement()).read()
+        return PartiQLResult.Value(partiql)
+    }
+
+    override fun toIon(value: PartiQLResult): IonValue {
+        if (value is PartiQLResult.Value) {
+            return value.value.toIon().toIonValue(ION)
+        }
+        error("PartiQLResult cannot be converted to Ion")
+    }
+
+    override fun compare(actual: PartiQLResult, expect: PartiQLResult): Boolean {
+        if (actual is PartiQLResult.Value && expect is PartiQLResult.Value) {
+            return actual.value == expect.value
+        }
+        error("Cannot compare different types of PartiQLResult")
+    }
+
+    companion object {
+        val parser = PartiQLParserBuilder.standard().build()
+        val engine = PartiQLEngine.default()
+    }
+
+    object Factory : TestExecutor.Factory<PartiQLStatement<*>, PartiQLResult> {
+
+        override fun create(env: IonStruct, options: CompileOptions): TestExecutor<PartiQLStatement<*>, PartiQLResult> {
+            val catalog = "default"
+            val data = env.toIonElement() as StructElement
+            val provider = MemoryCatalog.Provider()
+
+            // infer catalog from env
+            provider[catalog] = infer(data)
+
+            val plugin = MemoryPlugin(provider, data)
+            val session = PartiQLPlanner.Session(
+                queryId = "query",
+                userId = "user",
+                currentCatalog = catalog,
+                catalogConfig = mapOf(
+                    catalog to ionStructOf(
+                        "connector_name" to ionString("memory")
+                    )
+                )
+            )
+            return EvalExecutor(plugin, session)
+        }
+
+        /**
+         * Produces an inferred catalog from the environment.
+         * Until this point, PartiQL Kotlin has only done top-level bindings.
+         *
+         * @param env
+         * @return
+         */
+        private fun infer(env: StructElement): MemoryCatalog {
+            val map = mutableMapOf<String, StaticType>()
+            env.fields.forEach {
+                map[it.name] = StaticType.ANY
+            }
+            return MemoryCatalog(map)
+        }
+    }
+}

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/LegacyExecutor.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/LegacyExecutor.kt
@@ -1,4 +1,4 @@
-package org.partiql.runner.test.executor
+package org.partiql.runner.executor
 
 import com.amazon.ion.IonStruct
 import com.amazon.ion.IonValue


### PR DESCRIPTION
This PR introduces a `getBindings()` method to PartiQL Plugins. A plugin will return a PartiQLBindings object which returns a PartiQLValue given a BindingPath.

I have implemented this for the MemoryPlugin which is now used to load globals from the conformance test suite. This PR also includes an implementation of a TestExecutor for the ongoing evaluator work.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.