### PR TITLE
Support Cast In Eval Engine

### DIFF
--- a/partiql-cli/src/main/kotlin/org/partiql/cli/utils/ServiceLoaderUtil.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/utils/ServiceLoaderUtil.kt
@@ -42,12 +42,8 @@ import org.partiql.value.DateValue
 import org.partiql.value.DecimalValue
 import org.partiql.value.Float32Value
 import org.partiql.value.Float64Value
-import org.partiql.value.Int16Value
-import org.partiql.value.Int32Value
-import org.partiql.value.Int64Value
-import org.partiql.value.Int8Value
-import org.partiql.value.IntValue
 import org.partiql.value.ListValue
+import org.partiql.value.NumericValue
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.PartiQLValueType
@@ -185,23 +181,16 @@ class ServiceLoaderUtil {
                 PartiQLValueType.BOOL -> (partiqlValue as? BoolValue)?.value?.let { newBoolean(it) }
                     ?: ExprValue.nullValue
 
-                PartiQLValueType.INT8 -> (partiqlValue as? Int8Value)?.int?.let { newInt(it) } ?: ExprValue.nullValue
-
-                PartiQLValueType.INT16 -> (partiqlValue as? Int16Value)?.int?.let { newInt(it) } ?: ExprValue.nullValue
-
-                PartiQLValueType.INT32 -> (partiqlValue as? Int32Value)?.int?.let { newInt(it) } ?: ExprValue.nullValue
-
-                PartiQLValueType.INT64 -> (partiqlValue as? Int64Value)?.long?.let { newInt(it) } ?: ExprValue.nullValue
-
-                PartiQLValueType.INT -> (partiqlValue as? IntValue)?.long?.let { newInt(it) } ?: ExprValue.nullValue
+                PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32,
+                PartiQLValueType.INT64, PartiQLValueType.INT -> (partiqlValue as? NumericValue<*>)?.toInt64()?.value?.let { newInt(it) } ?: ExprValue.nullValue
 
                 PartiQLValueType.DECIMAL_ARBITRARY -> (partiqlValue as? DecimalValue)?.value?.let { newDecimal(it) }
                     ?: ExprValue.nullValue
 
-                PartiQLValueType.FLOAT32 -> (partiqlValue as? Float32Value)?.double?.let { newFloat(it) }
+                PartiQLValueType.FLOAT32 -> (partiqlValue as? Float32Value)?.toFloat64()?.value?.let { newFloat(it) }
                     ?: ExprValue.nullValue
 
-                PartiQLValueType.FLOAT64 -> (partiqlValue as? Float64Value)?.double?.let { newFloat(it) }
+                PartiQLValueType.FLOAT64 -> (partiqlValue as? Float64Value)?.value?.let { newFloat(it) }
                     ?: ExprValue.nullValue
 
                 PartiQLValueType.CHAR -> (partiqlValue as? CharValue)?.string?.let { newString(it) }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -16,6 +16,7 @@ import org.partiql.eval.internal.operator.rel.RelScanPermissive
 import org.partiql.eval.internal.operator.rex.ExprCallDynamic
 import org.partiql.eval.internal.operator.rex.ExprCallStatic
 import org.partiql.eval.internal.operator.rex.ExprCase
+import org.partiql.eval.internal.operator.rex.ExprCastOp
 import org.partiql.eval.internal.operator.rex.ExprCollection
 import org.partiql.eval.internal.operator.rex.ExprGlobal
 import org.partiql.eval.internal.operator.rex.ExprLiteral
@@ -160,7 +161,7 @@ internal class Compiler @OptIn(PartiQLFunctionExperimental::class) constructor(
         val args = node.args.map { visitRex(it, ctx).modeHandled() }.toTypedArray()
         val candidates = node.candidates.map { candidate ->
             val fn = getFunction(candidate.fn.signature)
-            val coercions = candidate.coercions.map { it?.signature?.let { sig -> getFunction(sig) } }
+            val coercions = candidate.coercions
             ExprCallDynamic.Candidate(candidate.parameters.toTypedArray(), fn, coercions)
         }
         return ExprCallDynamic(candidates, args)
@@ -232,6 +233,10 @@ internal class Compiler @OptIn(PartiQLFunctionExperimental::class) constructor(
         }
         val default = visitRex(node.default, ctx)
         return ExprCase(branches, default)
+    }
+
+    override fun visitRexOpCastOp(node: Rex.Op.CastOp, ctx: Unit): Operator {
+        return ExprCastOp(visitRex(node.arg, ctx), node.cast)
     }
 
     @OptIn(PartiQLValueExperimental::class)

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCastOp.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCastOp.kt
@@ -1,0 +1,354 @@
+package org.partiql.eval.internal.operator.rex
+
+import com.amazon.ion.Decimal
+import com.amazon.ionelement.api.ElementType
+import com.amazon.ionelement.api.IonElementException
+import com.amazon.ionelement.api.createIonElementLoader
+import org.partiql.errors.DataException
+import org.partiql.errors.TypeCheckException
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.plan.Cast
+import org.partiql.value.BagValue
+import org.partiql.value.BoolValue
+import org.partiql.value.CollectionValue
+import org.partiql.value.DecimalValue
+import org.partiql.value.Float32Value
+import org.partiql.value.Float64Value
+import org.partiql.value.Int16Value
+import org.partiql.value.Int32Value
+import org.partiql.value.Int64Value
+import org.partiql.value.Int8Value
+import org.partiql.value.IntValue
+import org.partiql.value.ListValue
+import org.partiql.value.NumericValue
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.PartiQLValueType
+import org.partiql.value.SexpValue
+import org.partiql.value.StringValue
+import org.partiql.value.SymbolValue
+import org.partiql.value.TextValue
+import org.partiql.value.bagValue
+import org.partiql.value.boolValue
+import org.partiql.value.decimalValue
+import org.partiql.value.float32Value
+import org.partiql.value.float64Value
+import org.partiql.value.int16Value
+import org.partiql.value.int32Value
+import org.partiql.value.int64Value
+import org.partiql.value.int8Value
+import org.partiql.value.intValue
+import org.partiql.value.listValue
+import org.partiql.value.sexpValue
+import org.partiql.value.stringValue
+import org.partiql.value.symbolValue
+import java.math.BigDecimal
+import java.math.BigInteger
+
+// TODO: This is incomplete
+internal class ExprCastOp(val arg: Operator.Expr, val cast: Cast) : Operator.Expr {
+    @OptIn(PartiQLValueExperimental::class)
+    override fun eval(record: Record): PartiQLValue {
+        val arg = arg.eval(record)
+        try {
+            return when (arg.type) {
+                PartiQLValueType.ANY -> TODO("Not Possible")
+                PartiQLValueType.BOOL -> castFromBool(arg as BoolValue, cast.target)
+                PartiQLValueType.INT8 -> castFromNumeric(arg as Int8Value, cast.target)
+                PartiQLValueType.INT16 -> castFromNumeric(arg as Int16Value, cast.target)
+                PartiQLValueType.INT32 -> castFromNumeric(arg as Int32Value, cast.target)
+                PartiQLValueType.INT64 -> castFromNumeric(arg as Int64Value, cast.target)
+                PartiQLValueType.INT -> castFromNumeric(arg as IntValue, cast.target)
+                PartiQLValueType.DECIMAL -> castFromNumeric(arg as DecimalValue, cast.target)
+                PartiQLValueType.DECIMAL_ARBITRARY -> castFromNumeric(arg as DecimalValue, cast.target)
+                PartiQLValueType.FLOAT32 -> castFromNumeric(arg as Float32Value, cast.target)
+                PartiQLValueType.FLOAT64 -> castFromNumeric(arg as Float64Value, cast.target)
+                PartiQLValueType.CHAR -> TODO("Char value implementation is wrong")
+                PartiQLValueType.STRING -> castFromText(arg as StringValue, cast.target)
+                PartiQLValueType.SYMBOL -> castFromText(arg as SymbolValue, cast.target)
+                PartiQLValueType.BINARY -> TODO("Static Type does not support Binary")
+                PartiQLValueType.BYTE -> TODO("Static Type does not support Byte")
+                PartiQLValueType.BLOB -> TODO("CAST FROM BLOB not yet implemented")
+                PartiQLValueType.CLOB -> TODO("CAST FROM CLOB not yet implemented")
+                PartiQLValueType.DATE -> TODO("CAST FROM DATE not yet implemented")
+                PartiQLValueType.TIME -> TODO("CAST FROM TIME not yet implemented")
+                PartiQLValueType.TIMESTAMP -> TODO("CAST FROM TIMESTAMP not yet implemented")
+                PartiQLValueType.INTERVAL -> TODO("Static Type does not support INTERVAL")
+                PartiQLValueType.BAG -> castFromCollection(arg as BagValue<*>, cast.target)
+                PartiQLValueType.LIST -> castFromCollection(arg as ListValue<*>, cast.target)
+                PartiQLValueType.SEXP -> castFromCollection(arg as SexpValue<*>, cast.target)
+                PartiQLValueType.STRUCT -> TODO("CAST FROM STRUCT not yet implemented")
+                PartiQLValueType.NULL -> error("cast from NULL should be handled by Typer")
+                PartiQLValueType.MISSING -> error("cast from MISSING should be handled by Typer")
+            }
+        } catch (e: DataException) {
+            throw TypeCheckException()
+        }
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    private fun castFromBool(value: BoolValue, t: PartiQLValueType): PartiQLValue {
+        val v = value.value
+        return when (t) {
+            PartiQLValueType.ANY -> value
+            PartiQLValueType.BOOL -> value
+            PartiQLValueType.INT8 -> when (v) {
+                true -> int8Value(1)
+                false -> int8Value(0)
+                null -> int8Value(null)
+            }
+
+            PartiQLValueType.INT16 -> when (v) {
+                true -> int16Value(1)
+                false -> int16Value(0)
+                null -> int16Value(null)
+            }
+
+            PartiQLValueType.INT32 -> when (v) {
+                true -> int32Value(1)
+                false -> int32Value(0)
+                null -> int32Value(null)
+            }
+
+            PartiQLValueType.INT64 -> when (v) {
+                true -> int64Value(1)
+                false -> int64Value(0)
+                null -> int64Value(null)
+            }
+
+            PartiQLValueType.INT -> when (v) {
+                true -> intValue(BigInteger.valueOf(1))
+                false -> intValue(BigInteger.valueOf(0))
+                null -> intValue(null)
+            }
+
+            PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY -> when (v) {
+                true -> decimalValue(BigDecimal.ONE)
+                false -> decimalValue(BigDecimal.ZERO)
+                null -> decimalValue(null)
+            }
+
+            PartiQLValueType.FLOAT32 -> {
+                when (v) {
+                    true -> float32Value(1.0.toFloat())
+                    false -> float32Value(0.0.toFloat())
+                    null -> float32Value(null)
+                }
+            }
+
+            PartiQLValueType.FLOAT64 -> when (v) {
+                true -> float64Value(1.0)
+                false -> float64Value(0.0)
+                null -> float64Value(null)
+            }
+
+            PartiQLValueType.CHAR -> TODO("Char value implementation is wrong")
+            PartiQLValueType.STRING -> stringValue(v?.toString())
+            PartiQLValueType.SYMBOL -> symbolValue(v?.toString())
+            PartiQLValueType.BINARY, PartiQLValueType.BYTE,
+            PartiQLValueType.BLOB, PartiQLValueType.CLOB,
+            PartiQLValueType.DATE, PartiQLValueType.TIME, PartiQLValueType.TIMESTAMP,
+            PartiQLValueType.INTERVAL,
+            PartiQLValueType.BAG, PartiQLValueType.LIST,
+            PartiQLValueType.SEXP,
+            PartiQLValueType.STRUCT -> error("can not perform cast from $value to $t")
+            PartiQLValueType.NULL -> error("cast to null not supported")
+            PartiQLValueType.MISSING -> error("cast to missing not supported")
+        }
+    }
+    @OptIn(PartiQLValueExperimental::class)
+    private fun castFromNumeric(value: NumericValue<*>, t: PartiQLValueType): PartiQLValue {
+        val v = value.value
+        return when (t) {
+            PartiQLValueType.ANY -> value
+            PartiQLValueType.BOOL -> when {
+                v == null -> boolValue(null)
+                v == 0.0 -> boolValue(false)
+                else -> boolValue(true)
+            }
+            PartiQLValueType.INT8 -> value.toInt8()
+            PartiQLValueType.INT16 -> value.toInt16()
+            PartiQLValueType.INT32 -> value.toInt32()
+            PartiQLValueType.INT64 -> value.toInt64()
+            PartiQLValueType.INT -> value.toInt()
+            PartiQLValueType.DECIMAL -> value.toDecimal()
+            PartiQLValueType.DECIMAL_ARBITRARY -> value.toDecimal()
+            PartiQLValueType.FLOAT32 -> value.toFloat32()
+            PartiQLValueType.FLOAT64 -> value.toFloat64()
+            PartiQLValueType.CHAR -> TODO("Char value implementation is wrong")
+            PartiQLValueType.STRING -> stringValue(v?.toString(), value.annotations)
+            PartiQLValueType.SYMBOL -> symbolValue(v?.toString(), value.annotations)
+            PartiQLValueType.BINARY, PartiQLValueType.BYTE,
+            PartiQLValueType.BLOB, PartiQLValueType.CLOB,
+            PartiQLValueType.DATE, PartiQLValueType.TIME, PartiQLValueType.TIMESTAMP,
+            PartiQLValueType.INTERVAL,
+            PartiQLValueType.BAG, PartiQLValueType.LIST,
+            PartiQLValueType.SEXP,
+            PartiQLValueType.STRUCT -> error("can not perform cast from $value to $t")
+            PartiQLValueType.NULL -> error("cast to null not supported")
+            PartiQLValueType.MISSING -> error("cast to missing not supported")
+        }
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    private fun castFromText(value: TextValue<String>, t: PartiQLValueType): PartiQLValue {
+        return when (t) {
+            PartiQLValueType.ANY -> value
+            PartiQLValueType.BOOL -> {
+                val str = value.value?.lowercase() ?: return boolValue(null, value.annotations)
+                if (str == "true") return boolValue(true, value.annotations)
+                if (str == "false") return boolValue(false, value.annotations)
+                throw TypeCheckException()
+            }
+            PartiQLValueType.INT8 -> {
+                val stringValue = value.value ?: return int8Value(null, value.annotations)
+                when (val number = getNumberValueFromString(stringValue)) {
+                    is BigInteger -> intValue(number, value.annotations).toInt8()
+                    else -> throw TypeCheckException()
+                }
+            }
+            PartiQLValueType.INT16 -> {
+                val stringValue = value.value ?: return int16Value(null, value.annotations)
+                when (val number = getNumberValueFromString(stringValue)) {
+                    is BigInteger -> intValue(number, value.annotations).toInt16()
+                    else -> throw TypeCheckException()
+                }
+            }
+            PartiQLValueType.INT32 -> {
+                val stringValue = value.value ?: return int32Value(null, value.annotations)
+                when (val number = getNumberValueFromString(stringValue)) {
+                    is BigInteger -> intValue(number, value.annotations).toInt32()
+                    else -> throw TypeCheckException()
+                }
+            }
+            PartiQLValueType.INT64 -> {
+                val stringValue = value.value ?: return int64Value(null, value.annotations)
+                when (val number = getNumberValueFromString(stringValue)) {
+                    is BigInteger -> intValue(number, value.annotations).toInt64()
+                    else -> throw TypeCheckException()
+                }
+            }
+            PartiQLValueType.INT -> {
+                val stringValue = value.value ?: return intValue(null, value.annotations)
+                when (val number = getNumberValueFromString(stringValue)) {
+                    is BigInteger -> intValue(number, value.annotations).toInt()
+                    else -> throw TypeCheckException()
+                }
+            }
+            PartiQLValueType.DECIMAL -> {
+                val stringValue = value.value ?: return int16Value(null, value.annotations)
+                when (val number = getNumberValueFromString(stringValue)) {
+                    is Decimal -> decimalValue(number, value.annotations).toDecimal()
+                    else -> throw TypeCheckException()
+                }
+            }
+            PartiQLValueType.DECIMAL_ARBITRARY -> {
+                val stringValue = value.value ?: return int16Value(null, value.annotations)
+                when (val number = getNumberValueFromString(stringValue)) {
+                    is Decimal -> decimalValue(number, value.annotations).toDecimal()
+                    else -> throw TypeCheckException()
+                }
+            }
+            PartiQLValueType.FLOAT32 -> {
+                val stringValue = value.value ?: return int16Value(null, value.annotations)
+                when (val number = getNumberValueFromString(stringValue)) {
+                    is Double -> float64Value(number, value.annotations).toFloat32()
+                    else -> throw TypeCheckException()
+                }
+            }
+            PartiQLValueType.FLOAT64 -> {
+                val stringValue = value.value ?: return int16Value(null, value.annotations)
+                when (val number = getNumberValueFromString(stringValue)) {
+                    is Double -> float64Value(number, value.annotations).toFloat32()
+                    else -> throw TypeCheckException()
+                }
+            }
+            PartiQLValueType.CHAR -> TODO("Char value implementation is wrong")
+            PartiQLValueType.STRING -> stringValue(value.value, value.annotations)
+            PartiQLValueType.SYMBOL -> symbolValue(value.value, value.annotations)
+            PartiQLValueType.BINARY, PartiQLValueType.BYTE,
+            PartiQLValueType.BLOB, PartiQLValueType.CLOB,
+            PartiQLValueType.DATE, PartiQLValueType.TIME, PartiQLValueType.TIMESTAMP,
+            PartiQLValueType.INTERVAL,
+            PartiQLValueType.BAG, PartiQLValueType.LIST,
+            PartiQLValueType.SEXP,
+            PartiQLValueType.STRUCT -> error("can not perform cast from INT8 to $t")
+            PartiQLValueType.NULL -> error("cast to null not supported")
+            PartiQLValueType.MISSING -> error("cast to missing not supported")
+        }
+    }
+
+    // TODO: Fix NULL Collection
+    @OptIn(PartiQLValueExperimental::class)
+    private fun castFromCollection(value: CollectionValue<*>, t: PartiQLValueType): PartiQLValue {
+        val elements = mutableListOf<PartiQLValue>()
+        value.iterator().forEachRemaining {
+            elements.add(it)
+        }
+        return when (t) {
+            PartiQLValueType.BAG -> bagValue(elements)
+            PartiQLValueType.LIST -> listValue(elements)
+            PartiQLValueType.SEXP -> sexpValue(elements)
+            else -> error("can not perform cast from $value to $t")
+        }
+    }
+
+    // For now, utilize ion to parse string such as 0b10, etc.
+    private fun getNumberValueFromString(str: String): Number? {
+        val ion = try {
+            str.let { createIonElementLoader().loadSingleElement(it.normalizeForCastToInt()) }
+        } catch (e: IonElementException) {
+            throw TypeCheckException()
+        }
+        return when (ion.type) {
+            ElementType.INT -> ion.bigIntegerValueOrNull
+            ElementType.FLOAT -> ion.doubleValueOrNull
+            ElementType.DECIMAL -> ion.decimalValueOrNull
+            else -> null
+        }
+    }
+
+    private fun String.normalizeForCastToInt(): String {
+        fun Char.isSign() = this == '-' || this == '+'
+        fun Char.isHexOrBase2Marker(): Boolean {
+            val c = this.lowercaseChar()
+
+            return c == 'x' || c == 'b'
+        }
+
+        fun String.possiblyHexOrBase2() = (length >= 2 && this[1].isHexOrBase2Marker()) ||
+            (length >= 3 && this[0].isSign() && this[2].isHexOrBase2Marker())
+
+        return when {
+            length == 0 -> this
+            possiblyHexOrBase2() -> {
+                if (this[0] == '+') {
+                    this.drop(1)
+                } else {
+                    this
+                }
+            }
+            else -> {
+                val (isNegative, startIndex) = when (this[0]) {
+                    '-' -> Pair(true, 1)
+                    '+' -> Pair(false, 1)
+                    else -> Pair(false, 0)
+                }
+
+                var toDrop = startIndex
+                while (toDrop < length && this[toDrop] == '0') {
+                    toDrop += 1
+                }
+
+                when {
+                    toDrop == length -> "0" // string is all zeros
+                    toDrop == 0 -> this
+                    toDrop == 1 && isNegative -> this
+                    toDrop > 1 && isNegative -> '-' + this.drop(toDrop)
+                    else -> this.drop(toDrop)
+                }
+            }
+        }
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathIndex.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathIndex.kt
@@ -1,5 +1,6 @@
 package org.partiql.eval.internal.operator.rex
 
+import org.partiql.errors.DataException
 import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
@@ -9,6 +10,7 @@ import org.partiql.value.Int32Value
 import org.partiql.value.Int64Value
 import org.partiql.value.Int8Value
 import org.partiql.value.IntValue
+import org.partiql.value.NumericValue
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.check
@@ -24,11 +26,15 @@ internal class ExprPathIndex(
 
         // Calculate index
         val index = when (val k = key.eval(record)) {
-            is Int16Value -> k.int
-            is Int32Value -> k.int
-            is Int64Value -> k.int
-            is Int8Value -> k.int
-            is IntValue -> k.int
+            is Int16Value,
+            is Int32Value,
+            is Int64Value,
+            is Int8Value,
+            is IntValue -> try {
+                (k as NumericValue<*>).toInt32().value
+            } catch (e: DataException) {
+                throw TypeCheckException()
+            }
             else -> throw TypeCheckException()
         } ?: throw TypeCheckException()
 

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/impl/PartiQLParserDefault.kt
@@ -853,7 +853,7 @@ internal class PartiQLParserDefault : PartiQLParser {
                 throw error(ctx, "Expected a path element literal")
             }
             when (val i = v.value) {
-                is NumericValue<*> -> pathStepIndex(i.int!!)
+                is NumericValue<*> -> pathStepIndex(i.toInt32().value!!)
                 is StringValue -> pathStepSymbol(
                     identifierSymbol(
                         i.value!!, Identifier.CaseSensitivity.SENSITIVE

--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -37,6 +37,18 @@ catalog::{
   ]
 }
 
+// System level cast table.
+// We currently do not allow custom override to the cast table
+cast::{
+  operand: partiql_value_type, // operand is a value.
+  target: partiql_value_type, // TODO: Consider change this to Static Type
+  cast_type: cast_type::[
+    COERCION,
+    EXPLICIT,
+    UNSAFE
+  ],
+}
+
 // Functions
 
 fn::{
@@ -102,6 +114,11 @@ rex::{
       symbol::{ root: rex, key: string },
     ],
 
+    cast_op::{
+      arg: rex,
+      cast: cast
+    },
+
     call::[
       static::{
         fn: fn,
@@ -127,7 +144,7 @@ rex::{
           candidate::{
             fn: fn,
             parameters: list::[partiql_value_type],
-            coercions: list::[optional::fn]
+            coercions: list::[optional::cast]
           }
         ]
       }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Plan.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Plan.kt
@@ -23,6 +23,9 @@ internal fun catalogSymbol(path: List<String>, type: StaticType): Catalog.Symbol
 internal fun catalogSymbolRef(catalog: Int, symbol: Int): Catalog.Symbol.Ref =
     Catalog.Symbol.Ref(catalog, symbol)
 
+internal fun cast(operand: PartiQLValueType, target: PartiQLValueType, castType: Cast.CastType) =
+    Cast(operand, target, castType)
+
 internal fun fnResolved(signature: FunctionSignature.Scalar): Fn.Resolved = Fn.Resolved(signature)
 
 internal fun fnUnresolved(identifier: Identifier, isHidden: Boolean): Fn.Unresolved =
@@ -73,7 +76,7 @@ internal fun rexOpCallDynamic(args: List<Rex>, candidates: List<Rex.Op.Call.Dyna
 internal fun rexOpCallDynamicCandidate(
     fn: Fn,
     parameters: List<PartiQLValueType>,
-    coercions: List<Fn?>,
+    coercions: List<Cast?>,
 ): Rex.Op.Call.Dynamic.Candidate = Rex.Op.Call.Dynamic.Candidate(fn, parameters, coercions)
 
 internal fun rexOpCase(branches: List<Rex.Op.Case.Branch>, default: Rex): Rex.Op.Case =
@@ -81,6 +84,9 @@ internal fun rexOpCase(branches: List<Rex.Op.Case.Branch>, default: Rex): Rex.Op
 
 internal fun rexOpCaseBranch(condition: Rex, rex: Rex): Rex.Op.Case.Branch =
     Rex.Op.Case.Branch(condition, rex)
+
+internal fun rexOpCastOp(arg: Rex, cast: Cast): Rex.Op.CastOp =
+    Rex.Op.CastOp(arg, cast)
 
 internal fun rexOpCollection(values: List<Rex>): Rex.Op.Collection = Rex.Op.Collection(values)
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilder.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilder.kt
@@ -3,6 +3,7 @@
 package org.partiql.planner.internal.ir.builder
 
 import org.partiql.planner.internal.ir.Agg
+import org.partiql.planner.internal.ir.Cast
 import org.partiql.planner.internal.ir.Catalog
 import org.partiql.planner.internal.ir.Fn
 import org.partiql.planner.internal.ir.Identifier
@@ -58,6 +59,17 @@ internal class PlanBuilder {
         block: CatalogSymbolRefBuilder.() -> Unit = {},
     ): Catalog.Symbol.Ref {
         val builder = CatalogSymbolRefBuilder(catalog, symbol)
+        builder.block()
+        return builder.build()
+    }
+
+    internal fun cast(
+        operand: PartiQLValueType? = null,
+        target: PartiQLValueType? = null,
+        castType: Cast.CastType? = null,
+        block: CastBuilder.() -> Unit = {},
+    ): Cast {
+        val builder = CastBuilder(operand, target, castType)
         builder.block()
         return builder.build()
     }
@@ -224,7 +236,7 @@ internal class PlanBuilder {
     internal fun rexOpCallDynamicCandidate(
         fn: Fn? = null,
         parameters: MutableList<PartiQLValueType> = mutableListOf(),
-        coercions: MutableList<Fn?> = mutableListOf(),
+        coercions: MutableList<Cast?> = mutableListOf(),
         block: RexOpCallDynamicCandidateBuilder.() -> Unit = {},
     ): Rex.Op.Call.Dynamic.Candidate {
         val builder = RexOpCallDynamicCandidateBuilder(fn, parameters, coercions)
@@ -248,6 +260,16 @@ internal class PlanBuilder {
         block: RexOpCaseBranchBuilder.() -> Unit = {},
     ): Rex.Op.Case.Branch {
         val builder = RexOpCaseBranchBuilder(condition, rex)
+        builder.block()
+        return builder.build()
+    }
+
+    internal fun rexOpCastOp(
+        arg: Rex? = null,
+        cast: Cast? = null,
+        block: RexOpCastOpBuilder.() -> Unit = {},
+    ): Rex.Op.CastOp {
+        val builder = RexOpCastOpBuilder(arg, cast)
         builder.block()
         return builder.build()
     }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilders.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/builder/PlanBuilders.kt
@@ -3,6 +3,7 @@
 package org.partiql.planner.internal.ir.builder
 
 import org.partiql.planner.internal.ir.Agg
+import org.partiql.planner.internal.ir.Cast
 import org.partiql.planner.internal.ir.Catalog
 import org.partiql.planner.internal.ir.Fn
 import org.partiql.planner.internal.ir.Identifier
@@ -87,6 +88,30 @@ internal class CatalogSymbolRefBuilder(
         catalog = catalog!!,
         symbol =
         symbol!!
+    )
+}
+
+internal class CastBuilder(
+    internal var operand: PartiQLValueType? = null,
+    internal var target: PartiQLValueType? = null,
+    internal var castType: Cast.CastType? = null
+) {
+    internal fun operand(operand: PartiQLValueType?): CastBuilder = this.apply {
+        this.operand = operand
+    }
+
+    internal fun target(target: PartiQLValueType?): CastBuilder = this.apply {
+        this.target = target
+    }
+
+    internal fun castType(castType: Cast.CastType?): CastBuilder = this.apply {
+        this.castType = castType
+    }
+
+    internal fun build(): Cast = Cast(
+        operand = operand!!,
+        target = target!!,
+        castType = castType!!
     )
 }
 
@@ -333,7 +358,7 @@ internal class RexOpCallDynamicBuilder(
 internal class RexOpCallDynamicCandidateBuilder(
     internal var fn: Fn? = null,
     internal var parameters: MutableList<PartiQLValueType> = mutableListOf(),
-    internal var coercions: MutableList<Fn?> = mutableListOf(),
+    internal var coercions: MutableList<Cast?> = mutableListOf(),
 ) {
     internal fun fn(fn: Fn?): RexOpCallDynamicCandidateBuilder = this.apply {
         this.fn = fn
@@ -344,7 +369,7 @@ internal class RexOpCallDynamicCandidateBuilder(
             this.parameters = parameters
         }
 
-    internal fun coercions(coercions: MutableList<Fn?>): RexOpCallDynamicCandidateBuilder = this.apply {
+    internal fun coercions(coercions: MutableList<Cast?>): RexOpCallDynamicCandidateBuilder = this.apply {
         this.coercions = coercions
     }
 
@@ -382,6 +407,21 @@ internal class RexOpCaseBranchBuilder(
     }
 
     internal fun build(): Rex.Op.Case.Branch = Rex.Op.Case.Branch(condition = condition!!, rex = rex!!)
+}
+
+internal class RexOpCastOpBuilder(
+    internal var arg: Rex? = null,
+    internal var cast: Cast? = null
+) {
+    internal fun arg(arg: Rex?): RexOpCastOpBuilder = this.apply {
+        this.arg = arg
+    }
+
+    internal fun cast(cast: Cast): RexOpCastOpBuilder = this.apply {
+        this.cast = cast
+    }
+
+    internal fun build(): Rex.Op.CastOp = Rex.Op.CastOp(arg!!, cast!!)
 }
 
 internal class RexOpCollectionBuilder(

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/util/PlanRewriter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/util/PlanRewriter.kt
@@ -266,7 +266,7 @@ internal abstract class PlanRewriter<C> : PlanBaseVisitor<PlanNode, C>() {
         PlanNode {
         val fn = visitFn(node.fn, ctx) as Fn
         val parameters = node.parameters
-        val coercions = _visitListNull(node.coercions, ctx, ::visitFn)
+        val coercions = _visitListNull(node.coercions, ctx, ::visitCast)
         return if (fn !== node.fn || parameters !== node.parameters || coercions !== node.coercions) {
             Rex.Op.Call.Dynamic.Candidate(fn, parameters, coercions)
         } else {

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/visitor/PlanBaseVisitor.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/visitor/PlanBaseVisitor.kt
@@ -3,6 +3,7 @@
 package org.partiql.planner.internal.ir.visitor
 
 import org.partiql.planner.internal.ir.Agg
+import org.partiql.planner.internal.ir.Cast
 import org.partiql.planner.internal.ir.Catalog
 import org.partiql.planner.internal.ir.Fn
 import org.partiql.planner.internal.ir.Identifier
@@ -18,12 +19,14 @@ internal abstract class PlanBaseVisitor<R, C> : PlanVisitor<R, C> {
 
     override fun visitPartiQLPlan(node: PartiQLPlan, ctx: C): R = defaultVisit(node, ctx)
 
-    public override fun visitCatalog(node: Catalog, ctx: C): R = defaultVisit(node, ctx)
+    override fun visitCatalog(node: Catalog, ctx: C): R = defaultVisit(node, ctx)
 
-    public override fun visitCatalogSymbol(node: Catalog.Symbol, ctx: C): R = defaultVisit(node, ctx)
+    override fun visitCatalogSymbol(node: Catalog.Symbol, ctx: C): R = defaultVisit(node, ctx)
 
-    public override fun visitCatalogSymbolRef(node: Catalog.Symbol.Ref, ctx: C): R =
+    override fun visitCatalogSymbolRef(node: Catalog.Symbol.Ref, ctx: C): R =
         defaultVisit(node, ctx)
+
+    override fun visitCast(node: Cast, ctx: C): R = defaultVisit(node, ctx)
 
     override fun visitFn(node: Fn, ctx: C): R = when (node) {
         is Fn.Resolved -> visitFnResolved(node, ctx)
@@ -74,6 +77,7 @@ internal abstract class PlanBaseVisitor<R, C> : PlanVisitor<R, C> {
         is Rex.Op.Path -> visitRexOpPath(node, ctx)
         is Rex.Op.Call -> visitRexOpCall(node, ctx)
         is Rex.Op.Case -> visitRexOpCase(node, ctx)
+        is Rex.Op.CastOp -> visitRexOpCastOp(node, ctx)
         is Rex.Op.Collection -> visitRexOpCollection(node, ctx)
         is Rex.Op.Struct -> visitRexOpStruct(node, ctx)
         is Rex.Op.Pivot -> visitRexOpPivot(node, ctx)
@@ -135,6 +139,11 @@ internal abstract class PlanBaseVisitor<R, C> : PlanVisitor<R, C> {
     override fun visitRexOpCase(node: Rex.Op.Case, ctx: C): R = defaultVisit(node, ctx)
 
     override fun visitRexOpCaseBranch(node: Rex.Op.Case.Branch, ctx: C): R = defaultVisit(
+        node,
+        ctx
+    )
+
+    override fun visitRexOpCastOp(node: Rex.Op.CastOp, ctx: C): R = defaultVisit(
         node,
         ctx
     )

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/visitor/PlanVisitor.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/visitor/PlanVisitor.kt
@@ -3,6 +3,7 @@
 package org.partiql.planner.internal.ir.visitor
 
 import org.partiql.planner.internal.ir.Agg
+import org.partiql.planner.internal.ir.Cast
 import org.partiql.planner.internal.ir.Catalog
 import org.partiql.planner.internal.ir.Fn
 import org.partiql.planner.internal.ir.Identifier
@@ -18,11 +19,13 @@ internal interface PlanVisitor<R, C> {
 
     fun visitPartiQLPlan(node: PartiQLPlan, ctx: C): R
 
-    public fun visitCatalog(node: Catalog, ctx: C): R
+    fun visitCatalog(node: Catalog, ctx: C): R
 
-    public fun visitCatalogSymbol(node: Catalog.Symbol, ctx: C): R
+    fun visitCatalogSymbol(node: Catalog.Symbol, ctx: C): R
 
-    public fun visitCatalogSymbolRef(node: Catalog.Symbol.Ref, ctx: C): R
+    fun visitCatalogSymbolRef(node: Catalog.Symbol.Ref, ctx: C): R
+
+    fun visitCast(node: Cast, ctx: C): R
 
     fun visitFn(node: Fn, ctx: C): R
 
@@ -79,6 +82,8 @@ internal interface PlanVisitor<R, C> {
     fun visitRexOpCase(node: Rex.Op.Case, ctx: C): R
 
     fun visitRexOpCaseBranch(node: Rex.Op.Case.Branch, ctx: C): R
+
+    fun visitRexOpCastOp(node: Rex.Op.CastOp, ctx: C): R
 
     fun visitRexOpCollection(node: Rex.Op.Collection, ctx: C): R
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/FnRegistry.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/FnRegistry.kt
@@ -76,11 +76,18 @@ internal class FnRegistry(private val metadata: Collection<ConnectorFunctions>) 
     /**
      * Returns the CAST function if exists, else null.
      */
-    internal fun lookupCoercion(operand: PartiQLValueType, target: PartiQLValueType): FunctionSignature.Scalar? {
+//    internal fun lookupCoercion(operand: PartiQLValueType, target: PartiQLValueType): FunctionSignature.Scalar? {
+//        val i = operand.ordinal
+//        val j = target.ordinal
+//        val rel = pCasts.graph[i][j] ?: return null
+//        return if (rel.castType == CastType.COERCION) rel.castFn else null
+//    }
+
+    internal fun lookupCoercion(operand: PartiQLValueType, target: PartiQLValueType): TypeRelationship? {
         val i = operand.ordinal
         val j = target.ordinal
         val rel = pCasts.graph[i][j] ?: return null
-        return if (rel.castType == CastType.COERCION) rel.castFn else null
+        return if (rel.castType == CastType.COERCION) rel else null
     }
 
     internal fun isUnsafeCast(specific: String): Boolean = pCasts.unsafeCastSet.contains(specific)

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/FnResolver.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/FnResolver.kt
@@ -21,7 +21,7 @@ internal typealias Args = List<FunctionParameter>
 /**
  * Parameter mapping list tells the planner where to insert implicit casts. Null is the identity.
  */
-internal typealias Mapping = List<FunctionSignature.Scalar?>
+internal typealias Mapping = List<TypeRelationship?>
 
 /**
  * Tells us which function matched, and how the arguments are mapped.
@@ -199,7 +199,7 @@ internal class FnResolver(private val metadata: Collection<ConnectorFunctions>) 
         if (signature.parameters.size != args.size) {
             return null
         }
-        val mapping = ArrayList<FunctionSignature.Scalar?>(args.size)
+        val mapping = ArrayList<TypeRelationship?>(args.size)
         for (i in args.indices) {
             val a = args[i]
             val p = signature.parameters[i]

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -825,9 +825,9 @@ internal class PlanTyper(
             }
             val rewritten = rexOpCastOp(arg, cast)
             return when (lookUp.castType) {
-                CastType.COERCION -> rex(cast.target.toStaticType(), rewritten)
-                CastType.EXPLICIT -> rex(cast.target.toStaticType(), rewritten)
-                CastType.UNSAFE -> rex(cast.target.toStaticType().asOptional(), rewritten)
+                CastType.COERCION -> rex(cast.target.toNonNullStaticType(), rewritten)
+                CastType.EXPLICIT -> rex(cast.target.toNonNullStaticType(), rewritten)
+                CastType.UNSAFE -> rex(cast.target.toNonNullStaticType().asOptional(), rewritten)
             }
         }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeCasts.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeCasts.kt
@@ -1,5 +1,7 @@
 package org.partiql.planner.internal.typer
 
+import org.partiql.planner.internal.ir.Cast
+import org.partiql.planner.internal.ir.cast
 import org.partiql.types.function.FunctionParameter
 import org.partiql.types.function.FunctionSignature
 import org.partiql.value.PartiQLValueExperimental
@@ -46,6 +48,17 @@ internal data class TypeRelationship(
     val castFn: FunctionSignature.Scalar,
 )
 
+@OptIn(PartiQLValueExperimental::class)
+internal fun TypeRelationship.toCast(): Cast {
+    val operand = this.castFn.parameters.first().type
+    val target = this.castFn.returns
+    return when (this.castType) {
+        CastType.COERCION -> cast(operand, target, Cast.CastType.COERCION)
+        CastType.EXPLICIT -> cast(operand, target, Cast.CastType.EXPLICIT)
+        CastType.UNSAFE -> cast(operand, target, Cast.CastType.UNSAFE)
+    }
+}
+
 /**
  * An COERCION will be inserted by the compiler during function resolution, an EXPLICIT CAST will never be inserted.
  *
@@ -60,11 +73,11 @@ internal enum class CastType { COERCION, EXPLICIT, UNSAFE }
  */
 @OptIn(PartiQLValueExperimental::class)
 internal class TypeCasts private constructor(
-    public val types: Array<PartiQLValueType>,
-    public val graph: TypeGraph,
+    val types: Array<PartiQLValueType>,
+    val graph: TypeGraph,
 ) {
 
-    internal fun relationships(): Sequence<TypeRelationship> = sequence {
+    fun relationships(): Sequence<TypeRelationship> = sequence {
         for (t1 in types) {
             for (t2 in types) {
                 val r = graph[t1][t2]
@@ -103,8 +116,28 @@ internal class TypeCasts private constructor(
             }
         }
 
+        private fun PartiQLValueType.relationships(coercion: List<PartiQLValueType>, explicit: List<PartiQLValueType>, unsafe: List<PartiQLValueType>): Array<TypeRelationship?> {
+            return with(RelationshipBuilder(this)) {
+                coercion.forEach { coercion(it) }
+                explicit.forEach { explicit(it) }
+                unsafe.forEach { unsafe(it) }
+                build()
+            }
+        }
+
+        private fun PartiQLValueType.selfCoercion(): Array<TypeRelationship?> {
+            return with(RelationshipBuilder(this)) {
+                coercion(this@selfCoercion)
+                build()
+            }
+        }
+
         /**
          * Build the PartiQL type lattice.
+         *
+         * graph[operand] = [operand].relationship {
+         *    func(target)
+         * }
          *
          * TODO this is incomplete.
          */
@@ -115,15 +148,24 @@ internal class TypeCasts private constructor(
                 // initialize all with empty relationships
                 graph[type] = arrayOfNulls(N)
             }
-            graph[ANY] = ANY.relationships {
-                coercion(ANY)
-            }
-            graph[NULL] = NULL.relationships {
-                coercion(NULL)
-            }
-            graph[MISSING] = MISSING.relationships {
-                coercion(MISSING)
-            }
+            // cast($any as type)
+            // permit coercion when type is ANY
+            // unsafe for all other types
+            graph[ANY] = ANY.relationships(
+                listOf(ANY),
+                emptyList(),
+                PartiQLValueType.values().filterNot { it == ANY }
+            )
+            // cast($null as type)
+            // permits coercion when for any type
+            graph[NULL] = NULL.relationships(
+                PartiQLValueType.values().filterNot { it == MISSING },
+                emptyList(),
+                emptyList()
+            )
+            // cast($missing as type)
+            // This does not make sense since function should propagate missing.
+            graph[MISSING] = arrayOfNulls(N)
             graph[BOOL] = BOOL.relationships {
                 coercion(BOOL)
                 explicit(INT8)
@@ -224,6 +266,11 @@ internal class TypeCasts private constructor(
             }
             graph[FLOAT32] = FLOAT32.relationships {
                 explicit(BOOL)
+                unsafe(INT8)
+                unsafe(INT16)
+                unsafe(INT32)
+                unsafe(INT64)
+                explicit(INT)
                 explicit(DECIMAL)
                 coercion(DECIMAL_ARBITRARY)
                 coercion(FLOAT32)
@@ -233,6 +280,11 @@ internal class TypeCasts private constructor(
             }
             graph[FLOAT64] = FLOAT64.relationships {
                 explicit(BOOL)
+                unsafe(INT8)
+                unsafe(INT16)
+                unsafe(INT32)
+                unsafe(INT64)
+                explicit(INT)
                 explicit(DECIMAL)
                 coercion(DECIMAL_ARBITRARY)
                 coercion(FLOAT64)
@@ -241,6 +293,11 @@ internal class TypeCasts private constructor(
             }
             graph[DECIMAL_ARBITRARY] = DECIMAL_ARBITRARY.relationships {
                 explicit(BOOL)
+                unsafe(INT8)
+                unsafe(INT16)
+                unsafe(INT32)
+                unsafe(INT64)
+                explicit(INT)
                 explicit(DECIMAL)
                 coercion(DECIMAL_ARBITRARY)
                 explicit(FLOAT32)
@@ -249,54 +306,89 @@ internal class TypeCasts private constructor(
                 explicit(SYMBOL)
             }
             graph[CHAR] = CHAR.relationships {
-                explicit(BOOL)
+                unsafe(BOOL)
                 coercion(CHAR)
                 coercion(STRING)
                 coercion(SYMBOL)
             }
             graph[STRING] = STRING.relationships {
-                explicit(BOOL)
+                unsafe(BOOL)
                 unsafe(INT8)
                 unsafe(INT16)
                 unsafe(INT32)
                 unsafe(INT64)
                 unsafe(INT)
+                unsafe(DECIMAL)
+                unsafe(DECIMAL_ARBITRARY)
+                unsafe(FLOAT32)
+                unsafe(FLOAT64)
                 coercion(STRING)
                 explicit(SYMBOL)
                 coercion(CLOB)
             }
             graph[SYMBOL] = SYMBOL.relationships {
-                explicit(BOOL)
+                unsafe(BOOL)
+                unsafe(INT8)
+                unsafe(INT16)
+                unsafe(INT32)
+                unsafe(INT64)
+                unsafe(INT)
+                unsafe(DECIMAL)
+                unsafe(DECIMAL_ARBITRARY)
+                unsafe(FLOAT32)
+                unsafe(FLOAT64)
                 coercion(STRING)
                 coercion(SYMBOL)
                 coercion(CLOB)
             }
             graph[CLOB] = CLOB.relationships {
+                unsafe(STRING)
+                unsafe(SYMBOL)
+                unsafe(CHAR)
                 coercion(CLOB)
             }
-            graph[BINARY] = arrayOfNulls(N)
-            graph[BYTE] = arrayOfNulls(N)
-            graph[BLOB] = arrayOfNulls(N)
-            graph[DATE] = arrayOfNulls(N)
-            graph[TIME] = arrayOfNulls(N)
-            graph[TIMESTAMP] = arrayOfNulls(N)
-            graph[INTERVAL] = arrayOfNulls(N)
+            graph[BINARY] = BINARY.selfCoercion()
+            graph[BYTE] = BYTE.selfCoercion()
+            graph[BLOB] = BLOB.selfCoercion()
+            graph[DATE] = DATE.relationships {
+                explicit(STRING)
+                explicit(CHAR)
+                explicit(SYMBOL)
+                coercion(DATE)
+                explicit(TIMESTAMP)
+            }
+            graph[TIME] = TIME.relationships {
+                explicit(STRING)
+                explicit(CHAR)
+                explicit(SYMBOL)
+                coercion(TIME)
+                explicit(TIMESTAMP)
+            }
+            graph[TIMESTAMP] = TIMESTAMP.relationships {
+                explicit(STRING)
+                explicit(CHAR)
+                explicit(SYMBOL)
+                coercion(TIMESTAMP)
+                explicit(DATE)
+                explicit(TIME)
+            }
+            graph[INTERVAL] = INTERVAL.selfCoercion()
             graph[BAG] = BAG.relationships {
                 coercion(BAG)
+                explicit(SEXP)
+                explicit(LIST)
             }
             graph[LIST] = LIST.relationships {
-                coercion(BAG)
-                coercion(SEXP)
+                explicit(BAG)
+                explicit(SEXP)
                 coercion(LIST)
             }
             graph[SEXP] = SEXP.relationships {
-                coercion(BAG)
+                explicit(BAG)
                 coercion(SEXP)
-                coercion(LIST)
+                explicit(LIST)
             }
-            graph[STRUCT] = STRUCT.relationships {
-                coercion(STRUCT)
-            }
+            graph[STRUCT] = STRUCT.selfCoercion()
             return TypeCasts(types, graph.requireNoNulls())
         }
     }
@@ -330,32 +422,4 @@ internal class TypeCasts private constructor(
                 isNullCall = true
             )
     }
-
-    // /**
-    //  * Dump the graph as an Asciidoc table.
-    //  */
-    // override fun toString(): String = buildString {
-    //     appendLine("|===")
-    //     appendLine()
-    //     // Header
-    //     append("| | ").appendLine(types.joinToString("| "))
-    //     // Body
-    //     for (t1 in types) {
-    //         append("| $t1 ")
-    //         for (t2 in types) {
-    //             val symbol = when (val r = graph[t1][t2]) {
-    //                 null -> "X"
-    //                 else -> when (r.castType) {
-    //                     CastType.COERCION -> "⬤"
-    //                     CastType.EXPLICIT -> "◯"
-    //                     CastType.UNSAFE -> "△"
-    //                 }
-    //             }
-    //             append("| $symbol ")
-    //         }
-    //         appendLine()
-    //     }
-    //     appendLine()
-    //     appendLine("|===")
-    // }
 }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/TypeLatticeTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/TypeLatticeTest.kt
@@ -2,6 +2,7 @@ package org.partiql.planner.internal.typer
 
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.partiql.value.PartiQLValueExperimental
 
 class TypeLatticeTest {
 
@@ -9,6 +10,63 @@ class TypeLatticeTest {
     @Disabled
     fun latticeAsciidocDump() {
         // this test only exists for dumping the type lattice as Asciidoc
-        println(TypeCasts.partiql())
+        println(toMarkdown(TypeCasts.partiql()))
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    internal fun toAscii(tbl: TypeCasts) = buildString {
+        appendLine("|===")
+        appendLine()
+        // Header
+        append("| | ").appendLine(tbl.types.joinToString("| "))
+        // Body
+        for (t1 in tbl.types) {
+            append("| $t1 ")
+            for (t2 in tbl.types) {
+                val symbol = when (val r = tbl.graph[t1.ordinal][t2.ordinal]) {
+                    null -> "X"
+                    else -> when (r.castType) {
+                        CastType.COERCION -> "⬤"
+                        CastType.EXPLICIT -> "◯"
+                        CastType.UNSAFE -> "△"
+                    }
+                }
+                append("| $symbol ")
+            }
+            appendLine()
+        }
+        appendLine()
+        appendLine("|===")
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    internal fun toMarkdown(tbl: TypeCasts) = buildString {
+        // Header
+        append("|")
+        append(tbl.types.joinToString("| "))
+        append("|")
+        appendLine()
+        append("|")
+        tbl.types.forEach {
+            append("-------|")
+        }
+        appendLine()
+        // Body
+        for (t1 in tbl.types) {
+            append("| $t1 ")
+            for (t2 in tbl.types) {
+                val symbol = when (val r = tbl.graph[t1.ordinal][t2.ordinal]) {
+                    null -> "X"
+                    else -> when (r.castType) {
+                        CastType.COERCION -> "⬤"
+                        CastType.EXPLICIT -> "◯"
+                        CastType.UNSAFE -> "△"
+                    }
+                }
+                append("| $symbol ")
+            }
+            append("|")
+            appendLine()
+        }
     }
 }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/casts/CastTests.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/casts/CastTests.kt
@@ -1,0 +1,200 @@
+package org.partiql.planner.internal.typer.casts
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DynamicContainer
+import org.junit.jupiter.api.TestFactory
+import org.partiql.planner.internal.typer.PartiQLTyperTestBase
+import org.partiql.types.StaticType
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.PartiQLValueType
+import java.util.stream.Stream
+
+@OptIn(PartiQLValueExperimental::class)
+class CastTests : CastTestBase() {
+
+    @TestFactory
+    @Disabled("Halt on CAST ... AS ANY for now")
+    fun test_any(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.ANY, PartiQLValueType.ANY, "cast_any", 0)
+    }
+
+    @TestFactory
+    @Disabled("Halt on CAST ... AS NULL for now.")
+    fun test_null(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.NULL, PartiQLValueType.NULL, "cast_null", 1)
+    }
+
+    @TestFactory
+    @Disabled("Halt on CAST ... AS MISSING for now.")
+    fun test_missing(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.MISSING, PartiQLValueType.MISSING, "cast_missing", 2)
+    }
+
+    @TestFactory
+    fun test_bool(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.BOOL, PartiQLValueType.BOOL, "cast_bool", 3)
+    }
+
+    @TestFactory
+    fun test_int2(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.INT2, PartiQLValueType.INT16, "cast_int2", 4)
+    }
+
+    @TestFactory
+    fun test_int4(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.INT4, PartiQLValueType.INT32, "cast_int4", 5)
+    }
+
+    @TestFactory
+    fun test_int8(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.INT8, PartiQLValueType.INT64, "cast_int8", 6)
+    }
+
+    @TestFactory
+    fun test_int(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.INT, PartiQLValueType.INT, "cast_int", 7)
+    }
+    @TestFactory
+    fun test_float64(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.FLOAT, PartiQLValueType.FLOAT64, "cast_float64", 10)
+    }
+
+    @TestFactory
+    fun test_decimal_arbitrary(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY, "cast_decimal_arbitrary", 11)
+    }
+
+    @TestFactory
+    @Disabled("Char constraint lost during Value Type to Static Type Conversion")
+    fun test_char(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.CHAR, PartiQLValueType.CHAR, "cast_char", 12)
+    }
+
+    @TestFactory
+    fun test_varchar(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.STRING, PartiQLValueType.STRING, "cast_varchar", 14)
+    }
+
+    @TestFactory
+    fun test_symbol(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.SYMBOL, PartiQLValueType.SYMBOL, "cast_symbol", 16)
+    }
+
+    @TestFactory
+    @Disabled("Halt on CAST ... AS CLOB for now.")
+    fun test_clob(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.CLOB, PartiQLValueType.CLOB, "cast_clob", 17)
+    }
+
+    @TestFactory
+    @Disabled("Halt on CAST ... AS BLOB for now.")
+    fun test_blob(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.BLOB, PartiQLValueType.BLOB, "cast_blob", 20)
+    }
+
+    @TestFactory
+    fun test_date(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.DATE, PartiQLValueType.DATE, "cast_date", 21)
+    }
+
+    @TestFactory
+    fun test_time(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.TIME, PartiQLValueType.TIME, "cast_time", 22)
+    }
+
+    @TestFactory
+    fun test_list(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.LIST, PartiQLValueType.LIST, "cast_list", 31)
+    }
+
+    @TestFactory
+    fun test_sexp(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.SEXP, PartiQLValueType.SEXP, "cast_sexp", 32)
+    }
+
+    @TestFactory
+    fun test_struct(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.STRUCT, PartiQLValueType.STRUCT, "cast_struct", 33)
+    }
+
+    @TestFactory
+    fun test_bag(): Stream<DynamicContainer> {
+        return super.testGen(StaticType.BAG, PartiQLValueType.BAG, "cast_bag", 34)
+    }
+}
+
+@OptIn(PartiQLValueExperimental::class)
+open class CastTestBase() : PartiQLTyperTestBase() {
+
+    private fun PartiQLValueType.valueTypeToStaticType() =
+        when (this) {
+            PartiQLValueType.ANY -> StaticType.ANY
+            PartiQLValueType.BOOL -> StaticType.BOOL
+            PartiQLValueType.INT8 -> null
+            PartiQLValueType.INT16 -> StaticType.INT2
+            PartiQLValueType.INT32 -> StaticType.INT4
+            PartiQLValueType.INT64 -> StaticType.INT8
+            PartiQLValueType.INT -> StaticType.INT
+            PartiQLValueType.DECIMAL_ARBITRARY -> StaticType.DECIMAL
+            PartiQLValueType.DECIMAL -> null
+            PartiQLValueType.FLOAT32 -> StaticType.FLOAT
+            PartiQLValueType.FLOAT64 -> StaticType.FLOAT
+            PartiQLValueType.CHAR -> StaticType.CHAR
+            PartiQLValueType.STRING -> StaticType.STRING
+            PartiQLValueType.SYMBOL -> StaticType.SYMBOL
+            PartiQLValueType.BINARY -> null
+            PartiQLValueType.BYTE -> null
+            PartiQLValueType.BLOB -> StaticType.BLOB
+            PartiQLValueType.CLOB -> StaticType.CLOB
+            PartiQLValueType.DATE -> StaticType.DATE
+            PartiQLValueType.TIME -> StaticType.TIME
+            PartiQLValueType.TIMESTAMP -> StaticType.TIMESTAMP
+            PartiQLValueType.INTERVAL -> null
+            PartiQLValueType.BAG -> StaticType.BAG
+            PartiQLValueType.LIST -> StaticType.LIST
+            PartiQLValueType.SEXP -> StaticType.SEXP
+            PartiQLValueType.STRUCT -> StaticType.STRUCT
+            PartiQLValueType.NULL -> StaticType.NULL
+            PartiQLValueType.MISSING -> StaticType.MISSING
+        }
+
+    fun testGen(
+        targetStaticType: StaticType,
+        targetPartiQLValueType: PartiQLValueType,
+        testName: String,
+        testId: Int
+    ): Stream<DynamicContainer> {
+        val tests = listOf(
+            "cast-${testId.toString().padStart(2, '0')}",
+        ).map { inputs.get("casts", it)!! }
+
+        val argsMap = buildMap {
+            val casts = PartiQLValueType.values().map { from ->
+                CastTestsUtil.getCastKind(from, targetPartiQLValueType) to from
+            }.groupBy(
+                { it.first }, // cast result
+                { it.second } // input type
+            )
+
+            (casts[null] ?: emptyList())
+                .mapNotNull { inputs ->
+                    inputs.valueTypeToStaticType()
+                }
+                .map { listOf(it) }
+                .let {
+                    put(TestResult.Failure, it.toSet())
+                }
+
+            casts
+                .filterNot { it.key == null }
+                .forEach { (castRes, inputs) ->
+                    val i = inputs.mapNotNull { input ->
+                        input.valueTypeToStaticType()
+                    }.map { listOf(it) }.toSet()
+                    put(TestResult.Success(castRes!!), i)
+                }
+        }
+
+        return super.testGen(testName, tests, argsMap)
+    }
+}

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/casts/CastTestsUtil.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/casts/CastTestsUtil.kt
@@ -1,5 +1,6 @@
 package org.partiql.planner.internal.typer.casts
 
+import org.partiql.planner.internal.typer.toNonNullStaticType
 import org.partiql.planner.internal.typer.toStaticType
 import org.partiql.types.StaticType
 import org.partiql.value.PartiQLValueExperimental
@@ -14,7 +15,7 @@ object CastTestsUtil {
                 PartiQLValueType.ANY -> StaticType.ANY
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
                 PartiQLValueType.MISSING -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
-                else -> to.toStaticType().asOptional()
+                else -> to.toNonNullStaticType().asOptional()
             }
             PartiQLValueType.BOOL -> when (to) {
                 PartiQLValueType.ANY -> StaticType.ANY
@@ -31,7 +32,7 @@ object CastTestsUtil {
                 PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
                 // TEXT
                 PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL
-                -> to.toStaticType()
+                -> to.toNonNullStaticType()
                 else -> null
             }
             PartiQLValueType.INT8 -> when (to) {
@@ -47,49 +48,49 @@ object CastTestsUtil {
                 PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
                 PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
 
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType()
                 else -> null
             }
             PartiQLValueType.INT16 -> when (to) {
                 PartiQLValueType.ANY -> StaticType.ANY
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
-                PartiQLValueType.INT8 -> to.toStaticType().asOptional()
+                PartiQLValueType.INT8 -> to.toNonNullStaticType().asOptional()
 
                 PartiQLValueType.BOOL,
                 PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
                 PartiQLValueType.INT,
                 PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
                 PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType()
                 else -> null
             }
             PartiQLValueType.INT32 -> when (to) {
                 PartiQLValueType.ANY -> StaticType.ANY
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
-                PartiQLValueType.INT8, PartiQLValueType.INT16 -> to.toStaticType().asOptional()
+                PartiQLValueType.INT8, PartiQLValueType.INT16 -> to.toNonNullStaticType().asOptional()
 
                 PartiQLValueType.BOOL,
                 PartiQLValueType.INT32, PartiQLValueType.INT64,
                 PartiQLValueType.INT,
                 PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
                 PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType()
                 else -> null
             }
             PartiQLValueType.INT64 -> when (to) {
                 PartiQLValueType.ANY -> StaticType.ANY
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
-                PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32 -> to.toStaticType().asOptional()
+                PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32 -> to.toNonNullStaticType().asOptional()
 
                 PartiQLValueType.BOOL,
                 PartiQLValueType.INT64,
                 PartiQLValueType.INT,
                 PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
                 PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType()
                 else -> null
             }
             PartiQLValueType.INT -> when (to) {
@@ -97,12 +98,12 @@ object CastTestsUtil {
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
                 PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64
-                -> to.toStaticType().asOptional()
+                -> to.toNonNullStaticType().asOptional()
                 PartiQLValueType.BOOL,
                 PartiQLValueType.INT,
                 PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
                 PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType()
                 else -> null
             }
             PartiQLValueType.DECIMAL -> when (to) {
@@ -110,14 +111,14 @@ object CastTestsUtil {
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
                 PartiQLValueType.INT8, PartiQLValueType.INT16,
-                PartiQLValueType.INT32, PartiQLValueType.INT64 -> to.toStaticType().asOptional()
+                PartiQLValueType.INT32, PartiQLValueType.INT64 -> to.toNonNullStaticType().asOptional()
 
                 PartiQLValueType.BOOL,
                 PartiQLValueType.INT,
                 PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
 
                 PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType()
                 else -> null
             }
             PartiQLValueType.DECIMAL_ARBITRARY -> when (to) {
@@ -125,12 +126,12 @@ object CastTestsUtil {
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
                 PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
-                PartiQLValueType.DECIMAL, -> to.toStaticType().asOptional()
+                PartiQLValueType.DECIMAL, -> to.toNonNullStaticType().asOptional()
 
                 PartiQLValueType.BOOL,
                 PartiQLValueType.INT, PartiQLValueType.DECIMAL_ARBITRARY,
                 PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType()
                 else -> null
             }
 
@@ -139,13 +140,13 @@ object CastTestsUtil {
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
                 PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
-                PartiQLValueType.DECIMAL, -> to.toStaticType().asOptional()
+                PartiQLValueType.DECIMAL, -> to.toNonNullStaticType().asOptional()
 
                 PartiQLValueType.BOOL,
                 PartiQLValueType.INT,
                 PartiQLValueType.DECIMAL_ARBITRARY,
                 PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType()
                 else -> null
             }
 
@@ -155,13 +156,13 @@ object CastTestsUtil {
 
                 PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
                 PartiQLValueType.DECIMAL,
-                PartiQLValueType.FLOAT32, -> to.toStaticType().asOptional()
+                PartiQLValueType.FLOAT32, -> to.toNonNullStaticType().asOptional()
 
                 PartiQLValueType.BOOL,
                 PartiQLValueType.INT,
                 PartiQLValueType.DECIMAL_ARBITRARY,
                 PartiQLValueType.FLOAT64,
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType()
                 else -> null
             }
 
@@ -173,9 +174,9 @@ object CastTestsUtil {
                 PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
                 PartiQLValueType.INT,
                 PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
-                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64 -> to.toStaticType().asOptional()
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64 -> to.toNonNullStaticType().asOptional()
 
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType()
                 else -> null
             }
 
@@ -188,9 +189,9 @@ object CastTestsUtil {
                 PartiQLValueType.INT32, PartiQLValueType.INT64, PartiQLValueType.DECIMAL,
                 PartiQLValueType.INT,
                 PartiQLValueType.DECIMAL_ARBITRARY, PartiQLValueType.FLOAT32,
-                PartiQLValueType.FLOAT64, -> to.toStaticType().asOptional()
+                PartiQLValueType.FLOAT64, -> to.toNonNullStaticType().asOptional()
 
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType()
                 else -> null
             }
 
@@ -202,9 +203,9 @@ object CastTestsUtil {
                 PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
                 PartiQLValueType.INT,
                 PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
-                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64, -> to.toStaticType().asOptional()
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64, -> to.toNonNullStaticType().asOptional()
 
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType()
                 else -> null
             }
 
@@ -216,7 +217,7 @@ object CastTestsUtil {
             }
             PartiQLValueType.CLOB -> when (to) {
                 PartiQLValueType.CLOB -> StaticType.CLOB.asNullable()
-                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType().asOptional()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toNonNullStaticType().asOptional()
                 else -> null
             }
             PartiQLValueType.DATE -> when (to) {
@@ -225,7 +226,7 @@ object CastTestsUtil {
 
                 PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL,
 
-                PartiQLValueType.DATE, PartiQLValueType.TIMESTAMP -> to.toStaticType()
+                PartiQLValueType.DATE, PartiQLValueType.TIMESTAMP -> to.toNonNullStaticType()
 
                 else -> null
             }
@@ -234,7 +235,7 @@ object CastTestsUtil {
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
                 PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL,
-                PartiQLValueType.TIME, PartiQLValueType.TIMESTAMP -> to.toStaticType()
+                PartiQLValueType.TIME, PartiQLValueType.TIMESTAMP -> to.toNonNullStaticType()
                 else -> null
             }
 
@@ -243,7 +244,7 @@ object CastTestsUtil {
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
                 PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL,
-                PartiQLValueType.DATE, PartiQLValueType.TIME, PartiQLValueType.TIMESTAMP -> to.toStaticType()
+                PartiQLValueType.DATE, PartiQLValueType.TIME, PartiQLValueType.TIMESTAMP -> to.toNonNullStaticType()
 
                 else -> null
             }
@@ -252,7 +253,7 @@ object CastTestsUtil {
                 PartiQLValueType.ANY -> StaticType.ANY
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
-                PartiQLValueType.LIST, PartiQLValueType.SEXP, PartiQLValueType.BAG, -> to.toStaticType()
+                PartiQLValueType.LIST, PartiQLValueType.SEXP, PartiQLValueType.BAG, -> to.toNonNullStaticType()
                 else -> null
             }
 
@@ -260,21 +261,21 @@ object CastTestsUtil {
                 PartiQLValueType.ANY -> StaticType.ANY
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
-                PartiQLValueType.LIST, PartiQLValueType.SEXP, PartiQLValueType.BAG, -> to.toStaticType()
+                PartiQLValueType.LIST, PartiQLValueType.SEXP, PartiQLValueType.BAG, -> to.toNonNullStaticType()
                 else -> null
             }
             PartiQLValueType.SEXP -> when (to) {
                 PartiQLValueType.ANY -> StaticType.ANY
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
-                PartiQLValueType.LIST, PartiQLValueType.SEXP, PartiQLValueType.BAG, -> to.toStaticType()
+                PartiQLValueType.LIST, PartiQLValueType.SEXP, PartiQLValueType.BAG, -> to.toNonNullStaticType()
                 else -> null
             }
             PartiQLValueType.STRUCT -> when (to) {
                 PartiQLValueType.ANY -> StaticType.ANY
                 PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
 
-                PartiQLValueType.STRUCT -> to.toStaticType()
+                PartiQLValueType.STRUCT -> to.toNonNullStaticType()
 
                 else -> null
             }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/casts/CastTestsUtil.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/casts/CastTestsUtil.kt
@@ -1,0 +1,289 @@
+package org.partiql.planner.internal.typer.casts
+
+import org.partiql.planner.internal.typer.toStaticType
+import org.partiql.types.StaticType
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.PartiQLValueType
+
+@OptIn(PartiQLValueExperimental::class)
+object CastTestsUtil {
+    // Simple nested when statement as this is just testing logic
+    fun getCastKind(from: PartiQLValueType, to: PartiQLValueType): StaticType? =
+        when (from) {
+            PartiQLValueType.ANY -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+                PartiQLValueType.MISSING -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+                else -> to.toStaticType().asOptional()
+            }
+            PartiQLValueType.BOOL -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+                // BOOL
+                PartiQLValueType.BOOL,
+                // Fix-Precision INT
+                PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
+                // Arbitrary Precision INT
+                PartiQLValueType.INT,
+                // DECIMAL
+                PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
+                // FLOAT
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
+                // TEXT
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL
+                -> to.toStaticType()
+                else -> null
+            }
+            PartiQLValueType.INT8 -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.BOOL,
+
+                PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
+
+                PartiQLValueType.INT,
+
+                PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
+
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                else -> null
+            }
+            PartiQLValueType.INT16 -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.INT8 -> to.toStaticType().asOptional()
+
+                PartiQLValueType.BOOL,
+                PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
+                PartiQLValueType.INT,
+                PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                else -> null
+            }
+            PartiQLValueType.INT32 -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.INT8, PartiQLValueType.INT16 -> to.toStaticType().asOptional()
+
+                PartiQLValueType.BOOL,
+                PartiQLValueType.INT32, PartiQLValueType.INT64,
+                PartiQLValueType.INT,
+                PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                else -> null
+            }
+            PartiQLValueType.INT64 -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32 -> to.toStaticType().asOptional()
+
+                PartiQLValueType.BOOL,
+                PartiQLValueType.INT64,
+                PartiQLValueType.INT,
+                PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                else -> null
+            }
+            PartiQLValueType.INT -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64
+                -> to.toStaticType().asOptional()
+                PartiQLValueType.BOOL,
+                PartiQLValueType.INT,
+                PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                else -> null
+            }
+            PartiQLValueType.DECIMAL -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.INT8, PartiQLValueType.INT16,
+                PartiQLValueType.INT32, PartiQLValueType.INT64 -> to.toStaticType().asOptional()
+
+                PartiQLValueType.BOOL,
+                PartiQLValueType.INT,
+                PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
+
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                else -> null
+            }
+            PartiQLValueType.DECIMAL_ARBITRARY -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
+                PartiQLValueType.DECIMAL, -> to.toStaticType().asOptional()
+
+                PartiQLValueType.BOOL,
+                PartiQLValueType.INT, PartiQLValueType.DECIMAL_ARBITRARY,
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                else -> null
+            }
+
+            PartiQLValueType.FLOAT32 -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
+                PartiQLValueType.DECIMAL, -> to.toStaticType().asOptional()
+
+                PartiQLValueType.BOOL,
+                PartiQLValueType.INT,
+                PartiQLValueType.DECIMAL_ARBITRARY,
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64,
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                else -> null
+            }
+
+            PartiQLValueType.FLOAT64 -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
+                PartiQLValueType.DECIMAL,
+                PartiQLValueType.FLOAT32, -> to.toStaticType().asOptional()
+
+                PartiQLValueType.BOOL,
+                PartiQLValueType.INT,
+                PartiQLValueType.DECIMAL_ARBITRARY,
+                PartiQLValueType.FLOAT64,
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                else -> null
+            }
+
+            PartiQLValueType.CHAR -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.BOOL,
+                PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
+                PartiQLValueType.INT,
+                PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64 -> to.toStaticType().asOptional()
+
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                else -> null
+            }
+
+            PartiQLValueType.STRING -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.BOOL,
+                PartiQLValueType.INT8, PartiQLValueType.INT16,
+                PartiQLValueType.INT32, PartiQLValueType.INT64, PartiQLValueType.DECIMAL,
+                PartiQLValueType.INT,
+                PartiQLValueType.DECIMAL_ARBITRARY, PartiQLValueType.FLOAT32,
+                PartiQLValueType.FLOAT64, -> to.toStaticType().asOptional()
+
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                else -> null
+            }
+
+            PartiQLValueType.SYMBOL -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.BOOL,
+                PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT32, PartiQLValueType.INT64,
+                PartiQLValueType.INT,
+                PartiQLValueType.DECIMAL, PartiQLValueType.DECIMAL_ARBITRARY,
+                PartiQLValueType.FLOAT32, PartiQLValueType.FLOAT64, -> to.toStaticType().asOptional()
+
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType()
+                else -> null
+            }
+
+            PartiQLValueType.BINARY -> null
+            PartiQLValueType.BYTE -> null
+            PartiQLValueType.BLOB -> when (to) {
+                PartiQLValueType.BLOB -> StaticType.BLOB.asNullable()
+                else -> null
+            }
+            PartiQLValueType.CLOB -> when (to) {
+                PartiQLValueType.CLOB -> StaticType.CLOB.asNullable()
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL -> to.toStaticType().asOptional()
+                else -> null
+            }
+            PartiQLValueType.DATE -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL,
+
+                PartiQLValueType.DATE, PartiQLValueType.TIMESTAMP -> to.toStaticType()
+
+                else -> null
+            }
+            PartiQLValueType.TIME -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL,
+                PartiQLValueType.TIME, PartiQLValueType.TIMESTAMP -> to.toStaticType()
+                else -> null
+            }
+
+            PartiQLValueType.TIMESTAMP -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.CHAR, PartiQLValueType.STRING, PartiQLValueType.SYMBOL,
+                PartiQLValueType.DATE, PartiQLValueType.TIME, PartiQLValueType.TIMESTAMP -> to.toStaticType()
+
+                else -> null
+            }
+            PartiQLValueType.INTERVAL -> null
+            PartiQLValueType.BAG -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.LIST, PartiQLValueType.SEXP, PartiQLValueType.BAG, -> to.toStaticType()
+                else -> null
+            }
+
+            PartiQLValueType.LIST -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.LIST, PartiQLValueType.SEXP, PartiQLValueType.BAG, -> to.toStaticType()
+                else -> null
+            }
+            PartiQLValueType.SEXP -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.LIST, PartiQLValueType.SEXP, PartiQLValueType.BAG, -> to.toStaticType()
+                else -> null
+            }
+            PartiQLValueType.STRUCT -> when (to) {
+                PartiQLValueType.ANY -> StaticType.ANY
+                PartiQLValueType.NULL -> StaticType.unionOf(StaticType.NULL, StaticType.MISSING)
+
+                PartiQLValueType.STRUCT -> to.toStaticType()
+
+                else -> null
+            }
+            PartiQLValueType.NULL -> to.toStaticType()
+            PartiQLValueType.MISSING -> when (to) {
+                PartiQLValueType.ANY -> null // TODO: SHOULD WE PERMIT THIS?
+                PartiQLValueType.NULL -> null
+                PartiQLValueType.MISSING -> StaticType.MISSING
+                else -> null
+            }
+        }
+}

