### PR TITLE
Adds support for ROW and SCALAR subquery coercion

### DIFF
--- a/partiql-ast/src/main/kotlin/org/partiql/ast/normalize/Normalize.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/normalize/Normalize.kt
@@ -23,7 +23,6 @@ public fun Statement.normalize(): Statement {
     // could be a fold, but this is nice for setting breakpoints
     var ast = this
     ast = NormalizeFromSource.apply(ast)
-    ast = NormalizeSelect.apply(ast)
     ast = NormalizeGroupBy.apply(ast)
     return ast
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSubquery.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSubquery.kt
@@ -1,0 +1,67 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.errors.TypeCheckException
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.CollectionValue
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.StructValue
+import org.partiql.value.check
+import org.partiql.value.listValue
+
+internal abstract class ExprSubquery : Operator.Expr {
+
+    abstract val subquery: Operator.Expr
+
+    internal class Row(
+        override val subquery: Operator.Expr
+    ) : ExprSubquery() {
+        @PartiQLValueExperimental
+        override fun eval(record: Record): PartiQLValue {
+            val values = getFirstAndOnlyTupleValues(record)
+            return listValue(values.asSequence().toList())
+        }
+    }
+
+    internal class Scalar(
+        override val subquery: Operator.Expr
+    ) : ExprSubquery() {
+        @PartiQLValueExperimental
+        override fun eval(record: Record): PartiQLValue {
+            val values = getFirstAndOnlyTupleValues(record)
+            if (values.hasNext().not()) {
+                throw TypeCheckException()
+            }
+            val singleValue = values.next()
+            if (values.hasNext()) {
+                throw TypeCheckException()
+            }
+            return singleValue
+        }
+    }
+
+    /**
+     * Procedure is as follows:
+     * 1. Asserts that the [subquery] returns a collection containing a single value. Throws a [TypeCheckException] if not.
+     * 2. Gets the first value from [subquery].
+     * 3. Asserts that the first value is a TUPLE ([StructValue]). Throws a [TypeCheckException] if not.
+     * 4. Returns an [Iterator] of the values contained within the [StructValue].
+     */
+    @OptIn(PartiQLValueExperimental::class)
+    fun getFirstAndOnlyTupleValues(record: Record): Iterator<PartiQLValue> {
+        val result = subquery.eval(record)
+        if (result !is CollectionValue<*>) {
+            throw TypeCheckException()
+        }
+        val resultIterator = result.iterator()
+        if (resultIterator.hasNext().not()) {
+            throw TypeCheckException()
+        }
+        val tuple = resultIterator.next().check<StructValue<*>>()
+        if (resultIterator.hasNext()) {
+            throw TypeCheckException()
+        }
+        return tuple.values.iterator()
+    }
+}

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -606,7 +606,7 @@ internal class PlanTyper(
                 }
                 is FnMatch.Error -> {
                     handleUnknownFunction(match)
-                    rexErr("Unknown scalar function $fn")
+                    rexErr("Unknown scalar function $fn for args: $args")
                 }
             }
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/transforms/NormalizeSelectTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/transforms/NormalizeSelectTest.kt
@@ -1,4 +1,4 @@
-package org.partiql.ast.normalize
+package org.partiql.planner.internal.transforms
 
 import org.junit.jupiter.api.Test
 import org.partiql.ast.Expr
@@ -38,7 +38,7 @@ class NormalizeSelectTest {
             "b" to variable("b"),
             "c" to variable("c"),
         )
-        val actual = NormalizeSelect.apply(input)
+        val actual = NormalizeSelect.normalize(input)
         assertEquals(expected, actual)
     }
 
@@ -63,7 +63,7 @@ class NormalizeSelectTest {
             "_2" to lit(2),
             "_3" to lit(3),
         )
-        val actual = NormalizeSelect.apply(input)
+        val actual = NormalizeSelect.normalize(input)
         assertEquals(expected, actual)
     }
 
