### PR TITLE
Remove redundancy by using ANY parameter for IS TYPE operators

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLHeader.kt
@@ -403,68 +403,61 @@ internal object PartiQLHeader : Header() {
     // To model type assertion, generating a list of assertion function based on the type,
     // and the parameter will be the value entered.
     //  i.e., 1 is INT2  => is_int16(1)
-    private fun isType(): List<FunctionSignature.Scalar> = types.all.filterNot { it == NULL || it == MISSING }.flatMap { element ->
-        types.all.filterNot { it == MISSING || it == ANY }.map { operand ->
+    private fun isType(): List<FunctionSignature.Scalar> =
+        types.all.filterNot { it == NULL || it == MISSING }.map { element ->
             FunctionSignature.Scalar(
                 name = "is_${element.name.lowercase()}",
                 returns = BOOL,
                 parameters = listOf(
-                    FunctionParameter("value", operand)
+                    FunctionParameter("value", ANY)
                 ),
                 isNullCall = false, // TODO: Should this be true?
                 isNullable = false
             )
         }
-    }
 
     // In type assertion, it is possible for types to have args
     // i.e., 'a' is CHAR(2)
     // we put type parameter before value.
-    private fun isTypeSingleArg(): List<FunctionSignature.Scalar> = listOf(CHAR, STRING).flatMap { element ->
-        types.all.filterNot { it == MISSING }.map { operand ->
-            FunctionSignature.Scalar(
-                name = "is_${element.name.lowercase()}",
-                returns = BOOL,
-                parameters = listOf(
-                    FunctionParameter("type_parameter_1", INT32),
-                    FunctionParameter("value", operand)
-                ),
-                isNullable = false, // TODO: Should this be true?
-                isNullCall = false
-            )
-        }
+    private fun isTypeSingleArg(): List<FunctionSignature.Scalar> = listOf(CHAR, STRING).map { element ->
+        FunctionSignature.Scalar(
+            name = "is_${element.name.lowercase()}",
+            returns = BOOL,
+            parameters = listOf(
+                FunctionParameter("type_parameter_1", INT32),
+                FunctionParameter("value", ANY)
+            ),
+            isNullable = false, // TODO: Should this be true?
+            isNullCall = false
+        )
     }
 
-    private fun isTypeDoubleArgsInt(): List<FunctionSignature.Scalar> = listOf(DECIMAL).flatMap { element ->
-        types.all.filterNot { it == MISSING }.map { operand ->
-            FunctionSignature.Scalar(
-                name = "is_${element.name.lowercase()}",
-                returns = BOOL,
-                parameters = listOf(
-                    FunctionParameter("type_parameter_1", INT32),
-                    FunctionParameter("type_parameter_2", INT32),
-                    FunctionParameter("value", operand)
-                ),
-                isNullable = false,
-                isNullCall = false
-            )
-        }
+    private fun isTypeDoubleArgsInt(): List<FunctionSignature.Scalar> = listOf(DECIMAL).map { element ->
+        FunctionSignature.Scalar(
+            name = "is_${element.name.lowercase()}",
+            returns = BOOL,
+            parameters = listOf(
+                FunctionParameter("type_parameter_1", INT32),
+                FunctionParameter("type_parameter_2", INT32),
+                FunctionParameter("value", ANY)
+            ),
+            isNullable = false,
+            isNullCall = false
+        )
     }
 
-    private fun isTypeTime(): List<FunctionSignature.Scalar> = listOf(TIME, TIMESTAMP).flatMap { element ->
-        types.all.filterNot { it == MISSING }.map { operand ->
-            FunctionSignature.Scalar(
-                name = "is_${element.name.lowercase()}",
-                returns = BOOL,
-                parameters = listOf(
-                    FunctionParameter("type_parameter_1", BOOL),
-                    FunctionParameter("type_parameter_2", INT32),
-                    FunctionParameter("value", operand) // TODO: Decide if we need to further segment this
-                ),
-                isNullCall = false,
-                isNullable = false
-            )
-        }
+    private fun isTypeTime(): List<FunctionSignature.Scalar> = listOf(TIME, TIMESTAMP).map { element ->
+        FunctionSignature.Scalar(
+            name = "is_${element.name.lowercase()}",
+            returns = BOOL,
+            parameters = listOf(
+                FunctionParameter("type_parameter_1", BOOL),
+                FunctionParameter("type_parameter_2", INT32),
+                FunctionParameter("value", ANY) // TODO: Decide if we need to further segment this
+            ),
+            isNullCall = false,
+            isNullable = false
+        )
     }
 
     // SUBSTRING (expression, start[, length]?)

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PartiQLHeader.kt
@@ -411,8 +411,8 @@ internal object PartiQLHeader : Header() {
                 parameters = listOf(
                     FunctionParameter("value", ANY)
                 ),
-                isNullCall = false, // TODO: Should this be true?
-                isNullable = false
+                isNullable = false,
+                isNullCall = false,
             )
         }
 
@@ -427,7 +427,7 @@ internal object PartiQLHeader : Header() {
                 FunctionParameter("type_parameter_1", INT32),
                 FunctionParameter("value", ANY)
             ),
-            isNullable = false, // TODO: Should this be true?
+            isNullable = false,
             isNullCall = false
         )
     }
@@ -455,8 +455,8 @@ internal object PartiQLHeader : Header() {
                 FunctionParameter("type_parameter_2", INT32),
                 FunctionParameter("value", ANY) // TODO: Decide if we need to further segment this
             ),
-            isNullCall = false,
-            isNullable = false
+            isNullable = false,
+            isNullCall = false
         )
     }
 

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -389,6 +389,66 @@ class PlanTyperTestsPorted {
         )
 
         @JvmStatic