--- a/partiql-planner/src/testFixtures/resources/inputs/casts/casts.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/casts/casts.sql
@@ -1,0 +1,118 @@
+--#[cast-00]
+cast(t1 as ANY);
+
+--#[cast-01]
+cast(t1 as NULL);
+
+--#[cast-02]
+cast(t1 as MISSING);
+
+--#[cast-03]
+cast(t1 as BOOL);
+
+--#[cast-04]
+cast(t1 as INT2);
+
+--#[cast-05]
+cast(t1 as INT4);
+
+--#[cast-06]
+cast(t1 as INT8);
+
+--#[cast-07]
+cast(t1 as INT);
+
+-- #[cast-08]
+-- TODO: Cast to parameterized type
+cast(t1 as DECIMAL(3,2));
+
+-- #[cast-09]
+-- TODO: Cast to parameterized type
+cast(t1 as FLOAT(32));
+
+--#[cast-10]
+cast(t1 as DOUBLE PRECISION);
+
+--#[cast-11]
+cast(t1 as DECIMAL);
+
+--#[cast-12]
+cast(t1 as CHAR);
+
+-- #[cast-13]
+-- TODO: Cast to parameterized type
+cast(t1 as CHAR(3));
+
+--#[cast-14]
+cast(t1 as STRING);
+
+-- #[cast-15]
+-- TODO: Cast to parameterized type
+cast(t1 as VARCHAR(10));
+
+--#[cast-16]
+cast(t1 as SYMBOL);
+
+--#[cast-17]
+cast(t1 as CLOB);
+
+-- #[cast-18]
+-- TODO: Not supported in static type
+cast(t1 as BINARY);
+
+--#[cast-19]
+-- TODO: Not supported in static type
+cast(t1 as BYTE);
+
+--#[cast-20]
+cast(t1 as BLOB);
+
+--#[cast-21]
+cast(t1 as DATE);
+
+--#[cast-22]
+cast(t1 as TIME);
+
+-- #[cast-23]
+-- TODO: Cast to parameterized type
+cast(t1 as TIME(3));
+
+-- #[cast-24]
+-- TODO: Cast to parameterized type
+cast(t1 as TIME WITH TIME ZONE);
+
+-- #[cast-25]
+-- TODO: Cast to parameterized type
+cast(t1 as TIME(3) WITH TIME ZONE);
+
+-- #[cast-26]
+-- TODO: Timestamp WITHOUT TIME ZONE semantics changes
+cast(t1 as TIMESTAMP);
+
+-- #[cast-27]
+-- TODO: Cast to parameterized type
+cast(t1 as TIMESTAMP(3));
+
+-- #[cast-28]
+-- TODO: Cast to parameterized type
+cast(t1 as TIMESTAMP WITH TIME ZONE);
+
+-- #[cast-29]
+-- TODO: Cast to parameterized type
+cast(t1 as TIMESTAMP(3) WITH TIME ZONE);
+
+-- #[cast-30]
+-- TODO: Interval not implemented
+cast(t1 as INTERVAL);
+
+--#[cast-31]
+cast(t1 as LIST);
+
+--#[cast-32]
+cast(t1 as SEXP);
+
+--#[cast-33]
+cast(t1 as STRUCT);
+
+--#[cast-34]
+cast(t1 as BAG);

