### PR TITLE
Upgrade IonJava to v1.11.1; prepare v0.13.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,25 @@ Thank you to all who have contributed!
 
 -->
 
+## [0.13.3] - 2024-01-25
+
+### Added
+
+### Changed
+- Upgrade IonJava dependency to v1.11.1
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
+### Contributors
+Thank you to all who have contributed!
+- @alancai98
+
 ## [0.13.2]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID      | Artifact ID           | Recommended Version |
 |---------------|-----------------------|---------------------|
-| `org.partiql` | `partiql-lang-kotlin` | `0.13.2`            |
+| `org.partiql` | `partiql-lang-kotlin` | `0.13.3`            |
 
 
 For Maven builds, add the following to your `pom.xml`:

--- a/buildSrc/src/main/kotlin/partiql.versions.kt
+++ b/buildSrc/src/main/kotlin/partiql.versions.kt
@@ -31,7 +31,7 @@ object Versions {
     const val gson = "2.10.1"
     const val guava = "31.1-jre"
     const val ionElement = "1.0.0"
-    const val ionJava = "1.10.2"
+    const val ionJava = "1.11.1"
     const val ionSchema = "1.2.1"
     const val jansi = "2.4.0"
     const val jgenhtml = "1.6"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=0.13.2
+version=0.13.3
 
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY


### PR DESCRIPTION
Backport of #1350. Targets base of v0.13.3 which is based off the v0.13.2 release version.

## Description
- Upgrades IonJava dependency to latest, v1.11.1
- Prepares next release version, v0.13.3

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.