### PR TITLE
Initializes bindings in connectors and globals

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/PartiQLEngine.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/PartiQLEngine.kt
@@ -1,11 +1,6 @@
 package org.partiql.eval
 
-import org.partiql.eval.internal.Compiler
-import org.partiql.eval.internal.Record
 import org.partiql.plan.PartiQLPlan
-import org.partiql.spi.Plugin
-import org.partiql.value.PartiQLValue
-import org.partiql.value.PartiQLValueExperimental
 
 /**
  * PartiQL's Experimental Engine.
@@ -29,46 +24,11 @@ public interface PartiQLEngine {
     public fun execute(statement: PartiQLStatement<*>): PartiQLResult
 
     companion object {
+
         @JvmStatic
-        @JvmOverloads
-        fun default(plugins: List<Plugin> = emptyList()) = Builder().plugins(plugins).build()
-    }
+        public fun builder(): PartiQLEngineBuilder = PartiQLEngineBuilder()
 
-    public class Builder {
-
-        private var plugins: List<Plugin> = emptyList()
-
-        public fun plugins(plugins: List<Plugin>): Builder = this.apply {
-            this.plugins = plugins
-        }
-
-        public fun build(): PartiQLEngine = Default(plugins)
-    }
-
-    private class Default(private val plugins: List<Plugin>) : PartiQLEngine {
-
-        @OptIn(PartiQLValueExperimental::class)
-        override fun prepare(plan: PartiQLPlan): PartiQLStatement<*> {
-            // Close over the expression.
-            // Right now we are assuming we only have a query statement hence a value statement.
-            val expression = Compiler.compile(plan)
-            return object : PartiQLStatement.Query {
-                override fun execute(): PartiQLValue {
-                    return expression.eval(Record.empty)
-                }
-            }
-        }
-
-        @OptIn(PartiQLValueExperimental::class)
-        override fun execute(statement: PartiQLStatement<*>): PartiQLResult {
-            return when (statement) {
-                is PartiQLStatement.Query -> try {
-                    val value = statement.execute()
-                    PartiQLResult.Value(value)
-                } catch (ex: Exception) {
-                    PartiQLResult.Error(ex)
-                }
-            }
-        }
+        @JvmStatic
+        fun default() = PartiQLEngineBuilder().build()
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/PartiQLEngineBuilder.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/PartiQLEngineBuilder.kt
@@ -1,0 +1,36 @@
+package org.partiql.eval
+
+import org.partiql.spi.connector.ConnectorBindings
+
+class PartiQLEngineBuilder {
+
+    private var catalogs: MutableMap<String, ConnectorBindings> = mutableMapOf()
+
+    /**
+     * Build the builder, return an implementation of a [PartiQLEngine]
+     *
+     * @return
+     */
+    public fun build(): PartiQLEngine = PartiQLEngineDefault(catalogs)
+
+    /**
+     * Java style method for assigning a Catalog name to [ConnectorBindings].
+     *
+     * @param catalog
+     * @param metadata
+     * @return
+     */
+    public fun addCatalog(catalog: String, bindings: ConnectorBindings): PartiQLEngineBuilder = this.apply {
+        this.catalogs[catalog] = bindings
+    }
+
+    /**
+     * Kotlin style method for assigning Catalog names to [ConnectorBindings].
+     *
+     * @param catalogs
+     * @return
+     */
+    public fun catalogs(vararg catalogs: Pair<String, ConnectorBindings>): PartiQLEngineBuilder = this.apply {
+        this.catalogs = mutableMapOf(*catalogs)
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/PartiQLEngineDefault.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/PartiQLEngineDefault.kt
@@ -1,0 +1,41 @@
+package org.partiql.eval
+
+import org.partiql.eval.internal.Compiler
+import org.partiql.eval.internal.Record
+import org.partiql.plan.PartiQLPlan
+import org.partiql.spi.connector.ConnectorBindings
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+
+internal class PartiQLEngineDefault(
+    private val catalogs: Map<String, ConnectorBindings>,
+) : PartiQLEngine {
+
+    @OptIn(PartiQLValueExperimental::class)
+    override fun prepare(plan: PartiQLPlan): PartiQLStatement<*> {
+        try {
+            val compiler = Compiler(plan, catalogs)
+            val expression = compiler.compile()
+            return object : PartiQLStatement.Query {
+                override fun execute(): PartiQLValue {
+                    return expression.eval(Record.empty)
+                }
+            }
+        } catch (ex: Exception) {
+            // TODO wrap in some PartiQL Exception
+            throw ex
+        }
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    override fun execute(statement: PartiQLStatement<*>): PartiQLResult {
+        return when (statement) {
+            is PartiQLStatement.Query -> try {
+                val value = statement.execute()
+                PartiQLResult.Value(value)
+            } catch (ex: Exception) {
+                PartiQLResult.Error(ex)
+            }
+        }
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -13,10 +13,10 @@ import org.partiql.eval.internal.operator.rex.ExprCase
 import org.partiql.eval.internal.operator.rex.ExprCollection
 import org.partiql.eval.internal.operator.rex.ExprGlobal
 import org.partiql.eval.internal.operator.rex.ExprLiteral
-import org.partiql.eval.internal.operator.rex.ExprPivot
 import org.partiql.eval.internal.operator.rex.ExprPathIndex
 import org.partiql.eval.internal.operator.rex.ExprPathKey
 import org.partiql.eval.internal.operator.rex.ExprPathSymbol
+import org.partiql.eval.internal.operator.rex.ExprPivot
 import org.partiql.eval.internal.operator.rex.ExprSelect
 import org.partiql.eval.internal.operator.rex.ExprStruct
 import org.partiql.eval.internal.operator.rex.ExprTupleUnion

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -11,9 +11,12 @@ import org.partiql.eval.internal.operator.rel.RelScan
 import org.partiql.eval.internal.operator.rel.RelScanIndexed
 import org.partiql.eval.internal.operator.rex.ExprCase
 import org.partiql.eval.internal.operator.rex.ExprCollection
+import org.partiql.eval.internal.operator.rex.ExprGlobal
 import org.partiql.eval.internal.operator.rex.ExprLiteral
-import org.partiql.eval.internal.operator.rex.ExprPathKey
 import org.partiql.eval.internal.operator.rex.ExprPivot
+import org.partiql.eval.internal.operator.rex.ExprPathIndex
+import org.partiql.eval.internal.operator.rex.ExprPathKey
+import org.partiql.eval.internal.operator.rex.ExprPathSymbol
 import org.partiql.eval.internal.operator.rex.ExprSelect
 import org.partiql.eval.internal.operator.rex.ExprStruct
 import org.partiql.eval.internal.operator.rex.ExprTupleUnion
@@ -24,127 +27,156 @@ import org.partiql.plan.Rel
 import org.partiql.plan.Rex
 import org.partiql.plan.Statement
 import org.partiql.plan.visitor.PlanBaseVisitor
+import org.partiql.spi.connector.ConnectorBindings
+import org.partiql.spi.connector.ConnectorObjectPath
 import org.partiql.value.PartiQLValueExperimental
+import java.lang.IllegalStateException
 
-internal object Compiler {
+internal class Compiler(
+    private val plan: PartiQLPlan,
+    private val catalogs: Map<String, ConnectorBindings>,
+) : PlanBaseVisitor<Operator, Unit>() {
 
-    fun compile(plan: PartiQLPlan): Operator.Expr {
-        return PlanToCodeTransformer.visitPartiQLPlan(plan, Unit)
+    fun compile(): Operator.Expr {
+        return visitPartiQLPlan(plan, Unit)
     }
 
-    private object PlanToCodeTransformer : PlanBaseVisitor<Operator, Unit>() {
+    override fun defaultReturn(node: PlanNode, ctx: Unit): Operator {
+        TODO("Not yet implemented")
+    }
 
-        override fun defaultReturn(node: PlanNode, ctx: Unit): Operator {
-            TODO("Not yet implemented")
+    override fun visitRexOpErr(node: Rex.Op.Err, ctx: Unit): Operator {
+        throw IllegalStateException(node.message)
+    }
+
+    override fun visitRelOpErr(node: Rel.Op.Err, ctx: Unit): Operator {
+        throw IllegalStateException(node.message)
+    }
+
+    // TODO: Re-look at
+    override fun visitPartiQLPlan(node: PartiQLPlan, ctx: Unit): Operator.Expr {
+        return visitStatement(node.statement, ctx) as Operator.Expr
+    }
+
+    // TODO: Re-look at
+    override fun visitStatementQuery(node: Statement.Query, ctx: Unit): Operator.Expr {
+        return visitRex(node.root, ctx)
+    }
+
+    // REX
+
+    override fun visitRex(node: Rex, ctx: Unit): Operator.Expr {
+        return super.visitRexOp(node.op, ctx) as Operator.Expr
+    }
+
+    override fun visitRexOpCollection(node: Rex.Op.Collection, ctx: Unit): Operator {
+        val values = node.values.map { visitRex(it, ctx) }
+        return ExprCollection(values)
+    }
+    override fun visitRexOpStruct(node: Rex.Op.Struct, ctx: Unit): Operator {
+        val fields = node.fields.map {
+            ExprStruct.Field(visitRex(it.k, ctx), visitRex(it.v, ctx))
         }
+        return ExprStruct(fields)
+    }
 
-        // REX
+    override fun visitRexOpSelect(node: Rex.Op.Select, ctx: Unit): Operator {
+        val rel = visitRel(node.rel, ctx)
+        val constructor = visitRex(node.constructor, ctx)
+        return ExprSelect(rel, constructor)
+    }
 
-        override fun visitRexOpStruct(node: Rex.Op.Struct, ctx: Unit): Operator {
-            val fields = node.fields.map {
-                ExprStruct.Field(visitRex(it.k, ctx), visitRex(it.v, ctx))
-            }
-            return ExprStruct(fields)
+    override fun visitRexOpPivot(node: Rex.Op.Pivot, ctx: Unit): Operator {
+        val rel = visitRel(node.rel, ctx)
+        val key = visitRex(node.key, ctx)
+        val value = visitRex(node.value, ctx)
+        return ExprPivot(rel, key, value)
+    }
+    override fun visitRexOpVar(node: Rex.Op.Var, ctx: Unit): Operator {
+        return ExprVar(node.ref)
+    }
+
+    override fun visitRexOpGlobal(node: Rex.Op.Global, ctx: Unit): Operator {
+        val catalog = plan.catalogs[node.ref.catalog]
+        val symbol = catalog.symbols[node.ref.symbol]
+        val path = ConnectorObjectPath(symbol.path)
+        val bindings = catalogs[catalog.name]!!
+        return ExprGlobal(path, bindings)
+    }
+
+    override fun visitRexOpPathKey(node: Rex.Op.Path.Key, ctx: Unit): Operator {
+        val root = visitRex(node.root, ctx)
+        val key = visitRex(node.key, ctx)
+        return ExprPathKey(root, key)
+    }
+
+    override fun visitRexOpPathSymbol(node: Rex.Op.Path.Symbol, ctx: Unit): Operator {
+        val root = visitRex(node.root, ctx)
+        val symbol = node.key
+        return ExprPathSymbol(root, symbol)
+    }
+
+    override fun visitRexOpPathIndex(node: Rex.Op.Path.Index, ctx: Unit): Operator {
+        val root = visitRex(node.root, ctx)
+        val index = visitRex(node.key, ctx)
+        return ExprPathIndex(root, index)
+    }
+
+    // REL
+
+    override fun visitRel(node: Rel, ctx: Unit): Operator.Relation {
+        return super.visitRelOp(node.op, ctx) as Operator.Relation
+    }
+
+    override fun visitRelOpScan(node: Rel.Op.Scan, ctx: Unit): Operator {
+        val rex = visitRex(node.rex, ctx)
+        return RelScan(rex)
+    }
+
+    override fun visitRelOpProject(node: Rel.Op.Project, ctx: Unit): Operator {
+        val input = visitRel(node.input, ctx)
+        val projections = node.projections.map { visitRex(it, ctx) }
+        return RelProject(input, projections)
+    }
+
+    override fun visitRelOpScanIndexed(node: Rel.Op.ScanIndexed, ctx: Unit): Operator {
+        val rex = visitRex(node.rex, ctx)
+        return RelScanIndexed(rex)
+    }
+
+    override fun visitRexOpTupleUnion(node: Rex.Op.TupleUnion, ctx: Unit): Operator {
+        val args = node.args.map { visitRex(it, ctx) }.toTypedArray()
+        return ExprTupleUnion(args)
+    }
+
+    override fun visitRelOpJoin(node: Rel.Op.Join, ctx: Unit): Operator {
+        val lhs = visitRel(node.lhs, ctx)
+        val rhs = visitRel(node.rhs, ctx)
+        val condition = visitRex(node.rex, ctx)
+        return when (node.type) {
+            Rel.Op.Join.Type.INNER -> RelJoinInner(lhs, rhs, condition)
+            Rel.Op.Join.Type.LEFT -> RelJoinLeft(lhs, rhs, condition)
+            Rel.Op.Join.Type.RIGHT -> RelJoinRight(lhs, rhs, condition)
+            Rel.Op.Join.Type.FULL -> RelJoinOuterFull(lhs, rhs, condition)
         }
+    }
 
-        override fun visitRexOpVar(node: Rex.Op.Var, ctx: Unit): Operator {
-            return ExprVar(node.ref)
+    override fun visitRexOpCase(node: Rex.Op.Case, ctx: Unit): Operator {
+        val branches = node.branches.map { branch ->
+            visitRex(branch.condition, ctx) to visitRex(branch.rex, ctx)
         }
+        val default = visitRex(node.default, ctx)
+        return ExprCase(branches, default)
+    }
 
-        override fun visitRexOpPathKey(node: Rex.Op.Path.Key, ctx: Unit): Operator {
-            val root = visitRex(node.root, ctx)
-            val key = visitRex(node.key, ctx)
-            return ExprPathKey(root, key)
-        }
+    @OptIn(PartiQLValueExperimental::class)
+    override fun visitRexOpLit(node: Rex.Op.Lit, ctx: Unit): Operator {
+        return ExprLiteral(node.value)
+    }
 
-        override fun visitRexOpCollection(node: Rex.Op.Collection, ctx: Unit): Operator {
-            val values = node.values.map { visitRex(it, ctx) }
-            return ExprCollection(values)
-        }
-
-        override fun visitRexOpSelect(node: Rex.Op.Select, ctx: Unit): Operator {
-            val rel = visitRel(node.rel, ctx)
-            val constructor = visitRex(node.constructor, ctx)
-            return ExprSelect(rel, constructor)
-        }
-
-        override fun visitRexOpPivot(node: Rex.Op.Pivot, ctx: Unit): Operator {
-            val rel = visitRel(node.rel, ctx)
-            val key = visitRex(node.key, ctx)
-            val value = visitRex(node.value, ctx)
-            return ExprPivot(rel, key, value)
-        }
-
-        @OptIn(PartiQLValueExperimental::class)
-        override fun visitRexOpLit(node: Rex.Op.Lit, ctx: Unit): Operator {
-            return ExprLiteral(node.value)
-        }
-
-        // REL
-
-        override fun visitRelOpScan(node: Rel.Op.Scan, ctx: Unit): Operator {
-            val rex = visitRex(node.rex, ctx)
-            return RelScan(rex)
-        }
-
-        override fun visitRelOpProject(node: Rel.Op.Project, ctx: Unit): Operator {
-            val input = visitRel(node.input, ctx)
-            val projections = node.projections.map { visitRex(it, ctx) }
-            return RelProject(input, projections)
-        }
-
-        override fun visitRelOpScanIndexed(node: Rel.Op.ScanIndexed, ctx: Unit): Operator {
-            val rex = visitRex(node.rex, ctx)
-            return RelScanIndexed(rex)
-        }
-
-        override fun visitRel(node: Rel, ctx: Unit): Operator.Relation {
-            return super.visitRelOp(node.op, ctx) as Operator.Relation
-        }
-
-        override fun visitRelOpFilter(node: Rel.Op.Filter, ctx: Unit): Operator {
-            val input = visitRel(node.input, ctx)
-            val condition = visitRex(node.predicate, ctx)
-            return RelFilter(input, condition)
-        }
-
-        override fun visitRex(node: Rex, ctx: Unit): Operator.Expr {
-            return super.visitRexOp(node.op, ctx) as Operator.Expr
-        }
-
-        override fun visitRexOpTupleUnion(node: Rex.Op.TupleUnion, ctx: Unit): Operator {
-            val args = node.args.map { visitRex(it, ctx) }.toTypedArray()
-            return ExprTupleUnion(args)
-        }
-
-        override fun visitRelOpJoin(node: Rel.Op.Join, ctx: Unit): Operator {
-            val lhs = visitRel(node.lhs, ctx)
-            val rhs = visitRel(node.rhs, ctx)
-            val condition = visitRex(node.rex, ctx)
-            return when (node.type) {
-                Rel.Op.Join.Type.INNER -> RelJoinInner(lhs, rhs, condition)
-                Rel.Op.Join.Type.LEFT -> RelJoinLeft(lhs, rhs, condition)
-                Rel.Op.Join.Type.RIGHT -> RelJoinRight(lhs, rhs, condition)
-                Rel.Op.Join.Type.FULL -> RelJoinOuterFull(lhs, rhs, condition)
-            }
-        }
-
-        override fun visitRexOpCase(node: Rex.Op.Case, ctx: Unit): Operator {
-            val branches = node.branches.map { branch ->
-                visitRex(branch.condition, ctx) to visitRex(branch.rex, ctx)
-            }
-            val default = visitRex(node.default, ctx)
-            return ExprCase(branches, default)
-        }
-
-        // TODO: Re-look at
-        override fun visitPartiQLPlan(node: PartiQLPlan, ctx: Unit): Operator.Expr {
-            return visitStatement(node.statement, ctx) as Operator.Expr
-        }
-
-        // TODO: Re-look at
-        override fun visitStatementQuery(node: Statement.Query, ctx: Unit): Operator.Expr {
-            return visitRex(node.root, ctx)
-        }
+    override fun visitRelOpFilter(node: Rel.Op.Filter, ctx: Unit): Operator {
+        val input = visitRel(node.input, ctx)
+        val condition = visitRex(node.predicate, ctx)
+        return RelFilter(input, condition)
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprGlobal.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprGlobal.kt
@@ -1,0 +1,17 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.spi.connector.ConnectorBindings
+import org.partiql.spi.connector.ConnectorObjectPath
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+
+@OptIn(PartiQLValueExperimental::class)
+internal class ExprGlobal(
+    private val path: ConnectorObjectPath,
+    private val bindings: ConnectorBindings,
+) : Operator.Expr {
+
+    override fun eval(record: Record): PartiQLValue = bindings.getValue(path)
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathIndex.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathIndex.kt
@@ -1,0 +1,48 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.CollectionValue
+import org.partiql.value.Int16Value
+import org.partiql.value.Int32Value
+import org.partiql.value.Int64Value
+import org.partiql.value.Int8Value
+import org.partiql.value.IntValue
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.check
+import org.partiql.value.missingValue
+
+internal class ExprPathIndex(
+    @JvmField val root: Operator.Expr,
+    @JvmField val key: Operator.Expr,
+) : Operator.Expr {
+
+    @OptIn(PartiQLValueExperimental::class)
+    override fun eval(record: Record): PartiQLValue {
+        val collection = root.eval(record).check<CollectionValue<PartiQLValue>>()
+        val value = missingValue()
+
+        // Calculate index
+        val index = when (val k = key.eval(record)) {
+            is Int16Value -> k.int
+            is Int32Value -> k.int
+            is Int64Value -> k.int
+            is Int8Value -> k.int
+            is IntValue -> k.int
+            else -> return value
+        } ?: return value
+
+        // Get element
+        val iterator = collection.iterator()
+        var i = 0
+        while (iterator.hasNext()) {
+            val v = iterator.next()
+            if (i == index) {
+                return v
+            }
+            i++
+        }
+        return value
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathSymbol.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathSymbol.kt
@@ -1,0 +1,32 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.StructValue
+import org.partiql.value.check
+import org.partiql.value.missingValue
+import org.partiql.value.nullValue
+
+internal class ExprPathSymbol(
+    @JvmField val root: Operator.Expr,
+    @JvmField val symbol: String,
+) : Operator.Expr {
+
+    @OptIn(PartiQLValueExperimental::class)
+    override fun eval(record: Record): PartiQLValue {
+        val struct = root.eval(record).check<StructValue<PartiQLValue>>()
+        if (struct.isNull) {
+            return nullValue()
+        }
+        var value: PartiQLValue = missingValue()
+        for ((k, v) in struct.entries) {
+            if (k.equals(symbol, ignoreCase = true)) {
+                value = v
+                break
+            }
+        }
+        return value
+    }
+}

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/Connector.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/Connector.kt
@@ -31,6 +31,13 @@ public interface Connector {
     public fun getMetadata(session: ConnectorSession): ConnectorMetadata
 
     /**
+     * Returns a [ConnectorBindings] which the engine uses to load values.
+     *
+     * @return
+     */
+    public fun getBindings(): ConnectorBindings
+
+    /**
      * A Plugin leverages a [Factory] to produce a [Connector] which is used for catalog metadata and data access.
      */
     public interface Factory {

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/ConnectorBindings.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/ConnectorBindings.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.spi.connector
+
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+
+@OptIn(PartiQLValueExperimental::class)
+public interface ConnectorBindings {
+
+    public fun getValue(path: ConnectorObjectPath): PartiQLValue
+}

--- a/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/LocalConnector.kt
+++ b/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/LocalConnector.kt
@@ -17,6 +17,7 @@ package org.partiql.plugins.local
 import com.amazon.ionelement.api.StructElement
 import org.partiql.spi.BindingPath
 import org.partiql.spi.connector.Connector
+import org.partiql.spi.connector.ConnectorBindings
 import org.partiql.spi.connector.ConnectorMetadata
 import org.partiql.spi.connector.ConnectorObjectHandle
 import org.partiql.spi.connector.ConnectorObjectPath
@@ -59,6 +60,10 @@ class LocalConnector(
     public fun listObjects(): List<BindingPath> = metadata.listObjects()
 
     override fun getMetadata(session: ConnectorSession): ConnectorMetadata = metadata
+
+    override fun getBindings(): ConnectorBindings {
+        TODO("Not yet implemented")
+    }
 
     class Factory : Connector.Factory {
 

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryBindings.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryBindings.kt
@@ -1,12 +1,9 @@
 package org.partiql.plugins.memory
 
-import com.amazon.ionelement.api.IonElement
-import com.amazon.ionelement.api.StructElement
 import org.partiql.spi.connector.ConnectorBindings
 import org.partiql.spi.connector.ConnectorObjectPath
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
-import org.partiql.value.io.PartiQLValueIonReaderBuilder
 import org.partiql.value.missingValue
 
 @OptIn(PartiQLValueExperimental::class)
@@ -20,33 +17,11 @@ class MemoryBindings(
         return bindings[key] ?: missingValue()
     }
 
-    internal fun iterator(): Iterator<PartiQLValue> = bindings.values.iterator()
-
     companion object {
 
         /**
          * No bindings.
          */
         val empty = MemoryBindings(emptyMap())
-
-        /**
-         * Loads each declared global of the catalog from the data element.
-         */
-        fun load(metadata: MemoryConnector.Metadata, data: StructElement): MemoryBindings {
-            val bindings = mutableMapOf<String, PartiQLValue>()
-            for ((key, _) in metadata.entries) {
-                var ion: IonElement = data
-                val steps = key.split(".")
-                steps.forEach { s ->
-                    if (ion is StructElement) {
-                        ion = (ion as StructElement).getOptional(s) ?: error("No value for binding $key")
-                    } else {
-                        error("No value for binding $key")
-                    }
-                }
-                bindings[key] = PartiQLValueIonReaderBuilder.standard().build(ion).read()
-            }
-            return MemoryBindings(bindings)
-        }
     }
 }

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryBindings.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryBindings.kt
@@ -1,0 +1,52 @@
+package org.partiql.plugins.memory
+
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.StructElement
+import org.partiql.spi.connector.ConnectorBindings
+import org.partiql.spi.connector.ConnectorObjectPath
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.io.PartiQLValueIonReaderBuilder
+import org.partiql.value.missingValue
+
+@OptIn(PartiQLValueExperimental::class)
+class MemoryBindings(
+    private val bindings: Map<String, PartiQLValue>,
+) : ConnectorBindings {
+
+    @OptIn(PartiQLValueExperimental::class)
+    override fun getValue(path: ConnectorObjectPath): PartiQLValue {
+        val key = path.steps.joinToString(".")
+        return bindings[key] ?: missingValue()
+    }
+
+    internal fun iterator(): Iterator<PartiQLValue> = bindings.values.iterator()
+
+    companion object {
+
+        /**
+         * No bindings.
+         */
+        val empty = MemoryBindings(emptyMap())
+
+        /**
+         * Loads each declared global of the catalog from the data element.
+         */
+        fun load(metadata: MemoryConnector.Metadata, data: StructElement): MemoryBindings {
+            val bindings = mutableMapOf<String, PartiQLValue>()
+            for ((key, _) in metadata.entries) {
+                var ion: IonElement = data
+                val steps = key.split(".")
+                steps.forEach { s ->
+                    if (ion is StructElement) {
+                        ion = (ion as StructElement).getOptional(s) ?: error("No value for binding $key")
+                    } else {
+                        error("No value for binding $key")
+                    }
+                }
+                bindings[key] = PartiQLValueIonReaderBuilder.standard().build(ion).read()
+            }
+            return MemoryBindings(bindings)
+        }
+    }
+}

--- a/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryConnector.kt
+++ b/plugins/partiql-memory/src/main/kotlin/org/partiql/plugins/memory/MemoryConnector.kt
@@ -4,6 +4,7 @@ import com.amazon.ionelement.api.StructElement
 import org.partiql.spi.BindingCase
 import org.partiql.spi.BindingPath
 import org.partiql.spi.connector.Connector
+import org.partiql.spi.connector.ConnectorBindings
 import org.partiql.spi.connector.ConnectorMetadata
 import org.partiql.spi.connector.ConnectorObjectHandle
 import org.partiql.spi.connector.ConnectorObjectPath
@@ -13,13 +14,18 @@ import org.partiql.types.StaticType
 /**
  * This is a plugin used for testing and is not a versioned API per semver.
  */
-public class MemoryConnector(private val metadata: ConnectorMetadata) : Connector {
+public class MemoryConnector(
+    private val metadata: ConnectorMetadata,
+    private val bindings: ConnectorBindings,
+) : Connector {
 
     companion object {
         const val CONNECTOR_NAME = "memory"
     }
 
     override fun getMetadata(session: ConnectorSession): ConnectorMetadata = metadata
+
+    override fun getBindings(): ConnectorBindings = bindings
 
     class Factory(private val catalogs: Map<String, MemoryConnector>) : Connector.Factory {
 
@@ -36,6 +42,9 @@ public class MemoryConnector(private val metadata: ConnectorMetadata) : Connecto
      * @property map
      */
     class Metadata(private val map: Map<String, StaticType>) : ConnectorMetadata {
+
+        public val entries: List<Pair<String, StaticType>>
+            get() = map.entries.map { it.key to it.value }
 
         companion object {
             @JvmStatic

--- a/test/partiql-tests-runner/build.gradle.kts
+++ b/test/partiql-tests-runner/build.gradle.kts
@@ -26,6 +26,8 @@ application {
 dependencies {
     implementation(Deps.ionElement)
     testImplementation(project(":partiql-lang"))
+    testImplementation(project(":partiql-eval"))
+    testImplementation(project(":plugins:partiql-memory"))
 }
 
 val tests = System.getenv()["PARTIQL_TESTS_DATA"] ?: "../partiql-tests/partiql-tests-data"

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestEval.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestEval.kt
@@ -1,38 +1,38 @@
 package org.partiql.runner
 
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
-import org.partiql.runner.executor.LegacyExecutor
+import org.partiql.lang.eval.CompileOptions
+import org.partiql.runner.executor.EvalExecutor
+import org.partiql.runner.report.ReportGenerator
 import org.partiql.runner.schema.TestCase
 import org.partiql.runner.skip.LANG_KOTLIN_EVAL_EQUIV_FAIL_LIST
-import org.partiql.runner.skip.LANG_KOTLIN_EVAL_FAIL_LIST
 import org.partiql.runner.test.TestProvider
 import org.partiql.runner.test.TestRunner
 
-/**
- * Runs the conformance tests with an expected list of failing tests. Ensures that tests not in the failing list
- * succeed with the expected result. Ensures that tests included in the failing list fail.
- *
- * These tests are included in the normal test/building.
- * Update May 2023: Now excluded from the normal build, because the fail lists are out of date.
- * TODO: Come up with a low-burden method of maintaining fail / exclusion lists.
- */
-class ConformanceTest {
+@ExtendWith(ReportGenerator::class)
+@Disabled
+class ConformanceTestEval {
 
-    private val factory = LegacyExecutor.Factory
+    private val factory = EvalExecutor.Factory
     private val runner = TestRunner(factory)
 
     // Tests the eval tests with the Kotlin implementation
     @ParameterizedTest(name = "{arguments}")
     @ArgumentsSource(TestProvider.Eval::class)
     fun validatePartiQLEvalTestData(tc: TestCase) {
+        // val skip = LANG_KOTLIN_EVAL_FAIL_LIST
+        val skip = emptyList<Pair<String, CompileOptions>>()
         when (tc) {
-            is TestCase.Eval -> runner.test(tc, LANG_KOTLIN_EVAL_FAIL_LIST)
+            is TestCase.Eval -> runner.test(tc, skip)
             else -> error("Unsupported test case category")
         }
     }
 
     // Tests the eval equivalence tests with the Kotlin implementation
+    @Disabled
     @ParameterizedTest(name = "{arguments}")
     @ArgumentsSource(TestProvider.Equiv::class)
     fun validatePartiQLEvalEquivTestData(tc: TestCase) {

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestReport.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestReport.kt
@@ -3,11 +3,11 @@ package org.partiql.runner
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
+import org.partiql.runner.executor.LegacyExecutor
 import org.partiql.runner.report.ReportGenerator
 import org.partiql.runner.schema.TestCase
 import org.partiql.runner.test.TestProvider
 import org.partiql.runner.test.TestRunner
-import org.partiql.runner.test.executor.LegacyExecutor
 
 /**
  * Runs the conformance tests without a fail list, so we can document the passing/failing tests in the conformance

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/EvalExecutor.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/EvalExecutor.kt
@@ -1,0 +1,110 @@
+package org.partiql.runner.executor
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonValue
+import com.amazon.ionelement.api.StructElement
+import com.amazon.ionelement.api.toIonElement
+import com.amazon.ionelement.api.toIonValue
+import org.partiql.eval.PartiQLEngine
+import org.partiql.eval.PartiQLResult
+import org.partiql.eval.PartiQLStatement
+import org.partiql.lang.eval.CompileOptions
+import org.partiql.parser.PartiQLParser
+import org.partiql.planner.PartiQLPlanner
+import org.partiql.planner.PartiQLPlannerBuilder
+import org.partiql.plugins.memory.MemoryBindings
+import org.partiql.plugins.memory.MemoryConnector
+import org.partiql.runner.ION
+import org.partiql.runner.test.TestExecutor
+import org.partiql.spi.connector.Connector
+import org.partiql.spi.connector.ConnectorSession
+import org.partiql.types.StaticType
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.io.PartiQLValueIonReaderBuilder
+import org.partiql.value.toIon
+
+@OptIn(PartiQLValueExperimental::class)
+class EvalExecutor(
+    private val connector: Connector,
+    private val session: PartiQLPlanner.Session,
+) : TestExecutor<PartiQLStatement<*>, PartiQLResult> {
+
+    private val planner = PartiQLPlannerBuilder()
+        .addCatalog(
+            "test",
+            connector.getMetadata(object : ConnectorSession {
+                override fun getQueryId(): String = session.queryId
+                override fun getUserId(): String = session.userId
+            })
+        )
+        .build()
+
+    override fun prepare(statement: String): PartiQLStatement<*> {
+        val stmt = parser.parse(statement).root
+        val plan = planner.plan(stmt, session)
+        return engine.prepare(plan.plan)
+    }
+
+    override fun execute(statement: PartiQLStatement<*>): PartiQLResult {
+        return engine.execute(statement)
+    }
+
+    override fun fromIon(value: IonValue): PartiQLResult {
+        val partiql = PartiQLValueIonReaderBuilder.standard().build(value.toIonElement()).read()
+        return PartiQLResult.Value(partiql)
+    }
+
+    override fun toIon(value: PartiQLResult): IonValue {
+        if (value is PartiQLResult.Value) {
+            return value.value.toIon().toIonValue(ION)
+        }
+        error("PartiQLResult cannot be converted to Ion")
+    }
+
+    override fun compare(actual: PartiQLResult, expect: PartiQLResult): Boolean {
+        if (actual is PartiQLResult.Value && expect is PartiQLResult.Value) {
+            return actual.value == expect.value
+        }
+        error("Cannot compare different types of PartiQLResult")
+    }
+
+    companion object {
+        val parser = PartiQLParser.default()
+        val engine = PartiQLEngine.default()
+    }
+
+    object Factory : TestExecutor.Factory<PartiQLStatement<*>, PartiQLResult> {
+
+        override fun create(env: IonStruct, options: CompileOptions): TestExecutor<PartiQLStatement<*>, PartiQLResult> {
+            val catalog = "default"
+            val data = env.toIonElement() as StructElement
+
+            // infer catalog from env
+            val connector = infer(data)
+
+            val session = PartiQLPlanner.Session(
+                queryId = "query",
+                userId = "user",
+                currentCatalog = catalog,
+            )
+            return EvalExecutor(connector, session)
+        }
+
+        /**
+         * Produces an inferred catalog from the environment.
+         * Until this point, PartiQL Kotlin has only done top-level bindings.
+         *
+         * @param env
+         * @return
+         */
+        private fun infer(env: StructElement): Connector {
+            val map = mutableMapOf<String, StaticType>()
+            env.fields.forEach {
+                map[it.name] = StaticType.ANY
+            }
+            val metadata = MemoryConnector.Metadata(map)
+            val bindings = MemoryBindings.load(metadata, env)
+            return MemoryConnector(metadata, bindings)
+        }
+    }
+}

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/LegacyExecutor.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/LegacyExecutor.kt
@@ -1,4 +1,4 @@
-package org.partiql.runner.test.executor
+package org.partiql.runner.executor
 
 import com.amazon.ion.IonStruct
 import com.amazon.ion.IonValue


### PR DESCRIPTION
## Description

This PR introduces a getBindings() method to PartiQL Plugins. A plugin will return a PartiQLBindings object which returns a PartiQLValue given a ConnectorObjectPath.

I have implemented this for the MemoryPlugin which is now used to load globals from the conformance test suite. This PR also includes an implementation of a TestExecutor for the ongoing evaluator work.

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.