### PR TITLE
Moves ConnectorMetadata to planner session for PartiQLPlanner re-use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ Thank you to all who have contributed!
 ## [Unreleased]
 
 ### Added
-- Adds the ability to pass a user-defined-function signature to the planner.
+- Adds the ability to define a user-defined-function in ConnectorMetadata
+- Move ConnectorMetadata map from PartiQLPlanner to PartiQLPlanner.Session for planner re-use.
 
 ### Changed
 
@@ -42,7 +43,7 @@ Thank you to all who have contributed!
 
 ### Contributors
 Thank you to all who have contributed!
-- @<your-username>
+- @rchowell
 
 ## [0.14.0-alpha] - 2023-12-15
 

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
@@ -52,12 +52,8 @@ object Debug {
 
     private val root = Paths.get(System.getProperty("user.home")).resolve(".partiql/local")
 
-    private val planner = PartiQLPlanner.builder()
-        .catalogs(
-            "local" to LocalConnector.Metadata(root)
-        )
-        .build()
     private val parser = PartiQLParser.default()
+    private val planner = PartiQLPlanner.default()
 
     // !!
     // IMPLEMENT DEBUG BEHAVIOR HERE
@@ -76,6 +72,9 @@ object Debug {
         val sess = PartiQLPlanner.Session(
             queryId = UUID.randomUUID().toString(),
             userId = "debug",
+            catalogs = mapOf(
+                "local" to LocalConnector.Metadata(root)
+            )
         )
         val result = planner.plan(statement, sess).plan
         out.info("-- Plan ----------")

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlanner.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlanner.kt
@@ -4,6 +4,7 @@ import org.partiql.ast.Statement
 import org.partiql.errors.Problem
 import org.partiql.errors.ProblemCallback
 import org.partiql.plan.PartiQLPlan
+import org.partiql.spi.connector.ConnectorMetadata
 import java.time.Instant
 
 /**
@@ -45,6 +46,7 @@ public interface PartiQLPlanner {
         public val userId: String,
         public val currentCatalog: String? = null,
         public val currentDirectory: List<String> = emptyList(),
+        public val catalogs: Map<String, ConnectorMetadata> = emptyMap(),
         public val instant: Instant = Instant.now(),
     )
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlannerBuilder.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlannerBuilder.kt
@@ -1,82 +1,41 @@
 package org.partiql.planner
 
-import org.partiql.spi.connector.ConnectorMetadata
-import org.partiql.types.function.FunctionSignature
-
 /**
  * PartiQLPlannerBuilder is used to programmatically construct a [PartiQLPlanner] implementation.
  *
  * Usage:
  *      PartiQLPlanner.builder()
- *                    .addCatalog("foo", FooConnector())
- *                    .addCatalog("bar", BarConnector())
- *                    .builder()
+ *                    .addPass(myPass)
+ *                    .build()
  */
 public class PartiQLPlannerBuilder {
 
-    private var fns: MutableList<FunctionSignature.Scalar> = mutableListOf()
-    private var catalogs: MutableMap<String, ConnectorMetadata> = mutableMapOf()
-    private var passes: List<PartiQLPlannerPass> = emptyList()
+    private val passes: MutableList<PartiQLPlannerPass> = mutableListOf()
 
     /**
      * Build the builder, return an implementation of a [PartiQLPlanner].
      *
      * @return
      */
-    public fun build(): PartiQLPlanner {
-        val headers = mutableListOf<Header>(PartiQLHeader)
-        if (fns.isNotEmpty()) {
-            val h = object : Header() {
-                override val namespace: String = "UDF"
-                override val functions = fns
-            }
-            headers.add(h)
-        }
-        return PartiQLPlannerDefault(headers, catalogs, passes)
+    public fun build(): PartiQLPlanner = PartiQLPlannerDefault(passes)
+
+    /**
+     * Java style method for adding a planner pass to this planner builder.
+     *
+     * @param pass
+     * @return
+     */
+    public fun addPass(pass: PartiQLPlannerPass): PartiQLPlannerBuilder = this.apply {
+        this.passes.add(pass)
     }
 
     /**
-     * Java style method for assigning a Catalog name to [ConnectorMetadata].
+     * Kotlin style method for adding a list of planner passes to this planner builder.
      *
-     * @param catalog
-     * @param metadata
+     * @param passes
      * @return
      */
-    public fun addCatalog(catalog: String, metadata: ConnectorMetadata): PartiQLPlannerBuilder = this.apply {
-        this.catalogs[catalog] = metadata
-    }
-
-    /**
-     * Kotlin style method for assigning Catalog names to [ConnectorMetadata].
-     *
-     * @param catalogs
-     * @return
-     */
-    public fun catalogs(vararg catalogs: Pair<String, ConnectorMetadata>): PartiQLPlannerBuilder = this.apply {
-        this.catalogs = mutableMapOf(*catalogs)
-    }
-
-    /**
-     * Java style method for adding a user-defined-function.
-     *
-     * @param function
-     * @return
-     */
-    public fun addFunction(function: FunctionSignature.Scalar): PartiQLPlannerBuilder = this.apply {
-        this.fns.add(function)
-    }
-
-    /**
-     * Kotlin style method for setting the user-defined functions. This replaces all existing user-defined functions previously passed to the builder.
-     *
-     * @param function
-     * @return
-     */
-    public fun functions(vararg functions: FunctionSignature.Scalar): PartiQLPlannerBuilder = this.apply {
-        this.fns = mutableListOf(*functions)
-    }
-
-    public fun passes(passes: List<PartiQLPlannerPass>): PartiQLPlannerBuilder = this.apply {
-        this.passes = passes
+    public fun addPasses(vararg passes: PartiQLPlannerPass): PartiQLPlannerBuilder = this.apply {
+        this.passes.addAll(passes)
     }
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlannerDefault.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlannerDefault.kt
@@ -8,14 +8,11 @@ import org.partiql.planner.internal.ir.PartiQLVersion
 import org.partiql.planner.internal.transforms.AstToPlan
 import org.partiql.planner.internal.transforms.PlanTransform
 import org.partiql.planner.internal.typer.PlanTyper
-import org.partiql.spi.connector.ConnectorMetadata
 
 /**
  * Default PartiQL logical query planner.
  */
 internal class PartiQLPlannerDefault(
-    private val headers: List<Header>,
-    private val catalogs: Map<String, ConnectorMetadata>,
     private val passes: List<PartiQLPlannerPass>,
 ) : PartiQLPlanner {
 
@@ -24,8 +21,9 @@ internal class PartiQLPlannerDefault(
         session: PartiQLPlanner.Session,
         onProblem: ProblemCallback,
     ): PartiQLPlanner.Result {
+
         // 0. Initialize the planning environment
-        val env = Env(headers, catalogs, session)
+        val env = Env(session)
 
         // 1. Normalize
         val ast = statement.normalize()

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Env.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Env.kt
@@ -1,6 +1,5 @@
 package org.partiql.planner.internal
 
-import org.partiql.planner.Header
 import org.partiql.planner.PartiQLPlanner
 import org.partiql.planner.internal.ir.Agg
 import org.partiql.planner.internal.ir.Catalog
@@ -20,6 +19,7 @@ import org.partiql.spi.connector.ConnectorSession
 import org.partiql.types.StaticType
 import org.partiql.types.StructType
 import org.partiql.types.TupleConstraint
+import org.partiql.types.function.FunctionSignature
 
 /**
  * Handle for associating a catalog name with catalog related metadata objects.
@@ -85,7 +85,7 @@ internal sealed interface ResolvedVar {
         override val ordinal: Int,
         val rootType: StaticType,
         val replacementSteps: List<BindingName>,
-        override val depth: Int
+        override val depth: Int,
     ) : ResolvedVar
 
     /**
@@ -100,7 +100,7 @@ internal sealed interface ResolvedVar {
         override val type: StaticType,
         override val ordinal: Int,
         override val depth: Int,
-        val position: Int
+        val position: Int,
     ) : ResolvedVar
 }
 
@@ -120,13 +120,9 @@ internal enum class ResolutionStrategy {
 /**
  * PartiQL Planner Global Environment of Catalogs backed by given plugins.
  *
- * @property headers        List of namespaced definitions
- * @property catalogs       List of plugins for global resolution
  * @property session        Session details
  */
 internal class Env(
-    private val headers: List<Header>,
-    private val connectors: Map<String, ConnectorMetadata>,
     private val session: PartiQLPlanner.Session,
 ) {
 
@@ -136,9 +132,30 @@ internal class Env(
     public val catalogs = mutableListOf<Catalog>()
 
     /**
-     * Encapsulate all function resolving logic within [FnResolver].
+     * Catalog Metadata for this query session.
      */
-    public val fnResolver = FnResolver(headers)
+    private val connectors = session.catalogs
+
+    /**
+     * Encapsulate all function resolving logic within [FnResolver].
+     *
+     * TODO we should be using a search_path for resolving functions. This is not possible at the moment, so we flatten
+     *      all builtin functions to live at the top-level. At the moment, we could technically use this to have
+     *      single-level `catalog`.`function`() syntax but that is out-of-scope for this commit.
+     */
+    public val fnResolver = FnResolver(object : Header() {
+
+        override val namespace: String = "builtins"
+
+        override val functions: List<FunctionSignature.Scalar> =
+            PartiQLHeader.functions + connectors.values.flatMap { it.functions }
+
+        override val operators: List<FunctionSignature.Scalar> =
+            PartiQLHeader.operators + connectors.values.flatMap { it.operators }
+
+        override val aggregations: List<FunctionSignature.Aggregation> =
+            PartiQLHeader.aggregations + connectors.values.flatMap { it.aggregations }
+    })
 
     private val connectorSession = object : ConnectorSession {
         override fun getQueryId(): String = session.queryId
@@ -146,13 +163,12 @@ internal class Env(
     }
 
     /**
-
-     * Leverages a [FunctionResolver] to find a matching function defined in the [Header] scalar function catalog.
+     * Leverages a [FnResolver] to find a matching function defined in the [Header] scalar function catalog.
      */
     internal fun resolveFn(fn: Fn.Unresolved, args: List<Rex>) = fnResolver.resolveFn(fn, args)
 
     /**
-     * Leverages a [FunctionResolver] to find a matching function defined in the [Header] aggregation function catalog.
+     * Leverages a [FnResolver] to find a matching function defined in the [Header] aggregation function catalog.
      */
     internal fun resolveAgg(agg: Agg.Unresolved, args: List<Rex>) = fnResolver.resolveAgg(agg, args)
 
@@ -211,7 +227,11 @@ internal class Env(
             getObjectHandle(cat, catalogPath)?.let { handle ->
                 getObjectDescriptor(handle).let { type ->
                     val depth = calculateMatched(originalPath, catalogPath, handle.second.absolutePath)
-                    val (catalogIndex, valueIndex) = getOrAddCatalogValue(handle.first, handle.second.absolutePath.steps, type)
+                    val (catalogIndex, valueIndex) = getOrAddCatalogValue(
+                        handle.first,
+                        handle.second.absolutePath.steps,
+                        type
+                    )
                     // Return resolution metadata
                     ResolvedVar.Global(type, catalogIndex, depth, valueIndex)
                 }
@@ -222,7 +242,11 @@ internal class Env(
     /**
      * @return a [Pair] where [Pair.first] is the catalog index and [Pair.second] is the value index within that catalog
      */
-    private fun getOrAddCatalogValue(catalogName: String, valuePath: List<String>, valueType: StaticType): Pair<Int, Int> {
+    private fun getOrAddCatalogValue(
+        catalogName: String,
+        valuePath: List<String>,
+        valueType: StaticType,
+    ): Pair<Int, Int> {
         val catalogIndex = getOrAddCatalog(catalogName)
         val symbols = catalogs[catalogIndex].symbols
         return symbols.indexOfFirst { value ->
@@ -337,7 +361,13 @@ internal class Env(
                 val varType = inferStructLookup(rootType, path)
                 if (varType != null) {
                     // we found this path within a struct!
-                    val match = ResolvedVar.Local(varType.resolvedType, ordinal, rootType, varType.replacementPath.steps, varType.replacementPath.steps.size)
+                    val match = ResolvedVar.Local(
+                        varType.resolvedType,
+                        ordinal,
+                        rootType,
+                        varType.replacementPath.steps,
+                        varType.replacementPath.steps.size
+                    )
                     matches.add(match)
                 }
             }
@@ -380,7 +410,7 @@ internal class Env(
      */
     private class ResolvedPath(
         val replacementPath: BindingPath,
-        val resolvedType: StaticType
+        val resolvedType: StaticType,
     )
 
     /**

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Header.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Header.kt
@@ -1,4 +1,4 @@
-package org.partiql.planner
+package org.partiql.planner.internal
 
 import org.partiql.planner.internal.typer.TypeLattice
 import org.partiql.types.function.FunctionParameter

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PartiQLHeader.kt
@@ -1,4 +1,4 @@
-package org.partiql.planner
+package org.partiql.planner.internal
 
 import org.partiql.ast.DatetimeField
 import org.partiql.types.function.FunctionParameter

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/FnResolver.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/FnResolver.kt
@@ -1,6 +1,6 @@
 package org.partiql.planner.internal.typer
 
-import org.partiql.planner.Header
+import org.partiql.planner.internal.Header
 import org.partiql.planner.internal.ir.Agg
 import org.partiql.planner.internal.ir.Fn
 import org.partiql.planner.internal.ir.Identifier
@@ -109,7 +109,7 @@ internal sealed class FnMatch<T : FunctionSignature> {
  * at the moment to keep that information (derived from the current TypeLattice) with the [FnResolver].
  */
 @OptIn(PartiQLValueExperimental::class)
-internal class FnResolver(private val headers: List<Header>) {
+internal class FnResolver(private val header: Header) {
 
     /**
      * All headers use the same type lattice (we don't have a design for plugging type systems at the moment).
@@ -140,10 +140,10 @@ internal class FnResolver(private val headers: List<Header>) {
         val (casts, unsafeCasts) = casts()
         unsafeCastSet = unsafeCasts
         // combine all header definitions
-        val fns = headers.flatMap { it.functions }
+        val fns = header.functions
         functions = fns.toFnMap()
-        operators = (headers.flatMap { it.operators } + casts).toFnMap()
-        aggregations = headers.flatMap { it.aggregations }.toFnMap()
+        operators = (header.operators + casts).toFnMap()
+        aggregations = header.aggregations.toFnMap()
     }
 
     /**

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/HeaderTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/HeaderTest.kt
@@ -2,6 +2,7 @@ package org.partiql.planner
 
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.partiql.planner.internal.PartiQLHeader
 
 class HeaderTest {
 

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/EnvTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/EnvTest.kt
@@ -3,7 +3,6 @@ package org.partiql.planner.internal
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.partiql.planner.PartiQLHeader
 import org.partiql.planner.PartiQLPlanner
 import org.partiql.planner.internal.ir.Catalog
 import org.partiql.planner.internal.ir.Rex
@@ -38,15 +37,14 @@ class EnvTest {
     @BeforeEach
     fun init() {
         env = Env(
-            listOf(PartiQLHeader),
-            mapOf(
-                "pql" to LocalConnector.Metadata(root)
-            ),
             PartiQLPlanner.Session(
                 queryId = Random().nextInt().toString(),
                 userId = "test-user",
                 currentCatalog = "pql",
                 currentDirectory = listOf("main"),
+                catalogs = mapOf(
+                    "pql" to LocalConnector.Metadata(root)
+                ),
             )
         )
     }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/FunctionResolverTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/FunctionResolverTest.kt
@@ -2,8 +2,7 @@ package org.partiql.planner.internal.typer
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
-import org.partiql.planner.Header
-import org.partiql.planner.PartiQLHeader
+import org.partiql.planner.internal.Header
 import org.partiql.types.function.FunctionParameter
 import org.partiql.types.function.FunctionSignature
 import org.partiql.value.PartiQLValueExperimental
@@ -67,7 +66,7 @@ class FunctionResolverTest {
             )
         }
 
-        private val resolver = FnResolver(listOf(PartiQLHeader, myHeader))
+        private val resolver = FnResolver(myHeader)
     }
 
     private sealed class Case {

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTest.kt
@@ -1,7 +1,6 @@
 package org.partiql.planner.internal.typer
 
 import org.junit.jupiter.api.Test
-import org.partiql.planner.PartiQLHeader
 import org.partiql.planner.PartiQLPlanner
 import org.partiql.planner.internal.Env
 import org.partiql.planner.internal.ir.Identifier
@@ -174,15 +173,14 @@ class PlanTyperTest {
         private fun getTyper(): PlanTyperWrapper {
             val collector = ProblemCollector()
             val env = Env(
-                listOf(PartiQLHeader),
-                mapOf(
-                    "pql" to LocalConnector.Metadata(root)
-                ),
                 PartiQLPlanner.Session(
                     queryId = Random().nextInt().toString(),
                     userId = "test-user",
                     currentCatalog = "pql",
                     currentDirectory = listOf("main"),
+                    catalogs = mapOf(
+                        "pql" to LocalConnector.Metadata(root)
+                    ),
                 )
             )
             return PlanTyperWrapper(PlanTyper(env, collector), collector)

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -17,7 +17,6 @@ import org.partiql.plan.PartiQLPlan
 import org.partiql.plan.Statement
 import org.partiql.plan.debug.PlanPrinter
 import org.partiql.planner.PartiQLPlanner
-import org.partiql.planner.PartiQLPlannerBuilder
 import org.partiql.planner.PlanningProblemDetails
 import org.partiql.planner.internal.typer.PlanTyperTestsPorted.TestCase.ErrorTestCase
 import org.partiql.planner.internal.typer.PlanTyperTestsPorted.TestCase.SuccessTestCase
@@ -85,6 +84,9 @@ class PlanTyperTestsPorted {
     }
 
     companion object {
+
+        private val parser = PartiQLParser.default()
+        private val planner = PartiQLPlanner.default()
 
         private fun assertProblemExists(problem: () -> Problem) = ProblemHandler { problems, ignoreSourceLocation ->
             when (ignoreSourceLocation) {
@@ -2980,10 +2982,6 @@ class PlanTyperTestsPorted {
         session: PartiQLPlanner.Session,
         problemCollector: ProblemCollector
     ): PartiQLPlan {
-        val parser = PartiQLParser.default()
-        val planner = PartiQLPlannerBuilder()
-            .catalogs(*catalogs.toTypedArray())
-            .build()
         val ast = parser.parse(query).root
         return planner.plan(ast, session, problemCollector).plan
     }
@@ -3000,6 +2998,7 @@ class PlanTyperTestsPorted {
             USER_ID,
             tc.catalog,
             tc.catalogPath,
+            catalogs = mapOf(*catalogs.toTypedArray())
         )
 
         val hasQuery = tc.query != null
@@ -3040,6 +3039,7 @@ class PlanTyperTestsPorted {
             USER_ID,
             tc.catalog,
             tc.catalogPath,
+            catalogs = mapOf(*catalogs.toTypedArray())
         )
         val collector = ProblemCollector()
 
@@ -3085,6 +3085,7 @@ class PlanTyperTestsPorted {
             USER_ID,
             tc.catalog,
             tc.catalogPath,
+            catalogs = mapOf(*catalogs.toTypedArray())
         )
         val collector = ProblemCollector()
         val exception = assertThrows<Throwable> {

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/ConnectorMetadata.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/ConnectorMetadata.kt
@@ -16,11 +16,30 @@ package org.partiql.spi.connector
 
 import org.partiql.spi.BindingPath
 import org.partiql.types.StaticType
+import org.partiql.types.function.FunctionSignature
 
 /**
  * Aids in retrieving relevant Catalog metadata for the purpose of planning and execution.
  */
 public interface ConnectorMetadata {
+
+    /**
+     * Scalar function signatures available via call syntax.
+     */
+    public val functions: List<FunctionSignature.Scalar>
+        get() = emptyList()
+
+    /**
+     * Scalar function signatures available via operator or special form syntax.
+     */
+    public val operators: List<FunctionSignature.Scalar>
+        get() = emptyList()
+
+    /**
+     * Aggregation function signatures.
+     */
+    public val aggregations: List<FunctionSignature.Aggregation>
+        get() = emptyList()
 
     /**
      * Returns the descriptor of an object. If the handle is unable to produce a [StaticType], implementers should


### PR DESCRIPTION
## Relevant Issues
N/A

## Description
This PR replaces https://github.com/partiql/partiql-lang-kotlin/pull/1309 as we need function information to come from the catalog (ConnectorMetadata).

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Yes

- Any backward-incompatible changes? **[YES/NO]**
  - < If YES, why? >
  - < For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base. >
Technically yes, but these are unreleased. This will be in a 0.14.1 patch to replace lost functionality of 0.14.0-alpha used by the transpiler.

- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >
 No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.