### PR TITLE
Re-adds removed builder APIs and adds deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ Thank you to all who have contributed!
 ## [Unreleased]
 
 ### Added
-- Adds the ability to define a user-defined-function in ConnectorMetadata
-- Move ConnectorMetadata map from PartiQLPlanner to PartiQLPlanner.Session for planner re-use.
+- Adds the ability to define a user-defined-function in `ConnectorMetadata`
+- Move `ConnectorMetadata` map from `PartiQLPlanner` to `PartiQLPlanner.Session` for planner re-use.
+  - Deprecates 2 APIs in `org.partiql.planner.PartiQLPlannerBuilder` in favor of using the ConnectorMetadata map in `PartiQLPlanner.Session`.
 
 ### Changed
 
@@ -44,6 +45,7 @@ Thank you to all who have contributed!
 ### Contributors
 Thank you to all who have contributed!
 - @rchowell
+- @johnedquinn
 
 ## [0.14.0-alpha] - 2023-12-15
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlannerBuilder.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlannerBuilder.kt
@@ -1,5 +1,7 @@
 package org.partiql.planner
 
+import org.partiql.spi.connector.ConnectorMetadata
+
 /**
  * PartiQLPlannerBuilder is used to programmatically construct a [PartiQLPlanner] implementation.
  *
@@ -36,6 +38,31 @@ public class PartiQLPlannerBuilder {
      * @return
      */
     public fun addPasses(vararg passes: PartiQLPlannerPass): PartiQLPlannerBuilder = this.apply {
+        this.passes.addAll(passes)
+    }
+
+    /**
+     * Java style method for assigning a Catalog name to [ConnectorMetadata].
+     *
+     * @param catalog
+     * @param metadata
+     * @return
+     */
+    @Deprecated("This will be removed in v0.15.0+.", ReplaceWith("Please use org.partiql.planner.PartiQLPlanner.Session"))
+    public fun addCatalog(catalog: String, metadata: ConnectorMetadata): PartiQLPlannerBuilder = this
+
+    /**
+     * Kotlin style method for assigning Catalog names to [ConnectorMetadata].
+     *
+     * @param catalogs
+     * @return
+     */
+    @Deprecated("This will be removed in v0.15.0+.", ReplaceWith("Please use org.partiql.planner.PartiQLPlanner.Session"))
+    public fun catalogs(vararg catalogs: Pair<String, ConnectorMetadata>): PartiQLPlannerBuilder = this
+
+    @Deprecated("This will be removed in v0.15.0+.", ReplaceWith("addPasses"))
+    public fun passes(passes: List<PartiQLPlannerPass>): PartiQLPlannerBuilder = this.apply {
+        this.passes.clear()
         this.passes.addAll(passes)
     }
 }


### PR DESCRIPTION
## Relevant Issues
- #1323 

## Description
- Re-adds removed builder APIs and adds deprecation notice
- I went through the JAPI compliance checker. Based on that, followed the guidance.
- This is a pre-req to v0.14.1 release.

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.