--- a/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/PartiQLValue.kt
@@ -94,17 +94,21 @@ public abstract class BoolValue : ScalarValue<Boolean?> {
 @PartiQLValueExperimental
 public sealed class NumericValue<T : Number> : ScalarValue<T> {
 
-    public val int: Int?
-        get() = value?.toInt()
+    public abstract fun toInt8(): Int8Value
 
-    public val long: Long?
-        get() = value?.toLong()
+    public abstract fun toInt16(): Int16Value
 
-    public val float: Float?
-        get() = value?.toFloat()
+    public abstract fun toInt32(): Int32Value
 
-    public val double: Double?
-        get() = value?.toDouble()
+    public abstract fun toInt64(): Int64Value
+
+    public abstract fun toInt(): IntValue
+
+    public abstract fun toDecimal(): DecimalValue
+
+    public abstract fun toFloat32(): Float32Value
+
+    public abstract fun toFloat64(): Float64Value
 
     abstract override fun copy(annotations: Annotations): NumericValue<T>
 
@@ -532,6 +536,8 @@ public abstract class NullValue : PartiQLValue {
     override val type: PartiQLValueType = PartiQLValueType.NULL
 
     override val isNull: Boolean = true
+
+    public abstract fun withType(type: PartiQLValueType): PartiQLValue
 
     abstract override fun copy(annotations: Annotations): NullValue
 

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/DecimalValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/DecimalValueImpl.kt
@@ -16,11 +16,27 @@ package org.partiql.value.impl
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
+import org.partiql.errors.DataException
 import org.partiql.value.Annotations
 import org.partiql.value.DecimalValue
+import org.partiql.value.Float32Value
+import org.partiql.value.Float64Value
+import org.partiql.value.Int16Value
+import org.partiql.value.Int32Value
+import org.partiql.value.Int64Value
+import org.partiql.value.Int8Value
+import org.partiql.value.IntValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.float32Value
+import org.partiql.value.float64Value
+import org.partiql.value.int16Value
+import org.partiql.value.int32Value
+import org.partiql.value.int64Value
+import org.partiql.value.int8Value
+import org.partiql.value.intValue
 import org.partiql.value.util.PartiQLValueVisitor
 import java.math.BigDecimal
+import java.math.RoundingMode
 
 @OptIn(PartiQLValueExperimental::class)
 internal data class DecimalValueImpl(
@@ -33,6 +49,56 @@ internal data class DecimalValueImpl(
     override fun withAnnotations(annotations: Annotations): DecimalValue = _withAnnotations(annotations)
 
     override fun withoutAnnotations(): DecimalValue = _withoutAnnotations()
+
+    // permits if no leading significant digits loss
+    // rounding down for cast
+    override fun toInt8(): Int8Value =
+        try {
+            int8Value(this.value?.setScale(0, RoundingMode.DOWN)?.byteValueExact(), annotations)
+        } catch (e: ArithmeticException) {
+            throw DataException("Overflow when casting ${this.value} to INT8")
+        }
+
+    override fun toInt16(): Int16Value =
+        try {
+            int16Value(this.value?.setScale(0, RoundingMode.DOWN)?.shortValueExact(), annotations)
+        } catch (e: ArithmeticException) {
+            throw DataException("Overflow when casting ${this.value} to INT16")
+        }
+
+    override fun toInt32(): Int32Value =
+        try {
+            int32Value(this.value?.setScale(0, RoundingMode.DOWN)?.intValueExact(), annotations)
+        } catch (e: ArithmeticException) {
+            throw DataException("Overflow when casting ${this.value} to INT32")
+        }
+
+    override fun toInt64(): Int64Value =
+        try {
+            int64Value(this.value?.setScale(0, RoundingMode.DOWN)?.longValueExact(), annotations)
+        } catch (e: ArithmeticException) {
+            throw DataException("Overflow when casting ${this.value} to INT64")
+        }
+
+    override fun toInt(): IntValue = intValue(this.value?.setScale(0, RoundingMode.DOWN)?.toBigInteger(), annotations)
+
+    override fun toDecimal(): DecimalValue = this
+
+    override fun toFloat32(): Float32Value {
+        val float = this.value?.toFloat()
+        if (float == Float.NEGATIVE_INFINITY || float == Float.NEGATIVE_INFINITY) {
+            throw DataException("Overflow when casting ${this.value} to FLOAT32")
+        }
+        return float32Value(float, annotations)
+    }
+
+    override fun toFloat64(): Float64Value {
+        val double = this.value?.toDouble()
+        if (double == Double.NEGATIVE_INFINITY || double == Double.NEGATIVE_INFINITY) {
+            throw DataException("Overflow when casting ${this.value} to FLOAT64")
+        }
+        return float64Value(double, annotations)
+    }
 
     override fun <R, C> accept(visitor: PartiQLValueVisitor<R, C>, ctx: C): R = visitor.visitDecimal(this, ctx)
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/Float32ValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/Float32ValueImpl.kt
@@ -16,10 +16,26 @@ package org.partiql.value.impl
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
+import org.partiql.errors.DataException
 import org.partiql.value.Annotations
+import org.partiql.value.DecimalValue
 import org.partiql.value.Float32Value
+import org.partiql.value.Float64Value
+import org.partiql.value.Int16Value
+import org.partiql.value.Int32Value
+import org.partiql.value.Int64Value
+import org.partiql.value.Int8Value
+import org.partiql.value.IntValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.decimalValue
+import org.partiql.value.float64Value
+import org.partiql.value.int16Value
+import org.partiql.value.int32Value
+import org.partiql.value.int64Value
+import org.partiql.value.int8Value
+import org.partiql.value.intValue
 import org.partiql.value.util.PartiQLValueVisitor
+import java.math.BigDecimal
 
 @OptIn(PartiQLValueExperimental::class)
 internal data class Float32ValueImpl(
@@ -32,6 +48,58 @@ internal data class Float32ValueImpl(
     override fun withAnnotations(annotations: Annotations): Float32Value = _withAnnotations(annotations)
 
     override fun withoutAnnotations(): Float32Value = _withoutAnnotations()
+    override fun toInt8(): Int8Value {
+        if (this.value == null) {
+            return int8Value(null, annotations)
+        }
+        if (this.value > Byte.MAX_VALUE || this.value < Byte.MIN_VALUE) {
+            throw DataException("Overflow when casting ${this.value} to INT8")
+        }
+        return int8Value(this.value.toInt().toByte(), annotations)
+    }
+
+    override fun toInt16(): Int16Value {
+        if (this.value == null) {
+            return int16Value(null, annotations)
+        }
+        if (this.value > Short.MAX_VALUE || this.value < Short.MIN_VALUE) {
+            throw DataException("Overflow when casting ${this.value} to INT16")
+        }
+        return int16Value(this.value.toInt().toShort(), annotations)
+    }
+
+    override fun toInt32(): Int32Value {
+        if (this.value == null) {
+            return int32Value(null, annotations)
+        }
+        if (this.value > Int.MAX_VALUE || this.value < Int.MIN_VALUE) {
+            throw DataException("Overflow when casting ${this.value} to INT32")
+        }
+        return int32Value(this.value.toInt(), annotations)
+    }
+
+    override fun toInt64(): Int64Value {
+        if (this.value == null) {
+            return int64Value(null, annotations)
+        }
+        if (this.value > Long.MAX_VALUE || this.value < Long.MIN_VALUE) {
+            throw DataException("Overflow when casting ${this.value} to INT64")
+        }
+        return int64Value(this.value.toLong(), annotations)
+    }
+
+    override fun toInt(): IntValue =
+        intValue(this.value?.toDouble()?.let { BigDecimal(it) }?.toBigInteger(), annotations)
+
+    // TODO: FIX-ME:
+    //  This first convert the float value to bigDecimal
+    //  which mess up with precision.
+    override fun toDecimal(): DecimalValue =
+        decimalValue(this.value?.toDouble()?.let { BigDecimal(it) }, annotations)
+
+    override fun toFloat32(): Float32Value = this
+
+    override fun toFloat64(): Float64Value = float64Value(this.value?.toDouble(), annotations)
 
     override fun <R, C> accept(visitor: PartiQLValueVisitor<R, C>, ctx: C): R = visitor.visitFloat32(this, ctx)
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/Float64ValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/Float64ValueImpl.kt
@@ -16,10 +16,26 @@ package org.partiql.value.impl
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
+import org.partiql.errors.DataException
 import org.partiql.value.Annotations
+import org.partiql.value.DecimalValue
+import org.partiql.value.Float32Value
 import org.partiql.value.Float64Value
+import org.partiql.value.Int16Value
+import org.partiql.value.Int32Value
+import org.partiql.value.Int64Value
+import org.partiql.value.Int8Value
+import org.partiql.value.IntValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.decimalValue
+import org.partiql.value.float32Value
+import org.partiql.value.int16Value
+import org.partiql.value.int32Value
+import org.partiql.value.int64Value
+import org.partiql.value.int8Value
+import org.partiql.value.intValue
 import org.partiql.value.util.PartiQLValueVisitor
+import java.math.BigDecimal
 
 @OptIn(PartiQLValueExperimental::class)
 internal data class Float64ValueImpl(
@@ -31,6 +47,63 @@ internal data class Float64ValueImpl(
     override fun withAnnotations(annotations: Annotations): Float64Value = _withAnnotations(annotations)
 
     override fun withoutAnnotations(): Float64Value = _withoutAnnotations()
+    override fun toInt8(): Int8Value {
+        if (this.value == null) {
+            return int8Value(null, annotations)
+        }
+        if (this.value > Byte.MAX_VALUE || this.value < Byte.MIN_VALUE) {
+            throw DataException("Overflow when casting ${this.value} to INT8")
+        }
+        return int8Value(this.value.toInt().toByte(), annotations)
+    }
+
+    override fun toInt16(): Int16Value {
+        if (this.value == null) {
+            return int16Value(null, annotations)
+        }
+        if (this.value > Short.MAX_VALUE || this.value < Short.MIN_VALUE) {
+            throw DataException("Overflow when casting ${this.value} to INT16")
+        }
+        return int16Value(this.value.toInt().toShort(), annotations)
+    }
+
+    override fun toInt32(): Int32Value {
+        if (this.value == null) {
+            return int32Value(null, annotations)
+        }
+        if (this.value > Int.MAX_VALUE || this.value < Int.MIN_VALUE) {
+            throw DataException("Overflow when casting ${this.value} to INT32")
+        }
+        return int32Value(this.value.toInt(), annotations)
+    }
+
+    override fun toInt64(): Int64Value {
+        if (this.value == null) {
+            return int64Value(null, annotations)
+        }
+        if (this.value > Long.MAX_VALUE || this.value < Long.MIN_VALUE) {
+            throw DataException("Overflow when casting ${this.value} to INT64")
+        }
+        return int64Value(this.value.toLong(), annotations)
+    }
+
+    override fun toInt(): IntValue =
+        intValue(this.value?.let { BigDecimal(it) }?.toBigInteger(), annotations)
+
+    override fun toDecimal(): DecimalValue =
+        decimalValue(this.value?.let { BigDecimal(it) }, annotations)
+
+    override fun toFloat32(): Float32Value {
+        if (this.value == null) {
+            return float32Value(null, annotations)
+        }
+        if (this.value > Float.MAX_VALUE || this.value < Float.MIN_VALUE) {
+            throw DataException("Overflow when casting ${this.value} to Float32")
+        }
+        return float32Value(this.value.toFloat(), annotations)
+    }
+
+    override fun toFloat64(): Float64Value = this
 
     override fun <R, C> accept(visitor: PartiQLValueVisitor<R, C>, ctx: C): R = visitor.visitFloat64(this, ctx)
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/Int16ValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/Int16ValueImpl.kt
@@ -16,10 +16,27 @@ package org.partiql.value.impl
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
+import org.partiql.errors.DataException
 import org.partiql.value.Annotations
+import org.partiql.value.DecimalValue
+import org.partiql.value.Float32Value
+import org.partiql.value.Float64Value
 import org.partiql.value.Int16Value
+import org.partiql.value.Int32Value
+import org.partiql.value.Int64Value
+import org.partiql.value.Int8Value
+import org.partiql.value.IntValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.datetime.DateTimeUtil.toBigDecimal
+import org.partiql.value.decimalValue
+import org.partiql.value.float32Value
+import org.partiql.value.float64Value
+import org.partiql.value.int32Value
+import org.partiql.value.int64Value
+import org.partiql.value.int8Value
+import org.partiql.value.intValue
 import org.partiql.value.util.PartiQLValueVisitor
+import java.math.BigInteger
 
 @OptIn(PartiQLValueExperimental::class)
 internal data class Int16ValueImpl(
@@ -32,6 +49,27 @@ internal data class Int16ValueImpl(
     override fun withAnnotations(annotations: Annotations): Int16Value = _withAnnotations(annotations)
 
     override fun withoutAnnotations(): Int16Value = _withoutAnnotations()
+    override fun toInt8(): Int8Value {
+        val byte = this.value?.toByte() ?: return int8Value(null, annotations)
+        if (byte.toShort() != this.value) {
+            throw DataException("Overflow when casting ${this.value} to INT8")
+        }
+        return int8Value(byte, annotations)
+    }
+
+    override fun toInt16(): Int16Value = this
+
+    override fun toInt32(): Int32Value = int32Value(this.value?.toInt(), annotations)
+
+    override fun toInt64(): Int64Value = int64Value(this.value?.toLong(), annotations)
+
+    override fun toInt(): IntValue = intValue(this.value?.toLong()?.let { BigInteger.valueOf(it) }, annotations)
+
+    override fun toDecimal(): DecimalValue = decimalValue(this.value?.toBigDecimal(), annotations)
+
+    override fun toFloat32(): Float32Value = float32Value(this.value?.toFloat(), annotations)
+
+    override fun toFloat64(): Float64Value = float64Value(this.value?.toDouble(), annotations)
 
     override fun <R, C> accept(visitor: PartiQLValueVisitor<R, C>, ctx: C): R = visitor.visitInt16(this, ctx)
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/Int32ValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/Int32ValueImpl.kt
@@ -16,10 +16,27 @@ package org.partiql.value.impl
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
+import org.partiql.errors.DataException
 import org.partiql.value.Annotations
+import org.partiql.value.DecimalValue
+import org.partiql.value.Float32Value
+import org.partiql.value.Float64Value
+import org.partiql.value.Int16Value
 import org.partiql.value.Int32Value
+import org.partiql.value.Int64Value
+import org.partiql.value.Int8Value
+import org.partiql.value.IntValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.datetime.DateTimeUtil.toBigDecimal
+import org.partiql.value.decimalValue
+import org.partiql.value.float32Value
+import org.partiql.value.float64Value
+import org.partiql.value.int16Value
+import org.partiql.value.int64Value
+import org.partiql.value.int8Value
+import org.partiql.value.intValue
 import org.partiql.value.util.PartiQLValueVisitor
+import java.math.BigInteger
 
 @OptIn(PartiQLValueExperimental::class)
 internal data class Int32ValueImpl(
@@ -32,6 +49,33 @@ internal data class Int32ValueImpl(
     override fun withAnnotations(annotations: Annotations): Int32Value = _withAnnotations(annotations)
 
     override fun withoutAnnotations(): Int32Value = _withoutAnnotations()
+    override fun toInt8(): Int8Value {
+        val byte = this.value?.toByte() ?: return int8Value(null, annotations)
+        if (byte.toInt() != this.value) {
+            throw DataException("Overflow when casting ${this.value} to INT8")
+        }
+        return int8Value(byte, annotations)
+    }
+
+    override fun toInt16(): Int16Value {
+        val short = this.value?.toShort() ?: return int16Value(null, annotations)
+        if (short.toInt() != this.value) {
+            throw DataException("Overflow when casting ${this.value} to INT16")
+        }
+        return int16Value(short, annotations)
+    }
+
+    override fun toInt32(): Int32Value = this
+
+    override fun toInt64(): Int64Value = int64Value(this.value?.toLong(), annotations)
+
+    override fun toInt(): IntValue = intValue(this.value?.toLong()?.let { BigInteger.valueOf(it) }, annotations)
+
+    override fun toDecimal(): DecimalValue = decimalValue(this.value?.toBigDecimal(), annotations)
+
+    override fun toFloat32(): Float32Value = float32Value(this.value?.toFloat(), annotations)
+
+    override fun toFloat64(): Float64Value = float64Value(this.value?.toDouble(), annotations)
 
     override fun <R, C> accept(visitor: PartiQLValueVisitor<R, C>, ctx: C): R = visitor.visitInt32(this, ctx)
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/Int64ValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/Int64ValueImpl.kt
@@ -16,10 +16,27 @@ package org.partiql.value.impl
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
+import org.partiql.errors.DataException
 import org.partiql.value.Annotations
+import org.partiql.value.DecimalValue
+import org.partiql.value.Float32Value
+import org.partiql.value.Float64Value
+import org.partiql.value.Int16Value
+import org.partiql.value.Int32Value
 import org.partiql.value.Int64Value
+import org.partiql.value.Int8Value
+import org.partiql.value.IntValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.datetime.DateTimeUtil.toBigDecimal
+import org.partiql.value.decimalValue
+import org.partiql.value.float32Value
+import org.partiql.value.float64Value
+import org.partiql.value.int16Value
+import org.partiql.value.int32Value
+import org.partiql.value.int8Value
+import org.partiql.value.intValue
 import org.partiql.value.util.PartiQLValueVisitor
+import java.math.BigInteger
 
 @OptIn(PartiQLValueExperimental::class)
 internal data class Int64ValueImpl(
@@ -31,6 +48,39 @@ internal data class Int64ValueImpl(
     override fun withAnnotations(annotations: Annotations): Int64Value = _withAnnotations(annotations)
 
     override fun withoutAnnotations(): Int64Value = _withoutAnnotations()
+    override fun toInt8(): Int8Value {
+        val byte = this.value?.toByte() ?: return int8Value(null, annotations)
+        if (byte.toLong() != this.value) {
+            throw DataException("Overflow when casting ${this.value} to INT8")
+        }
+        return int8Value(byte, annotations)
+    }
+
+    override fun toInt16(): Int16Value {
+        val short = this.value?.toShort() ?: return int16Value(null, annotations)
+        if (short.toLong() != this.value) {
+            throw DataException("Overflow when casting ${this.value} to INT16")
+        }
+        return int16Value(short, annotations)
+    }
+
+    override fun toInt32(): Int32Value {
+        val int = this.value?.toInt() ?: return int32Value(null, annotations)
+        if (int.toLong() != this.value) {
+            throw DataException("Overflow when casting ${this.value} to INT16")
+        }
+        return int32Value(int, annotations)
+    }
+
+    override fun toInt64(): Int64Value = this
+
+    override fun toInt(): IntValue = intValue(this.value?.let { BigInteger.valueOf(it) }, annotations)
+
+    override fun toDecimal(): DecimalValue = decimalValue(this.value?.toBigDecimal(), annotations)
+
+    override fun toFloat32(): Float32Value = float32Value(this.value?.toFloat(), annotations)
+
+    override fun toFloat64(): Float64Value = float64Value(this.value?.toDouble(), annotations)
 
     override fun <R, C> accept(visitor: PartiQLValueVisitor<R, C>, ctx: C): R = visitor.visitInt64(this, ctx)
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/Int8ValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/Int8ValueImpl.kt
@@ -17,9 +17,25 @@ package org.partiql.value.impl
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import org.partiql.value.Annotations
+import org.partiql.value.DecimalValue
+import org.partiql.value.Float32Value
+import org.partiql.value.Float64Value
+import org.partiql.value.Int16Value
+import org.partiql.value.Int32Value
+import org.partiql.value.Int64Value
 import org.partiql.value.Int8Value
+import org.partiql.value.IntValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.datetime.DateTimeUtil.toBigDecimal
+import org.partiql.value.decimalValue
+import org.partiql.value.float32Value
+import org.partiql.value.float64Value
+import org.partiql.value.int16Value
+import org.partiql.value.int32Value
+import org.partiql.value.int64Value
+import org.partiql.value.intValue
 import org.partiql.value.util.PartiQLValueVisitor
+import java.math.BigInteger
 
 @OptIn(PartiQLValueExperimental::class)
 internal data class Int8ValueImpl(
@@ -32,5 +48,21 @@ internal data class Int8ValueImpl(
     override fun withAnnotations(annotations: Annotations): Int8Value = _withAnnotations(annotations)
 
     override fun withoutAnnotations(): Int8Value = _withoutAnnotations()
+    override fun toInt8(): Int8Value = this
+
+    override fun toInt16(): Int16Value = int16Value(this.value?.toShort(), annotations)
+
+    override fun toInt32(): Int32Value = int32Value(this.value?.toInt(), annotations)
+
+    override fun toInt64(): Int64Value = int64Value(this.value?.toLong(), annotations)
+
+    override fun toInt(): IntValue = intValue(this.value?.toLong()?.let { BigInteger.valueOf(it) }, annotations)
+
+    override fun toDecimal(): DecimalValue = decimalValue(this.value?.toBigDecimal(), annotations)
+
+    override fun toFloat32(): Float32Value = float32Value(this.value?.toFloat(), annotations)
+
+    override fun toFloat64(): Float64Value = float64Value(this.value?.toDouble(), annotations)
+
     override fun <R, C> accept(visitor: PartiQLValueVisitor<R, C>, ctx: C): R = visitor.visitInt8(this, ctx)
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/IntValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/IntValueImpl.kt
@@ -16,9 +16,24 @@ package org.partiql.value.impl
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
+import org.partiql.errors.DataException
 import org.partiql.value.Annotations
+import org.partiql.value.DecimalValue
+import org.partiql.value.Float32Value
+import org.partiql.value.Float64Value
+import org.partiql.value.Int16Value
+import org.partiql.value.Int32Value
+import org.partiql.value.Int64Value
+import org.partiql.value.Int8Value
 import org.partiql.value.IntValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.decimalValue
+import org.partiql.value.float32Value
+import org.partiql.value.float64Value
+import org.partiql.value.int16Value
+import org.partiql.value.int32Value
+import org.partiql.value.int64Value
+import org.partiql.value.int8Value
 import org.partiql.value.util.PartiQLValueVisitor
 import java.math.BigInteger
 
@@ -33,6 +48,41 @@ internal data class IntValueImpl(
     override fun withAnnotations(annotations: Annotations): IntValue = _withAnnotations(annotations)
 
     override fun withoutAnnotations(): IntValue = _withoutAnnotations()
+    override fun toInt8(): Int8Value =
+        try {
+            int8Value(this.value?.byteValueExact(), annotations)
+        } catch (e: ArithmeticException) {
+            throw DataException("Overflow when casting ${this.value} to INT8")
+        }
+
+    override fun toInt16(): Int16Value =
+        try {
+            int16Value(this.value?.shortValueExact(), annotations)
+        } catch (e: ArithmeticException) {
+            throw DataException("Overflow when casting ${this.value} to INT16")
+        }
+
+    override fun toInt32(): Int32Value =
+        try {
+            int32Value(this.value?.intValueExact(), annotations)
+        } catch (e: ArithmeticException) {
+            throw DataException("Overflow when casting ${this.value} to INT32")
+        }
+
+    override fun toInt64(): Int64Value =
+        try {
+            int64Value(this.value?.longValueExact(), annotations)
+        } catch (e: ArithmeticException) {
+            throw DataException("Overflow when casting ${this.value} to INT64")
+        }
+
+    override fun toInt(): IntValue = this
+
+    override fun toDecimal(): DecimalValue = decimalValue(this.value?.toBigDecimal(), annotations)
+
+    override fun toFloat32(): Float32Value = float32Value(this.value?.toFloat(), annotations)
+
+    override fun toFloat64(): Float64Value = float64Value(this.value?.toDouble(), annotations)
 
     override fun <R, C> accept(visitor: PartiQLValueVisitor<R, C>, ctx: C): R = visitor.visitInt(this, ctx)
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/NullValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/NullValueImpl.kt
@@ -21,6 +21,7 @@ import org.partiql.value.NullValue
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.PartiQLValueType
+import org.partiql.value.bagValue
 import org.partiql.value.binaryValue
 import org.partiql.value.blobValue
 import org.partiql.value.boolValue
@@ -37,7 +38,10 @@ import org.partiql.value.int64Value
 import org.partiql.value.int8Value
 import org.partiql.value.intValue
 import org.partiql.value.intervalValue
+import org.partiql.value.listValue
+import org.partiql.value.sexpValue
 import org.partiql.value.stringValue
+import org.partiql.value.structValue
 import org.partiql.value.symbolValue
 import org.partiql.value.timeValue
 import org.partiql.value.timestampValue
@@ -70,10 +74,10 @@ internal data class NullValueImpl(
         PartiQLValueType.TIME -> timeValue(null, annotations)
         PartiQLValueType.TIMESTAMP -> timestampValue(null, annotations)
         PartiQLValueType.INTERVAL -> intervalValue(null, annotations)
-        PartiQLValueType.BAG -> TODO("NULL.BAG not implemented")
-        PartiQLValueType.LIST -> TODO("NULL.LIST not implemented")
-        PartiQLValueType.SEXP -> TODO("NULL.SEXP not implemented")
-        PartiQLValueType.STRUCT -> TODO("NULL.STRUCT not implemented")
+        PartiQLValueType.BAG -> bagValue<PartiQLValue>(null, annotations)
+        PartiQLValueType.LIST -> listValue<PartiQLValue>(null, annotations)
+        PartiQLValueType.SEXP -> sexpValue<PartiQLValue>(null, annotations)
+        PartiQLValueType.STRUCT -> structValue<PartiQLValue>(null, annotations)
         PartiQLValueType.NULL -> this
         PartiQLValueType.MISSING -> error("cast to missing not supported")
     }

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/NullValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/NullValueImpl.kt
@@ -18,13 +18,65 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import org.partiql.value.Annotations
 import org.partiql.value.NullValue
+import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.PartiQLValueType
+import org.partiql.value.binaryValue
+import org.partiql.value.blobValue
+import org.partiql.value.boolValue
+import org.partiql.value.byteValue
+import org.partiql.value.charValue
+import org.partiql.value.clobValue
+import org.partiql.value.dateValue
+import org.partiql.value.decimalValue
+import org.partiql.value.float32Value
+import org.partiql.value.float64Value
+import org.partiql.value.int16Value
+import org.partiql.value.int32Value
+import org.partiql.value.int64Value
+import org.partiql.value.int8Value
+import org.partiql.value.intValue
+import org.partiql.value.intervalValue
+import org.partiql.value.stringValue
+import org.partiql.value.symbolValue
+import org.partiql.value.timeValue
+import org.partiql.value.timestampValue
 import org.partiql.value.util.PartiQLValueVisitor
 
 @OptIn(PartiQLValueExperimental::class)
 internal data class NullValueImpl(
     override val annotations: PersistentList<String>,
 ) : NullValue() {
+    override fun withType(type: PartiQLValueType): PartiQLValue = when (type) {
+        PartiQLValueType.ANY -> this
+        PartiQLValueType.BOOL -> boolValue(null, annotations)
+        PartiQLValueType.INT8 -> int8Value(null, annotations)
+        PartiQLValueType.INT16 -> int16Value(null, annotations)
+        PartiQLValueType.INT32 -> int32Value(null, annotations)
+        PartiQLValueType.INT64 -> int64Value(null, annotations)
+        PartiQLValueType.INT -> intValue(null, annotations)
+        PartiQLValueType.DECIMAL -> decimalValue(null, annotations)
+        PartiQLValueType.DECIMAL_ARBITRARY -> decimalValue(null, annotations)
+        PartiQLValueType.FLOAT32 -> float32Value(null, annotations)
+        PartiQLValueType.FLOAT64 -> float64Value(null, annotations)
+        PartiQLValueType.CHAR -> charValue(null, annotations)
+        PartiQLValueType.STRING -> stringValue(null, annotations)
+        PartiQLValueType.SYMBOL -> symbolValue(null, annotations)
+        PartiQLValueType.BINARY -> binaryValue(null, annotations)
+        PartiQLValueType.BYTE -> byteValue(null, annotations)
+        PartiQLValueType.BLOB -> blobValue(null, annotations)
+        PartiQLValueType.CLOB -> clobValue(null, annotations)
+        PartiQLValueType.DATE -> dateValue(null, annotations)
+        PartiQLValueType.TIME -> timeValue(null, annotations)
+        PartiQLValueType.TIMESTAMP -> timestampValue(null, annotations)
+        PartiQLValueType.INTERVAL -> intervalValue(null, annotations)
+        PartiQLValueType.BAG -> TODO("NULL.BAG not implemented")
+        PartiQLValueType.LIST -> TODO("NULL.LIST not implemented")
+        PartiQLValueType.SEXP -> TODO("NULL.SEXP not implemented")
+        PartiQLValueType.STRUCT -> TODO("NULL.STRUCT not implemented")
+        PartiQLValueType.NULL -> this
+        PartiQLValueType.MISSING -> error("cast to missing not supported")
+    }
 
     override fun copy(annotations: Annotations) = NullValueImpl(annotations.toPersistentList())
 

--- a/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnDateAddDay.kt
+++ b/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnDateAddDay.kt
@@ -3,6 +3,8 @@
 
 package org.partiql.plugin.internal.fn.scalar
 
+import org.partiql.errors.DataException
+import org.partiql.errors.TypeCheckException
 import org.partiql.spi.function.PartiQLFunction
 import org.partiql.spi.function.PartiQLFunctionExperimental
 import org.partiql.types.function.FunctionParameter
@@ -44,7 +46,7 @@ internal object Fn_DATE_ADD_DAY__INT32_DATE__DATE : PartiQLFunction.Scalar {
             dateValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.toInt64().value!!
             dateValue(datetimeValue.plusDays(intervalValue))
         }
     }
@@ -71,7 +73,7 @@ internal object Fn_DATE_ADD_DAY__INT64_DATE__DATE : PartiQLFunction.Scalar {
             dateValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.value!!
             dateValue(datetimeValue.plusDays(intervalValue))
         }
     }
@@ -98,8 +100,7 @@ internal object Fn_DATE_ADD_DAY__INT_DATE__DATE : PartiQLFunction.Scalar {
             dateValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            // TODO: We need to consider overflow here
-            val intervalValue = interval.long!!
+            val intervalValue = try { interval.toInt64().value!! } catch (e: DataException) { throw TypeCheckException() }
             dateValue(datetimeValue.plusDays(intervalValue))
         }
     }
@@ -126,7 +127,7 @@ internal object Fn_DATE_ADD_DAY__INT32_TIMESTAMP__TIMESTAMP : PartiQLFunction.Sc
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.toInt64().value!!
             timestampValue(datetimeValue.plusDays(intervalValue))
         }
     }
@@ -153,7 +154,7 @@ internal object Fn_DATE_ADD_DAY__INT64_TIMESTAMP__TIMESTAMP : PartiQLFunction.Sc
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.value!!
             timestampValue(datetimeValue.plusDays(intervalValue))
         }
     }
@@ -180,8 +181,7 @@ internal object Fn_DATE_ADD_DAY__INT_TIMESTAMP__TIMESTAMP : PartiQLFunction.Scal
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            // TODO: We need to consider overflow here
-            val intervalValue = interval.long!!
+            val intervalValue = try { interval.toInt64().value!! } catch (e: DataException) { throw TypeCheckException() }
             timestampValue(datetimeValue.plusDays(intervalValue))
         }
     }

--- a/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnDateAddHour.kt
+++ b/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnDateAddHour.kt
@@ -3,6 +3,8 @@
 
 package org.partiql.plugin.internal.fn.scalar
 
+import org.partiql.errors.DataException
+import org.partiql.errors.TypeCheckException
 import org.partiql.spi.function.PartiQLFunction
 import org.partiql.spi.function.PartiQLFunctionExperimental
 import org.partiql.types.function.FunctionParameter
@@ -44,7 +46,7 @@ internal object Fn_DATE_ADD_HOUR__INT32_TIME__TIME : PartiQLFunction.Scalar {
             timeValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.toInt64().value!!
             timeValue(datetimeValue.plusHours(intervalValue))
         }
     }
@@ -71,7 +73,7 @@ internal object Fn_DATE_ADD_HOUR__INT64_TIME__TIME : PartiQLFunction.Scalar {
             timeValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.value!!
             timeValue(datetimeValue.plusHours(intervalValue))
         }
     }
@@ -98,8 +100,7 @@ internal object Fn_DATE_ADD_HOUR__INT_TIME__TIME : PartiQLFunction.Scalar {
             timeValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            // TODO: We need to consider overflow here
-            val intervalValue = interval.long!!
+            val intervalValue = try { interval.toInt64().value!! } catch (e: DataException) { throw TypeCheckException() }
             timeValue(datetimeValue.plusHours(intervalValue))
         }
     }
@@ -126,7 +127,7 @@ internal object Fn_DATE_ADD_HOUR__INT32_TIMESTAMP__TIMESTAMP : PartiQLFunction.S
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.toInt64().value!!
             timestampValue(datetimeValue.plusHours(intervalValue))
         }
     }
@@ -153,7 +154,7 @@ internal object Fn_DATE_ADD_HOUR__INT64_TIMESTAMP__TIMESTAMP : PartiQLFunction.S
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.value!!
             timestampValue(datetimeValue.plusHours(intervalValue))
         }
     }
@@ -181,7 +182,7 @@ internal object Fn_DATE_ADD_HOUR__INT_TIMESTAMP__TIMESTAMP : PartiQLFunction.Sca
         } else {
             val datetimeValue = datetime.value!!
             // TODO: We need to consider overflow here
-            val intervalValue = interval.long!!
+            val intervalValue = try { interval.toInt64().value!! } catch (e: DataException) { throw TypeCheckException() }
             timestampValue(datetimeValue.plusHours(intervalValue))
         }
     }

--- a/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnDateAddMinute.kt
+++ b/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnDateAddMinute.kt
@@ -3,6 +3,8 @@
 
 package org.partiql.plugin.internal.fn.scalar
 
+import org.partiql.errors.DataException
+import org.partiql.errors.TypeCheckException
 import org.partiql.spi.function.PartiQLFunction
 import org.partiql.spi.function.PartiQLFunctionExperimental
 import org.partiql.types.function.FunctionParameter
@@ -44,7 +46,7 @@ internal object Fn_DATE_ADD_MINUTE__INT32_TIME__TIME : PartiQLFunction.Scalar {
             timeValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.toInt64().value!!
             timeValue(datetimeValue.plusMinutes(intervalValue))
         }
     }
