### PR TITLE
add conformance reporting

### DIFF
--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 env:
   PATH_TO_TEST_RUNNER: test/partiql-tests-runner
-  CONFORMANCE_REPORT_NAME: conformance_test_results.ion
+  CONFORMANCE_REPORT_RELATIVE_PATH: build/conformance-test-report
   COMPARISON_REPORT_NAME: comparison_report.md
 
 jobs:
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
       - name: Use Java 17
         uses: actions/setup-java@v3
@@ -27,12 +28,12 @@ jobs:
       # Run the conformance tests and save to an Ion file.
       - name: gradle test of the conformance tests (can fail) and save to Ion file
         continue-on-error: true
-        run: gradle :test:partiql-tests-runner:test --tests "*ConformanceTestReport" -PconformanceReport
+        run: gradle :test:partiql-tests-runner:ConformanceTestReport
       # Upload conformance report for future viewing and comparison with future runs.
-      - name: Upload `conformance_test_results.ion`
+      - name: Upload `conformance-test-report` folder
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.PATH_TO_TEST_RUNNER }}/${{ env.CONFORMANCE_REPORT_NAME }}
+          path: ${{ env.PATH_TO_TEST_RUNNER }}/build/conformance-test-report
       # Cache the conformance report for `conformance-report-comparison` job (pull_request event only)
       - name: Cache conformance report and build
         if: github.event_name == 'pull_request'
@@ -86,23 +87,23 @@ jobs:
         continue-on-error: true
         run: |
           cd ${{ github.event.pull_request.base.sha }}
-          gradle :test:partiql-tests-runner:test --tests "*ConformanceTestReport" -PconformanceReport
+          gradle :test:partiql-tests-runner:ConformanceTestReport
       - name: (If download of target branch conformance report fails) Move conformance test report of target branch to ./artifact directory
         if: ${{ steps.download-report.outcome == 'failure' }}
         continue-on-error: true
         run: |
           mkdir -p $GITHUB_WORKSPACE/artifact
-          cp -r $GITHUB_WORKSPACE/${{ github.event.pull_request.base.sha }}/$PATH_TO_TEST_RUNNER/$CONFORMANCE_REPORT_NAME $GITHUB_WORKSPACE/artifact/$CONFORMANCE_REPORT_NAME
+          cp -r $GITHUB_WORKSPACE/${{ github.event.pull_request.base.sha }}/$PATH_TO_TEST_RUNNER/$CONFORMANCE_REPORT_RELATIVE_PATH $GITHUB_WORKSPACE/artifact/$CONFORMANCE_REPORT_RELATIVE_PATH
       # Run conformance report comparison. Generates `comparison_report.md`
       - name: Run conformance report comparison. Generates `comparison_report.md`
         continue-on-error: true
         run: |
-          ARGS="$GITHUB_WORKSPACE/artifact/$CONFORMANCE_REPORT_NAME $CONFORMANCE_REPORT_NAME ${{ github.event.pull_request.base.sha }} $GITHUB_SHA $COMPARISON_REPORT_NAME"
+          ARGS="$GITHUB_WORKSPACE/artifact $CONFORMANCE_REPORT_RELATIVE_PATH ${{ github.event.pull_request.base.sha }} $GITHUB_SHA $COMPARISON_REPORT_NAME"
           gradle :test:partiql-tests-runner:run --args="$ARGS"
       # Print conformance report to GitHub actions workflow summary page
       - name: Print markdown in run
         continue-on-error: true
-        run: cat $PATH_TO_TEST_RUNNER/$COMPARISON_REPORT_NAME >> $GITHUB_STEP_SUMMARY
+        run: echo $PATH_TO_TEST_RUNNER/$COMPARISON_REPORT_NAME >> $GITHUB_STEP_SUMMARY
       # Find comment w/ conformance comparison if previous comment published
       - name: Find Comment
         uses: peter-evans/find-comment@v2

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -5,6 +5,8 @@ env:
   PATH_TO_TEST_RUNNER: test/partiql-tests-runner
   CONFORMANCE_REPORT_RELATIVE_PATH: build/conformance-test-report
   COMPARISON_REPORT_NAME: comparison_report.md
+  COMPARISON_REPORT_NAME_WITH_LIMIT: comparison_report_limited.md
+  COMMENT_SIZE_LIMIT: 10
 
 jobs:
   conformance-report:
@@ -95,7 +97,7 @@ jobs:
           mkdir -p $GITHUB_WORKSPACE/artifact
           cp -r $GITHUB_WORKSPACE/${{ github.event.pull_request.base.sha }}/$PATH_TO_TEST_RUNNER/$CONFORMANCE_REPORT_RELATIVE_PATH $GITHUB_WORKSPACE/artifact/$CONFORMANCE_REPORT_RELATIVE_PATH
       # Run conformance report comparison. Generates `comparison_report.md`
