### PR TITLE
Adds qualifiers to function call expressions

### DIFF
--- a/partiql-parser/src/main/antlr/PartiQL.g4
+++ b/partiql-parser/src/main/antlr/PartiQL.g4
@@ -709,11 +709,15 @@ trimFunction
 dateFunction
     : func=(DATE_ADD|DATE_DIFF) PAREN_LEFT dt=IDENTIFIER COMMA expr COMMA expr PAREN_RIGHT;
 
+// SQL-99 10.4 — <routine invocation> ::= <routine name> <SQL argument list>
 functionCall
-    : name=( CHAR_LENGTH | CHARACTER_LENGTH | OCTET_LENGTH |
-        BIT_LENGTH | UPPER | LOWER | SIZE | EXISTS | COUNT )
-        PAREN_LEFT ( expr ( COMMA expr )* )? PAREN_RIGHT                         # FunctionCallReserved
-    | name=symbolPrimitive PAREN_LEFT ( expr ( COMMA expr )* )? PAREN_RIGHT      # FunctionCallIdent
+    : functionName PAREN_LEFT ( expr ( COMMA expr )* )? PAREN_RIGHT
+    ;
+
+// SQL-99 10.4 — <routine name> ::= [ <schema name> <period> ] <qualified identifier>
+functionName
+    : (qualifier+=symbolPrimitive PERIOD)* name=( CHAR_LENGTH | CHARACTER_LENGTH | OCTET_LENGTH | BIT_LENGTH | UPPER | LOWER | SIZE | EXISTS | COUNT )  # FunctionNameReserved
+    | (qualifier+=symbolPrimitive PERIOD)* name=symbolPrimitive                                                                                         # FunctionNameSymbol
     ;
 
 pathStep

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/PartiQLParser.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/PartiQLParser.kt
@@ -15,7 +15,7 @@
 package org.partiql.parser
 
 import org.partiql.ast.Statement