@@ -71,7 +73,7 @@ internal object Fn_DATE_ADD_MINUTE__INT64_TIME__TIME : PartiQLFunction.Scalar {
             timeValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.value!!
             timeValue(datetimeValue.plusMinutes(intervalValue))
         }
     }
@@ -98,8 +100,7 @@ internal object Fn_DATE_ADD_MINUTE__INT_TIME__TIME : PartiQLFunction.Scalar {
             timeValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            // TODO: We need to consider overflow here
-            val intervalValue = interval.long!!
+            val intervalValue = try { interval.toInt64().value!! } catch (e: DataException) { throw TypeCheckException() }
             timeValue(datetimeValue.plusMinutes(intervalValue))
         }
     }
@@ -126,7 +127,7 @@ internal object Fn_DATE_ADD_MINUTE__INT32_TIMESTAMP__TIMESTAMP : PartiQLFunction
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.toInt64().value!!
             timestampValue(datetimeValue.plusMinutes(intervalValue))
         }
     }
@@ -153,7 +154,7 @@ internal object Fn_DATE_ADD_MINUTE__INT64_TIMESTAMP__TIMESTAMP : PartiQLFunction
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.value!!
             timestampValue(datetimeValue.plusMinutes(intervalValue))
         }
     }
@@ -180,8 +181,7 @@ internal object Fn_DATE_ADD_MINUTE__INT_TIMESTAMP__TIMESTAMP : PartiQLFunction.S
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            // TODO: We need to consider overflow here
-            val intervalValue = interval.long!!
+            val intervalValue = try { interval.toInt64().value!! } catch (e: DataException) { throw TypeCheckException() }
             timestampValue(datetimeValue.plusMinutes(intervalValue))
         }
     }

