### PR TITLE
Use Iterable for PartiQLValue collections rather than Sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Thank you to all who have contributed!
   - The new plan is fully resolved and typed.
   - Operators will be converted to function call. 
 - Changes the return type of `filter_distinct` to a list if input collection is list
+- `PartiQLValue` collections are backed by iterables rather than just sequences.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Thank you to all who have contributed!
   - The new plan is fully resolved and typed.
   - Operators will be converted to function call. 
 - Changes the return type of `filter_distinct` to a list if input collection is list
-- `PartiQLValue` collections are backed by iterables rather than just sequences.
+- Changes the `PartiQLValue` collections to implement Iterable rather than Sequence, allowing for multiple consumption.
 
 ### Deprecated
 

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/utils/ServiceLoaderUtil.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/utils/ServiceLoaderUtil.kt
@@ -447,7 +447,7 @@ class ServiceLoaderUtil {
                 PartiQLValueType.INTERVAL -> TODO()
                 PartiQLValueType.BAG -> when (exprValue.type) {
                     ExprValueType.NULL -> bagValue(null)
-                    ExprValueType.BAG -> bagValue(exprValue.map { ExprToPartiQLValue(it, ExprToPartiQLValueType(it)) }.asSequence())
+                    ExprValueType.BAG -> bagValue(exprValue.map { ExprToPartiQLValue(it, ExprToPartiQLValueType(it)) })
                     else -> throw ExprToPartiQLValueTypeMismatchException(
                         PartiQLValueType.BAG, ExprToPartiQLValueType(exprValue)
                     )
@@ -459,7 +459,7 @@ class ServiceLoaderUtil {
                             ExprToPartiQLValue(
                                 it, ExprToPartiQLValueType(it)
                             )
-                        }.asSequence()
+                        }
                     )
                     else -> throw ExprToPartiQLValueTypeMismatchException(
                         PartiQLValueType.LIST, ExprToPartiQLValueType(exprValue)
@@ -472,7 +472,7 @@ class ServiceLoaderUtil {
                             ExprToPartiQLValue(
                                 it, ExprToPartiQLValueType(it)
                             )
-                        }.asSequence()
+                        }
                     )
                     else -> throw ExprToPartiQLValueTypeMismatchException(
                         PartiQLValueType.SEXP, ExprToPartiQLValueType(exprValue)
@@ -485,7 +485,7 @@ class ServiceLoaderUtil {
                             Pair(
                                 it.name?.stringValue() ?: "", ExprToPartiQLValue(it, ExprToPartiQLValueType(it))
                             )
-                        }.asSequence()
+                        }
                     )
                     else -> throw ExprToPartiQLValueTypeMismatchException(
                         PartiQLValueType.STRUCT, ExprToPartiQLValueType(exprValue)

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/utils/ServiceLoaderUtil.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/utils/ServiceLoaderUtil.kt
@@ -268,28 +268,42 @@ class ServiceLoaderUtil {
                 PartiQLValueType.INTERVAL -> TODO()
 
                 PartiQLValueType.BAG -> {
-                    (partiqlValue as? BagValue<*>)?.elements?.map { PartiQLtoExprValue(it) }?.let { newBag(it) }
-                        ?: ExprValue.nullValue
+                    if (partiqlValue.isNull) {
+                        ExprValue.nullValue
+                    } else {
+                        newBag((partiqlValue as? BagValue<*>)!!.map { PartiQLtoExprValue(it) })
+                    }
                 }
 
                 PartiQLValueType.LIST -> {
-                    (partiqlValue as? ListValue<*>)?.elements?.map { PartiQLtoExprValue(it) }?.let { newList(it) }
-                        ?: ExprValue.nullValue
+                    if (partiqlValue.isNull) {
+                        ExprValue.nullValue
+                    } else {
+                        newList((partiqlValue as? ListValue<*>)!!.map { PartiQLtoExprValue(it) })
+                    }
                 }
 
                 PartiQLValueType.SEXP -> {
-                    (partiqlValue as? SexpValue<*>)?.elements?.map { PartiQLtoExprValue(it) }?.let { newSexp(it) }
-                        ?: ExprValue.nullValue
+                    if (partiqlValue.isNull) {
+                        ExprValue.nullValue
+                    } else {
+                        newSexp((partiqlValue as? SexpValue<*>)!!.map { PartiQLtoExprValue(it) })
+                    }
                 }
 
                 PartiQLValueType.STRUCT -> {
-                    (partiqlValue as? StructValue<*>)?.fields?.map {
-                        PartiQLtoExprValue(it.second).namedValue(
-                            newString(
-                                it.first
+                    if (partiqlValue.isNull) {
+                        ExprValue.nullValue
+                    } else {
+                        val entries = (partiqlValue as? StructValue<*>)!!.entries
+                        entries.map {
+                            PartiQLtoExprValue(it.second).namedValue(
+                                newString(
+                                    it.first
+                                )
                             )
-                        )
-                    }?.let { newStruct(it, StructOrdering.ORDERED) } ?: ExprValue.nullValue
+                        }.let { newStruct(it, StructOrdering.ORDERED) }
+                    }
                 }
 
                 PartiQLValueType.DECIMAL -> TODO()

--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQL.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQL.kt
@@ -38,12 +38,12 @@ import org.partiql.value.impl.Int64ValueImpl
 import org.partiql.value.impl.Int8ValueImpl
 import org.partiql.value.impl.IntValueImpl
 import org.partiql.value.impl.IntervalValueImpl
+import org.partiql.value.impl.IterableStructValueImpl
 import org.partiql.value.impl.ListValueImpl
 import org.partiql.value.impl.MapStructValueImpl
 import org.partiql.value.impl.MissingValueImpl
 import org.partiql.value.impl.MultiMapStructValueImpl
 import org.partiql.value.impl.NullValueImpl
-import org.partiql.value.impl.SequenceStructValueImpl
 import org.partiql.value.impl.SexpValueImpl
 import org.partiql.value.impl.StringValueImpl
 import org.partiql.value.impl.SymbolValueImpl
@@ -344,9 +344,24 @@ public fun intervalValue(
 @JvmOverloads
 @PartiQLValueExperimental
 public fun <T : PartiQLValue> bagValue(
-    elements: Sequence<T>?,
+    elements: Iterable<T>?,
     annotations: Annotations = emptyList(),
 ): BagValue<T> = BagValueImpl(elements, annotations.toPersistentList())
+
+/**
+ * BAG type value.
+ *
+ * @param T
+ * @param elements
+ * @param annotations
+ * @return
+ */
+@JvmOverloads
+@PartiQLValueExperimental
+public fun <T : PartiQLValue> bagValue(
+    vararg elements: T,
+    annotations: Annotations = emptyList(),
+): BagValue<T> = BagValueImpl(elements.asIterable(), annotations.toPersistentList())
 
 /**
  * LIST type value.
@@ -359,9 +374,24 @@ public fun <T : PartiQLValue> bagValue(
 @JvmOverloads
 @PartiQLValueExperimental
 public fun <T : PartiQLValue> listValue(
-    elements: Sequence<T>?,
+    elements: Iterable<T>?,
     annotations: Annotations = emptyList(),
 ): ListValue<T> = ListValueImpl(elements, annotations.toPersistentList())
+
+/**
+ * LIST type value.
+ *
+ * @param T
+ * @param elements
+ * @param annotations
+ * @return
+ */
+@JvmOverloads
+@PartiQLValueExperimental
+public fun <T : PartiQLValue> listValue(
+    vararg elements: T,
+    annotations: Annotations = emptyList(),
+): ListValue<T> = ListValueImpl(elements.asIterable(), annotations.toPersistentList())
 
 /**
  * SEXP type value.
@@ -374,12 +404,27 @@ public fun <T : PartiQLValue> listValue(
 @JvmOverloads
 @PartiQLValueExperimental
 public fun <T : PartiQLValue> sexpValue(
-    elements: Sequence<T>?,
+    elements: Iterable<T>?,
     annotations: Annotations = emptyList(),
 ): SexpValue<T> = SexpValueImpl(elements, annotations.toPersistentList())
 
 /**
- * STRUCT type value.
+ * SEXP type value.
+ *
+ * @param T
+ * @param elements
+ * @param annotations
+ * @return
+ */
+@JvmOverloads
+@PartiQLValueExperimental
+public fun <T : PartiQLValue> sexpValue(
+    vararg elements: T,
+    annotations: Annotations = emptyList(),
+): SexpValue<T> = SexpValueImpl(elements.asIterable(), annotations.toPersistentList())
+
+/**
+ * Create a PartiQL struct value backed by an iterable of key-value field pairs.
  *
  * @param T
  * @param fields
@@ -389,12 +434,12 @@ public fun <T : PartiQLValue> sexpValue(
 @JvmOverloads
 @PartiQLValueExperimental
 public fun <T : PartiQLValue> structValue(
-    fields: Sequence<Pair<String, T>>?,
+    fields: Iterable<Pair<String, T>>?,
     annotations: Annotations = emptyList(),
-): StructValue<T> = SequenceStructValueImpl(fields, annotations.toPersistentList())
+): StructValue<T> = IterableStructValueImpl(fields, annotations.toPersistentList())
 
 /**
- * STRUCT type value.
+ * Create a PartiQL struct value backed by an iterable of key-value field pairs.
  *
  * @param T
  * @param fields
@@ -403,13 +448,30 @@ public fun <T : PartiQLValue> structValue(
  */
 @JvmOverloads
 @PartiQLValueExperimental
-public fun <T : PartiQLValue> structValueWithDuplicates(
+public fun <T : PartiQLValue> structValue(
+    vararg fields: Pair<String, T>,
+    annotations: Annotations = emptyList(),
+): StructValue<T> = IterableStructValueImpl(fields.toList(), annotations.toPersistentList())
+
+/**
+ * Create a PartiQL struct value backed by a multimap of keys with a list of values. This supports having multiple
+ * values per key, while improving lookup performance compared to using an iterable.
+ *
+ * @param T
+ * @param fields
+ * @param annotations
+ * @return
+ */
+@JvmOverloads
+@PartiQLValueExperimental
+public fun <T : PartiQLValue> structValueMultiMap(
     fields: Map<String, Iterable<T>>?,
     annotations: Annotations = emptyList(),
 ): StructValue<T> = MultiMapStructValueImpl(fields, annotations.toPersistentList())
 
 /**
- * STRUCT type value.
+ * Create a PartiQL struct value backed by a map of keys with a list of values. This does not support having multiple
+ * values per key, but uses a Java HashMap for quicker lookup than an iterable backed StructValue.
  *
  * @param T
  * @param fields
@@ -418,7 +480,7 @@ public fun <T : PartiQLValue> structValueWithDuplicates(
  */
 @JvmOverloads
 @PartiQLValueExperimental
-public fun <T : PartiQLValue> structValueNoDuplicates(
+public fun <T : PartiQLValue> structValueMap(
     fields: Map<String, T>?,
     annotations: Annotations = emptyList(),
 ): StructValue<T> = MapStructValueImpl(fields, annotations.toPersistentList())

--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
@@ -67,10 +67,7 @@ public sealed interface ScalarValue<T> : PartiQLValue {
 @PartiQLValueExperimental
 public sealed interface CollectionValue<T : PartiQLValue> : PartiQLValue, Iterable<T> {
 
-    public val elements: Collection<T>?
-
     override val isNull: Boolean
-        get() = elements == null
 
     override fun iterator(): Iterator<T>
 
@@ -388,8 +385,8 @@ public abstract class BagValue<T : PartiQLValue> : CollectionValue<T> {
         if (this.isNull || other.isNull) return this.isNull == other.isNull
 
         // both not null, compare values
-        val lhs = this.elements!!
-        val rhs = other.elements!!
+        val lhs = this.toList()
+        val rhs = other.toList()
         // this is incorrect as it assumes ordered-ness, but we don't have a sort or hash yet
         return lhs == rhs
     }
@@ -421,8 +418,8 @@ public abstract class ListValue<T : PartiQLValue> : CollectionValue<T> {
         if (this.isNull || other.isNull) return this.isNull == other.isNull
 
         // both not null, compare values
-        val lhs = this.elements!!
-        val rhs = other.elements!!
+        val lhs = this.toList()
+        val rhs = other.toList()
         return lhs == rhs
     }
 
@@ -452,8 +449,8 @@ public abstract class SexpValue<T : PartiQLValue> : CollectionValue<T> {
         if (this.isNull || other.isNull) return this.isNull == other.isNull
 
         // both not null, compare values
-        val lhs = this.elements!!
-        val rhs = other.elements!!
+        val lhs = this.toList()
+        val rhs = other.toList()
         return lhs == rhs
     }
 
@@ -464,16 +461,15 @@ public abstract class SexpValue<T : PartiQLValue> : CollectionValue<T> {
 }
 
 @PartiQLValueExperimental
-public abstract class StructValue<T : PartiQLValue> : PartiQLValue, Iterable<Pair<String, T>> {
+public abstract class StructValue<T : PartiQLValue> : PartiQLValue {
 
     override val type: PartiQLValueType = PartiQLValueType.STRUCT
 
-    public abstract val fields: Collection<Pair<String, T>>?
+    public abstract val fields: Iterable<String>
 
-    override val isNull: Boolean
-        get() = fields == null
+    public abstract val values: Iterable<T>
 
-    override fun iterator(): Iterator<Pair<String, T>> = fields!!.iterator()
+    public abstract val entries: Iterable<Pair<String, T>>
 
     public abstract operator fun get(key: String): T?
 
@@ -486,9 +482,7 @@ public abstract class StructValue<T : PartiQLValue> : PartiQLValue, Iterable<Pai
     abstract override fun withoutAnnotations(): StructValue<T>
 
     /**
-     * See equality of IonElement StructElementImpl
-     *
-     * https://github.com/amazon-ion/ion-element-kotlin/blob/master/src/com/amazon/ionelement/impl/StructElementImpl.kt
+     * Checks equality of struct entries, ignoring ordering.
      *
      * @param other
      * @return
@@ -502,15 +496,15 @@ public abstract class StructValue<T : PartiQLValue> : PartiQLValue, Iterable<Pai
         if (this.isNull || other.isNull) return this.isNull == other.isNull
 
         // both not null, compare fields
-        val lhs = this.fields!!.groupBy({ it.first }, { it.second })
-        val rhs = other.fields!!.groupBy({ it.first }, { it.second })
+        val lhs = this.entries.asIterable().groupBy({ it.first }, { it.second })
+        val rhs = other.entries.asIterable().groupBy({ it.first }, { it.second })
 
         // check size
         if (lhs.size != rhs.size) return false
         if (lhs.keys != rhs.keys) return false
 
         // check values
-        lhs.forEach { (key, values) ->
+        lhs.entries.forEach { (key, values) ->
             val lGroup: Map<PartiQLValue, Int> = values.groupingBy { it }.eachCount()
             val rGroup: Map<PartiQLValue, Int> = rhs[key]!!.groupingBy { it }.eachCount()
             if (lGroup != rGroup) return false

--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
@@ -65,14 +65,14 @@ public sealed interface ScalarValue<T> : PartiQLValue {
 }
 
 @PartiQLValueExperimental
-public sealed interface CollectionValue<T : PartiQLValue> : PartiQLValue, Sequence<T> {
+public sealed interface CollectionValue<T : PartiQLValue> : PartiQLValue, Iterable<T> {
 
-    public val elements: Sequence<T>?
+    public val elements: Collection<T>?
 
     override val isNull: Boolean
         get() = elements == null
 
-    override fun iterator(): Iterator<T> = elements!!.iterator()
+    override fun iterator(): Iterator<T>
 
     override fun copy(annotations: Annotations): CollectionValue<T>
 
@@ -388,8 +388,8 @@ public abstract class BagValue<T : PartiQLValue> : CollectionValue<T> {
         if (this.isNull || other.isNull) return this.isNull == other.isNull
 
         // both not null, compare values
-        val lhs = this.elements!!.toList()
-        val rhs = other.elements!!.toList()
+        val lhs = this.elements!!
+        val rhs = other.elements!!
         // this is incorrect as it assumes ordered-ness, but we don't have a sort or hash yet
         return lhs == rhs
     }
@@ -421,8 +421,8 @@ public abstract class ListValue<T : PartiQLValue> : CollectionValue<T> {
         if (this.isNull || other.isNull) return this.isNull == other.isNull
 
         // both not null, compare values
-        val lhs = this.elements!!.toList()
-        val rhs = other.elements!!.toList()
+        val lhs = this.elements!!
+        val rhs = other.elements!!
         return lhs == rhs
     }
 
@@ -452,8 +452,8 @@ public abstract class SexpValue<T : PartiQLValue> : CollectionValue<T> {
         if (this.isNull || other.isNull) return this.isNull == other.isNull
 
         // both not null, compare values
-        val lhs = this.elements!!.toList()
-        val rhs = other.elements!!.toList()
+        val lhs = this.elements!!
+        val rhs = other.elements!!
         return lhs == rhs
     }
 
@@ -464,11 +464,11 @@ public abstract class SexpValue<T : PartiQLValue> : CollectionValue<T> {
 }
 
 @PartiQLValueExperimental
-public abstract class StructValue<T : PartiQLValue> : PartiQLValue, Sequence<Pair<String, T>> {
+public abstract class StructValue<T : PartiQLValue> : PartiQLValue, Iterable<Pair<String, T>> {
 
     override val type: PartiQLValueType = PartiQLValueType.STRUCT
 
-    public abstract val fields: Sequence<Pair<String, T>>?
+    public abstract val fields: Collection<Pair<String, T>>?
 
     override val isNull: Boolean
         get() = fields == null

--- a/partiql-types/src/main/kotlin/org/partiql/value/helpers/ToIon.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/helpers/ToIon.kt
@@ -258,31 +258,31 @@ internal object ToIon : PartiQLValueBaseVisitor<IonElement, Unit>() {
     override fun visitInterval(v: IntervalValue, ctx: Unit): IonElement = TODO("Not Yet supported")
 
     override fun visitBag(v: BagValue<*>, ctx: Unit): IonElement = v.annotate {
-        when (val elements = v.elements) {
-            null -> ionNull(ElementType.LIST)
-            else -> ionListOf(elements.map { it.accept(ToIon, Unit) }.toList())
+        when (v.isNull) {
+            true -> ionNull(ElementType.LIST)
+            else -> ionListOf(v.map { it.accept(ToIon, Unit) }.toList())
         }
     }.withAnnotations(BAG_ANNOTATION)
 
     override fun visitList(v: ListValue<*>, ctx: Unit): IonElement = v.annotate {
-        when (val elements = v.elements) {
-            null -> ionNull(ElementType.LIST)
-            else -> ionListOf(elements.map { it.accept(ToIon, Unit) }.toList())
+        when (v.isNull) {
+            true -> ionNull(ElementType.LIST)
+            else -> ionListOf(v.map { it.accept(ToIon, Unit) }.toList())
         }
     }
 
     override fun visitSexp(v: SexpValue<*>, ctx: Unit): IonElement = v.annotate {
-        when (val elements = v.elements) {
-            null -> ionNull(ElementType.SEXP)
-            else -> ionSexpOf(elements.map { it.accept(ToIon, Unit) }.toList())
+        when (v.isNull) {
+            true -> ionNull(ElementType.SEXP)
+            else -> ionSexpOf(v.map { it.accept(ToIon, Unit) }.toList())
         }
     }
 
     override fun visitStruct(v: StructValue<*>, ctx: Unit): IonElement = v.annotate {
-        when (val fields = v.fields) {
-            null -> ionNull(ElementType.STRUCT)
+        when (v.isNull) {
+            true -> ionNull(ElementType.STRUCT)
             else -> {
-                val ionFields = fields.map {
+                val ionFields = entries.map {
                     val fk = it.first
                     val fv = it.second.accept(ToIon, ctx)
                     field(fk, fv)

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/BagValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/BagValueImpl.kt
@@ -28,7 +28,7 @@ internal class BagValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : BagValue<T>() {
 
-    override val elements: Collection<T>? = delegate?.toList()
+    override val isNull: Boolean = delegate == null
 
     override fun iterator(): Iterator<T> = delegate!!.iterator()
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/BagValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/BagValueImpl.kt
@@ -24,11 +24,13 @@ import org.partiql.value.util.PartiQLValueVisitor
 
 @OptIn(PartiQLValueExperimental::class)
 internal class BagValueImpl<T : PartiQLValue>(
-    private val delegate: Sequence<T>?,
+    private val delegate: Iterable<T>?,
     override val annotations: PersistentList<String>,
 ) : BagValue<T>() {
 
-    override val elements: Sequence<T>? = delegate
+    override val elements: Collection<T>? = delegate?.toList()
+
+    override fun iterator(): Iterator<T> = delegate!!.iterator()
 
     override fun copy(annotations: Annotations) = BagValueImpl(delegate, annotations.toPersistentList())
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/ListValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/ListValueImpl.kt
@@ -24,11 +24,13 @@ import org.partiql.value.util.PartiQLValueVisitor
 
 @OptIn(PartiQLValueExperimental::class)
 internal class ListValueImpl<T : PartiQLValue>(
-    private val delegate: Sequence<T>?,
+    private val delegate: Iterable<T>?,
     override val annotations: PersistentList<String>,
 ) : ListValue<T>() {
 
-    override val elements: Sequence<T>? = delegate
+    override val elements: Collection<T>? = delegate?.toList()
+
+    override fun iterator(): Iterator<T> = delegate!!.iterator()
 
     override fun copy(annotations: Annotations) = ListValueImpl(delegate, annotations.toPersistentList())
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/ListValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/ListValueImpl.kt
@@ -28,7 +28,7 @@ internal class ListValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : ListValue<T>() {
 
-    override val elements: Collection<T>? = delegate?.toList()
+    override val isNull: Boolean = delegate == null
 
     override fun iterator(): Iterator<T> = delegate!!.iterator()
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/SexpValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/SexpValueImpl.kt
@@ -28,7 +28,7 @@ internal class SexpValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : SexpValue<T>() {
 
-    override val elements: Collection<T>? = delegate?.toList()
+    override val isNull: Boolean = delegate == null
 
     override fun iterator(): Iterator<T> = delegate!!.iterator()
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/SexpValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/SexpValueImpl.kt
@@ -24,11 +24,13 @@ import org.partiql.value.util.PartiQLValueVisitor
 
 @OptIn(PartiQLValueExperimental::class)
 internal class SexpValueImpl<T : PartiQLValue>(
-    private val delegate: Sequence<T>?,
+    private val delegate: Iterable<T>?,
     override val annotations: PersistentList<String>,
 ) : SexpValue<T>() {
 
-    override val elements: Sequence<T>? = delegate
+    override val elements: Collection<T>? = delegate?.toList()
+
+    override fun iterator(): Iterator<T> = delegate!!.iterator()
 
     override fun copy(annotations: Annotations) = SexpValueImpl(delegate, annotations.toPersistentList())
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/StructValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/StructValueImpl.kt
@@ -23,19 +23,19 @@ import org.partiql.value.StructValue
 import org.partiql.value.util.PartiQLValueVisitor
 
 /**
- * Implementation of a [StructValue<T>] backed by a Sequence.
+ * Implementation of a [StructValue<T>] backed by an iterator.
  *
  * @param T
  * @property delegate
  * @property annotations
  */
 @OptIn(PartiQLValueExperimental::class)
-internal class SequenceStructValueImpl<T : PartiQLValue>(
-    private val delegate: Sequence<Pair<String, T>>?,
+internal class IterableStructValueImpl<T : PartiQLValue>(
+    private val delegate: Iterable<Pair<String, T>>?,
     override val annotations: PersistentList<String>,
 ) : StructValue<T>() {
 
-    override val fields: Sequence<Pair<String, T>>? = delegate
+    override val fields: Collection<Pair<String, T>>? = delegate?.toList()
 
     override operator fun get(key: String): T? {
         if (delegate == null) {
@@ -51,7 +51,7 @@ internal class SequenceStructValueImpl<T : PartiQLValue>(
         return delegate.filter { it.first == key }.map { it.second }.asIterable()
     }
 
-    override fun copy(annotations: Annotations) = SequenceStructValueImpl(delegate, annotations.toPersistentList())
+    override fun copy(annotations: Annotations) = IterableStructValueImpl(delegate, annotations.toPersistentList())
 
     override fun withAnnotations(annotations: Annotations): StructValue<T> = _withAnnotations(annotations)
 
@@ -73,12 +73,12 @@ internal class MultiMapStructValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : StructValue<T>() {
 
-    override val fields: Sequence<Pair<String, T>>?
+    override val fields: Collection<Pair<String, T>>?
         get() {
             if (delegate == null) {
                 return null
             }
-            return delegate.asSequence().map { f -> f.value.map { v -> f.key to v } }.flatten()
+            return delegate.entries.map { f -> f.value.map { v -> f.key to v } }.flatten()
         }
 
     override operator fun get(key: String): T? = getAll(key).firstOrNull()
@@ -112,12 +112,12 @@ internal class MapStructValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : StructValue<T>() {
 
-    override val fields: Sequence<Pair<String, T>>?
+    override val fields: Collection<Pair<String, T>>?
         get() {
             if (delegate == null) {
                 return null
             }
-            return delegate.asSequence().map { f -> f.key to f.value }
+            return delegate.entries.map { f -> f.key to f.value }
         }
 
     override operator fun get(key: String): T? {

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/StructValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/StructValueImpl.kt
@@ -35,7 +35,16 @@ internal class IterableStructValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : StructValue<T>() {
 
-    override val fields: Collection<Pair<String, T>>? = delegate?.toList()
+    override val isNull: Boolean = delegate == null
+
+    override val fields: Iterable<String>
+        get() = delegate!!.map { it.first }
+
+    override val values: Iterable<T>
+        get() = delegate!!.map { it.second }
+
+    override val entries: Iterable<Pair<String, T>>
+        get() = delegate!!
 
     override operator fun get(key: String): T? {
         if (delegate == null) {
@@ -73,13 +82,14 @@ internal class MultiMapStructValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : StructValue<T>() {
 
-    override val fields: Collection<Pair<String, T>>?
-        get() {
-            if (delegate == null) {
-                return null
-            }
-            return delegate.entries.map { f -> f.value.map { v -> f.key to v } }.flatten()
-        }
+    override val isNull: Boolean = delegate == null
+
+    override val fields: Iterable<String> = delegate!!.map { it.key }
+
+    override val values: Iterable<T> = delegate!!.flatMap { it.value }
+
+    override val entries: Iterable<Pair<String, T>> =
+        delegate!!.entries.map { f -> f.value.map { v -> f.key to v } }.flatten()
 
     override operator fun get(key: String): T? = getAll(key).firstOrNull()
 
@@ -112,13 +122,13 @@ internal class MapStructValueImpl<T : PartiQLValue>(
     override val annotations: PersistentList<String>,
 ) : StructValue<T>() {
 
-    override val fields: Collection<Pair<String, T>>?
-        get() {
-            if (delegate == null) {
-                return null
-            }
-            return delegate.entries.map { f -> f.key to f.value }
-        }
+    override val isNull: Boolean = delegate == null
+
+    override val fields: Iterable<String> = delegate!!.map { it.key }
+
+    override val values: Iterable<T> = delegate!!.map { it.value }
+
+    override val entries: Iterable<Pair<String, T>> = delegate!!.entries.map { it.key to it.value }
 
     override operator fun get(key: String): T? {
         if (delegate == null) {

--- a/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
@@ -167,7 +167,7 @@ internal class PartiQLValueIonReader(
                     }
                 }
                 reader.stepOut()
-                listValue(elements.asSequence(), annotations)
+                listValue(elements, annotations)
             }
 
             IonType.SEXP -> {
@@ -179,7 +179,7 @@ internal class PartiQLValueIonReader(
                     }
                 }
                 reader.stepOut()
-                sexpValue(elements.asSequence(), annotation)
+                sexpValue(elements, annotation)
             }
 
             IonType.STRUCT -> {
@@ -192,7 +192,7 @@ internal class PartiQLValueIonReader(
                     }
                 }
                 reader.stepOut()
-                structValue(elements.asSequence(), annotations)
+                structValue(elements, annotations)
             }
 
             IonType.DATAGRAM -> throw IllegalArgumentException("Datagram not supported")
@@ -394,7 +394,7 @@ internal class PartiQLValueIonReader(
                                 }
                             }
                             reader.stepOut()
-                            bagValue(elements.asSequence(), annotations.dropLast(1))
+                            bagValue(elements, annotations.dropLast(1))
                         }
                     }
                     PARTIQL_ANNOTATION.DATE_ANNOTATION -> throw IllegalArgumentException("DATE_ANNOTATION with List Value")
@@ -412,7 +412,7 @@ internal class PartiQLValueIonReader(
                                 }
                             }
                             reader.stepOut()
-                            listValue(elements.asSequence(), annotations)
+                            listValue(elements, annotations)
                         }
                     }
                 }
@@ -437,7 +437,7 @@ internal class PartiQLValueIonReader(
                                 }
                             }
                             reader.stepOut()
-                            sexpValue(elements.asSequence(), annotations)
+                            sexpValue(elements, annotations)
                         }
                     }
                 }
@@ -525,8 +525,7 @@ internal class PartiQLValueIonReader(
                     PARTIQL_ANNOTATION.GRAPH_ANNOTATION -> TODO("Not yet implemented")
                     null -> {
                         if (reader.isNullValue) {
-                            val nullSequence: Sequence<Pair<String, PartiQLValue>>? = null
-                            structValue<PartiQLValue>(nullSequence, annotations)
+                            structValue(null, annotations)
                         } else {
                             reader.stepIn()
                             val elements = mutableListOf<Pair<String, PartiQLValue>>().also { elements ->
@@ -536,7 +535,7 @@ internal class PartiQLValueIonReader(
                                 }
                             }
                             reader.stepOut()
-                            structValue(elements.asSequence(), annotations)
+                            structValue(elements, annotations)
                         }
                     }
                 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueTextWriter.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueTextWriter.kt
@@ -199,14 +199,17 @@ public class PartiQLValueTextWriter(
         override fun visitSexp(v: SexpValue<*>, format: Format?) = collection(v, format, "(" to ")", " ")
 
         override fun visitStruct(v: StructValue<*>, format: Format?): String = buildString {
+            if (v.isNull) {
+                return "null"
+            }
             // null.struct
-            val fields = v.fields?.toList() ?: return "null"
+            val entries = v.entries.toList()
             // {}
-            if (fields.isEmpty() || format == null) {
+            if (entries.isEmpty() || format == null) {
                 format?.let { append(it.prefix) }
                 annotate(v, this)
                 append("{")
-                val items = fields.map {
+                val items = entries.map {
                     val fk = it.first
                     val fv = it.second.accept(ToString, null) // it.toString()
                     "$fk:$fv"
@@ -219,10 +222,10 @@ public class PartiQLValueTextWriter(
             append(format.prefix)
             annotate(v, this)
             appendLine("{")
-            fields.forEachIndexed { i, e ->
+            entries.forEachIndexed { i, e ->
                 val fk = e.first
                 val fv = e.second.accept(ToString, format.nest()).trimStart() // e.toString(format)
-                val suffix = if (i == fields.size - 1) "" else ","
+                val suffix = if (i == entries.size - 1) "" else ","
                 append(format.prefix + format.indent)
                 append("$fk: $fv")
                 appendLine(suffix)
@@ -238,7 +241,10 @@ public class PartiQLValueTextWriter(
             separator: CharSequence = ",",
         ) = buildString {
             // null.bag, null.list, null.sexp
-            val elements = v.elements?.toList() ?: return "null"
+            if (v.isNull) {
+                return "null"
+            }
+            val elements = v.toList()
             // skip empty
             if (elements.isEmpty() || format == null) {
                 format?.let { append(it.prefix) }

--- a/partiql-types/src/main/kotlin/org/partiql/value/util/PartiQLValueBaseVisitor.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/util/PartiQLValueBaseVisitor.kt
@@ -53,10 +53,14 @@ public abstract class PartiQLValueBaseVisitor<R, C> : PartiQLValueVisitor<R, C> 
     public open fun defaultVisit(v: PartiQLValue, ctx: C): R {
         when (v) {
             is CollectionValue<*> -> {
-                v.elements?.forEach { it?.accept(this, ctx) }
+                if (!v.isNull) {
+                    v.forEach { it.accept(this, ctx) }
+                }
             }
             is StructValue<*> -> {
-                v.fields?.forEach { it.second.accept(this, ctx) }
+                if (!v.isNull) {
+                    v.entries.forEach { it.second.accept(this, ctx) }
+                }
             }
             else -> {}
         }

--- a/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueIonSerdeTest.kt
+++ b/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueIonSerdeTest.kt
@@ -360,24 +360,22 @@ class PartiQLValueIonSerdeTest {
         @JvmStatic
         fun collections() = listOf(
             roundTrip(
-                bagValue(emptySequence()),
+                bagValue<PartiQLValue>(),
                 ION.newEmptyList().apply { addTypeAnnotation("\$bag") },
             ),
             roundTrip(
-                listValue(emptySequence()),
+                listValue<PartiQLValue>(),
                 ION.newEmptyList()
             ),
             roundTrip(
-                sexpValue(emptySequence()),
+                sexpValue<PartiQLValue>(),
                 ION.newEmptySexp()
             ),
             oneWayTrip(
                 bagValue(
-                    sequenceOf(
-                        int32Value(1),
-                        int32Value(2),
-                        int32Value(3),
-                    )
+                    int32Value(1),
+                    int32Value(2),
+                    int32Value(3),
                 ),
                 ION.newList(
                     ION.newInt(1),
@@ -385,20 +383,16 @@ class PartiQLValueIonSerdeTest {
                     ION.newInt(3)
                 ).apply { addTypeAnnotation("\$bag") },
                 bagValue(
-                    sequenceOf(
-                        intValue(BigInteger.ONE),
-                        intValue(BigInteger.valueOf(2L)),
-                        intValue(BigInteger.valueOf(3L)),
-                    )
+                    intValue(BigInteger.ONE),
+                    intValue(BigInteger.valueOf(2L)),
+                    intValue(BigInteger.valueOf(3L)),
                 )
             ),
             roundTrip(
                 listValue(
-                    sequenceOf(
-                        stringValue("a"),
-                        stringValue("b"),
-                        stringValue("c"),
-                    )
+                    stringValue("a"),
+                    stringValue("b"),
+                    stringValue("c"),
                 ),
                 ION.newList(
                     ION.newString("a"),
@@ -408,11 +402,9 @@ class PartiQLValueIonSerdeTest {
             ),
             oneWayTrip(
                 sexpValue(
-                    sequenceOf(
-                        int32Value(1),
-                        int32Value(2),
-                        int32Value(3),
-                    )
+                    int32Value(1),
+                    int32Value(2),
+                    int32Value(3),
                 ),
                 ION.newSexp(
                     ION.newInt(1),
@@ -420,19 +412,15 @@ class PartiQLValueIonSerdeTest {
                     ION.newInt(3)
                 ),
                 sexpValue(
-                    sequenceOf(
-                        intValue(BigInteger.ONE),
-                        intValue(BigInteger.valueOf(2L)),
-                        intValue(BigInteger.valueOf(3L)),
-                    )
+                    intValue(BigInteger.ONE),
+                    intValue(BigInteger.valueOf(2L)),
+                    intValue(BigInteger.valueOf(3L)),
                 )
             ),
             oneWayTrip(
                 structValue(
-                    sequenceOf(
-                        "a" to int32Value(1),
-                        "b" to stringValue("x"),
-                    )
+                    "a" to int32Value(1),
+                    "b" to stringValue("x"),
                 ),
                 ION.newEmptyStruct()
                     .apply {
@@ -440,10 +428,8 @@ class PartiQLValueIonSerdeTest {
                         add("b", ION.newString("x"))
                     },
                 structValue(
-                    sequenceOf(
-                        "a" to intValue(BigInteger.ONE),
-                        "b" to stringValue("x"),
-                    )
+                    "a" to intValue(BigInteger.ONE),
+                    "b" to stringValue("x"),
                 ),
             )
         )

--- a/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueTextWriterTest.kt
+++ b/partiql-types/src/test/kotlin/org/partiql/value/io/PartiQLValueTextWriterTest.kt
@@ -322,44 +322,38 @@ class PartiQLValueTextWriterTest {
         @JvmStatic
         fun collections() = listOf(
             case(
-                value = bagValue(emptySequence()),
+                value = bagValue<PartiQLValue>(),
                 expected = "<<>>",
             ),
             case(
-                value = listValue(emptySequence()),
+                value = listValue<PartiQLValue>(),
                 expected = "[]",
             ),
             case(
-                value = sexpValue(emptySequence()),
+                value = sexpValue<PartiQLValue>(),
                 expected = "()",
             ),
             case(
                 value = bagValue(
-                    sequenceOf(
-                        int32Value(1),
-                        int32Value(2),
-                        int32Value(3),
-                    )
+                    int32Value(1),
+                    int32Value(2),
+                    int32Value(3),
                 ),
                 expected = "<<1,2,3>>",
             ),
             case(
                 value = listValue(
-                    sequenceOf(
-                        stringValue("a"),
-                        stringValue("b"),
-                        stringValue("c"),
-                    )
+                    stringValue("a"),
+                    stringValue("b"),
+                    stringValue("c"),
                 ),
                 expected = "['a','b','c']",
             ),
             case(
                 value = sexpValue(
-                    sequenceOf(
-                        int32Value(1),
-                        int32Value(2),
-                        int32Value(3),
-                    )
+                    int32Value(1),
+                    int32Value(2),
+                    int32Value(3),
                 ),
                 expected = "(1 2 3)",
             ),
@@ -385,15 +379,13 @@ class PartiQLValueTextWriterTest {
         @JvmStatic
         fun struct() = listOf(
             case(
-                value = structValue<PartiQLValue>(emptySequence()),
+                value = structValue<PartiQLValue>(),
                 expected = "{}",
             ),
             case(
                 value = structValue(
-                    sequenceOf(
-                        "a" to int32Value(1),
-                        "b" to stringValue("x"),
-                    )
+                    "a" to int32Value(1),
+                    "b" to stringValue("x"),
                 ),
                 expected = "{a:1,b:'x'}",
             ),
@@ -403,11 +395,9 @@ class PartiQLValueTextWriterTest {
         fun collectionsFormatted() = listOf(
             formatted(
                 value = bagValue(
-                    sequenceOf(
-                        int32Value(1),
-                        int32Value(2),
-                        int32Value(3),
-                    )
+                    int32Value(1),
+                    int32Value(2),
+                    int32Value(3),
                 ),
                 expected = """
                     |<<
@@ -419,11 +409,9 @@ class PartiQLValueTextWriterTest {
             ),
             formatted(
                 value = listValue(
-                    sequenceOf(
-                        stringValue("a"),
-                        stringValue("b"),
-                        stringValue("c"),
-                    )
+                    stringValue("a"),
+                    stringValue("b"),
+                    stringValue("c"),
                 ),
                 expected = """
                     |[
@@ -435,11 +423,9 @@ class PartiQLValueTextWriterTest {
             ),
             formatted(
                 value = sexpValue(
-                    sequenceOf(
-                        int32Value(1),
-                        int32Value(2),
-                        int32Value(3),
-                    )
+                    int32Value(1),
+                    int32Value(2),
+                    int32Value(3),
                 ),
                 expected = """
                     |(
@@ -454,15 +440,13 @@ class PartiQLValueTextWriterTest {
         @JvmStatic
         fun structFormatted() = listOf(
             formatted(
-                value = structValue<PartiQLValue>(emptySequence()),
+                value = structValue<PartiQLValue>(),
                 expected = "{}",
             ),
             formatted(
                 value = structValue(
-                    sequenceOf(
-                        "a" to int32Value(1),
-                        "b" to stringValue("x"),
-                    )
+                    "a" to int32Value(1),
+                    "b" to stringValue("x"),
                 ),
                 expected = """
                     |{
@@ -477,29 +461,21 @@ class PartiQLValueTextWriterTest {
         fun nestedCollectionsFormatted() = listOf(
             formatted(
                 value = structValue(
-                    sequenceOf(
-                        "bag" to bagValue(
-                            sequenceOf(
-                                int32Value(1),
-                                int32Value(2),
-                                int32Value(3),
-                            )
-                        ),
-                        "list" to listValue(
-                            sequenceOf(
-                                stringValue("a"),
-                                stringValue("b"),
-                                stringValue("c"),
-                            )
-                        ),
-                        "sexp" to sexpValue(
-                            sequenceOf(
-                                int32Value(1),
-                                int32Value(2),
-                                int32Value(3),
-                            )
-                        ),
-                    )
+                    "bag" to bagValue(
+                        int32Value(1),
+                        int32Value(2),
+                        int32Value(3),
+                    ),
+                    "list" to listValue(
+                        stringValue("a"),
+                        stringValue("b"),
+                        stringValue("c"),
+                    ),
+                    "sexp" to sexpValue(
+                        int32Value(1),
+                        int32Value(2),
+                        int32Value(3),
+                    ),
                 ),
                 expected = """
                     |{
@@ -523,28 +499,20 @@ class PartiQLValueTextWriterTest {
             ),
             formatted(
                 value = bagValue(
-                    sequenceOf(
-                        listValue(
-                            sequenceOf(
-                                stringValue("a"),
-                                stringValue("b"),
-                                stringValue("c"),
-                            )
-                        ),
-                        sexpValue(
-                            sequenceOf(
-                                int32Value(1),
-                                int32Value(2),
-                                int32Value(3),
-                            )
-                        ),
-                        structValue(
-                            sequenceOf(
-                                "a" to int32Value(1),
-                                "b" to stringValue("x"),
-                            )
-                        ),
-                    )
+                    listValue(
+                        stringValue("a"),
+                        stringValue("b"),
+                        stringValue("c"),
+                    ),
+                    sexpValue(
+                        int32Value(1),
+                        int32Value(2),
+                        int32Value(3),
+                    ),
+                    structValue(
+                        "a" to int32Value(1),
+                        "b" to stringValue("x"),
+                    ),
                 ),
                 expected = """
                     |<<
@@ -567,11 +535,9 @@ class PartiQLValueTextWriterTest {
             ),
             formatted(
                 value = structValue(
-                    sequenceOf(
-                        "bag" to bagValue<PartiQLValue>(emptySequence()),
-                        "list" to listValue<PartiQLValue>(emptySequence()),
-                        "sexp" to sexpValue<PartiQLValue>(emptySequence()),
-                    )
+                    "bag" to bagValue<PartiQLValue>(),
+                    "list" to listValue<PartiQLValue>(),
+                    "sexp" to sexpValue<PartiQLValue>(),
                 ),
                 expected = """
                     |{
@@ -583,11 +549,9 @@ class PartiQLValueTextWriterTest {
             ),
             formatted(
                 value = bagValue(
-                    sequenceOf(
-                        listValue<PartiQLValue>(emptySequence()),
-                        sexpValue<PartiQLValue>(emptySequence()),
-                        structValue<PartiQLValue>(emptySequence()),
-                    )
+                    listValue<PartiQLValue>(),
+                    sexpValue<PartiQLValue>(),
+                    structValue<PartiQLValue>(),
                 ),
                 expected = """
                     |<<
@@ -690,39 +654,31 @@ class PartiQLValueTextWriterTest {
             // TODO TIMESTAMP
             // TODO INTERVAL
             case(
-                value = bagValue(emptySequence(), annotations),
+                value = bagValue<PartiQLValue>(annotations = annotations),
                 expected = "x::y::<<>>",
             ),
             case(
-                value = listValue(emptySequence(), annotations),
+                value = listValue<PartiQLValue>(annotations = annotations),
                 expected = "x::y::[]",
             ),
             case(
-                value = sexpValue(emptySequence(), annotations),
+                value = sexpValue<PartiQLValue>(annotations = annotations),
                 expected = "x::y::()",
             ),
             formatted(
                 value = bagValue(
-                    sequenceOf(
-                        listValue(
-                            sequenceOf(
-                                stringValue("a", listOf("x")),
-                            ),
-                            listOf("list")
-                        ),
-                        sexpValue(
-                            sequenceOf(
-                                int32Value(1, listOf("y")),
-                            ),
-                            listOf("sexp")
-                        ),
-                        structValue(
-                            sequenceOf(
-                                "a" to int32Value(1, listOf("z")),
-                            ),
-                            listOf("struct")
-                        ),
-                    )
+                    listValue(
+                        stringValue("a", listOf("x")),
+                        annotations = listOf("list")
+                    ),
+                    sexpValue(
+                        int32Value(1, listOf("y")),
+                        annotations = listOf("sexp")
+                    ),
+                    structValue(
+                        "a" to int32Value(1, listOf("z")),
+                        annotations = listOf("struct")
+                    ),
                 ),
                 expected = """
                     |<<


### PR DESCRIPTION
## Relevant Issues
N/A

## Description
A sequence gets exhausted after consumed once which does not make it a good option for the **default** backing field. This PR replaces the collection data structure with the Iterable interface. This allows requesting a new iterator which gives freedom in the implementation of the backing structure. You can use sequences or lazily-generated iterators, but importantly this is not the default.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Yes

- Any backward-incompatible changes? **[YES/NO]**
No. PartiQLValue is considered experimental.

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.