### PR TITLE
Prepare v0.14.1-SNAPSHOT; remove duplicate dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -947,6 +947,7 @@ breaking changes if migrating from v0.9.2. The breaking changes accidentally int
 Initial alpha release of PartiQL.
 
 [Unreleased]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.13.2-alpha...HEAD
+[0.14.0-alpha]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.13.2-alpha...v0.14.0-alpha
 [0.13.2-alpha]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.13.1-alpha...v0.13.2-alpha
 [0.13.1-alpha]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.13.0-alpha...v0.13.1-alpha
 [0.13.0-alpha]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.12.0-alpha...v0.13.0-alpha

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=0.14.0
+version=0.14.1-SNAPSHOT
 
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -32,8 +32,6 @@ dependencies {
     api(project(":partiql-planner"))
     api(project(":partiql-spi"))
     api(project(":partiql-types"))
-    api(project(":partiql-plan"))
-    api(project(":partiql-planner"))
     //
     api(Deps.ionElement)
     api(Deps.ionJava)


### PR DESCRIPTION
## Description
- Prepares v0.14.1-SNAPSHOT
- Adds link for v0.13.2 to v0.14.0 commit comparison
- Removes some redundant dependencies in `partiql-lang`

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.