### PR TITLE
Fixes parsing of PIVOT, replicates the bug in legacy conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Thank you to all who have contributed!
 ### Fixed
 - Fixes the CLI hanging on invalid queries. See issue #1230.
 - Fixes Timestamp Type parsing issue. Previously Timestamp Type would get parsed to a Time type.
+- Fixes PIVOT parsing to assign the key and value as defined by spec section 14.
 
 ### Removed
 - **Breaking** Removed IR factory in favor of static top-level functions. Change `Ast.foo()`

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
@@ -708,9 +708,12 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
             projectExpr(expr, alias, metas)
         }
 
+    // !!
+    // Legacy AST mislabels key and value in PIVOT, swapping the order here to recreate bug for compatibility.
+    // !!
     override fun visitSelectPivot(node: Select.Pivot, ctx: Ctx) = translate(node) { metas ->
-        val value = visitExpr(node.value, ctx)
-        val key = visitExpr(node.key, ctx)
+        val key = visitExpr(node.value, ctx) // SWAP val -> key
+        val value = visitExpr(node.key, ctx) // SWAP key -> val
         projectPivot(value, key, metas)
     }
 

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
@@ -536,10 +536,14 @@ class ToLegacyAstTest {
                     }
                 }
             },
-            expect("(project_pivot (lit 1) (lit 2))") {
+            expect("(project_pivot (lit 2) (lit 1))") {
                 selectPivot {
-                    value = exprLit(int32Value(1))
+                    // PIVOT 1 AT 2
+                    //  - 1 is the VALUE
+                    //  - 2 is the KEY
+                    // In the legacy implementation these were accidentally flipped
                     key = exprLit(int32Value(2))
+                    value = exprLit(int32Value(1))
                 }
             },
             expect("(project_value (lit null))") {

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
@@ -939,8 +939,8 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitSelectPivot(ctx: GeneratedParser.SelectPivotContext) = translate(ctx) {
-            val key = visitExpr(ctx.pivot)
-            val value = visitExpr(ctx.at)
+            val key = visitExpr(ctx.at)
+            val value = visitExpr(ctx.pivot)
             selectPivot(key, value)
         }
 


### PR DESCRIPTION
## Relevant Issues
N/A couldn't find an issue for this.

## Description

Fixes the PIVOT "key" and "value". It's` <value> AT <key>` but we've had this flipped.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Yes

- Any backward-incompatible changes? **[YES/NO]**
For semver no, but it's a bug fix.

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.