### PR TITLE
Fix jmh benchmark after #1309

### DIFF
--- a/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLParserBenchmark.kt
+++ b/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLParserBenchmark.kt
@@ -29,7 +29,7 @@ import org.partiql.jmh.utils.MEASUREMENT_ITERATION_VALUE_RECOMMENDED
 import org.partiql.jmh.utils.MEASUREMENT_TIME_VALUE_RECOMMENDED
 import org.partiql.jmh.utils.WARMUP_ITERATION_VALUE_RECOMMENDED
 import org.partiql.jmh.utils.WARMUP_TIME_VALUE_RECOMMENDED
-import org.partiql.parser.PartiQLParserBuilder
+import org.partiql.parser.PartiQLParser
 import org.partiql.parser.PartiQLParserException
 import java.util.concurrent.TimeUnit
 
@@ -854,7 +854,7 @@ internal open class PartiQLParserBenchmark {
     @State(Scope.Thread)
     open class MyState {
 
-        val parser = PartiQLParserBuilder.standard().build()
+        val parser = PartiQLParser.default()
 
         val query15OrsAndLikes = """
             SELECT * 


### PR DESCRIPTION
## Description
JMH benchmark was using the old `PartiQLParserBuilder.standard().build()` to create the parser. Following #1309, JMH benchmark GH actions CI broke. Changed to use `PartiQLParser.default()`.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - No change to public api

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.