+        fun isTypeCases() = listOf(
+            SuccessTestCase(
+                name = "IS BOOL",
+                key = key("is-type-00"),
+                catalog = "pql",
+                catalogPath = listOf("main"),
+                expected = StaticType.BOOL
+            ),
+            SuccessTestCase(
+                name = "IS INT",
+                key = key("is-type-01"),
+                catalog = "pql",
+                catalogPath = listOf("main"),
+                expected = StaticType.BOOL
+            ),
+            SuccessTestCase(
+                name = "IS STRING",
+                key = key("is-type-02"),
+                catalog = "pql",
+                catalogPath = listOf("main"),
+                expected = StaticType.BOOL
+            ),
+            SuccessTestCase(
+                name = "IS NULL",
+                key = key("is-type-03"),
+                catalog = "pql",
+                expected = StaticType.BOOL,
+            ),
+            SuccessTestCase(
+                name = "MISSING IS NULL",
+                key = key("is-type-04"),
+                catalog = "pql",
+                expected = StaticType.BOOL,
+            ),
+            SuccessTestCase(
+                name = "NULL IS NULL",
+                key = key("is-type-05"),
+                catalog = "pql",
+                expected = StaticType.BOOL,
+            ),
+            SuccessTestCase(
+                name = "MISSING IS MISSING",
+                key = key("is-type-06"),
+                catalog = "pql",
+                expected = StaticType.BOOL,
+            ),
+            SuccessTestCase(
+                name = "NULL IS MISSING",
+                key = key("is-type-07"),
+                catalog = "pql",
+                expected = StaticType.BOOL,
+            ),
+            ErrorTestCase(
+                name = "ERROR always MISSING",
+                key = key("is-type-08"),
+                catalog = "pql",
+            ),
+        )
+
+        @JvmStatic
         fun sessionVariables() = listOf(
             SuccessTestCase(
                 name = "Current User",
@@ -536,7 +596,10 @@ class PlanTyperTestsPorted {
                 problemHandler = assertProblemExists {
                     Problem(
                         UNKNOWN_PROBLEM_LOCATION,
-                        PlanningProblemDetails.UnknownFunction("bitwise_and", listOf(StaticType.INT4, StaticType.STRING))
+                        PlanningProblemDetails.UnknownFunction(
+                            "bitwise_and",
+                            listOf(StaticType.INT4, StaticType.STRING)
+                        )
                     )
                 }
             ),
@@ -2972,6 +3035,11 @@ class PlanTyperTestsPorted {
     @Execution(ExecutionMode.CONCURRENT)
     fun testPivot(tc: TestCase) = runTest(tc)
 
+    @ParameterizedTest
+    @MethodSource("isTypeCases")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun testIsType(tc: TestCase) = runTest(tc)
+
     // --------- Finish Parameterized Tests ------
 
     //
@@ -2980,7 +3048,7 @@ class PlanTyperTestsPorted {
     private fun infer(
         query: String,
         session: PartiQLPlanner.Session,
-        problemCollector: ProblemCollector
+        problemCollector: ProblemCollector,
     ): PartiQLPlan {
         val ast = parser.parse(query).root
         return planner.plan(ast, session, problemCollector).plan

--- a/partiql-planner/src/testFixtures/resources/inputs/schema_inferencer/is_type.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/schema_inferencer/is_type.sql
@@ -1,0 +1,27 @@
+--#[is-type-00]
+false IS BOOL;
+
+--#[is-type-01]
+item.i_class_id IS INT;
+
+--#[is-type-02]
+item.i_brand IS STRING;
+
+--#[is-type-03]
+1 IS NULL;
+
+--#[is-type-04]
+MISSING IS NULL;
+
+--#[is-type-05]
+NULL IS NULL;
+
+--#[is-type-06]
+MISSING IS MISSING;
+
+--#[is-type-07]
+NULL IS MISSING;
+
+--#[is-type-08]
+-- ERROR! always MISSING
+MISSING IS BOOL;


### PR DESCRIPTION
## Relevant Issues
N/A

## Description
Reduces redundancy of the IS TYPE operators as they do not need to be defined for each individual type.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
  - < If YES, why? >
  - < For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base. >
No, internal typer concern for 0.14

- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.