-      - name: Run conformance report comparison. Generates `comparison_report.md`
+      - name: Run conformance report comparison for artifact. Generates `comparison_report.md`
         continue-on-error: true
         run: |
           ARGS="$GITHUB_WORKSPACE/artifact $CONFORMANCE_REPORT_RELATIVE_PATH ${{ github.event.pull_request.base.sha }} $GITHUB_SHA $COMPARISON_REPORT_NAME"
@@ -104,6 +106,17 @@ jobs:
       - name: Print markdown in run
         continue-on-error: true
         run: echo $PATH_TO_TEST_RUNNER/$COMPARISON_REPORT_NAME >> $GITHUB_STEP_SUMMARY
+      # Uploaded the full comparison report to artifact
+      - name: Upload `comparison_report.md`
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.PATH_TO_TEST_RUNNER }}/$COMPARISON_REPORT_NAME
+      # Rebuild the test report with a size limit for comment
+      - name: Run conformance report comparison for comment. Generates `comparison_report_limited.md`
+        continue-on-error: true
+        run: |
+          ARGS="$GITHUB_WORKSPACE/artifact $CONFORMANCE_REPORT_RELATIVE_PATH ${{ github.event.pull_request.base.sha }} $GITHUB_SHA $COMPARISON_REPORT_NAME_WITH_LIMIT $COMMENT_SIZE_LIMIT"
+          gradle :test:partiql-tests-runner:run --args="$ARGS"
       # Find comment w/ conformance comparison if previous comment published
       - name: Find Comment
         uses: peter-evans/find-comment@v2
@@ -120,5 +133,5 @@ jobs:
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
-          body-file: ${{ env.PATH_TO_TEST_RUNNER }}/${{ env.COMPARISON_REPORT_NAME }}
+          body-file: ${{ env.PATH_TO_TEST_RUNNER }}/${{ env.COMPARISON_REPORT_NAME_WITH_LIMIT }}
           edit-mode: replace

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Print markdown in run
         continue-on-error: true
         run: cat $PATH_TO_TEST_RUNNER/$COMPARISON_REPORT_NAME >> $GITHUB_STEP_SUMMARY
-      # Uploaded the full comparison report to artifact
+      # Upload the full comparison report to CI artifact
       - name: Upload `comparison_report.md`
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -30,7 +30,7 @@ jobs:
       # Run the conformance tests and save to an Ion file.
       - name: gradle test of the conformance tests (can fail) and save to Ion file
         continue-on-error: true
-        run: gradle :test:partiql-tests-runner:ConformanceTestReport
+        run: gradle :test:partiql-tests-runner:generateTestReport
       # Upload conformance report for future viewing and comparison with future runs.
       - name: Upload `conformance-test-report` folder
         uses: actions/upload-artifact@v3
@@ -89,7 +89,7 @@ jobs:
         continue-on-error: true
         run: |
           cd ${{ github.event.pull_request.base.sha }}
-          gradle :test:partiql-tests-runner:ConformanceTestReport
+          gradle :test:partiql-tests-runner:generateTestReport
       - name: (If download of target branch conformance report fails) Move conformance test report of target branch to ./artifact directory
         if: ${{ steps.download-report.outcome == 'failure' }}
         continue-on-error: true

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -105,12 +105,12 @@ jobs:
       # Print conformance report to GitHub actions workflow summary page
       - name: Print markdown in run
         continue-on-error: true
-        run: echo $PATH_TO_TEST_RUNNER/$COMPARISON_REPORT_NAME >> $GITHUB_STEP_SUMMARY
+        run: cat $PATH_TO_TEST_RUNNER/$COMPARISON_REPORT_NAME >> $GITHUB_STEP_SUMMARY
       # Uploaded the full comparison report to artifact
       - name: Upload `comparison_report.md`
         uses: actions/upload-artifact@v3
         with:
-          path: ${{ env.PATH_TO_TEST_RUNNER }}/$COMPARISON_REPORT_NAME
+          path: ${{ env.PATH_TO_TEST_RUNNER }}/comparison_report.md
       # Rebuild the test report with a size limit for comment
       - name: Run conformance report comparison for comment. Generates `comparison_report_limited.md`
         continue-on-error: true

--- a/test/partiql-tests-runner/README.md
+++ b/test/partiql-tests-runner/README.md
@@ -12,22 +12,18 @@ This package enables:
 
 ```shell
 # default, test data from partiql-tests submodule will be used
-./gradlew :test:partiql-tests-runner:test --tests "*ConformanceTestReport" -PconformanceReport
+./gradlew :test:partiql-tests-runner:ConformanceTestReport
 
 # override test data location
 PARTIQL_TESTS_DATA=/path/to/partiql-tests/data \
-./gradlew :test:partiql-tests-runner:test --tests "*ConformanceTestReport" -PconformanceReport
+./gradlew :test:partiql-tests-runner:ConformanceTestReport
 ```