--- a/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnDateAddMonth.kt
+++ b/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnDateAddMonth.kt
@@ -3,6 +3,8 @@
 
 package org.partiql.plugin.internal.fn.scalar
 
+import org.partiql.errors.DataException
+import org.partiql.errors.TypeCheckException
 import org.partiql.spi.function.PartiQLFunction
 import org.partiql.spi.function.PartiQLFunctionExperimental
 import org.partiql.types.function.FunctionParameter
@@ -44,7 +46,7 @@ internal object Fn_DATE_ADD_MONTH__INT32_DATE__DATE : PartiQLFunction.Scalar {
             dateValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.toInt64().value!!
             dateValue(datetimeValue.plusMonths(intervalValue))
         }
     }
@@ -71,7 +73,7 @@ internal object Fn_DATE_ADD_MONTH__INT64_DATE__DATE : PartiQLFunction.Scalar {
             dateValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.value!!
             dateValue(datetimeValue.plusMonths(intervalValue))
         }
     }
@@ -98,7 +100,7 @@ internal object Fn_DATE_ADD_MONTH__INT_DATE__DATE : PartiQLFunction.Scalar {
             dateValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = try { interval.toInt64().value!! } catch (e: DataException) { throw TypeCheckException() }
             dateValue(datetimeValue.plusMonths(intervalValue))
         }
     }
