### PR TITLE
Adds support for dynamic dispatch in evaluation

### DIFF
--- a/partiql-eval/build.gradle.kts
+++ b/partiql-eval/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     testImplementation(project(":partiql-parser"))
     testImplementation(project(":plugins:partiql-local"))
     testImplementation(project(":plugins:partiql-memory"))
+    testImplementation(project(":plugins:partiql-plugin"))
     testImplementation(testFixtures(project(":partiql-planner")))
     testImplementation(testFixtures(project(":partiql-lang")))
     testImplementation(Deps.junit4)

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
@@ -1,0 +1,68 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.spi.function.PartiQLFunction
+import org.partiql.spi.function.PartiQLFunctionExperimental
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.PartiQLValueType
+import org.partiql.value.missingValue
+
+/**
+ * This represents Dynamic Dispatch.
+ *
+ * For the purposes of efficiency, this implementation aims to reduce any re-execution of compiled arguments. It
+ * does this by avoiding the compilation of [Candidate.fn] and [Candidate.coercions] into
+ * [ExprCallStatic]'s. By doing this, this implementation can evaluate ([eval]) the input [Record], execute and gather the
+ * arguments, and pass the [PartiQLValue]s directly to the [Candidate.eval].
+ */
+internal class ExprCallDynamic(
+    private val candidates: List<Candidate>,
+    private val args: Array<Operator.Expr>
+) : Operator.Expr {
+
+    @OptIn(PartiQLValueExperimental::class)
+    override fun eval(record: Record): PartiQLValue {
+        val actualArgs = args.map { it.eval(record) }.toTypedArray()
+        candidates.forEach { candidate ->
+            if (candidate.matches(actualArgs)) {
+                candidate.eval(actualArgs)
+            }
+        }
+        return missingValue()
+    }
+
+    /**
+     * This represents a single candidate for dynamic dispatch.
+     *
+     * This implementation assumes that the [eval] input [Record] contains the original arguments for the desired [fn].
+     * It performs the coercions (if necessary) before computing the result.
+     *
+     * @see ExprCallDynamic
+     */
+    internal class Candidate @OptIn(PartiQLValueExperimental::class, PartiQLFunctionExperimental::class) constructor(
+        val types: Array<PartiQLValueType>,
+        val fn: PartiQLFunction.Scalar,
+        val coercions: List<PartiQLFunction.Scalar?>
+    ) {
+
+        @OptIn(PartiQLValueExperimental::class, PartiQLFunctionExperimental::class)
+        fun eval(originalArgs: Array<PartiQLValue>): PartiQLValue {
+            val args = coercions.mapIndexed { index, coercion ->
+                coercion?.invoke(arrayOf(originalArgs[index])) ?: originalArgs[index]
+            }.toTypedArray()
+            return fn.invoke(args)
+        }
+
+        @OptIn(PartiQLValueExperimental::class)
+        internal fun matches(args: Array<PartiQLValue>): Boolean {
+            for (i in args.indices) {
+                if (args[i].type != types[i]) {
+                    return false
+                }
+            }
+            return true
+        }
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
@@ -1,5 +1,6 @@
 package org.partiql.eval.internal.operator.rex
 
+import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.spi.function.PartiQLFunction
@@ -7,7 +8,6 @@ import org.partiql.spi.function.PartiQLFunctionExperimental
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.PartiQLValueType
-import org.partiql.value.missingValue
 
 /**
  * This represents Dynamic Dispatch.
@@ -30,7 +30,7 @@ internal class ExprCallDynamic(
                 candidate.eval(actualArgs)
             }
         }
-        return missingValue()
+        throw TypeCheckException()
     }
 
     /**

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
@@ -27,7 +27,7 @@ internal class ExprCallDynamic(
         val actualArgs = args.map { it.eval(record) }.toTypedArray()
         candidates.forEach { candidate ->
             if (candidate.matches(actualArgs)) {
-                candidate.eval(actualArgs)
+                return candidate.eval(actualArgs)
             }
         }
         throw TypeCheckException()

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallStatic.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallStatic.kt
@@ -11,7 +11,7 @@ import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.missingValue
 
 @OptIn(PartiQLValueExperimental::class, PartiQLFunctionExperimental::class)
-internal class ExprCall(
+internal class ExprCallStatic(
     private val fn: PartiQLFunction.Scalar,
     private val inputs: Array<Operator.Expr>,
 ) : Operator.Expr {

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -262,6 +262,12 @@ class PartiQLEngineDefaultTest {
                     ;
                 """.trimIndent(),
                 expected = stringValue("isOne")
+            ),
+            SuccessTestCase(
+                input = """
+                    `null.bool` IS NULL
+                """.trimIndent(),
+                expected = boolValue(true)
             )
         )
     }

--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -1,6 +1,7 @@
 imports::{
   kotlin: [
     partiql_value::'org.partiql.value.PartiQLValue',
+    partiql_value_type::'org.partiql.value.PartiQLValueType',
     static_type::'org.partiql.types.StaticType',
     scalar_signature::'org.partiql.types.function.FunctionSignature$Scalar',
     aggregation_signature::'org.partiql.types.function.FunctionSignature$Aggregation',
@@ -116,8 +117,16 @@ rex::{
         args: list::[rex],
         candidates: list::[candidate],
         _: [
+          // Represents a potential candidate for dynamic dispatch. AKA `SELECT abs(a) FROM << 1, 2.0 >> AS a` can invoke
+          // ABS(INT32) -> INT32 or ABS(DEC) -> DEC. In this scenario, we maintain the two potential candidates.
+          //
+          // @param fn - represents the function to invoke (ex: ABS(INT32) -> INT32)
+          // @param parameters - represents the input type(s) to match. (ex: INT32)
+          // @param coercions - represents the optional coercion to use on the argument(s). It will be NULL if no coercion
+          //  is necessary.
           candidate::{
             fn: fn,
+            parameters: list::[partiql_value_type],
             coercions: list::[optional::fn]
           }
         ]

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
@@ -65,6 +65,7 @@ import org.partiql.types.StaticType
 import org.partiql.types.function.FunctionSignature
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.PartiQLValueType
 import kotlin.random.Random
 
 internal abstract class PlanNode {
@@ -550,9 +551,11 @@ internal data class Rex(
 
                 internal data class Candidate(
                     @JvmField
-                    internal val fn: Fn.Resolved,
+                    internal val fn: Fn,
                     @JvmField
-                    internal val coercions: List<Fn.Resolved?>,
+                    internal val parameters: List<PartiQLValueType>,
+                    @JvmField
+                    internal val coercions: List<Fn?>,
                 ) : PlanNode() {
                     internal override val children: List<PlanNode> by lazy {
                         val kids = mutableListOf<PlanNode?>()

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Plan.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Plan.kt
@@ -7,6 +7,7 @@ import org.partiql.types.StaticType
 import org.partiql.types.function.FunctionSignature
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.PartiQLValueType
 
 internal fun partiQLPlan(
     version: PartiQLVersion,
@@ -69,8 +70,11 @@ internal fun rexOpCallStatic(fn: Fn, args: List<Rex>): Rex.Op.Call.Static = Rex.
 internal fun rexOpCallDynamic(args: List<Rex>, candidates: List<Rex.Op.Call.Dynamic.Candidate>):
     Rex.Op.Call.Dynamic = Rex.Op.Call.Dynamic(args, candidates)
 
-internal fun rexOpCallDynamicCandidate(fn: Fn.Resolved, coercions: List<Fn.Resolved?>):
-    Rex.Op.Call.Dynamic.Candidate = Rex.Op.Call.Dynamic.Candidate(fn, coercions)
+internal fun rexOpCallDynamicCandidate(
+    fn: Fn,
+    parameters: List<PartiQLValueType>,
+    coercions: List<Fn?>,
+): Rex.Op.Call.Dynamic.Candidate = Rex.Op.Call.Dynamic.Candidate(fn, parameters, coercions)
 
 internal fun rexOpCase(branches: List<Rex.Op.Case.Branch>, default: Rex): Rex.Op.Case =
     Rex.Op.Case(branches, default)

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilder.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilder.kt
@@ -16,6 +16,7 @@ import org.partiql.types.StaticType
 import org.partiql.types.function.FunctionSignature
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.PartiQLValueType
 
 internal fun <T : PlanNode> plan(block: PlanBuilder.() -> T) = PlanBuilder().block()
 
@@ -219,12 +220,14 @@ internal class PlanBuilder {
         return builder.build()
     }
 
+    @OptIn(PartiQLValueExperimental::class)
     internal fun rexOpCallDynamicCandidate(
-        fn: Fn.Resolved? = null,
-        coercions: MutableList<Fn.Resolved?> = mutableListOf(),
+        fn: Fn? = null,
+        parameters: MutableList<PartiQLValueType> = mutableListOf(),
+        coercions: MutableList<Fn?> = mutableListOf(),
         block: RexOpCallDynamicCandidateBuilder.() -> Unit = {},
     ): Rex.Op.Call.Dynamic.Candidate {
-        val builder = RexOpCallDynamicCandidateBuilder(fn, coercions)
+        val builder = RexOpCallDynamicCandidateBuilder(fn, parameters, coercions)
         builder.block()
         return builder.build()
     }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilders.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilders.kt
@@ -15,6 +15,7 @@ import org.partiql.types.StaticType
 import org.partiql.types.function.FunctionSignature
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.PartiQLValueType
 
 internal class PartiQlPlanBuilder(
     internal var version: PartiQLVersion? = null,
@@ -328,22 +329,28 @@ internal class RexOpCallDynamicBuilder(
     )
 }
 
+@OptIn(PartiQLValueExperimental::class)
 internal class RexOpCallDynamicCandidateBuilder(
-    internal var fn: Fn.Resolved? = null,
-    internal var coercions: MutableList<Fn.Resolved?> = mutableListOf(),
+    internal var fn: Fn? = null,
+    internal var parameters: MutableList<PartiQLValueType> = mutableListOf(),
+    internal var coercions: MutableList<Fn?> = mutableListOf(),
 ) {
-    internal fun fn(fn: Fn.Resolved?): RexOpCallDynamicCandidateBuilder = this.apply {
+    internal fun fn(fn: Fn?): RexOpCallDynamicCandidateBuilder = this.apply {
         this.fn = fn
     }
 
-    internal fun coercions(coercions: MutableList<Fn.Resolved?>): RexOpCallDynamicCandidateBuilder =
+    internal fun parameters(parameters: MutableList<PartiQLValueType>): RexOpCallDynamicCandidateBuilder =
         this.apply {
-            this.coercions = coercions
+            this.parameters = parameters
         }
+
+    internal fun coercions(coercions: MutableList<Fn?>): RexOpCallDynamicCandidateBuilder = this.apply {
+        this.coercions = coercions
+    }
 
     internal fun build(): Rex.Op.Call.Dynamic.Candidate = Rex.Op.Call.Dynamic.Candidate(
         fn = fn!!,
-        coercions = coercions
+        parameters = parameters, coercions = coercions
     )
 }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/util/PlanRewriter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/util/PlanRewriter.kt
@@ -262,11 +262,13 @@ internal abstract class PlanRewriter<C> : PlanBaseVisitor<PlanNode, C>() {
         }
     }
 
-    override fun visitRexOpCallDynamicCandidate(node: Rex.Op.Call.Dynamic.Candidate, ctx: C): PlanNode {
-        val fn = visitFnResolved(node.fn, ctx) as Fn.Resolved
-        val coercions = _visitListNull(node.coercions, ctx, ::visitFnResolved)
-        return if (fn !== node.fn || coercions !== node.coercions) {
-            Rex.Op.Call.Dynamic.Candidate(fn, coercions)
+    public override fun visitRexOpCallDynamicCandidate(node: Rex.Op.Call.Dynamic.Candidate, ctx: C):
+        PlanNode {
+        val fn = visitFn(node.fn, ctx) as Fn
+        val parameters = node.parameters
+        val coercions = _visitListNull(node.coercions, ctx, ::visitFn)
+        return if (fn !== node.fn || parameters !== node.parameters || coercions !== node.coercions) {
+            Rex.Op.Call.Dynamic.Candidate(fn, parameters, coercions)
         } else {
             node
         }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -162,6 +162,7 @@ internal object PlanTransform : PlanBaseVisitor<PlanNode, ProblemCallback>() {
         )
     }
 
+    @OptIn(PartiQLValueExperimental::class)
     override fun visitRexOpCallDynamicCandidate(node: Rex.Op.Call.Dynamic.Candidate, ctx: ProblemCallback): PlanNode {
         val fn = visitFn(node.fn, ctx)
         if (fn is org.partiql.plan.Rex.Op.Err) return fn
@@ -173,7 +174,7 @@ internal object PlanTransform : PlanBaseVisitor<PlanNode, ProblemCallback>() {
                 c as org.partiql.plan.Fn
             }
         }
-        return org.partiql.plan.Rex.Op.Call.Dynamic.Candidate(fn, coercions)
+        return org.partiql.plan.Rex.Op.Call.Dynamic.Candidate(fn, node.parameters, coercions)
     }
 
     override fun visitRexOpCase(node: Rex.Op.Case, ctx: ProblemCallback) = org.partiql.plan.Rex.Op.Case(

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -598,10 +598,11 @@ internal class PlanTyper(
                         val resolvedFn = staticCall.fn as? Fn.Resolved ?: error("This should have been resolved")
                         types.add(rex.type)
                         val coercions = candidate.mapping.map { it?.let { fnResolved(it) } }
-                        rexOpCallDynamicCandidate(fn = resolvedFn, coercions = coercions)
+                        val originalInputTypes = candidate.inputParameterTypes
+                        rexOpCallDynamicCandidate(fn = resolvedFn, parameters = originalInputTypes, coercions = coercions)
                     }
                     val op = rexOpCallDynamic(args = args, candidates = candidates)
-                    rex(type = StaticType.unionOf(types).flatten(), op = op)
+                    rex(type = unionOf(types).flatten(), op = op)
                 }
                 is FnMatch.Error -> {
                     handleUnknownFunction(match)


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds support for dynamic dispatch in evaluation
- As all of the logic for matching function resides in the planner, I updated the plan representation of dynamic dispatch to hold the expected argument types for each candidate function. This should make our implementation faster, as the checks are minute.
- As the function pathing is still being worked on, I added a temporary deprecated API to help load in functions for execution. This will be removed once pathing is added.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **YES**
  - The modelling of dynamic dispatch has changed slightly in the plan representation.
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.