### PR TITLE
Adds UNPIVOT, LIMIT, and OFFSET to partiql-eval

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelLimit.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelLimit.kt
@@ -1,24 +1,37 @@
 package org.partiql.eval.internal.operator.rel
 
+import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.NumericValue
+import org.partiql.value.PartiQLValueExperimental
 
+@OptIn(PartiQLValueExperimental::class)
 internal class RelLimit(
     private val input: Operator.Relation,
-    private val limit: Long,
+    private val limit: Operator.Expr,
 ) : Operator.Relation {
 
-    private var seen = 0
+    private var _seen: Long = 0
+    private var _limit: Long = 0
 
     override fun open() {
         input.open()
-        seen = 0
+        _seen = 0
+
+        // TODO pass outer scope to limit expression
+        val l = limit.eval(Record.empty)
+        if (l is NumericValue<*>) {
+            _limit = l.toInt64().value ?: 0L
+        } else {
+            throw TypeCheckException()
+        }
     }
 
     override fun next(): Record? {
-        if (seen < limit) {
+        if (_seen < _limit) {
             val row = input.next() ?: return null
-            seen += 1
+            _seen += 1
             return row
         }
         return null

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOffset.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOffset.kt
@@ -1,27 +1,40 @@
 package org.partiql.eval.internal.operator.rel
 
+import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.NumericValue
+import org.partiql.value.PartiQLValueExperimental
 
+@OptIn(PartiQLValueExperimental::class)
 internal class RelOffset(
     private val input: Operator.Relation,
-    private val offset: Long,
+    private val offset: Operator.Expr,
 ) : Operator.Relation {
 
     private var init = false
-    private var seen = 0
+    private var _seen: Long = 0
+    private var _offset: Long = 0
 
     override fun open() {
         input.open()
         init = false
-        seen = 0
+        _seen = 0
+
+        // TODO pass outer scope to offset expression
+        val o = offset.eval(Record.empty)
+        if (o is NumericValue<*>) {
+            _offset = o.toInt64().value ?: 0L
+        } else {
+            throw TypeCheckException()
+        }
     }
 
     override fun next(): Record? {
         if (!init) {
-            while (seen < offset) {
+            while (_seen < _offset) {
                 input.next() ?: return null
-                seen += 1
+                _seen += 1
             }
             init = true
         }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelUnpivot.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelUnpivot.kt
@@ -1,0 +1,84 @@
+package org.partiql.eval.internal.operator.rel
+
+import org.partiql.errors.TypeCheckException
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.MissingValue
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.StructValue
+import org.partiql.value.stringValue
+import org.partiql.value.structValue
+
+/**
+ * The unpivot operator produces a bag of records from a struct.
+ *
+ *  Input:   { k_0: v_0, ..., k_i: v_i }
+ *  Output:  [ k_0, v_0 ] ... [ k_i, v_i ]
+ */
+@OptIn(PartiQLValueExperimental::class)
+internal sealed class RelUnpivot : Operator.Relation {
+
+    /**
+     * Iterator of the struct fields.
+     */
+    private lateinit var _iterator: Iterator<Pair<String, PartiQLValue>>
+
+    /**
+     * Each mode overrides.
+     */
+    abstract fun struct(): StructValue<*>
+
+    /**
+     * Initialize the _iterator from the concrete implementation's struct()
+     */
+    override fun open() {
+        _iterator = struct().entries.iterator()
+    }
+
+    override fun next(): Record? {
+        if (!_iterator.hasNext()) {
+            return null
+        }
+        val f = _iterator.next()
+        val k = stringValue(f.first)
+        val v = f.second
+        return Record.of(k, v)
+    }
+
+    override fun close() {}
+
+    /**
+     * In strict mode, the UNPIVOT operator raises an error on mistyped input.
+     *
+     * @property expr
+     */
+    class Strict(private val expr: Operator.Expr) : RelUnpivot() {
+
+        override fun struct(): StructValue<*> {
+            val v = expr.eval(Record.empty)
+            if (v !is StructValue<*>) {
+                throw TypeCheckException()
+            }
+            return v
+        }
+    }
+
+    /**
+     * In permissive mode, the UNPIVOT operator coerces the input (v) to a struct.
+     *
+     *  1. If v is a struct, return it.
+     *  2. If v is MISSING, return { }.
+     *  3. Else, return { '_1': v }.
+     *
+     * @property expr
+     */
+    class Permissive(private val expr: Operator.Expr) : RelUnpivot() {
+
+        override fun struct(): StructValue<*> = when (val v = expr.eval(Record.empty)) {
+            is StructValue<*> -> v
+            is MissingValue -> structValue<PartiQLValue>()
+            else -> structValue("_1" to v)
+        }
+    }
+}


### PR DESCRIPTION
## Description

This adds UNPIVOT, LIMIT, and OFFSET to partiql-eval. We will need to update LIMIT and OFFSET to use the upvalues introduced in John's correlated subquery PR.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
N/A

- Any backward-incompatible changes? **[YES/NO]**
No

- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >
 No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.