### PR TITLE
Fix Rex.Op.Path typo

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -115,13 +115,13 @@ internal object PlanTransform : PlanBaseVisitor<PlanNode, ProblemCallback>() {
 
     override fun visitRexOpPathIndex(node: Rex.Op.Path.Index, ctx: ProblemCallback): PlanNode {
         val root = visitRex(node.root, ctx)
-        val key = visitRex(node.root, ctx)
+        val key = visitRex(node.key, ctx)
         return org.partiql.plan.Rex.Op.Path.Index(root, key)
     }
 
     override fun visitRexOpPathKey(node: Rex.Op.Path.Key, ctx: ProblemCallback): PlanNode {
         val root = visitRex(node.root, ctx)
-        val key = visitRex(node.root, ctx)
+        val key = visitRex(node.key, ctx)
         return org.partiql.plan.Rex.Op.Path.Key(root, key)
     }
 


### PR DESCRIPTION
## Relevant Issues
N/A

## Description
Fixes typo when producing public API plan from the internal typed plan. Should be patched released asap.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.