### PR TITLE
Adds support for evaluation of CASE WHEN THEN

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -8,6 +8,7 @@ import org.partiql.eval.internal.operator.rel.RelJoinOuterFull
 import org.partiql.eval.internal.operator.rel.RelJoinRight
 import org.partiql.eval.internal.operator.rel.RelProject
 import org.partiql.eval.internal.operator.rel.RelScan
+import org.partiql.eval.internal.operator.rex.ExprCase
 import org.partiql.eval.internal.operator.rex.ExprCollection
 import org.partiql.eval.internal.operator.rex.ExprLiteral
 import org.partiql.eval.internal.operator.rex.ExprSelect
@@ -100,6 +101,14 @@ internal object Compiler {
                 Rel.Op.Join.Type.RIGHT -> RelJoinRight(lhs, rhs, condition)
                 Rel.Op.Join.Type.FULL -> RelJoinOuterFull(lhs, rhs, condition)
             }
+        }
+
+        override fun visitRexOpCase(node: Rex.Op.Case, ctx: Unit): Operator {
+            val branches = node.branches.map { branch ->
+                visitRex(branch.condition, ctx) to visitRex(branch.rex, ctx)
+            }
+            val default = visitRex(node.default, ctx)
+            return ExprCase(branches, default)
         }
 
         // TODO: Re-look at

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCase.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCase.kt
@@ -1,0 +1,29 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.BoolValue
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+
+internal class ExprCase(
+    private val branches: List<Pair<Operator.Expr, Operator.Expr>>,
+    private val default: Operator.Expr
+) : Operator.Expr {
+
+    @OptIn(PartiQLValueExperimental::class)
+    override fun eval(record: Record): PartiQLValue {
+        branches.forEach { branch ->
+            val condition = branch.first.eval(record)
+            if (condition.isTrue()) {
+                return branch.second.eval(record)
+            }
+        }
+        return default.eval(record)
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    private fun PartiQLValue.isTrue(): Boolean {
+        return this is BoolValue && this.value == true
+    }
+}

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -168,6 +168,30 @@ class PartiQLEngineDefaultTest {
 
     @OptIn(PartiQLValueExperimental::class)
     @Test
+    fun testCaseLiteral00() {
+        val source = """
+            CASE
+                WHEN NULL THEN 'isNull'
+                WHEN MISSING THEN 'isMissing'
+                WHEN FALSE THEN 'isFalse'
+                WHEN TRUE THEN 'isTrue'
+            END
+            ;
+        """.trimIndent()
+        val statement = parser.parse(source).root
+        val session = PartiQLPlanner.Session("q", "u")
+        val plan = planner.plan(statement, session)
+
+        val prepared = engine.prepare(plan.plan)
+        val result = engine.execute(prepared) as PartiQLResult.Value
+        val output = result.value
+
+        val expected = stringValue("isTrue")
+        assertEquals(expected, output)
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    @Test
     fun testJoinOuterFullOnTrue() {
         val statement =
             parser.parse("SELECT a, b FROM << { 'a': 1 } >> t FULL OUTER JOIN << { 'b': 2 } >> s ON TRUE;").root
@@ -212,6 +236,31 @@ class PartiQLEngineDefaultTest {
         val output = result.value
 
         val expected = structValue<PartiQLValue>(null)
+
+        assertEquals(expected, output)
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    @Test
+    fun testCaseLiteral01() {
+        val source = """
+            CASE
+                WHEN NULL THEN 'isNull'
+                WHEN MISSING THEN 'isMissing'
+                WHEN FALSE THEN 'isFalse'
+            END
+            ;
+        """.trimIndent()
+        val statement = parser.parse(source).root
+        val session = PartiQLPlanner.Session("q", "u")
+        val plan = planner.plan(statement, session)
+
+        val prepared = engine.prepare(plan.plan)
+
+        val result = engine.execute(prepared) as PartiQLResult.Value
+        val output = result.value
+
+        val expected = nullValue()
         assertEquals(expected, output)
     }
 
@@ -245,8 +294,32 @@ class PartiQLEngineDefaultTest {
         val prepared = engine.prepare(plan.plan)
         val result = engine.execute(prepared) as PartiQLResult.Value
         val output = result.value
-
         val expected = missingValue()
+        assertEquals(expected, output)
+    }
+
+    @Disabled("This is disabled because FN EQUALS is not yet implemented.")
+    @OptIn(PartiQLValueExperimental::class)
+    @Test
+    fun testCaseLiteral02() {
+        val source = """
+            CASE (1)
+                WHEN NULL THEN 'isNull'
+                WHEN MISSING THEN 'isMissing'
+                WHEN 2 THEN 'isTwo'
+                WHEN 1 THEN 'isOne'
+            END
+            ;
+        """.trimIndent()
+        val statement = parser.parse(source).root
+        val session = PartiQLPlanner.Session("q", "u")
+        val plan = planner.plan(statement, session)
+
+        val prepared = engine.prepare(plan.plan)
+        val result = engine.execute(prepared) as PartiQLResult.Value
+        val output = result.value
+
+        val expected = stringValue("isOne")
         assertEquals(expected, output)
     }
 
@@ -259,6 +332,7 @@ class PartiQLEngineDefaultTest {
                 { 'b': TRUE },
                 { 'c': 'hello' }
             );
+            
         """.trimIndent()
         val statement = parser.parse(source).root
         val session = PartiQLPlanner.Session("q", "u")
@@ -274,6 +348,29 @@ class PartiQLEngineDefaultTest {
             "b" to boolValue(true),
             "c" to stringValue("hello")
         )
+        assertEquals(expected, output)
+    }
+
+    @Disabled("This is disabled because FN EQUALS is not yet implemented.")
+    @OptIn(PartiQLValueExperimental::class)
+    @Test
+    fun testCaseLiteral03() {
+        val source = """
+            CASE (1)
+                WHEN NULL THEN 'isNull'
+                WHEN MISSING THEN 'isMissing'
+                WHEN 2 THEN 'isTwo'
+            END
+            ;
+        """.trimIndent()
+        val statement = parser.parse(source).root
+        val session = PartiQLPlanner.Session("q", "u")
+        val plan = planner.plan(statement, session)
+
+        val prepared = engine.prepare(plan.plan)
+        val result = engine.execute(prepared) as PartiQLResult.Value
+        val output = result.value
+        val expected = nullValue()
         assertEquals(expected, output)
     }
 


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds support for evaluation of CASE WHEN THEN
- See the `@Disabled` tests. Since we don't have EQUALS implemented yet, those tests are disabled.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.