### PR TITLE
Adds generic catalog reference with typed catalog items

### DIFF
--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -12,38 +12,28 @@ parti_q_l_plan::{
   statement:  statement,            // (statement ...)
 }
 
-// Represent an instance of a database.
-// - Currently, `symbols` represents all values from this catalog to be used in this plan.
-// - Eventually, TODO functions may be resolved to a specific namespace within a catalog.
 catalog::{
-  name: string,
-  symbols: list::[symbol],
+  name:   string,
+  items:  list::[item],
   _: [
-    // A reference to a value contained within a catalog.
-    symbol::{
-      // The path to a value WITHIN a catalog. Note: This should not start with the catalog's name. Also, this
-      //  should not be empty
-      path: list::[string],
-      type: static_type,
-      _: [
-        // A reference to a symbol
-        ref::{
-          catalog: int,
-          symbol: int
-        }
-      ]
-    }
+    item::[
+      value::{
+        path: list::[string],
+        type: static_type,
+      },
+      fn::{
+        path:     list::[string],
+        specific: string,
+      },
+    ]
   ]
 }
 
-// Functions
+// Reference to some item in a catalog.
 
-fn::{
-  signature: scalar_signature,
-}
-
-agg::{
-  signature: aggregation_signature,
+ref::{
+  catalog: int,
+  symbol: int
 }
 
 // Statements
@@ -87,7 +77,7 @@ rex::{
     },
 
     global::{
-      ref: '.catalog.symbol.ref'
+      ref: ref,
     },
 
     path::[
@@ -103,7 +93,7 @@ rex::{
 
     call::[
       static::{
-        fn: fn,
+        fn:   ref,
         args: list::[rex]
       },
 
@@ -117,8 +107,8 @@ rex::{
         candidates: list::[candidate],
         _: [
           candidate::{
-            fn: fn,
-            coercions: list::[optional::fn]
+            fn: ref,
+            coercions: list::[optional::ref]
           }
         ]
       }
@@ -280,7 +270,7 @@ rel::{
       groups:   list::[rex],
       _: [
         call::{
-          agg:  agg,
+          fn:   ref,
           args: list::[rex],
         },
       ],


### PR DESCRIPTION
## Description

This PR refactors catalog references to use an untyped pointer (ref) with typed entries for values and functions.

This is a prerequisite to part 2 of https://github.com/partiql/partiql-lang-kotlin/pull/1335

- Any backward-incompatible changes? **[YES/NO]**
Yes

- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.