@@ -88,7 +88,7 @@ class NormalizeSelectTest {
             "_1" to lit(2),
             "_2" to lit(3),
         )
-        val actual = NormalizeSelect.apply(input)
+        val actual = NormalizeSelect.normalize(input)
         assertEquals(expected, actual)
     }
 
@@ -113,7 +113,7 @@ class NormalizeSelectTest {
             "b" to lit(2),
             "c" to lit(3),
         )
-        val actual = NormalizeSelect.apply(input)
+        val actual = NormalizeSelect.normalize(input)
         assertEquals(expected, actual)
     }
 
@@ -128,43 +128,39 @@ class NormalizeSelectTest {
     )
 
     private fun select(vararg items: Select.Project.Item) = ast {
-        statementQuery {
-            expr = exprSFW {
-                select = selectProject {
-                    this.items += items
-                }
-                from = fromValue {
-                    expr = variable("T")
-                    type = From.Value.Type.SCAN
-                }
+        exprSFW {
+            select = selectProject {
+                this.items += items
+            }
+            from = fromValue {
+                expr = variable("T")
+                type = From.Value.Type.SCAN
             }
         }
     }
 
     @OptIn(PartiQLValueExperimental::class)
     private fun selectValue(vararg items: Pair<String, Expr>) = ast {
-        statementQuery {
-            expr = exprSFW {
-                select = selectValue {
-                    constructor = exprStruct {
-                        for ((k, v) in items) {
-                            fields += exprStructField {
-                                name = exprLit(stringValue(k))
-                                value = v
-                            }
+        exprSFW {
+            select = selectValue {
+                constructor = exprStruct {
+                    for ((k, v) in items) {
+                        fields += exprStructField {
+                            name = exprLit(stringValue(k))
+                            value = v
                         }
                     }
                 }
-                from = fromValue {
-                    expr = exprVar {
-                        identifier = identifierSymbol {
-                            symbol = "T"
-                            caseSensitivity = Identifier.CaseSensitivity.INSENSITIVE
-                        }
-                        scope = Expr.Var.Scope.DEFAULT
+            }
+            from = fromValue {
+                expr = exprVar {
+                    identifier = identifierSymbol {
+                        symbol = "T"
+                        caseSensitivity = Identifier.CaseSensitivity.INSENSITIVE
                     }
-                    type = From.Value.Type.SCAN
+                    scope = Expr.Var.Scope.DEFAULT
                 }
+                type = From.Value.Type.SCAN
             }
         }
     }


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds support for ROW and SCALAR subquery coercion
- NOTE: There is a bug with correlated subqueries (not subquery coercion which is this PR) that doesn't let us handle references to variables in the outer scope. See https://github.com/partiql/partiql-lang-kotlin/pull/1353#discussion_r1471748883. I've looked further into it, and it is likely going to require an overhaul of planning/evaluation. I've decided to exclude this from this PR, as this is specifically for coercion.

## How PR accomplishes this
- According to the PartiQL Specification, when SQL's SELECT is seen in a query (not on the RHS of an IN, not on the RHS of a FROM, and not as a top-level expression), it is coerced to a scalar. It does this by grabbing the first attribute of the first value (a tuple) of the SQL SELECT. However, if it is on the LHS or RHS of a literal array, then it gets coerced into a LIST. It does this by grabbing all attribute of the first value (a tuple) of the SQL SELECT.
- In order to accomplish this, we need to maintain the original query's semantics upon typing the plan. That being said, we cannot preemptively normalize a SQL SELECT to a PARTIQL SELECT VALUE. We need to first gather sufficient information to determine whether a SELECT should be coerced at all (and if so, whether it should be a SCALAR or ROW coercion). This PR moves the `NormalizeSelect` to occur **during** the `RelConverter`'s transformation.
- With this change, at planning time, we have a clear understanding of the user's intentions while coercing subqueries.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **Potentially**
  - Potentially yes for behavioral changes. `NormalizeSelect` no longer occurs in the `org.partiql.ast.normalize` API.
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.