@@ -125,7 +127,7 @@ internal object Fn_DATE_ADD_MONTH__INT32_TIMESTAMP__TIMESTAMP : PartiQLFunction.
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.toInt64().value!!
             timestampValue(datetimeValue.plusMonths(intervalValue))
         }
     }
@@ -152,7 +154,7 @@ internal object Fn_DATE_ADD_MONTH__INT64_TIMESTAMP__TIMESTAMP : PartiQLFunction.
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.value!!
             timestampValue(datetimeValue.plusMonths(intervalValue))
         }
     }
@@ -179,8 +181,7 @@ internal object Fn_DATE_ADD_MONTH__INT_TIMESTAMP__TIMESTAMP : PartiQLFunction.Sc
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            // TODO: We need to consider overflow here
-            val intervalValue = interval.long!!
+            val intervalValue = try { interval.toInt64().value!! } catch (e: DataException) { throw TypeCheckException() }
             timestampValue(datetimeValue.plusMonths(intervalValue))
         }
     }

--- a/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnDateAddSecond.kt
+++ b/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnDateAddSecond.kt
@@ -3,6 +3,8 @@
 
 package org.partiql.plugin.internal.fn.scalar
 
+import org.partiql.errors.DataException
+import org.partiql.errors.TypeCheckException
 import org.partiql.spi.function.PartiQLFunction
 import org.partiql.spi.function.PartiQLFunctionExperimental
 import org.partiql.types.function.FunctionParameter