-import org.partiql.parser.impl.PartiQLParserDefault
+import org.partiql.parser.internal.PartiQLParserDefault
 
 public interface PartiQLParser {
 

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/PartiQLParserBuilder.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/PartiQLParserBuilder.kt
@@ -14,7 +14,7 @@
 
 package org.partiql.parser
 
-import org.partiql.parser.impl.PartiQLParserDefault
+import org.partiql.parser.internal.PartiQLParserDefault
 
 /**
  * A builder class to instantiate a [PartiQLParser].

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/util/DateTimeUtils.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/util/DateTimeUtils.kt
@@ -1,4 +1,4 @@
-package org.partiql.parser.impl.util
+package org.partiql.parser.internal.util
 
 import org.partiql.value.datetime.Date
 import org.partiql.value.datetime.DateTimeException

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserFunctionCallTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserFunctionCallTests.kt
@@ -1,0 +1,136 @@
+package org.partiql.parser.internal
+
+import org.junit.jupiter.api.Test
+import org.partiql.ast.AstNode
+import org.partiql.ast.Expr
+import org.partiql.ast.Identifier
+import org.partiql.ast.exprCall
+import org.partiql.ast.identifierQualified
+import org.partiql.ast.identifierSymbol
+import org.partiql.ast.statementQuery
+import kotlin.test.assertEquals
+
+class PartiQLParserFunctionCallTests {
+
+    private val parser = PartiQLParserDefault()
+
+    private inline fun query(body: () -> Expr) = statementQuery(body())
+
+    @Test
+    fun callUnqualifiedNonReservedInsensitive() = assertExpression(
+        "foo()",
+        query {
+            exprCall(
+                function = identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
+                args = emptyList()
+            )
+        }
+    )
+
+    @Test
+    fun callUnqualifiedNonReservedSensitive() = assertExpression(
+        "\"foo\"()",
+        query {
+            exprCall(
+                function = identifierSymbol("foo", Identifier.CaseSensitivity.SENSITIVE),
+                args = emptyList()
+            )
+        }
+    )
+
+    @Test
+    fun callUnqualifiedReservedInsensitive() = assertExpression(
+        "upper()",
+        query {
+            exprCall(
+                function = identifierSymbol("upper", Identifier.CaseSensitivity.INSENSITIVE),
+                args = emptyList()
+            )
+        }
+    )
+
+    @Test
+    fun callUnqualifiedReservedSensitive() = assertExpression(
+        "\"upper\"()",
+        query {
+            exprCall(
+                function = identifierSymbol("upper", Identifier.CaseSensitivity.SENSITIVE),
+                args = emptyList()
+            )
+        }
+    )
+
+    @Test
+    fun callQualifiedNonReservedInsensitive() = assertExpression(
+        "my_catalog.my_schema.foo()",
+        query {
+            exprCall(
+                function = identifierQualified(
+                    root = identifierSymbol("my_catalog", Identifier.CaseSensitivity.INSENSITIVE),
+                    steps = listOf(
+                        identifierSymbol("my_schema", Identifier.CaseSensitivity.INSENSITIVE),
+                        identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
+                    )
+                ),
+                args = emptyList()
+            )
+        }
+    )
+
+    @Test
+    fun callQualifiedNonReservedSensitive() = assertExpression(
+        "my_catalog.my_schema.\"foo\"()",
+        query {
+            exprCall(
+                function = identifierQualified(
+                    root = identifierSymbol("my_catalog", Identifier.CaseSensitivity.INSENSITIVE),
+                    steps = listOf(
+                        identifierSymbol("my_schema", Identifier.CaseSensitivity.INSENSITIVE),
+                        identifierSymbol("foo", Identifier.CaseSensitivity.SENSITIVE),
+                    )
+                ),
+                args = emptyList()
+            )
+        }
+    )
+
+    @Test
+    fun callQualifiedReservedInsensitive() = assertExpression(
+        "my_catalog.my_schema.upper()",
+        query {
+            exprCall(
+                function = identifierQualified(
+                    root = identifierSymbol("my_catalog", Identifier.CaseSensitivity.INSENSITIVE),
+                    steps = listOf(
+                        identifierSymbol("my_schema", Identifier.CaseSensitivity.INSENSITIVE),
+                        identifierSymbol("upper", Identifier.CaseSensitivity.INSENSITIVE),
+                    )
+                ),
+                args = emptyList()
+            )
+        }
+    )
+
+    @Test
+    fun callQualifiedReservedSensitive() = assertExpression(
+        "my_catalog.my_schema.\"upper\"()",
+        query {
+            exprCall(
+                function = identifierQualified(
+                    root = identifierSymbol("my_catalog", Identifier.CaseSensitivity.INSENSITIVE),
+                    steps = listOf(
+                        identifierSymbol("my_schema", Identifier.CaseSensitivity.INSENSITIVE),
+                        identifierSymbol("upper", Identifier.CaseSensitivity.SENSITIVE),
+                    )
+                ),
+                args = emptyList()
+            )
+        }
+    )
+
+    private fun assertExpression(input: String, expected: AstNode) {
+        val result = parser.parse(input)
+        val actual = result.root
+        assertEquals(expected, actual)
+    }
+}

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserSessionAttributeTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserSessionAttributeTests.kt
@@ -1,4 +1,4 @@
-package org.partiql.parser.impl
+package org.partiql.parser.internal
 
 import org.junit.jupiter.api.Test
 import org.partiql.ast.AstNode


### PR DESCRIPTION
## Description

This PR extends the PartiQL grammar to support qualified identifiers in routine invocation (FunctionCall). The AST already models this so this PR does not introduce an AST changes.

SQL-99 10.4 p.354 — Routine Invocation
```bnf
<routine invocation> ::= <routine name> <SQL argument list>

<routine name> ::= [ <schema name> <period> ] <qualified identifier>
```

**IMPORTANT**

We _may_ need to introduce larger changes to the grammar as this PR does not add qualified names to special forms.

## Other Information

- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
No

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.