-The report is written into file `test/partiql-tests-runner/conformance_test_results.ion`.
-
-## Run Conformance Tests in UI
-
-The above project property `-PconformanceReport` is checked in `test/partiql-tests-runner/build.gradle.kts`,
-to exclude the conformance test suite from executing during a normal project-build test run. 
-Unfortunately, this also disables running `ConformanceTestReport` in a UI runner. 
-To make that possible locally, temporarily comment out the check in `test/partiql-tests-runner/build.gradle.kts`.
+The report is written into folder `test/partiql-tests-runner/build/conformance_test_results`.
 
 ## Compare Conformance Reports locally
+The report contains two type of comparison: 
+1. Cross Commit: Comparing using the same engine based on the pull request commit and head of target branch commit. 
+2. Cross Engine: Comparing using different engine based on the pull request commit. 
 
 ```shell
 ./gradlew :test:partiql-tests-runner:run --args="pathToFirstConformanceTestResults pathToSecondConformanceTestResults firstCommitId secondCommitId pathToComparisonReport"

--- a/test/partiql-tests-runner/build.gradle.kts
+++ b/test/partiql-tests-runner/build.gradle.kts
@@ -1,3 +1,5 @@
+
+
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
@@ -31,6 +33,7 @@ dependencies {
 }
 
 val tests = System.getenv()["PARTIQL_TESTS_DATA"] ?: "../partiql-tests/partiql-tests-data"
+val reportDir = file("$buildDir/conformance-test-report").absolutePath
 
 object Env {
     const val PARTIQL_EVAL = "PARTIQL_EVAL_TESTS_DATA"
@@ -49,16 +52,19 @@ tasks.test {
     exclude("org/partiql/runner/ConformanceTest.class")
 }
 
-tasks.register<Test>("ConformanceTestReport") {
-    val reportDir = file("$buildDir/conformance-test-report").absolutePath
+val createReportDir by tasks.registering {
     if (File(reportDir).exists()) {
         delete(File(reportDir))
     }
+    mkdir(reportDir)
+}
+
+val generateTestReport by tasks.registering(Test::class) {
+    dependsOn(createReportDir)
     useJUnitPlatform()
     environment(Env.PARTIQL_EVAL, file("$tests/eval/").absolutePath)
     environment(Env.PARTIQL_EQUIV, file("$tests/eval-equiv/").absolutePath)
     environment("conformanceReportDir", reportDir)
-    mkdir(reportDir)
     include("org/partiql/runner/ConformanceTestEval.class", "org/partiql/runner/ConformanceTestLegacy.class")
     if (project.hasProperty("Engine")) {
         val engine = property("Engine")!! as String

--- a/test/partiql-tests-runner/build.gradle.kts
+++ b/test/partiql-tests-runner/build.gradle.kts
@@ -1,5 +1,3 @@
-
-
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *

--- a/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
+++ b/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
@@ -209,7 +209,7 @@ Number failing in ${first.engine} engine but pass in ${second.engine} engine: ${
             }
 
             if (failureFirstPassingSecond.isNotEmpty()) {
-                if (failureFirstPassingSecond.size < 10) {
+                if (failureFirstPassingSecond.size < limit) {
                     this.appendLine(
                         "The following test(s) are failing in ${first.engine} but pass in ${second.engine}. Before merging, confirm they are intended to pass: \n<details><summary>Click here to see</summary>\n\n"
                     )

--- a/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
+++ b/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
@@ -190,7 +190,7 @@ Number failing in ${first.engine} engine but pass in ${second.engine} engine: ${
             )
             if (passingFirstFailingSecond.isNotEmpty()) {
                 if (passingFirstFailingSecond.size < 10) {
-                    this.appendLine(":interrobang: CONFORMANCE REPORT REGRESSION DETECTED :interrobang:. The following test(s) were previously passing in ${first.engine} but fail in ${second.engine}:\n<details><summary>Click here to see</summary>\n\n")
+                    this.appendLine(":interrobang: CONFORMANCE REPORT REGRESSION DETECTED :interrobang:. The following test(s) are passing in ${first.engine} but fail in ${second.engine}:\n<details><summary>Click here to see</summary>\n\n")
 
                     passingFirstFailingSecond.forEach { testName ->
                         this.appendLine("- $testName")

--- a/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
+++ b/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
@@ -204,7 +204,7 @@ Number failing in ${first.engine} engine but pass in ${second.engine} engine: ${
             if (failureFirstPassingSecond.isNotEmpty()) {
                 if (failureFirstPassingSecond.size < 10) {
                     this.appendLine(
-                        "The following test(s) were failing in ${first.engine} but now pass in ${second.engine}. Before merging, confirm they are intended to pass: \n<details><summary>Click here to see</summary>\n\n"
+                        "The following test(s) are failing in ${first.engine} but pass in ${second.engine}. Before merging, confirm they are intended to pass: \n<details><summary>Click here to see</summary>\n\n"
                     )
                     failureFirstPassingSecond.forEach { testName ->
                         this.appendLine("- ${testName}\n")

--- a/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
+++ b/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
@@ -11,91 +11,208 @@ fun main(args: Array<String>) {
         )
     }
 
-    val origInput = File(args[0]).readText()
-    val newInput = File(args[1]).readText()
+    val old = File(args[0])
+    val new = File(args[1])
 
-    val origInputStruct = loadSingleElement(origInput).asStruct()
-    val newInputStruct = loadSingleElement(newInput).asStruct()
-
-    val origPassingSet = origInputStruct["passing"].listValues.map { it.stringValue }
-    val origFailingSet = origInputStruct["failing"].listValues.map { it.stringValue }
-    val origIgnoredSet = origInputStruct["ignored"].listValues.map { it.stringValue }
-
-    val newPassingSet = newInputStruct["passing"].listValues.map { it.stringValue }
-    val newFailingSet = newInputStruct["failing"].listValues.map { it.stringValue }
-    val newIgnoredSet = newInputStruct["ignored"].listValues.map { it.stringValue }
-
-    val origCommitId = args[2]
+    val oldCommitId = args[2]
     val newCommitId = args[3]
 
-    val passingInBoth = origPassingSet.intersect(newPassingSet)
-    val failingInBoth = origFailingSet.intersect(newFailingSet)
-    val passingOrigFailingNew = origPassingSet.intersect(newFailingSet)
-    val failureOrigPassingNew = origFailingSet.intersect(newPassingSet)
-
+    val oldReports = loadReport(old, oldCommitId)
+    val newReports = loadReport(new, newCommitId)
     val comparisonReportFile = File(args[4])
+
     comparisonReportFile.createNewFile()
 
-    val numOrigPassing = origPassingSet.size
-    val numNewPassing = newPassingSet.size
+    analyze(comparisonReportFile, newReports)
 
-    val numOrigFailing = origFailingSet.size
-    val numNewFailing = newFailingSet.size
+    val all = oldReports + newReports
 
-    val numOrigIgnored = origIgnoredSet.size
-    val numNewIgnored = newIgnoredSet.size
+    // cross commit comparsion
+    all
+        .groupBy { it.engine }
+        .forEach { (_, reports) ->
+            analyze(comparisonReportFile, reports)
+        }
+}
+data class Report(
+    val engine: String,
+    val commitId: String,
+    val passingSet: Set<String>,
+    val failingSet: Set<String>,
+    val ignoredSet: Set<String>
+)
 
-    val totalOrig = numOrigPassing + numOrigFailing + numOrigIgnored
-    val totalNew = numNewPassing + numNewFailing + numNewIgnored
+fun analyze(file: File, reports: List<Report>) {
+    var first = 0
+    var second = first + 1
+    while (first < second && second < reports.size) {
+        val report = ReportAnalyzer.build(reports[first], reports[second]).generateComparisonReport()
+        file.appendText(report)
+        file.appendText("\n")
+        if (second < reports.size - 1) {
+            second += 1
+        } else {
+            first += 1
+            second = first + 1
+        }
+    }
+}
 
-    val origPassingPercent = numOrigPassing.toDouble() / totalOrig * 100
-    val newPassingPercent = numNewPassing.toDouble() / totalNew * 100
+fun loadReport(dir: File, commitId: String) =
+    dir.listFiles()?.map { sub ->
+        val engine = sub.name
+        val report =
+            (sub.listFiles() ?: throw IllegalArgumentException("sub-dir ${sub.absolutePath} not exist")).first().readText()
+        loadReport(report, engine, commitId)
+    } ?: throw IllegalArgumentException("dir ${dir.absolutePath} not exist")
 
-    comparisonReportFile.writeText(
-        """### Conformance comparison report
-| | Base ($origCommitId) | $newCommitId | +/- |
+fun loadReport(report: String, engine: String, commitId: String): Report {
+    val inputStruct = loadSingleElement(report).asStruct()
+    val passingSet = inputStruct["passing"].listValues.map { it.stringValue }
+    val failingSet = inputStruct["failing"].listValues.map { it.stringValue }
+    val ignoredSet = inputStruct["ignored"].listValues.map { it.stringValue }
+    return Report(engine, commitId, passingSet.toSet(), failingSet.toSet(), ignoredSet.toSet())
+}
+
+abstract class ReportAnalyzer(first: Report, second: Report) {
+    companion object {
+        fun build(first: Report, second: Report) =
+            if (first.engine == second.engine) {
+                CrossCommitReportAnalyzer(first, second)
+            } else {
+                CrossEngineReportAnalyzer(first, second)
+            }
+    }
+    val passingInBoth = first.passingSet.intersect(second.passingSet)
+    val failingInBoth = first.failingSet.intersect(second.failingSet)
+    val passingFirstFailingSecond = first.passingSet.intersect(second.failingSet)
+    val failureFirstPassingSecond = first.failingSet.intersect(second.passingSet)
+    val firstPassingSize = first.passingSet.size
+    val firstFailingSize = first.failingSet.size
+    val firstIgnoreSize = first.ignoredSet.size
+    val secondPassingSize = second.passingSet.size
+    val secondFailingSize = second.failingSet.size
+    val secondIgnoreSize = second.ignoredSet.size
+
+    val firstTotalSize = firstPassingSize + firstFailingSize + firstIgnoreSize
+    val secondTotalSize = secondPassingSize + secondFailingSize + secondIgnoreSize
+
+    val firstPassingPercent = firstPassingSize.toDouble() / firstTotalSize * 100
+    val secondPassingPercent = secondPassingSize.toDouble() / secondTotalSize * 100
+
+    abstract val reportTitle: String
+    abstract fun generateComparisonReport(): String
+}
+
+class CrossCommitReportAnalyzer(private val first: Report, private val second: Report) :
+    ReportAnalyzer(first, second) {
+    override val reportTitle: String = "Conformance comparison report-Cross Commit-${first.engine.uppercase()}"
+    override fun generateComparisonReport() =
+        buildString {
+            this.appendLine(
+                """### $reportTitle
+| | Base (${first.commitId}) | ${second.commitId} | +/- |
 | --- | ---: | ---: | ---: |
-| % Passing | ${"%.2f".format(origPassingPercent)}% | ${"%.2f".format(newPassingPercent)}% | ${"%.2f".format(newPassingPercent - origPassingPercent)}% |
-| :white_check_mark: Passing | $numOrigPassing | $numNewPassing | ${numNewPassing - numOrigPassing} |
-| :x: Failing | $numOrigFailing | $numNewFailing | ${numNewFailing - numOrigFailing} |
-| :large_orange_diamond: Ignored | $numOrigIgnored | $numNewIgnored | ${numNewIgnored - numOrigIgnored} |
-| Total Tests | $totalOrig | $totalNew | ${totalNew - totalOrig} |
-""",
-    )
-
-    comparisonReportFile.appendText(
-"""
+| % Passing | ${"%.2f".format(firstPassingPercent)}% | ${"%.2f".format(secondPassingPercent)}% | ${"%.2f".format(secondPassingPercent - firstPassingPercent)}% |
+| :white_check_mark: Passing | $firstPassingSize | $secondPassingSize | ${secondPassingSize - firstPassingSize} |
+| :x: Failing | $firstFailingSize | $secondFailingSize | ${secondFailingSize - firstFailingSize} |
+| :large_orange_diamond: Ignored | $firstIgnoreSize | $secondIgnoreSize | ${secondIgnoreSize - firstIgnoreSize} |
+| Total Tests | $firstTotalSize | $secondTotalSize | ${secondTotalSize - firstTotalSize} |
+                """.trimIndent()
+            )
+            this.appendLine(
+                """
 Number passing in both: ${passingInBoth.count()}
 
 Number failing in both: ${failingInBoth.count()}
 
-Number passing in Base ($origCommitId) but now fail: ${passingOrigFailingNew.count()}
+Number passing in Base (${first.commitId}) but now fail: ${passingFirstFailingSecond.count()}
 
-Number failing in Base ($origCommitId) but now pass: ${failureOrigPassingNew.count()}
-"""
-    )
+Number failing in Base (${first.commitId}) but now pass: ${failureFirstPassingSecond.count()}
+                """.trimIndent()
+            )
+            if (passingFirstFailingSecond.isNotEmpty()) {
+                // character count limitation with comments in GitHub
+                // also, not ideal to list out hundreds of test names
+                if (passingFirstFailingSecond.size < 10) {
+                    this.appendLine(":interrobang: CONFORMANCE REPORT REGRESSION DETECTED :interrobang:. The following test(s) were previously passing but now fail:\n<details><summary>Click here to see</summary>\n\n")
 
-    if (!passingOrigFailingNew.isEmpty()) {
-        comparisonReportFile.appendText(
-            "\n:interrobang: CONFORMANCE REPORT REGRESSION DETECTED :interrobang:. The following test(s) were previously passing but now fail:\n<details><summary>Click here to see</summary>\n\n"
-        )
-        passingOrigFailingNew.forEach { testName ->
-            comparisonReportFile
-                .appendText("- ${testName}\n")
+                    passingFirstFailingSecond.forEach { testName ->
+                        this.appendLine("- $testName")
+                    }
+                    this.appendLine("</details>")
+                } else {
+                    this.appendLine(":interrobang: CONFORMANCE REPORT REGRESSION DETECTED :interrobang:")
+                }
+            }
+
+            if (failureFirstPassingSecond.isNotEmpty()) {
+                if (failureFirstPassingSecond.size < 10) {
+                    this.appendLine(
+                        "The following test(s) were previously failing but now pass. Before merging, confirm they are intended to pass: \n<details><summary>Click here to see</summary>\n\n"
+                    )
+                    failureFirstPassingSecond.forEach { testName ->
+                        this.appendLine("- ${testName}\n")
+                    }
+                    this.appendLine("</details>")
+                } else {
+                    this.appendLine("${failureFirstPassingSecond.size} test(s) were previously failing but now pass. Before merging, confirm they are intended to pass")
+                }
+            }
         }
-        comparisonReportFile
-            .appendText("\n</details>")
-    }
+}
 
-    if (!failureOrigPassingNew.isEmpty()) {
-        comparisonReportFile.appendText(
-            "\nThe following test(s) were previously failing but now pass. Before merging, confirm they are intended to pass: \n<details><summary>Click here to see</summary>\n\n"
-        )
-        failureOrigPassingNew.forEach { testName ->
-            comparisonReportFile
-                .appendText("- ${testName}\n")
+class CrossEngineReportAnalyzer(private val first: Report, private val second: Report) : ReportAnalyzer(first, second) {
+    override val reportTitle: String = "Conformance comparison report-Cross Engine"
+    override fun generateComparisonReport() =
+        buildString {
+            this.appendLine(
+                """### $reportTitle
+| | Base ${first.engine} | ${second.engine} | +/- |
+| --- | ---: | ---: | ---: |
+| % Passing | ${"%.2f".format(firstPassingPercent)}% | ${"%.2f".format(secondPassingPercent)}% | ${"%.2f".format(secondPassingPercent - firstPassingPercent)}% |
+| :white_check_mark: Passing | $firstPassingSize | $secondPassingSize | ${secondPassingSize - firstPassingSize} |
+| :x: Failing | $firstFailingSize | $secondFailingSize | ${secondFailingSize - firstFailingSize} |
+| :large_orange_diamond: Ignored | $firstIgnoreSize | $secondIgnoreSize | ${secondIgnoreSize - firstIgnoreSize} |
+| Total Tests | $firstTotalSize | $secondTotalSize | ${secondTotalSize - firstTotalSize} |
+                """.trimIndent()
+            )
+            this.appendLine(
+                """
+Number passing in both: ${passingInBoth.count()}
+
+Number failing in both: ${failingInBoth.count()}
+
+Number passing in ${first.engine} engine but fail in ${second.engine} engine: ${passingFirstFailingSecond.count()}
+
+Number failing in ${first.engine} engine but pass in ${second.engine} engine: ${failureFirstPassingSecond.count()}
+                """.trimIndent()
+            )
+            if (passingFirstFailingSecond.isNotEmpty()) {
+                if (passingFirstFailingSecond.size < 10) {
+                    this.appendLine(":interrobang: CONFORMANCE REPORT REGRESSION DETECTED :interrobang:. The following test(s) were previously passing in ${first.engine} but fail in ${second.engine}:\n<details><summary>Click here to see</summary>\n\n")
+
+                    passingFirstFailingSecond.forEach { testName ->
+                        this.appendLine("- $testName")
+                    }
+                    this.appendLine("</details>")
+                } else {
+                    this.appendLine(":interrobang: CONFORMANCE REPORT REGRESSION DETECTED :interrobang:")
+                }
+            }
+
+            if (failureFirstPassingSecond.isNotEmpty()) {
+                if (failureFirstPassingSecond.size < 10) {
+                    this.appendLine(
+                        "The following test(s) were failing in ${first.engine} but now pass in ${second.engine}. Before merging, confirm they are intended to pass: \n<details><summary>Click here to see</summary>\n\n"
+                    )
+                    failureFirstPassingSecond.forEach { testName ->
+                        this.appendLine("- ${testName}\n")
+                    }
+                    this.appendLine("</details>")
+                } else {
+                    this.appendLine("${failureFirstPassingSecond.size} test(s) were failing in ${first.engine} but now pass in ${second.engine}. Before merging, confirm they are intended to pass.")
+                }
+            }
         }
-        comparisonReportFile
-            .appendText("\n</details>")
-    }
 }

--- a/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
+++ b/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
@@ -168,7 +168,7 @@ class CrossEngineReportAnalyzer(private val first: Report, private val second: R
         buildString {
             this.appendLine(
                 """### $reportTitle
-| | Base ${first.engine} | ${second.engine} | +/- |
+| | Base (${first.engine}) | ${second.engine} | +/- |
 | --- | ---: | ---: | ---: |
 | % Passing | ${"%.2f".format(firstPassingPercent)}% | ${"%.2f".format(secondPassingPercent)}% | ${"%.2f".format(secondPassingPercent - firstPassingPercent)}% |
 | :white_check_mark: Passing | $firstPassingSize | $secondPassingSize | ${secondPassingSize - firstPassingSize} |

--- a/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
+++ b/test/partiql-tests-runner/src/main/kotlin/org/partiql/runner/ConformanceComparison.kt
@@ -147,7 +147,7 @@ Number failing in Base (${first.commitId}) but now pass: ${failureFirstPassingSe
                     this.appendLine("</details>")
                 } else {
                     this.appendLine(":interrobang: CONFORMANCE REPORT REGRESSION DETECTED :interrobang:")
-                    this.appendLine("Download Artifact from Summary to view the complete list")
+                    this.appendLine("The complete list can be found in GitHub CI summary, either from Step Summary or in the Artifact.")
                 }
             }
 
@@ -162,7 +162,7 @@ Number failing in Base (${first.commitId}) but now pass: ${failureFirstPassingSe
                     this.appendLine("</details>")
                 } else {
                     this.appendLine("${failureFirstPassingSecond.size} test(s) were previously failing but now pass. Before merging, confirm they are intended to pass")
-                    this.appendLine("Download Artifact from Summary to view the complete list")
+                    this.appendLine("The complete list can be found in GitHub CI summary, either from Step Summary or in the Artifact.")
                 }
             }
         }
@@ -204,7 +204,7 @@ Number failing in ${first.engine} engine but pass in ${second.engine} engine: ${
                     this.appendLine("</details>")
                 } else {
                     this.appendLine(":interrobang: CONFORMANCE REPORT REGRESSION DETECTED :interrobang:")
-                    this.appendLine("Download Artifact from Summary to view the complete list")
+                    this.appendLine("The complete list can be found in GitHub CI summary, either from Step Summary or in the Artifact.")
                 }
             }
 
@@ -219,7 +219,7 @@ Number failing in ${first.engine} engine but pass in ${second.engine} engine: ${
                     this.appendLine("</details>")
                 } else {
                     this.appendLine("${failureFirstPassingSecond.size} test(s) were failing in ${first.engine} but now pass in ${second.engine}. Before merging, confirm they are intended to pass.")
-                    this.appendLine("Download Artifact from Summary to view the complete list")
+                    this.appendLine("The complete list can be found in GitHub CI summary, either from Step Summary or in the Artifact.")
                 }
             }
         }

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestBase.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestBase.kt
@@ -1,28 +1,15 @@
 package org.partiql.runner
 
-import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
-import org.partiql.runner.executor.LegacyExecutor
-import org.partiql.runner.report.ReportGenerator
 import org.partiql.runner.schema.TestCase
 import org.partiql.runner.test.TestProvider
 import org.partiql.runner.test.TestRunner
 
-/**
- * Runs the conformance tests without a fail list, so we can document the passing/failing tests in the conformance
- * report.
- *
- * These tests are excluded from normal testing/building unless the `conformanceReport` gradle property is
- * specified (i.e. `gradle test ... -PconformanceReport`)
- */
-@ExtendWith(ReportGenerator::class)
-class ConformanceTestReport {
+abstract class ConformanceTestBase<T, V> {
+    abstract val runner: TestRunner<T, V>
 
-    private val factory = LegacyExecutor.Factory
-    private val runner = TestRunner(factory)
-
-    // Tests the eval tests with the Kotlin implementation without a fail list
+    // Tests the eval tests with the Kotlin implementation
     @ParameterizedTest(name = "{arguments}")
     @ArgumentsSource(TestProvider.Eval::class)
     fun validatePartiQLEvalTestData(tc: TestCase) {
@@ -32,7 +19,7 @@ class ConformanceTestReport {
         }
     }
 
-    // Tests the eval equivalence tests with the Kotlin implementation without a fail list
+    // Tests the eval equivalence tests with the Kotlin implementation
     @ParameterizedTest(name = "{arguments}")
     @ArgumentsSource(TestProvider.Equiv::class)
     fun validatePartiQLEvalEquivTestData(tc: TestCase) {

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestEval.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestEval.kt
@@ -1,44 +1,18 @@
 package org.partiql.runner
 
-import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ArgumentsSource
-import org.partiql.lang.eval.CompileOptions
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.partiql.eval.PartiQLResult
+import org.partiql.eval.PartiQLStatement
 import org.partiql.runner.executor.EvalExecutor
 import org.partiql.runner.report.ReportGenerator
-import org.partiql.runner.schema.TestCase
-import org.partiql.runner.skip.LANG_KOTLIN_EVAL_EQUIV_FAIL_LIST
-import org.partiql.runner.test.TestProvider
 import org.partiql.runner.test.TestRunner
 
-@ExtendWith(ReportGenerator::class)
-@Disabled
-class ConformanceTestEval {
-
+class ConformanceTestEval : ConformanceTestBase<PartiQLStatement<*>, PartiQLResult>() {
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        val reporter = ReportGenerator("eval")
+    }
     private val factory = EvalExecutor.Factory
-    private val runner = TestRunner(factory)
-
-    // Tests the eval tests with the Kotlin implementation
-    @ParameterizedTest(name = "{arguments}")
-    @ArgumentsSource(TestProvider.Eval::class)
-    fun validatePartiQLEvalTestData(tc: TestCase) {
-        // val skip = LANG_KOTLIN_EVAL_FAIL_LIST
-        val skip = emptyList<Pair<String, CompileOptions>>()
-        when (tc) {
-            is TestCase.Eval -> runner.test(tc, skip)
-            else -> error("Unsupported test case category")
-        }
-    }
-
-    // Tests the eval equivalence tests with the Kotlin implementation
-    @Disabled
-    @ParameterizedTest(name = "{arguments}")
-    @ArgumentsSource(TestProvider.Equiv::class)
-    fun validatePartiQLEvalEquivTestData(tc: TestCase) {
-        when (tc) {
-            is TestCase.Equiv -> runner.test(tc, LANG_KOTLIN_EVAL_EQUIV_FAIL_LIST)
-            else -> error("Unsupported test case category")
-        }
-    }
+    override val runner = TestRunner(factory)
 }

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestLegacy.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/ConformanceTestLegacy.kt
@@ -1,0 +1,27 @@
+package org.partiql.runner
+
+import com.amazon.ion.IonValue
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.partiql.lang.eval.ExprValue
+import org.partiql.runner.executor.LegacyExecutor
+import org.partiql.runner.report.ReportGenerator
+import org.partiql.runner.test.TestRunner
+
+/**
+ * Runs the conformance tests without a fail list, so we can document the passing/failing tests in the conformance
+ * report.
+ *
+ * These tests are excluded from normal testing/building unless the `conformanceReport` gradle property is
+ * specified (i.e. `gradle test ... -PconformanceReport`)
+ */
+class ConformanceTestLegacy : ConformanceTestBase<ExprValue, IonValue>() {
+
+    companion object {
+        @JvmStatic
+        @RegisterExtension
+        val reporter = ReportGenerator("legacy")
+    }
+
+    private val factory = LegacyExecutor.Factory
+    override val runner = TestRunner(factory)
+}

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/report/ReportGenerator.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/report/ReportGenerator.kt
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.TestWatcher
 import java.io.File
+import java.nio.file.Files
+import kotlin.io.path.Path
 
-class ReportGenerator : TestWatcher, AfterAllCallback {
+class ReportGenerator(val engine: String) : TestWatcher, AfterAllCallback {
     var failingTests = emptySet<String>()
     var passingTests = emptySet<String>()
     var ignoredTests = emptySet<String>()
@@ -22,7 +24,9 @@ class ReportGenerator : TestWatcher, AfterAllCallback {
     }
 
     override fun afterAll(p0: ExtensionContext?) {
-        val file = File("./conformance_test_results.ion")
+        val basePath = System.getenv("conformanceReportDir")
+        val dir = Files.createDirectory(Path("$basePath/$engine")).toFile()
+        val file = File(dir, "conformance_test_results.ion")
         val outputStream = file.outputStream()
         val writer = IonTextWriterBuilder.pretty().build(outputStream)
         writer.stepIn(IonType.STRUCT) // in: outer struct


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] N/A

## Description
Update: We can now access the full report from Github Action run. In both the step summary and the produced artifact. See [link](https://github.com/yliuuuu/partiql-lang-kotlin/actions/runs/7483462300?pr=15).  

- This PRs builds on #1289. The main goal is to have incorporate multiple backend in conformance tests GitHub action. 
- For every pull request, the GitHub CI now posts comments on 1) cross engine comparison base on the pull request commit; 2) cross commit comparison for every engine between pull request commit and head of target commit. 

For an example comment message, see: https://github.com/yliuuuu/partiql-lang-kotlin/pull/15#issuecomment-1886095877

Note: For the new eval engine: there is one test (`path expression with ambiguous table alias (lowercase), compileOption: LEGACY`) that is showing up in Success-in-previous-but-failed-in-current and failed-in-previous-but-success-in-current. I suspect that this issue is caused by test cases with duplicated name but different query, but have not yet looked into this. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No. 

- Any backward-incompatible changes? **[YES/NO]**
  - No. 
  

- Any new external dependencies? **[YES/NO]**
  - No.
  
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
  Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.