### PR TITLE
Adds UDF scalar signatures to planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Thank you to all who have contributed!
 ## [Unreleased]
 
 ### Added
+- Adds the ability to pass a user-defined-function signature to the planner.
 
 ### Changed
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlannerBuilder.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlannerBuilder.kt
@@ -67,7 +67,7 @@ public class PartiQLPlannerBuilder {
     }
 
     /**
-     * Kotlin style method for adding a user-defined-function.
+     * Kotlin style method for setting the user-defined functions. This replaces all existing user-defined functions previously passed to the builder.
      *
      * @param function
      * @return


### PR DESCRIPTION
## Relevant Issues
N/A

## Description
This commit adds the ability to pass a user-defined-function signature to the planner.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Yes

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >
 No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.