@@ -44,7 +46,7 @@ internal object Fn_DATE_ADD_SECOND__INT32_TIME__TIME : PartiQLFunction.Scalar {
             timeValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.toInt64().value!!
             timeValue(datetimeValue.plusSeconds(intervalValue))
         }
     }
@@ -71,7 +73,7 @@ internal object Fn_DATE_ADD_SECOND__INT64_TIME__TIME : PartiQLFunction.Scalar {
             timeValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.value!!
             timeValue(datetimeValue.plusSeconds(intervalValue))
         }
     }
@@ -98,8 +100,7 @@ internal object Fn_DATE_ADD_SECOND__INT_TIME__TIME : PartiQLFunction.Scalar {
             timeValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            // TODO: We need to consider overflow here
-            val intervalValue = interval.long!!
+            val intervalValue = try { interval.toInt64().value!! } catch (e: DataException) { throw TypeCheckException() }
             timeValue(datetimeValue.plusSeconds(intervalValue))
         }
     }
@@ -126,7 +127,7 @@ internal object Fn_DATE_ADD_SECOND__INT32_TIMESTAMP__TIMESTAMP : PartiQLFunction
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.toInt64().value!!
             timestampValue(datetimeValue.plusSeconds(intervalValue))
         }
     }
@@ -153,7 +154,7 @@ internal object Fn_DATE_ADD_SECOND__INT64_TIMESTAMP__TIMESTAMP : PartiQLFunction
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.value!!
             timestampValue(datetimeValue.plusSeconds(intervalValue))
         }
     }
