### PR TITLE
Adds support for PERMISSIVE vs STRICT

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/PartiQLEngine.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/PartiQLEngine.kt
@@ -38,6 +38,12 @@ public interface PartiQLEngine {
 
     public class Session @OptIn(PartiQLFunctionExperimental::class) constructor(
         val bindings: Map<String, ConnectorBindings> = mapOf(),
-        val functions: Map<String, List<PartiQLFunction>> = mapOf()
+        val functions: Map<String, List<PartiQLFunction>> = mapOf(),
+        val mode: Mode = Mode.PERMISSIVE
     )
+
+    public enum class Mode {
+        PERMISSIVE,
+        STRICT // AKA, Type Checking Mode in the PartiQL Specification
+    }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelScanPermissive.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelScanPermissive.kt
@@ -1,13 +1,12 @@
 package org.partiql.eval.internal.operator.rel
 
-import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.value.CollectionValue
 import org.partiql.value.PartiQLValueExperimental
 
 @OptIn(PartiQLValueExperimental::class)
-internal class RelScan(
+internal class RelScanPermissive(
     private val expr: Operator.Expr
 ) : Operator.Relation {
 
@@ -17,10 +16,7 @@ internal class RelScan(
         val r = expr.eval(Record.empty)
         records = when (r) {
             is CollectionValue<*> -> r.map { Record.of(it) }.iterator()
-            else -> {
-                close()
-                throw TypeCheckException()
-            }
+            else -> iterator { yield(Record.of(r)) }
         }
     }
 

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
@@ -58,6 +58,9 @@ internal class ExprCallDynamic(
         @OptIn(PartiQLValueExperimental::class)
         internal fun matches(args: Array<PartiQLValue>): Boolean {
             for (i in args.indices) {
+                if (types[i] == PartiQLValueType.ANY) {
+                    return true
+                }
                 if (args[i].type != types[i]) {
                     return false
                 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallStatic.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallStatic.kt
@@ -1,6 +1,5 @@
 package org.partiql.eval.internal.operator.rex
 
-import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.helpers.toNull
 import org.partiql.eval.internal.operator.Operator
@@ -8,7 +7,6 @@ import org.partiql.spi.function.PartiQLFunction
 import org.partiql.spi.function.PartiQLFunctionExperimental
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
-import org.partiql.value.missingValue
 
 @OptIn(PartiQLValueExperimental::class, PartiQLFunctionExperimental::class)
 internal class ExprCallStatic(
@@ -30,32 +28,5 @@ internal class ExprCallStatic(
             r
         }.toTypedArray()
         return fn.invoke(args)
-    }
-
-    @OptIn(PartiQLValueExperimental::class, PartiQLFunctionExperimental::class)
-    internal class Permissive(
-        private val fn: PartiQLFunction.Scalar,
-        private val inputs: Array<Operator.Expr>,
-    ) : Operator.Expr {
-
-        /**
-         * Memoize creation of
-         */
-        @OptIn(PartiQLValueExperimental::class)
-        private val nil = fn.signature.returns.toNull()
-
-        override fun eval(record: Record): PartiQLValue {
-            // Evaluate arguments
-            val args = inputs.map { input ->
-                try {
-                    val r = input.eval(record)
-                    if (r.isNull && fn.signature.isNullCall) return nil()
-                    r
-                } catch (e: TypeCheckException) {
-                    missingValue()
-                }
-            }.toTypedArray()
-            return fn.invoke(args)
-        }
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathIndex.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathIndex.kt
@@ -1,5 +1,6 @@
 package org.partiql.eval.internal.operator.rex
 
+import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.value.CollectionValue
@@ -11,7 +12,6 @@ import org.partiql.value.IntValue
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.check
-import org.partiql.value.missingValue
 
 internal class ExprPathIndex(
     @JvmField val root: Operator.Expr,
@@ -21,7 +21,6 @@ internal class ExprPathIndex(
     @OptIn(PartiQLValueExperimental::class)
     override fun eval(record: Record): PartiQLValue {
         val collection = root.eval(record).check<CollectionValue<PartiQLValue>>()
-        val value = missingValue()
 
         // Calculate index
         val index = when (val k = key.eval(record)) {
@@ -30,8 +29,8 @@ internal class ExprPathIndex(
             is Int64Value -> k.int
             is Int8Value -> k.int
             is IntValue -> k.int
-            else -> return value
-        } ?: return value
+            else -> throw TypeCheckException()
+        } ?: throw TypeCheckException()
 
         // Get element
         val iterator = collection.iterator()
@@ -43,6 +42,6 @@ internal class ExprPathIndex(
             }
             i++
         }
-        return value
+        throw TypeCheckException()
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathKey.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathKey.kt
@@ -1,5 +1,6 @@
 package org.partiql.eval.internal.operator.rex
 
+import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.value.PartiQLValue
@@ -7,7 +8,6 @@ import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.StringValue
 import org.partiql.value.StructValue
 import org.partiql.value.check
-import org.partiql.value.missingValue
 
 internal class ExprPathKey(
     @JvmField val root: Operator.Expr,
@@ -19,6 +19,6 @@ internal class ExprPathKey(
         val rootEvaluated = root.eval(record).check<StructValue<PartiQLValue>>()
         val keyEvaluated = key.eval(record).check<StringValue>()
         val keyString = keyEvaluated.value ?: error("String value was null")
-        return rootEvaluated[keyString] ?: missingValue()
+        return rootEvaluated[keyString] ?: throw TypeCheckException()
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathSymbol.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathSymbol.kt
@@ -1,12 +1,12 @@
 package org.partiql.eval.internal.operator.rex
 
+import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.StructValue
 import org.partiql.value.check
-import org.partiql.value.missingValue
 import org.partiql.value.nullValue
 
 internal class ExprPathSymbol(
@@ -20,13 +20,11 @@ internal class ExprPathSymbol(
         if (struct.isNull) {
             return nullValue()
         }
-        var value: PartiQLValue = missingValue()
         for ((k, v) in struct.entries) {
             if (k.equals(symbol, ignoreCase = true)) {
-                value = v
-                break
+                return v
             }
         }
-        return value
+        throw TypeCheckException()
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPermissive.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPermissive.kt
@@ -1,0 +1,22 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.errors.TypeCheckException
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.missingValue
+
+internal class ExprPermissive(
+    val target: Operator.Expr
+) : Operator.Expr {
+
+    @OptIn(PartiQLValueExperimental::class)
+    override fun eval(record: Record): PartiQLValue {
+        return try {
+            target.eval(record)
+        } catch (e: TypeCheckException) {
+            missingValue()
+        }
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPivotPermissive.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPivotPermissive.kt
@@ -1,0 +1,29 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.StringValue
+import org.partiql.value.structValue
+
+@OptIn(PartiQLValueExperimental::class)
+internal class ExprPivotPermissive(
+    private val input: Operator.Relation,
+    private val key: Operator.Expr,
+    private val value: Operator.Expr,
+) : Operator.Expr {
+
+    override fun eval(record: Record): PartiQLValue {
+        input.open()
+        val fields = mutableListOf<Pair<String, PartiQLValue>>()
+        while (true) {
+            val row = input.next() ?: break
+            val k = key.eval(row) as? StringValue ?: continue
+            val v = value.eval(row)
+            fields.add(k.value!! to v)
+        }
+        input.close()
+        return structValue(fields)
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprStruct.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprStruct.kt
@@ -2,6 +2,7 @@ package org.partiql.eval.internal.operator.rex
 
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.MissingValue
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.StringValue
@@ -11,10 +12,12 @@ import org.partiql.value.structValue
 internal class ExprStruct(val fields: List<Field>) : Operator.Expr {
     @OptIn(PartiQLValueExperimental::class)
     override fun eval(record: Record): PartiQLValue {
-        val fields = fields.map {
+        val fields = fields.mapNotNull {
             val key = it.key.eval(record).check<StringValue>()
-            val value = it.value.eval(record)
-            key.value!! to value
+            when (val value = it.value.eval(record)) {
+                is MissingValue -> null
+                else -> key.value!! to value
+            }
         }
         return structValue(fields)
     }

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -17,15 +17,19 @@ import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.bagValue
 import org.partiql.value.boolValue
+import org.partiql.value.decimalValue
 import org.partiql.value.int32Value
 import org.partiql.value.int64Value
 import org.partiql.value.io.PartiQLValueIonWriterBuilder
+import org.partiql.value.listValue
 import org.partiql.value.missingValue
 import org.partiql.value.nullValue
 import org.partiql.value.stringValue
 import org.partiql.value.structValue
 import java.io.ByteArrayOutputStream
+import java.math.BigDecimal
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 /**
  * This holds sanity tests during the development of the [PartiQLEngine.default] implementation.
@@ -37,6 +41,11 @@ class PartiQLEngineDefaultTest {
     @MethodSource("sanityTestsCases")
     @Execution(ExecutionMode.CONCURRENT)
     fun sanityTests(tc: SuccessTestCase) = tc.assert()
+
+    @ParameterizedTest
+    @MethodSource("typingModeTestCases")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun typingModeTests(tc: TypingTestCase) = tc.assert()
 
     companion object {
 
@@ -194,23 +203,6 @@ class PartiQLEngineDefaultTest {
                 )
             ),
             SuccessTestCase(
-                input = "SELECT v, i FROM << 'a', 'b', 'c' >> AS v AT i",
-                expected = bagValue(
-                    structValue(
-                        "v" to stringValue("a"),
-                        "i" to int64Value(0),
-                    ),
-                    structValue(
-                        "v" to stringValue("b"),
-                        "i" to int64Value(1),
-                    ),
-                    structValue(
-                        "v" to stringValue("c"),
-                        "i" to int64Value(2),
-                    ),
-                )
-            ),
-            SuccessTestCase(
                 input = "SELECT DISTINCT VALUE t FROM <<true, false, true, false, false, false>> AS t;",
                 expected = bagValue(boolValue(true), boolValue(false))
             ),
@@ -268,12 +260,193 @@ class PartiQLEngineDefaultTest {
                     `null.bool` IS NULL
                 """.trimIndent(),
                 expected = boolValue(true)
-            )
+            ),
+            SuccessTestCase(
+                input = "MISSING IS MISSING;",
+                expected = boolValue(true)
+            ),
+            SuccessTestCase(
+                input = "MISSING IS MISSING;",
+                expected = boolValue(true), // TODO: Is this right?
+                mode = PartiQLEngine.Mode.STRICT
+            ),
+            // PartiQL Specification Section 7.1.1 -- Equality
+            SuccessTestCase(
+                input = "5 = 'a';",
+                expected = boolValue(false),
+            ),
+            // PartiQL Specification Section 7.1.1 -- Equality
+            SuccessTestCase(
+                input = "5 = 'a';",
+                expected = boolValue(false), // TODO: Is this correct? See: The eqg, unlike the =, returns true when a NULL is compared to a NULL or a MISSING to a MISSING
+                mode = PartiQLEngine.Mode.STRICT
+            ),
+            // PartiQL Specification Section 8
+            SuccessTestCase(
+                input = "MISSING AND TRUE;",
+                expected = boolValue(null),
+            ),
+            // PartiQL Specification Section 8
+            SuccessTestCase(
+                input = "MISSING AND TRUE;",
+                expected = boolValue(null), // TODO: Is this right?
+                mode = PartiQLEngine.Mode.STRICT
+            ),
+            // PartiQL Specification Section 8
+            SuccessTestCase(
+                input = "NULL IS MISSING;",
+                expected = boolValue(false),
+            ),
+            // PartiQL Specification Section 8
+            SuccessTestCase(
+                input = "NULL IS MISSING;",
+                expected = boolValue(false),
+                mode = PartiQLEngine.Mode.STRICT
+            ),
+        )
+
+        @JvmStatic
+        fun typingModeTestCases() = listOf(
+            TypingTestCase(
+                name = "Expected missing value in collection",
+                input = "SELECT VALUE t.a FROM << { 'a': 1 }, { 'b': 2 } >> AS t;",
+                expectedPermissive = bagValue(int32Value(1), missingValue())
+            ),
+            TypingTestCase(
+                name = "Expected missing value in tuple in collection",
+                input = "SELECT t.a AS \"a\" FROM << { 'a': 1 }, { 'b': 2 } >> AS t;",
+                expectedPermissive = bagValue(
+                    structValue(
+                        "a" to int32Value(1),
+                    ),
+                    structValue(),
+                )
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 4.2 -- index negative",
+                input = "[1,2,3][-1];",
+                expectedPermissive = missingValue()
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 4.2 -- out of bounds",
+                input = "[1,2,3][3];",
+                expectedPermissive = missingValue()
+            ),
+            TypingTestCase(
+                name = "PartiQL Spec Section 5.1.1 -- Position variable on bags",
+                input = "SELECT v, p FROM << 5 >> AS v AT p;",
+                expectedPermissive = bagValue(
+                    structValue(
+                        "v" to int32Value(5)
+                    )
+                )
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 5.1.1 -- Iteration over a scalar value",
+                input = "SELECT v FROM 0 AS v;",
+                expectedPermissive = bagValue(
+                    structValue(
+                        "v" to int32Value(0)
+                    )
+                )
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 5.1.1 -- Iteration over a scalar value (with at)",
+                input = "SELECT v, p FROM 0 AS v AT p;",
+                expectedPermissive = bagValue(
+                    structValue(
+                        "v" to int32Value(0)
+                    )
+                )
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 5.1.1 -- Iteration over a tuple value",
+                input = "SELECT v.a AS a FROM { 'a': 1 } AS v;",
+                expectedPermissive = bagValue(
+                    structValue(
+                        "a" to int32Value(1)
+                    )
+                )
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 5.1.1 -- Iteration over an absent value (missing)",
+                input = "SELECT v AS v FROM MISSING AS v;",
+                expectedPermissive = bagValue(structValue<PartiQLValue>())
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 5.1.1 -- Iteration over an absent value (null)",
+                input = "SELECT v AS v FROM NULL AS v;",
+                expectedPermissive = bagValue(
+                    structValue(
+                        "v" to nullValue()
+                    )
+                )
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 6.1.4 -- when constructing tuples",
+                input = "SELECT VALUE {'a':v.a, 'b':v.b} FROM [{'a':1, 'b':1}, {'a':2}] AS v;",
+                expectedPermissive = bagValue(
+                    structValue(
+                        "a" to int32Value(1),
+                        "b" to int32Value(1),
+                    ),
+                    structValue(
+                        "a" to int32Value(2),
+                    )
+                )
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 6.1.4 -- when constructing bags (1)",
+                input = "SELECT VALUE v.b FROM [{'a':1, 'b':1}, {'a':2}] AS v;",
+                expectedPermissive = bagValue(
+                    int32Value(1),
+                    missingValue()
+                )
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 6.1.4 -- when constructing bags (2)",
+                input = "SELECT VALUE <<v.a, v.b>> FROM [{'a':1, 'b':1}, {'a':2}] AS v;",
+                expectedPermissive = bagValue(
+                    bagValue(
+                        int32Value(1),
+                        int32Value(1),
+                    ),
+                    bagValue(
+                        int32Value(2),
+                        missingValue()
+                    )
+                )
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 6.2 -- Pivoting a Collection into a Variable-Width Tuple",
+                input = "PIVOT t.price AT t.\"symbol\" FROM [{'symbol':25, 'price':31.52}, {'symbol':'amzn', 'price':840.05}] AS t;",
+                expectedPermissive = structValue(
+                    "amzn" to decimalValue(BigDecimal.valueOf(840.05))
+                )
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 7.1 -- Inputs with wrong types Example 28 (1)",
+                input = "SELECT VALUE 5 + v FROM <<1, MISSING>> AS v;",
+                expectedPermissive = bagValue(int32Value(6), missingValue())
+            ),
+            TypingTestCase(
+                name = "PartiQL Specification Section 7.1 -- Inputs with wrong types Example 28 (3)",
+                input = "SELECT VALUE NOT v FROM << false, {'a':1} >> AS v;",
+                expectedPermissive = bagValue(boolValue(true), missingValue())
+            ),
+
+            TypingTestCase(
+                name = "PartiQL Specification Section 7.1 -- Inputs with wrong types Example 28 (2)",
+                input = "SELECT VALUE 5 > v FROM <<1, 'a'>> AS v;",
+                expectedPermissive = bagValue(boolValue(true), missingValue())
+            ),
         )
     }
+
     public class SuccessTestCase @OptIn(PartiQLValueExperimental::class) constructor(
         val input: String,
-        val expected: PartiQLValue
+        val expected: PartiQLValue,
+        val mode: PartiQLEngine.Mode = PartiQLEngine.Mode.PERMISSIVE
     ) {
 
         @OptIn(PartiQLFunctionExperimental::class)
@@ -313,6 +486,63 @@ class PartiQLEngineDefaultTest {
         }
     }
 
+    public class TypingTestCase @OptIn(PartiQLValueExperimental::class) constructor(
+        val name: String,
+        val input: String,
+        val expectedPermissive: PartiQLValue
+    ) {
+
+        @OptIn(PartiQLFunctionExperimental::class)
+        private val engine = PartiQLEngine.builder().build()
+        private val planner = PartiQLPlannerBuilder().build()
+        private val parser = PartiQLParser.default()
+
+        @OptIn(PartiQLValueExperimental::class, PartiQLFunctionExperimental::class)
+        internal fun assert() {
+            val permissiveResult = run(mode = PartiQLEngine.Mode.PERMISSIVE)
+            assertEquals(expectedPermissive, permissiveResult, comparisonString(expectedPermissive, permissiveResult))
+            var error: Throwable? = null
+            try {
+                run(mode = PartiQLEngine.Mode.STRICT)
+            } catch (e: Throwable) {
+                error = e
+            }
+            assertNotNull(error)
+        }
+
+        @OptIn(PartiQLFunctionExperimental::class)
+        private fun run(mode: PartiQLEngine.Mode): PartiQLValue {
+            val statement = parser.parse(input).root
+            val session = PartiQLPlanner.Session("q", "u")
+            val plan = planner.plan(statement, session)
+            val functions = mapOf(
+                "partiql" to PartiQLPlugin.functions
+            )
+            val prepared = engine.prepare(plan.plan, PartiQLEngine.Session(functions = functions, mode = mode))
+            when (val result = engine.execute(prepared)) {
+                is PartiQLResult.Value -> return result.value
+                is PartiQLResult.Error -> throw result.cause
+            }
+        }
+
+        @OptIn(PartiQLValueExperimental::class)
+        private fun comparisonString(expected: PartiQLValue, actual: PartiQLValue): String {
+            val expectedBuffer = ByteArrayOutputStream()
+            val expectedWriter = PartiQLValueIonWriterBuilder.standardIonTextBuilder().build(expectedBuffer)
+            expectedWriter.append(expected)
+            return buildString {
+                appendLine("Expected : $expectedBuffer")
+                expectedBuffer.reset()
+                expectedWriter.append(actual)
+                appendLine("Actual   : $expectedBuffer")
+            }
+        }
+
+        override fun toString(): String {
+            return "$name -- $input"
+        }
+    }
+
     @Test
     @Disabled("CASTS have not yet been implemented.")
     fun testCast1() = SuccessTestCase(
@@ -326,4 +556,122 @@ class PartiQLEngineDefaultTest {
         input = "SELECT DISTINCT VALUE t * 100 FROM <<0, 1, 2.0, 3.0>> AS t;",
         expected = bagValue(int32Value(0), int32Value(100), int32Value(200), int32Value(300))
     ).assert()
+
+    @Test
+    @Disabled("We need to support section 5.1")
+    fun testTypingOfPositionVariable() = TypingTestCase(
+        name = "PartiQL Spec Section 5.1.1 -- Position variable on bags",
+        input = "SELECT v, p FROM << 5 >> AS v AT p;",
+        expectedPermissive = bagValue(
+            structValue(
+                "v" to int32Value(5)
+            )
+        )
+    ).assert()
+
+    @Test
+    @Disabled("Subqueries aren't supported yet.")
+    fun test() = TypingTestCase(
+        name = "PartiQL Specification Section 9.1",
+        input = """
+            SELECT o.name AS orderName,
+                (SELECT c.name FROM << { 'name': 'John', 'id': 1 }, { 'name': 'Alan', 'id': 1 } >> c WHERE c.id=o.custId) AS customerName
+            FROM << { 'name': 'apples', 'custId': 1 } >> o
+        """.trimIndent(),
+        expectedPermissive = bagValue(
+            structValue(
+                "orderName" to stringValue("apples")
+            )
+        )
+    ).assert()
+
+    @Test
+    @Disabled("This is just a placeholder. We should add support for this. Grouping is not yet supported.")
+    fun test3() =
+        TypingTestCase(
+            name = "PartiQL Specification Section 11.1",
+            input = """
+                    PLACEHOLDER FOR THE EXAMPLE IN THE RELEVANT SECTION. GROUPING NOT YET SUPPORTED.
+            """.trimIndent(),
+            expectedPermissive = missingValue()
+        ).assert()
+
+    @Test
+    @Disabled("The planner fails this, though it should pass for permissive mode.")
+    fun test5() =
+        TypingTestCase(
+            name = "PartiQL Specification Section 5.2.1 -- Mistyping Cases",
+            input = "SELECT v, n FROM UNPIVOT 1 AS v AT n;",
+            expectedPermissive = bagValue(
+                structValue(
+                    "v" to int32Value(1),
+                    "n" to stringValue("_1")
+                )
+            )
+        ).assert()
+
+    @Test
+    @Disabled("We don't yet support arrays.")
+    fun test7() =
+        TypingTestCase(
+            name = "PartiQL Specification Section 6.1.4 -- when constructing arrays",
+            input = "SELECT VALUE [v.a, v.b] FROM [{'a':1, 'b':1}, {'a':2}] AS v;",
+            expectedPermissive = bagValue(
+                listValue(
+                    int32Value(1),
+                    int32Value(1),
+                ),
+                listValue(
+                    int32Value(2),
+                    missingValue()
+                )
+            )
+        ).assert()
+
+    @Test
+    @Disabled("There is a bug in the planner which makes this always return missing.")
+    fun test8() =
+        TypingTestCase(
+            name = "PartiQL Specification Section 4.2 -- non integer index",
+            input = "SELECT VALUE [1,2,3][v] FROM <<1, 1.0>> AS v;",
+            expectedPermissive = bagValue(int32Value(2), missingValue())
+        ).assert()
+
+    @Test
+    @Disabled("CASTs aren't supported yet.")
+    fun test9() =
+        TypingTestCase(
+            name = "PartiQL Specification Section 7.1 -- Inputs with wrong types Example 27",
+            input = "SELECT VALUE {'a':3*v.a, 'b':3*(CAST (v.b AS INTEGER))} FROM [{'a':1, 'b':'1'}, {'a':2}] v;",
+            expectedPermissive = bagValue(
+                structValue(
+                    "a" to int32Value(3),
+                    "b" to int32Value(3),
+                ),
+                structValue(
+                    "a" to int32Value(6),
+                ),
+            )
+        ).assert()
+
+    @Test
+    @Disabled("Arrays aren't supported yet.")
+    fun test10() =
+        SuccessTestCase(
+            input = "SELECT v, i FROM [ 'a', 'b', 'c' ] AS v AT i",
+            expected = bagValue(
+                structValue(
+                    "v" to stringValue("a"),
+                    "i" to int64Value(0),
+                ),
+                structValue(
+                    "v" to stringValue("b"),
+                    "i" to int64Value(1),
+                ),
+                structValue(
+                    "v" to stringValue("c"),
+                    "i" to int64Value(2),
+                ),
+            )
+        ).assert()
 }

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -270,6 +270,10 @@ class PartiQLEngineDefaultTest {
                 expected = boolValue(true), // TODO: Is this right?
                 mode = PartiQLEngine.Mode.STRICT
             ),
+            SuccessTestCase(
+                input = "SELECT VALUE t.a IS MISSING FROM << { 'b': 1 }, { 'a': 2 } >> AS t;",
+                expected = bagValue(boolValue(true), boolValue(false))
+            ),
             // PartiQL Specification Section 7.1.1 -- Equality
             SuccessTestCase(
                 input = "5 = 'a';",
@@ -278,7 +282,7 @@ class PartiQLEngineDefaultTest {
             // PartiQL Specification Section 7.1.1 -- Equality
             SuccessTestCase(
                 input = "5 = 'a';",
-                expected = boolValue(false), // TODO: Is this correct? See: The eqg, unlike the =, returns true when a NULL is compared to a NULL or a MISSING to a MISSING
+                expected = boolValue(false), // TODO: Is this correct?
                 mode = PartiQLEngine.Mode.STRICT
             ),
             // PartiQL Specification Section 8
@@ -462,7 +466,7 @@ class PartiQLEngineDefaultTest {
             val functions = mapOf(
                 "partiql" to PartiQLPlugin.functions
             )
-            val prepared = engine.prepare(plan.plan, PartiQLEngine.Session(functions = functions))
+            val prepared = engine.prepare(plan.plan, PartiQLEngine.Session(functions = functions, mode = mode))
             val result = engine.execute(prepared) as PartiQLResult.Value
             val output = result.value
             assertEquals(expected, output, comparisonString(expected, output))

--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
@@ -545,7 +545,7 @@ public abstract class MissingValue : PartiQLValue {
 
     override val type: PartiQLValueType = PartiQLValueType.MISSING
 
-    override val isNull: Boolean = true
+    override val isNull: Boolean = false
 
     abstract override fun copy(annotations: Annotations): MissingValue
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
@@ -28,7 +28,6 @@ import org.partiql.value.nullValue
 import org.partiql.value.sexpValue
 import org.partiql.value.stringValue
 import org.partiql.value.structValue
-import org.partiql.value.symbolValue
 import org.partiql.value.timeValue
 import org.partiql.value.timestampValue
 import java.io.ByteArrayInputStream
@@ -126,11 +125,13 @@ internal class PartiQLValueIonReader(
                 }
             }
 
+            // TODO: From discussions with the PartiQL Maintainers, it seems like SYMBOL should be used just as a
+            //  pointer to somewhere on the symbol table. If nothing is pointed to, it should be a STRING.
             IonType.SYMBOL -> {
                 if (reader.isNullValue) {
-                    symbolValue(null, reader.typeAnnotations.toList())
+                    stringValue(null, reader.typeAnnotations.toList())
                 } else {
-                    symbolValue(reader.stringValue(), reader.typeAnnotations.toList())
+                    stringValue(reader.stringValue(), reader.typeAnnotations.toList())
                 }
             }
 
@@ -318,9 +319,9 @@ internal class PartiQLValueIonReader(
                     PARTIQL_ANNOTATION.GRAPH_ANNOTATION -> throw IllegalArgumentException("GRAPH_ANNOTATION with Symbol Value")
                     null -> {
                         if (reader.isNullValue) {
-                            symbolValue(null, annotations)
+                            stringValue(null, annotations)
                         } else {
-                            symbolValue(reader.stringValue(), annotations)
+                            stringValue(reader.stringValue(), annotations)
                         }
                     }
                 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
@@ -28,6 +28,7 @@ import org.partiql.value.nullValue
 import org.partiql.value.sexpValue
 import org.partiql.value.stringValue
 import org.partiql.value.structValue
+import org.partiql.value.symbolValue
 import org.partiql.value.timeValue
 import org.partiql.value.timestampValue
 import java.io.ByteArrayInputStream
@@ -125,13 +126,11 @@ internal class PartiQLValueIonReader(
                 }
             }
 
-            // TODO: From discussions with the PartiQL Maintainers, it seems like SYMBOL should be used just as a
-            //  pointer to somewhere on the symbol table. If nothing is pointed to, it should be a STRING.
             IonType.SYMBOL -> {
                 if (reader.isNullValue) {
-                    stringValue(null, reader.typeAnnotations.toList())
+                    symbolValue(null, reader.typeAnnotations.toList())
                 } else {
-                    stringValue(reader.stringValue(), reader.typeAnnotations.toList())
+                    symbolValue(reader.stringValue(), reader.typeAnnotations.toList())
                 }
             }
 
@@ -319,9 +318,9 @@ internal class PartiQLValueIonReader(
                     PARTIQL_ANNOTATION.GRAPH_ANNOTATION -> throw IllegalArgumentException("GRAPH_ANNOTATION with Symbol Value")
                     null -> {
                         if (reader.isNullValue) {
-                            stringValue(null, annotations)
+                            symbolValue(null, annotations)
                         } else {
-                            stringValue(reader.stringValue(), annotations)
+                            symbolValue(reader.stringValue(), annotations)
                         }
                     }
                 }

--- a/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnLike.kt
+++ b/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnLike.kt
@@ -3,16 +3,23 @@
 
 package org.partiql.plugin.internal.fn.scalar
 
+import com.amazon.ion.IonValue
+import org.partiql.errors.TypeCheckException
 import org.partiql.spi.function.PartiQLFunction
 import org.partiql.spi.function.PartiQLFunctionExperimental
 import org.partiql.types.function.FunctionParameter
 import org.partiql.types.function.FunctionSignature
+import org.partiql.value.BoolValue
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.PartiQLValueType.BOOL
 import org.partiql.value.PartiQLValueType.CLOB
 import org.partiql.value.PartiQLValueType.STRING
 import org.partiql.value.PartiQLValueType.SYMBOL
+import org.partiql.value.StringValue
+import org.partiql.value.boolValue
+import org.partiql.value.check
+import java.util.regex.Pattern
 
 @OptIn(PartiQLValueExperimental::class, PartiQLFunctionExperimental::class)
 internal object Fn_LIKE__STRING_STRING__BOOL : PartiQLFunction.Scalar {
@@ -29,7 +36,10 @@ internal object Fn_LIKE__STRING_STRING__BOOL : PartiQLFunction.Scalar {
     )
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
-        TODO("Function like not implemented")
+        val value = args[0].check<StringValue>()
+        val pattern = args[1].check<StringValue>()
+        val pps = LikeUtils.getRegexPattern(pattern, null)
+        return LikeUtils.matchRegexPattern(value, pps)
     }
 }
 
@@ -68,5 +78,231 @@ internal object Fn_LIKE__CLOB_CLOB__BOOL : PartiQLFunction.Scalar {
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
         TODO("Function like not implemented")
+    }
+}
+
+@OptIn(PartiQLValueExperimental::class)
+internal object LikeUtils {
+
+    private const val ANY_MANY = '%'.code
+    private const val ANY_ONE = '_'.code
+    private const val PATTERN_ADDITIONAL_BUFFER = 8
+
+    fun matchRegexPattern(value: StringValue, likePattern: (() -> Pattern)): BoolValue {
+        return boolValue(likePattern().matcher(value.value!!).matches())
+    }
+
+    fun getRegexPattern(pattern: StringValue, escape: StringValue?): (() -> Pattern) {
+        val (patternString: String, escapeChar: Int?) =
+            checkPattern(pattern.value!!, escape?.value)
+        val likeRegexPattern = when {
+            patternString.isEmpty() -> Pattern.compile("")
+            else -> parsePattern(patternString, escapeChar)
+        }
+        return { likeRegexPattern }
+    }
+
+    /**
+     * Given the pattern and optional escape character in a `LIKE` predicate as [IonValue]s
+     * check their validity based on the SQL92 spec and return a triple that contains in order
+     *
+     * - the search pattern as a string
+     * - the escape character, possibly `null`
+     * - the length of the search pattern. The length of the search pattern is either
+     *   - the length of the string representing the search pattern when no escape character is used
+     *   - the length of the string representing the search pattern without counting uses of the escape character
+     *     when an escape character is used
+     *
+     * A search pattern is valid when
+     * 1. pattern is not null
+     * 1. pattern contains characters where `_` means any 1 character and `%` means any string of length 0 or more
+     * 1. if the escape character is specified then pattern can be deterministically partitioned into character groups where
+     *     1. A length 1 character group consists of any character other than the ESCAPE character
+     *     1. A length 2 character group consists of the ESCAPE character followed by either `_` or `%` or the ESCAPE character itself
+     *
+     * @param pattern search pattern
+     * @param escape optional escape character provided in the `LIKE` predicate
+     *
+     * @return a triple that contains in order the search pattern as a [String], optionally the code point for the escape character if one was provided
+     * and the size of the search pattern excluding uses of the escape character
+     */
+    private fun checkPattern(
+        pattern: String,
+        escape: String?,
+    ): Pair<String, Int?> {
+
+        escape?.let {
+            val escapeCharString = checkEscapeChar(escape)
+            val escapeCharCodePoint = escapeCharString.codePointAt(0) // escape is a string of length 1
+            val validEscapedChars = setOf('_'.code, '%'.code, escapeCharCodePoint)
+            val iter = pattern.codePointSequence().iterator()
+
+            while (iter.hasNext()) {
+                val current = iter.next()
+                if (current == escapeCharCodePoint && (!iter.hasNext() || !validEscapedChars.contains(iter.next()))) {
+                    // TODO: Invalid escape sequence
+                    throw TypeCheckException()
+                }
+            }
+            return Pair(pattern, escapeCharCodePoint)
+        }
+        return Pair(pattern, null)
+    }
+
+    /**
+     * Given an [IonValue] to be used as the escape character in a `LIKE` predicate check that it is
+     * a valid character based on the SQL Spec.
+     *
+     *
+     * A value is a valid escape when
+     * 1. it is 1 character long, and,
+     * 1. Cannot be null (SQL92 spec marks this cases as *unknown*)
+     *
+     * @param escape value provided as an escape character for a `LIKE` predicate
+     *
+     * @return the escape character as a [String] or throws an exception when the input is invalid
+     */
+    private fun checkEscapeChar(escape: String): String {
+        when (escape) {
+            "" -> {
+                // Cannot use empty character as ESCAPE character in a LIKE predicate
+                throw TypeCheckException()
+            }
+
+            else -> {
+                if (escape.trim().length != 1) {
+                    // Escape character must have size 1
+                    throw TypeCheckException()
+                }
+            }
+        }
+        return escape
+    }
+
+    /** Provides a lazy sequence over the code points in the given string. */
+    fun String.codePointSequence(): Sequence<Int> {
+        val text = this
+        return Sequence {
+            var pos = 0
+            object : Iterator<Int> {
+                override fun hasNext(): Boolean = pos < text.length
+                override fun next(): Int {
+                    val cp = text.codePointAt(pos)
+                    pos += Character.charCount(cp)
+                    return cp
+                }
+            }
+        }
+    }
+
+    /**
+     * Translates a SQL-style `LIKE` pattern to a regular expression.
+     *
+     * Roughly the algorithm is to
+     *   - call `Pattern.quote` on the literal parts of the pattern
+     *   - translate a single `_` (with no contiguous `%`) to `.`
+     *   - translate a consecutive <n> `_` (with no contiguous `%`) to `.{n,n}`
+     *   - translate any number of consecutive `%` to `.*?`
+     *   - translate any number of consecutive `%` with a `_` contiguous to `.+?`
+     *   - translate any number of consecutive `%` with <n> `_` contiguous to `.{n,}?`
+     *   - prefix the pattern translated via the above rule with '^' and suffix with '$'
+     *
+     * @param likePattern A `LIKE` match pattern (i.e. a string where '%' means zero or more <any char> and '_' means 1 <any char>).
+     * @param escapeChar The escape character for the `LIKE` pattern.
+     *
+     * @return a [Pattern] which is a regular expression corresponding to the specified `LIKE` pattern.
+     *
+     * Examples:
+     * ```
+     *   val ESCAPE = '\\'.toInt()
+     *
+     *   assertEquals("^.*?\\Qfoo\\E$",                 parsePattern("%foo", ESCAPE).pattern())
+     *   assertEquals("^\\Qfoo\\E.*?$",                 parsePattern("foo%", ESCAPE).pattern())
+     *   assertEquals("^\\Qfoo\\E.*?\\Qbar\\E$",        parsePattern("foo%bar", ESCAPE).pattern())
+     *   assertEquals("^\\Qfoo\\E.*?\\Qbar\\E$",        parsePattern("foo%%bar", ESCAPE).pattern())
+     *   assertEquals("^\\Qfoo\\E.*?\\Qbar\\E$",        parsePattern("foo%%%bar", ESCAPE).pattern())
+     *   assertEquals("^\\Qfoo\\E.*?\\Qbar\\E$",        parsePattern("foo%%%%bar", ESCAPE).pattern())
+     *   assertEquals("^.*?\\Qfoo\\E.*?\\Qbar\\E.*?$",
+     *                parsePattern("%foo%%%%bar%", ESCAPE).pattern())
+     *   assertEquals("^\\Qfoo\\E.{2,}?\\Qbar\\E$",     parsePattern("foo_%_bar", ESCAPE).pattern())
+     *   assertEquals("^\\Qfoo\\E.{2,}?\\Qbar\\E$",     parsePattern("foo_%_%bar", ESCAPE).pattern())
+     *   assertEquals("^\\Qfoo\\E.{2,}?\\Qbar\\E$",     parsePattern("foo%_%%_%bar", ESCAPE).pattern())
+     * ```
+     *
+     *
+     * @see java.util.regex.Pattern
+     */
+    internal fun parsePattern(likePattern: String, escapeChar: Int?): Pattern {
+        val buf = StringBuilder(likePattern.length + PATTERN_ADDITIONAL_BUFFER)
+        buf.append("^")
+
+        var isEscaped = false
+        var wildcardMin = -1
+        var wildcardUnbounded = false
+        val literal = StringBuilder()
+
+        // If a wildcard (e.g. a sequence of '%' and '_') has been accumulated, write out the regex equivalent
+        val flushWildcard = {
+            if (wildcardMin != -1) {
+                if (wildcardUnbounded) {
+                    when (wildcardMin) {
+                        0 -> buf.append(".*?")
+                        1 -> buf.append(".+?")
+                        else -> buf.append(".{$wildcardMin,}?")
+                    }
+                } else {
+                    when (wildcardMin) {
+                        1 -> buf.append(".")
+                        else -> buf.append(".{$wildcardMin,$wildcardMin}")
+                    }
+                }
+                wildcardMin = -1
+                wildcardUnbounded = false
+            }
+        }
+
+        // if a literal has been accumulated, write it out, regex-quoted
+        val flushLiteral = {
+            if (literal.isNotEmpty()) {
+                buf.append(Pattern.quote(literal.toString()))
+                literal.clear()
+            }
+        }
+
+        for (codepoint in likePattern.codePoints()) {
+            if (!isEscaped) {
+                if (codepoint == escapeChar) {
+                    isEscaped = true
+                    continue // skip to the next codepoint
+                }
+                when (codepoint) {
+                    ANY_ONE -> {
+                        flushLiteral()
+                        wildcardMin = maxOf(wildcardMin, 0) + 1
+                    }
+
+                    ANY_MANY -> {
+                        flushLiteral()
+                        wildcardMin = maxOf(wildcardMin, 0)
+                        wildcardUnbounded = true
+                    }
+
+                    else -> {
+                        flushWildcard()
+                        literal.appendCodePoint(codepoint)
+                    }
+                }
+            } else {
+                flushWildcard()
+                literal.appendCodePoint(codepoint)
+                isEscaped = false
+            }
+        }
+
+        flushLiteral()
+        flushWildcard()
+
+        buf.append("$")
+        return Pattern.compile(buf.toString())
     }
 }

--- a/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnLikeEscape.kt
+++ b/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnLikeEscape.kt
@@ -13,6 +13,8 @@ import org.partiql.value.PartiQLValueType.BOOL
 import org.partiql.value.PartiQLValueType.CLOB
 import org.partiql.value.PartiQLValueType.STRING
 import org.partiql.value.PartiQLValueType.SYMBOL
+import org.partiql.value.StringValue
+import org.partiql.value.check
 
 @OptIn(PartiQLValueExperimental::class, PartiQLFunctionExperimental::class)
 internal object Fn_LIKE_ESCAPE__STRING_STRING_STRING__BOOL : PartiQLFunction.Scalar {
@@ -30,7 +32,11 @@ internal object Fn_LIKE_ESCAPE__STRING_STRING_STRING__BOOL : PartiQLFunction.Sca
     )
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
-        TODO("Function like_escape not implemented")
+        val value = args[0].check<StringValue>()
+        val pattern = args[1].check<StringValue>()
+        val escape = args[2].check<StringValue>()
+        val pps = LikeUtils.getRegexPattern(pattern, escape)
+        return LikeUtils.matchRegexPattern(value, pps)
     }
 }
 

--- a/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnLower.kt
+++ b/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnLower.kt
@@ -31,7 +31,7 @@ internal object Fn_LOWER__STRING__STRING : PartiQLFunction.Scalar {
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
         val string = args[0].check<StringValue>().string
-        val result = string?.uppercase()
+        val result = string?.lowercase()
         return stringValue(result)
     }
 }
@@ -49,7 +49,7 @@ internal object Fn_LOWER__SYMBOL__SYMBOL : PartiQLFunction.Scalar {
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
         val string = args[0].check<SymbolValue>().string
-        val result = string?.uppercase()
+        val result = string?.lowercase()
         return stringValue(result)
     }
 }
@@ -67,7 +67,7 @@ internal object Fn_LOWER__CLOB__CLOB : PartiQLFunction.Scalar {
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
         val string = args[0].check<ClobValue>().string
-        val result = string?.uppercase()
+        val result = string?.lowercase()
         return stringValue(result)
     }
 }

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/EvalExecutor.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/EvalExecutor.kt
@@ -11,6 +11,7 @@ import org.partiql.eval.PartiQLEngine
 import org.partiql.eval.PartiQLResult
 import org.partiql.eval.PartiQLStatement
 import org.partiql.lang.eval.CompileOptions
+import org.partiql.lang.eval.TypingMode
 import org.partiql.parser.PartiQLParser
 import org.partiql.planner.PartiQLPlanner
 import org.partiql.plugin.PartiQLPlugin
@@ -120,6 +121,10 @@ class EvalExecutor(
                     })
                 )
             )
+            val mode = when (options.typingMode) {
+                TypingMode.PERMISSIVE -> PartiQLEngine.Mode.PERMISSIVE
+                TypingMode.LEGACY -> PartiQLEngine.Mode.STRICT
+            }
 
             val evalSession = PartiQLEngine.Session(
                 bindings = mutableMapOf(
@@ -127,7 +132,8 @@ class EvalExecutor(
                 ),
                 functions = mutableMapOf(
                     "partiql" to PartiQLPlugin.functions
-                )
+                ),
+                mode = mode
             )
             return EvalExecutor(session, evalSession)
         }


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds support for PERMISSIVE vs STRICT
- In short, this implementation attempts to reduce as much computation/checking as possible. In STRICT mode, we never attempt to recover from a TypeCheckException. In Permissive mode, given that MISSING represents a type-check exception and is largely propagated through operations, we attempt to catch TypeCheckExceptions as infrequently as possible (only when we need to). We specifically catch the errors (according to the specification) when:
  - the value of an attribute in a struct results in a TypeCheckException.
  - an element in an array results in a TypeCheckException
  - creating the elements of a SELECT VALUE (AKA the constructor results in a TypeCheckException)
  - when the inputs to a function (that takes in ANY/MISSING) results in a TypeCheckException
  - top-level expressions (AKA under StatementQuery)
- There are also multiple scenarios specified in the PartiQL Specification that handle mistyping cases that are edge-cases. For example: Iteration over a scalar value, iteration over an absent value, iteration over a tuple value, position variable on bags, out-of-bounds indexing, and more. In these scenarios, this implementation occasionally attempts to mitigate as many runtime checks as possible by compiling the nodes to permissive-specific nodes. See `RelScanPermissive` for example.
- This PR also adds support for `LIKE` by copying much of the logic from EvaluatingCompiler. If requested, I can remove these additions and include them in a separate PR.

## Testing
- This PR follows the specification to find guidance on when to use MISSING and when to error. See the naming of tests to see the relevant PartiQL Specification sections.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.