@@ -180,8 +181,7 @@ internal object Fn_DATE_ADD_SECOND__INT_TIMESTAMP__TIMESTAMP : PartiQLFunction.S
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            // TODO: We need to consider overflow here
-            val intervalValue = interval.long!!
+            val intervalValue = try { interval.toInt64().value!! } catch (e: DataException) { throw TypeCheckException() }
             timestampValue(datetimeValue.plusSeconds(intervalValue))
         }
     }

--- a/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnDateAddYear.kt
+++ b/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnDateAddYear.kt
@@ -3,6 +3,8 @@
 
 package org.partiql.plugin.internal.fn.scalar
 
+import org.partiql.errors.DataException
+import org.partiql.errors.TypeCheckException
 import org.partiql.spi.function.PartiQLFunction
 import org.partiql.spi.function.PartiQLFunctionExperimental
 import org.partiql.types.function.FunctionParameter
@@ -44,7 +46,7 @@ internal object Fn_DATE_ADD_YEAR__INT32_DATE__DATE : PartiQLFunction.Scalar {
             dateValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.toInt64().value!!
             dateValue(datetimeValue.plusYears(intervalValue))
         }
     }
@@ -71,7 +73,7 @@ internal object Fn_DATE_ADD_YEAR__INT64_DATE__DATE : PartiQLFunction.Scalar {
             dateValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.value!!
             dateValue(datetimeValue.plusYears(intervalValue))
         }
     }
@@ -98,8 +100,7 @@ internal object Fn_DATE_ADD_YEAR__INT_DATE__DATE : PartiQLFunction.Scalar {
             dateValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            // TODO: We need to consider overflow here
-            val intervalValue = interval.long!!
+            val intervalValue = try { interval.toInt64().value!! } catch (e: DataException) { throw TypeCheckException() }
             dateValue(datetimeValue.plusYears(intervalValue))
         }
     }
@@ -126,7 +127,7 @@ internal object Fn_DATE_ADD_YEAR__INT32_TIMESTAMP__TIMESTAMP : PartiQLFunction.S
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.toInt64().value!!
             timestampValue(datetimeValue.plusYears(intervalValue))
         }
     }
@@ -153,7 +154,7 @@ internal object Fn_DATE_ADD_YEAR__INT64_TIMESTAMP__TIMESTAMP : PartiQLFunction.S
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            val intervalValue = interval.long!!
+            val intervalValue = interval.value!!
             timestampValue(datetimeValue.plusYears(intervalValue))
         }
     }
@@ -180,8 +181,7 @@ internal object Fn_DATE_ADD_YEAR__INT_TIMESTAMP__TIMESTAMP : PartiQLFunction.Sca
             timestampValue(null)
         } else {
             val datetimeValue = datetime.value!!
-            // TODO: We need to consider overflow here
-            val intervalValue = interval.long!!
+            val intervalValue = try { interval.toInt64().value!! } catch (e: DataException) { throw TypeCheckException() }
             timestampValue(datetimeValue.plusYears(intervalValue))
         }
     }

--- a/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnIsChar.kt
+++ b/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnIsChar.kt
@@ -55,7 +55,7 @@ internal object Fn_IS_CHAR__INT32_ANY__BOOL : PartiQLFunction.Scalar {
     )
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
-        val length = args[0].check<Int32Value>().int
+        val length = args[0].check<Int32Value>().value
         if (length == null || length < 0) {
             throw TypeCheckException()
         }

--- a/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnIsString.kt
+++ b/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnIsString.kt
@@ -54,7 +54,7 @@ internal object Fn_IS_STRING__INT32_ANY__BOOL : PartiQLFunction.Scalar {
     )
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
-        val length = args[0].check<Int32Value>().int
+        val length = args[0].check<Int32Value>().value
         if (length == null || length < 0) {
             throw TypeCheckException()
         }

--- a/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnSubstring.kt
+++ b/plugins/partiql-plugin/src/main/kotlin/org/partiql/plugin/internal/fn/scalar/FnSubstring.kt
@@ -3,6 +3,7 @@
 
 package org.partiql.plugin.internal.fn.scalar
 
+import org.partiql.errors.DataException
 import org.partiql.errors.TypeCheckException
 import org.partiql.plugin.internal.extensions.codepointSubstring
 import org.partiql.spi.function.PartiQLFunction
@@ -108,7 +109,7 @@ internal object Fn_SUBSTRING__STRING_INT64__STRING : PartiQLFunction.Scalar {
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
         val value = args[0].check<StringValue>().string
-        val start = args[1].check<Int64Value>().int
+        val start = try { args[1].check<Int64Value>().toInt32().value } catch (e: DataException) { throw TypeCheckException() }
         if (value == null || start == null) {
             return stringValue(null)
         }
@@ -134,8 +135,8 @@ internal object Fn_SUBSTRING__STRING_INT64_INT64__STRING : PartiQLFunction.Scala
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
         val value = args[0].check<SymbolValue>().string
-        val start = args[1].check<Int64Value>().int
-        val end = args[2].check<Int64Value>().int
+        val start = try { args[1].check<Int64Value>().toInt32().value } catch (e: DataException) { throw TypeCheckException() }
+        val end = try { args[2].check<Int64Value>().toInt32().value } catch (e: DataException) { throw TypeCheckException() }
         if (value == null || start == null || end == null) {
             return stringValue(null)
         }
@@ -163,7 +164,7 @@ internal object Fn_SUBSTRING__SYMBOL_INT64__SYMBOL : PartiQLFunction.Scalar {
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
         val value = args[0].check<SymbolValue>().string
-        val start = args[1].check<Int64Value>().int
+        val start = try { args[1].check<Int64Value>().toInt32().value } catch (e: DataException) { throw TypeCheckException() }
         if (value == null || start == null) {
             return stringValue(null)
         }
@@ -189,7 +190,7 @@ internal object Fn_SUBSTRING__SYMBOL_INT64_INT64__SYMBOL : PartiQLFunction.Scala
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
         val value = args[0].check<ClobValue>().string
-        val start = args[1].check<Int64Value>().int
+        val start = try { args[1].check<Int64Value>().toInt32().value } catch (e: DataException) { throw TypeCheckException() }
         if (value == null || start == null) {
             return stringValue(null)
         }
@@ -234,8 +235,8 @@ internal object Fn_SUBSTRING__CLOB_INT64_INT64__CLOB : PartiQLFunction.Scalar {
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
         val value = args[0].check<ClobValue>().string
-        val start = args[1].check<Int64Value>().int
-        val end = args[2].check<Int64Value>().int
+        val start = try { args[1].check<Int64Value>().toInt32().value } catch (e: DataException) { throw TypeCheckException() }
+        val end = try { args[2].check<Int64Value>().toInt32().value } catch (e: DataException) { throw TypeCheckException() }
         if (value == null || start == null || end == null) {
             return stringValue(null)
         }

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/EvalExecutor.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/EvalExecutor.kt
@@ -2,6 +2,7 @@ package org.partiql.runner.executor
 
 import com.amazon.ion.IonStruct
 import com.amazon.ion.IonValue
+import com.amazon.ionelement.api.AnyElement
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.StructElement
@@ -150,7 +151,7 @@ class EvalExecutor(
             val map = mutableMapOf<String, StaticType>()
 
             env.fields.forEach {
-                map[it.name] = inferEnv(env)
+                map[it.name] = inferEnv(it.value)
             }
             val metadata = MemoryConnector.Metadata(map)
             val globals = load(metadata, env)
@@ -158,7 +159,7 @@ class EvalExecutor(
             return MemoryConnector(metadata, bindings)
         }
 
-        private fun inferEnv(env: StructElement): StaticType {
+        private fun inferEnv(env: AnyElement): StaticType {
             val connector = MemoryConnector(MemoryConnector.Metadata(emptyMap()), MemoryBindings(emptyMap()))
             val session = PartiQLPlanner.Session(
                 queryId = "query",

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/test/TestRunner.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/test/TestRunner.kt
@@ -46,7 +46,7 @@ class TestRunner<T, V>(private val factory: TestExecutor.Factory<T, V>) {
             }
         } catch (e: Exception) {
             when (case.assertion) {
-                is Assertion.EvaluationSuccess -> error("Expected success but exception thrown: $e")
+                is Assertion.EvaluationSuccess -> error("Expected success but exception thrown: $e trace: ${e.stackTrace.forEach { println(it) }}")
                 is Assertion.EvaluationFailure -> {} // skip
             }
         }


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
In this PR, we model Cast as its own Plan Node. 

Added Plan Node: 
```
cast::{
  operand: partiql_value_type, // operand is a value.
  target: partiql_value_type, // TODO: Consider change this to Static Type
  cast_type: cast_type::[
    COERCION,
    EXPLICIT,
    UNSAFE
  ],
}

rex::{
  op:[
    cast_op::{
      arg: rex,
      cast: cast
    },
  ]
}    
```

Internal Plan Node is modeled exactly the same as public Plan Node for now. 

### Cast Table
The cast table are hard coded for now. Check [here](https://github.com/partiql/partiql-lang-kotlin/blob/2d493c625e09c2a0695a707e6b41841b9b73e2d6/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeCasts.kt) for the cast table. 

### Planning
During planning, the planner will check if there is a available cast relationship exist. If so, the planner store the cast relationship in cast Node, and the `castOp` node points to the cast Node. 

Note that if in planning time, we know that the arg is NULL, we reduce the cast op to a `RexOpLit($typedNullValue)` with type as the target type. If the arg is `missing` then we reduce the cast op to a `RexOpLit(missingValue())`

Note that for dynamic function, instead of storing a function signature that hints on the correct cast to invoke, we store a Cast ref to achieve the same functionality. 

Example: 
```
t_int2 : StaticType.INT2
t2: StaticType.unionOf(INT4, DECIMAL) 

t_int2 + t2 

⚬ PartiQLPlan[tag=Plan-9835b5f]
   ├──Catalog[name=test, tag=Plan-b2e2597c]
   │  ├──Symbol[type=int2, tag=Plan-90f65f9e]
   │  └──Symbol[type=union(decimal, int4), tag=Plan-1ba87674]
   └──Query[tag=Plan-810bfdb7]
      └──Rex[type=union(decimal, int4), tag=Plan-df596342]
         └──Dynamic[tag=Plan-8aa94980]
            ├──Rex[type=int2, tag=Plan-3ff7f113]
            │  └──Global[tag=Plan-7675096]
            │     └──Ref[catalog=0, symbol=0, tag=Plan-7412482]
            ├──Rex[type=union(decimal, int4), tag=Plan-c84905a8]
            │  └──Global[tag=Plan-ec8cbafe]
            │     └──Ref[catalog=0, symbol=1, tag=Plan-443bf140]
            ├──Candidate[tag=Plan-8502a68c]
            │  ├──Fn[signature=PLUS__DECIMAL_ARBITRARY_DECIMAL_ARBITRARY__DECIMAL_ARBITRARY, tag=Plan-89b81583]
            │  └──Cast[castType=COERCION, operand=INT16, target=DECIMAL_ARBITRARY, tag=Plan-530ad5f8]
            └──Candidate[tag=Plan-324b0bb7]
               ├──Fn[signature=PLUS__INT32_INT32__INT32, tag=Plan-8ced4d96]
               └──Cast[castType=COERCION, operand=INT16, target=INT32, tag=Plan-cfbb004f]
```


### Updated Cast Table
|ANY| BOOL| INT8| INT16| INT32| INT64| INT| DECIMAL| DECIMAL_ARBITRARY| FLOAT32| FLOAT64| CHAR| STRING| SYMBOL| BINARY| BYTE| BLOB| CLOB| DATE| TIME| TIMESTAMP| INTERVAL| BAG| LIST| SEXP| STRUCT| NULL| MISSING|
|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|-------|
| ANY | ⬤ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ |
| BOOL | X | ⬤ | ◯ | ◯ | ◯ | ◯ | ◯ | ◯ | ◯ | ◯ | ◯ | ◯ | ◯ | ◯ | X | X | X | X | X | X | X | X | X | X | X | X | X | X |
| INT8 | X | ◯ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ◯ | ⬤ | ⬤ | ⬤ | X | ◯ | ◯ | X | X | X | X | X | X | X | X | X | X | X | X | X | X |
| INT16 | X | ◯ | △ | ⬤ | ⬤ | ⬤ | ⬤ | ◯ | ⬤ | ⬤ | ⬤ | X | ◯ | ◯ | X | X | X | X | X | X | X | X | X | X | X | X | X | X |
| INT32 | X | ◯ | △ | △ | ⬤ | ⬤ | ⬤ | ◯ | ⬤ | ⬤ | ⬤ | X | ◯ | ◯ | X | X | X | X | X | X | X | X | X | X | X | X | X | X |
| INT64 | X | ◯ | △ | △ | △ | ⬤ | ⬤ | ◯ | ⬤ | ⬤ | ⬤ | X | ◯ | ◯ | X | X | X | X | X | X | X | X | X | X | X | X | X | X |
| INT | X | ◯ | △ | △ | △ | △ | ⬤ | ◯ | ⬤ | ⬤ | ⬤ | X | ◯ | ◯ | X | X | X | X | X | X | X | X | X | X | X | X | X | X |
| DECIMAL | X | ◯ | ◯ | ◯ | ◯ | ◯ | X | ◯ | ◯ | ◯ | ◯ | X | ◯ | ◯ | X | X | X | X | X | X | X | X | X | X | X | X | X | X |
| DECIMAL_ARBITRARY | X | ◯ | △ | △ | △ | △ | ◯ | ◯ | ⬤ | ◯ | ◯ | X | ◯ | ◯ | X | X | X | X | X | X | X | X | X | X | X | X | X | X |
| FLOAT32 | X | ◯ | △ | △ | △ | △ | ◯ | ◯ | ⬤ | ⬤ | ⬤ | X | ◯ | ◯ | X | X | X | X | X | X | X | X | X | X | X | X | X | X |
| FLOAT64 | X | ◯ | △ | △ | △ | △ | ◯ | ◯ | ⬤ | X | ⬤ | X | ◯ | ◯ | X | X | X | X | X | X | X | X | X | X | X | X | X | X |
| CHAR | X | △ | X | X | X | X | X | X | X | X | X | ⬤ | ⬤ | ⬤ | X | X | X | X | X | X | X | X | X | X | X | X | X | X |
| STRING | X | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | X | ⬤ | ◯ | X | X | X | ⬤ | X | X | X | X | X | X | X | X | X | X |
| SYMBOL | X | △ | △ | △ | △ | △ | △ | △ | △ | △ | △ | X | ⬤ | ⬤ | X | X | X | ⬤ | X | X | X | X | X | X | X | X | X | X |
| BINARY | X | X | X | X | X | X | X | X | X | X | X | X | X | X | ⬤ | X | X | X | X | X | X | X | X | X | X | X | X | X |
| BYTE | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | ⬤ | X | X | X | X | X | X | X | X | X | X | X | X |
| BLOB | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | ⬤ | X | X | X | X | X | X | X | X | X | X | X |
| CLOB | X | X | X | X | X | X | X | X | X | X | X | △ | △ | △ | X | X | X | ⬤ | X | X | X | X | X | X | X | X | X | X |
| DATE | X | X | X | X | X | X | X | X | X | X | X | ◯ | ◯ | ◯ | X | X | X | X | ⬤ | X | ◯ | X | X | X | X | X | X | X |
| TIME | X | X | X | X | X | X | X | X | X | X | X | ◯ | ◯ | ◯ | X | X | X | X | X | ⬤ | ◯ | X | X | X | X | X | X | X |
| TIMESTAMP | X | X | X | X | X | X | X | X | X | X | X | ◯ | ◯ | ◯ | X | X | X | X | ◯ | ◯ | ⬤ | X | X | X | X | X | X | X |
| INTERVAL | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | ⬤ | X | X | X | X | X | X |
| BAG | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | ⬤ | ◯ | ◯ | X | X | X |
| LIST | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | ◯ | ⬤ | ◯ | X | X | X |
| SEXP | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | ◯ | ◯ | ⬤ | X | X | X |
| STRUCT | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | ⬤ | X | X |
| NULL | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | ⬤ | X |
| MISSING | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X | X |

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - < If NO, why? >

- Any backward-incompatible changes? **[YES/NO]**
  - < If YES, why? >
  - < For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base. >

- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.