### PR TITLE
Adds support for correlated subqueries & coercions via scoping

### DIFF
--- a/partiql-ast/src/main/kotlin/org/partiql/ast/normalize/Normalize.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/normalize/Normalize.kt
@@ -23,7 +23,6 @@ public fun Statement.normalize(): Statement {
     // could be a fold, but this is nice for setting breakpoints
     var ast = this
     ast = NormalizeFromSource.apply(ast)
-    ast = NormalizeSelect.apply(ast)
     ast = NormalizeGroupBy.apply(ast)
     return ast
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -23,7 +23,6 @@ import org.partiql.eval.internal.operator.rex.ExprCase
 import org.partiql.eval.internal.operator.rex.ExprCast
 import org.partiql.eval.internal.operator.rex.ExprCollection
 import org.partiql.eval.internal.operator.rex.ExprLiteral
-import org.partiql.eval.internal.operator.rex.ExprLocal
 import org.partiql.eval.internal.operator.rex.ExprPathIndex
 import org.partiql.eval.internal.operator.rex.ExprPathKey
 import org.partiql.eval.internal.operator.rex.ExprPathSymbol
@@ -34,7 +33,8 @@ import org.partiql.eval.internal.operator.rex.ExprSelect
 import org.partiql.eval.internal.operator.rex.ExprStruct
 import org.partiql.eval.internal.operator.rex.ExprSubquery
 import org.partiql.eval.internal.operator.rex.ExprTupleUnion
-import org.partiql.eval.internal.operator.rex.ExprUpvalue
+import org.partiql.eval.internal.operator.rex.ExprVarLocal
+import org.partiql.eval.internal.operator.rex.ExprVarOuter
 import org.partiql.plan.Catalog
 import org.partiql.plan.PartiQLPlan
 import org.partiql.plan.PlanNode
@@ -49,7 +49,6 @@ import org.partiql.types.StaticType
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.PartiQLValueType
 import java.lang.IllegalStateException
-import java.util.Stack
 
 internal class Compiler(
     private val plan: PartiQLPlan,
@@ -134,12 +133,12 @@ internal class Compiler(
         }
     }
 
-    override fun visitRexOpVarUpvalue(node: Rex.Op.Var.Upvalue, ctx: StaticType?): Operator {
-        return ExprUpvalue(node.frameRef, node.valueRef, env)
+    override fun visitRexOpVarOuter(node: Rex.Op.Var.Outer, ctx: StaticType?): Operator {
+        return ExprVarOuter(node.scope, node.ref, env)
     }
 
     override fun visitRexOpVarLocal(node: Rex.Op.Var.Local, ctx: StaticType?): Operator {
-        return ExprLocal(node.ref)
+        return ExprVarLocal(node.ref)
     }
 
     override fun visitRexOpVarGlobal(node: Rex.Op.Var.Global, ctx: StaticType?): Operator = symbols.getGlobal(node.ref)

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Environment.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Environment.kt
@@ -1,0 +1,14 @@
+package org.partiql.eval.internal
+
+import java.util.Stack
+
+internal class Environment {
+
+    private val scopes: Stack<Record> = Stack<Record>()
+
+    internal inline fun scope(record: Record, block: () -> Unit) {
+        scopes.push(record)
+        block.invoke()
+        scopes.pop()
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Environment.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Environment.kt
@@ -30,9 +30,10 @@ internal class Environment {
     }
 
     /**
-     * Gets the scope/record/variables-environment at the requested [index].
+     * Gets the scope/record/variables-environment at the requested [depth].
      */
-    operator fun get(index: Int): Record {
+    operator fun get(depth: Int): Record {
+        val index = scopes.lastIndex - depth
         return scopes[index]
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Environment.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Environment.kt
@@ -29,10 +29,9 @@ internal class Environment {
     }
 
     /**
-     * Gets the scope/record/variables-environment at the requested [depth].
+     * Gets the scope/record/variables-environment at the requested [index].
      */
-    operator fun get(depth: Int): Record {
-        val index = scopes.lastIndex - depth
+    operator fun get(index: Int): Record {
         return scopes[index]
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Environment.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Environment.kt
@@ -19,14 +19,13 @@ internal class Environment {
      */
     internal inline fun <T> scope(record: Record, block: () -> T): T {
         scopes.push(record)
-        val result = try {
-            block.invoke()
+        try {
+            return block.invoke()
         } catch (t: Throwable) {
-            scopes.pop()
             throw t
+        } finally {
+            scopes.pop()
         }
-        scopes.pop()
-        return result
     }
 
     /**

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Environment.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Environment.kt
@@ -2,10 +2,21 @@ package org.partiql.eval.internal
 
 import java.util.Stack
 
+/**
+ * This class represents the Variables Environment defined in the PartiQL Specification. It differs slightly as it does
+ * not hold the "current" [Record]. The reason for this is that the PartiQL Maintainers have opted to use the Volcano
+ * Model for query execution (see [org.partiql.eval.internal.operator.Operator.Relation.next] and
+ * [org.partiql.eval.internal.operator.Operator.Expr.eval]), however, the use of the [Environment] is to provide the
+ * functionality defined in the PartiQL Specification. It accomplishes this by wrapping the "outer" variables
+ * environments (or [scopes]).
+ */
 internal class Environment {
 
     private val scopes: Stack<Record> = Stack<Record>()
 
+    /**
+     * Creates a new scope using the [record] to execute the [block]. Pops the [record] once the [block] is done executing.
+     */
     internal inline fun <T> scope(record: Record, block: () -> T): T {
         scopes.push(record)
         val result = try {
@@ -18,6 +29,9 @@ internal class Environment {
         return result
     }
 
+    /**
+     * Gets the scope/record/variables-environment at the requested [index].
+     */
     operator fun get(index: Int): Record {
         return scopes[index]
     }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Environment.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Environment.kt
@@ -6,9 +6,19 @@ internal class Environment {
 
     private val scopes: Stack<Record> = Stack<Record>()
 
-    internal inline fun scope(record: Record, block: () -> Unit) {
+    internal inline fun <T> scope(record: Record, block: () -> T): T {
         scopes.push(record)
-        block.invoke()
+        val result = try {
+            block.invoke()
+        } catch (t: Throwable) {
+            scopes.pop()
+            throw t
+        }
         scopes.pop()
+        return result
+    }
+
+    operator fun get(index: Int): Record {
+        return scopes[index]
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Record.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Record.kt
@@ -4,7 +4,7 @@ import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 
 @OptIn(PartiQLValueExperimental::class)
-internal class Record(val values: Array<PartiQLValue>) {
+internal data class Record(val values: Array<PartiQLValue>) {
 
     companion object {
         val empty = Record(emptyArray())
@@ -28,5 +28,9 @@ internal class Record(val values: Array<PartiQLValue>) {
 
     public fun copy(): Record {
         return Record(this.values.copyOf())
+    }
+
+    public operator fun get(index: Int): PartiQLValue {
+        return this.values[index]
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Symbols.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Symbols.kt
@@ -3,7 +3,7 @@
 package org.partiql.eval.internal
 
 import org.partiql.eval.PartiQLEngine
-import org.partiql.eval.internal.operator.rex.ExprGlobal
+import org.partiql.eval.internal.operator.rex.ExprVarGlobal
 import org.partiql.plan.Catalog
 import org.partiql.plan.PartiQLPlan
 import org.partiql.plan.Ref
@@ -31,14 +31,14 @@ internal class Symbols private constructor(private val catalogs: Array<C>) {
         override fun toString(): String = name
     }
 
-    fun getGlobal(ref: Ref): ExprGlobal {
+    fun getGlobal(ref: Ref): ExprVarGlobal {
         val catalog = catalogs[ref.catalog]
         val item = catalog.items.getOrNull(ref.symbol)
         if (item == null || item !is Catalog.Item.Value) {
             error("Invalid reference $ref; missing value entry for catalog `$catalog`.")
         }
         val path = ConnectorPath(item.path)
-        return ExprGlobal(path, catalog.bindings)
+        return ExprVarGlobal(path, catalog.bindings)
     }
 
     fun getFn(ref: Ref): Fn {

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelExclude.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelExclude.kt
@@ -3,7 +3,6 @@ package org.partiql.eval.internal.operator.rel
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.plan.Rel
-import org.partiql.plan.Rex
 import org.partiql.plan.relOpExcludeTypeCollIndex
 import org.partiql.plan.relOpExcludeTypeCollWildcard
 import org.partiql.plan.relOpExcludeTypeStructKey
@@ -35,14 +34,9 @@ internal class RelExclude(
     override fun next(): Record? {
         val record = input.next() ?: return null
         exclusions.forEach { path ->
-            when (val root = path.root) {
-                is Rex.Op.Var.Local -> {
-                    val value = record.values[root.ref]
-                    record.values[root.ref] = exclude(value, path.steps)
-                }
-                is Rex.Op.Var.Outer -> { TODO("Remove values from stack.") }
-                is Rex.Op.Var.Global -> { TODO("Add and remove value from stack.") }
-            }
+            val root = path.root.ref
+            val value = record.values[root]
+            record.values[root] = exclude(value, path.steps)
         }
         return record
     }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelExclude.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelExclude.kt
@@ -40,7 +40,7 @@ internal class RelExclude(
                     val value = record.values[root.ref]
                     record.values[root.ref] = exclude(value, path.steps)
                 }
-                is Rex.Op.Var.Upvalue -> { TODO("Remove values from stack.") }
+                is Rex.Op.Var.Outer -> { TODO("Remove values from stack.") }
                 is Rex.Op.Var.Global -> { TODO("Add and remove value from stack.") }
             }
         }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelExclude.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelExclude.kt
@@ -3,6 +3,7 @@ package org.partiql.eval.internal.operator.rel
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.plan.Rel
+import org.partiql.plan.Rex
 import org.partiql.plan.relOpExcludeTypeCollIndex
 import org.partiql.plan.relOpExcludeTypeCollWildcard
 import org.partiql.plan.relOpExcludeTypeStructKey
@@ -34,9 +35,14 @@ internal class RelExclude(
     override fun next(): Record? {
         val record = input.next() ?: return null
         exclusions.forEach { path ->
-            val root = path.root.ref
-            val value = record.values[root]
-            record.values[root] = exclude(value, path.steps)
+            when (val root = path.root) {
+                is Rex.Op.Var.Local -> {
+                    val value = record.values[root.ref]
+                    record.values[root.ref] = exclude(value, path.steps)
+                }
+                is Rex.Op.Var.Upvalue -> { TODO("Remove values from stack.") }
+                is Rex.Op.Var.Global -> { TODO("Add and remove value from stack.") }
+            }
         }
         return record
     }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinInner.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinInner.kt
@@ -1,14 +1,14 @@
 package org.partiql.eval.internal.operator.rel
 
+import org.partiql.eval.internal.Environment
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
-import java.util.Stack
 
 internal class RelJoinInner(
     override val lhs: Operator.Relation,
     override val rhs: Operator.Relation,
     override val condition: Operator.Expr,
-    override val scopes: Stack<Record>
+    override val env: Environment
 ) : RelJoinNestedLoop() {
     override fun join(condition: Boolean, lhs: Record, rhs: Record): Record? {
         return when (condition) {

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinInner.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinInner.kt
@@ -2,11 +2,13 @@ package org.partiql.eval.internal.operator.rel
 
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
+import java.util.Stack
 
 internal class RelJoinInner(
     override val lhs: Operator.Relation,
     override val rhs: Operator.Relation,
-    override val condition: Operator.Expr
+    override val condition: Operator.Expr,
+    override val scopes: Stack<Record>
 ) : RelJoinNestedLoop() {
     override fun join(condition: Boolean, lhs: Record, rhs: Record): Record? {
         return when (condition) {

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinLeft.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinLeft.kt
@@ -1,14 +1,14 @@
 package org.partiql.eval.internal.operator.rel
 
+import org.partiql.eval.internal.Environment
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
-import java.util.Stack
 
 internal class RelJoinLeft(
     override val lhs: Operator.Relation,
     override val rhs: Operator.Relation,
     override val condition: Operator.Expr,
-    override val scopes: Stack<Record>
+    override val env: Environment
 ) : RelJoinNestedLoop() {
 
     override fun join(condition: Boolean, lhs: Record, rhs: Record): Record {

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinLeft.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinLeft.kt
@@ -2,11 +2,13 @@ package org.partiql.eval.internal.operator.rel
 
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
+import java.util.Stack
 
 internal class RelJoinLeft(
     override val lhs: Operator.Relation,
     override val rhs: Operator.Relation,
-    override val condition: Operator.Expr
+    override val condition: Operator.Expr,
+    override val scopes: Stack<Record>
 ) : RelJoinNestedLoop() {
 
     override fun join(condition: Boolean, lhs: Record, rhs: Record): Record {

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinOuterFull.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinOuterFull.kt
@@ -2,6 +2,7 @@ package org.partiql.eval.internal.operator.rel
 
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
+import java.util.Stack
 
 /**
  * Here's a simple implementation of FULL OUTER JOIN. The idea is fairly straightforward:
@@ -22,7 +23,8 @@ import org.partiql.eval.internal.operator.Operator
 internal class RelJoinOuterFull(
     override val lhs: Operator.Relation,
     override val rhs: Operator.Relation,
-    override val condition: Operator.Expr
+    override val condition: Operator.Expr,
+    override val scopes: Stack<Record>
 ) : RelJoinNestedLoop() {
 
     private var previousLhs: Record? = null

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinOuterFull.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinOuterFull.kt
@@ -1,8 +1,8 @@
 package org.partiql.eval.internal.operator.rel
 
+import org.partiql.eval.internal.Environment
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
-import java.util.Stack
 
 /**
  * Here's a simple implementation of FULL OUTER JOIN. The idea is fairly straightforward:
@@ -24,7 +24,7 @@ internal class RelJoinOuterFull(
     override val lhs: Operator.Relation,
     override val rhs: Operator.Relation,
     override val condition: Operator.Expr,
-    override val scopes: Stack<Record>
+    override val env: Environment
 ) : RelJoinNestedLoop() {
 
     private var previousLhs: Record? = null

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinRight.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinRight.kt
@@ -1,14 +1,14 @@
 package org.partiql.eval.internal.operator.rel
 
+import org.partiql.eval.internal.Environment
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
-import java.util.Stack
 
 internal class RelJoinRight(
     lhs: Operator.Relation,
     rhs: Operator.Relation,
     override val condition: Operator.Expr,
-    override val scopes: Stack<Record>
+    override val env: Environment
 ) : RelJoinNestedLoop() {
 
     override val lhs: Operator.Relation = rhs

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinRight.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinRight.kt
@@ -2,11 +2,13 @@ package org.partiql.eval.internal.operator.rel
 
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
+import java.util.Stack
 
 internal class RelJoinRight(
     lhs: Operator.Relation,
     rhs: Operator.Relation,
-    override val condition: Operator.Expr
+    override val condition: Operator.Expr,
+    override val scopes: Stack<Record>
 ) : RelJoinNestedLoop() {
 
     override val lhs: Operator.Relation = rhs

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprLocal.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprLocal.kt
@@ -7,13 +7,13 @@ import org.partiql.value.PartiQLValueExperimental
 
 /**
  * Returns the value in the given record index.
- *
- * @property index
  */
-internal class ExprVar(private val index: Int) : Operator.Expr {
+internal class ExprLocal(
+    private val ref: Int,
+) : Operator.Expr {
 
     @PartiQLValueExperimental
     override fun eval(record: Record): PartiQLValue {
-        return record.values[index]
+        return record.values[ref]
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPermissive.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPermissive.kt
@@ -1,5 +1,6 @@
 package org.partiql.eval.internal.operator.rex
 
+import org.partiql.errors.CardinalityViolation
 import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
@@ -16,6 +17,8 @@ internal class ExprPermissive(
         return try {
             target.eval(record)
         } catch (e: TypeCheckException) {
+            missingValue()
+        } catch (e: CardinalityViolation) {
             missingValue()
         }
     }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSelect.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSelect.kt
@@ -6,6 +6,7 @@ import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.bagValue
 import org.partiql.value.listValue
+import java.util.Stack
 
 /**
  * Invoke the constructor over all inputs.
@@ -14,9 +15,10 @@ import org.partiql.value.listValue
  * @property constructor
  */
 internal class ExprSelect(
-    val input: Operator.Relation,
-    val constructor: Operator.Expr,
-    val ordered: Boolean
+    private val input: Operator.Relation,
+    private val constructor: Operator.Expr,
+    private val ordered: Boolean,
+    private val scopes: Stack<Record>,
 ) : Operator.Expr {
 
     /**
@@ -26,12 +28,14 @@ internal class ExprSelect(
     @PartiQLValueExperimental
     override fun eval(record: Record): PartiQLValue {
         val elements = mutableListOf<PartiQLValue>()
+        scopes.push(record)
         input.open()
         while (true) {
             val r = input.next() ?: break
             val e = constructor.eval(r)
             elements.add(e)
         }
+        scopes.pop()
         input.close()
         return when (ordered) {
             true -> listValue(elements)

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSelect.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSelect.kt
@@ -7,7 +7,6 @@ import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.bagValue
 import org.partiql.value.listValue
-import java.util.Stack
 
 /**
  * Invoke the constructor over all inputs.

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSubquery.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSubquery.kt
@@ -1,0 +1,83 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.errors.TypeCheckException
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.StructValue
+import org.partiql.value.check
+import org.partiql.value.listValue
+import org.partiql.value.nullValue
+import java.util.Stack
+
+/**
+ * The PartiQL Specification talks about subqueries and how they are coerced. Specifically, subqueries are
+ * modeled as a COLL_TO_SCALAR(SELECT VALUE <tuple> ...) where the SELECT VALUE must return a single row containing
+ * a TUPLE.
+ *
+ * @see [getValues]
+ */
+internal abstract class ExprSubquery : Operator.Expr {
+
+    abstract val constructor: Operator.Expr
+    abstract val input: Operator.Relation
+    abstract val scopes: Stack<Record>
+
+    internal class Row(
+        override val constructor: Operator.Expr,
+        override val input: Operator.Relation,
+        override val scopes: Stack<Record>
+    ) : ExprSubquery() {
+        @PartiQLValueExperimental
+        override fun eval(record: Record): PartiQLValue {
+            val values = getValues(record) ?: return nullValue()
+            return listValue(values.asSequence().toList())
+        }
+    }
+
+    internal class Scalar(
+        override val constructor: Operator.Expr,
+        override val input: Operator.Relation,
+        override val scopes: Stack<Record>
+    ) : ExprSubquery() {
+        @PartiQLValueExperimental
+        override fun eval(record: Record): PartiQLValue {
+            val values = getValues(record) ?: return nullValue()
+            if (values.hasNext().not()) {
+                throw TypeCheckException()
+            }
+            val singleValue = values.next()
+            if (values.hasNext()) {
+                throw TypeCheckException()
+            }
+            return singleValue
+        }
+    }
+
+    /**
+     * This grabs the first row of the [input], asserts that the [constructor] evaluates to a TUPLE, and returns an
+     * [Iterator] of the [constructor]'s values. These values are then used by [Scalar] and [Row].
+     *
+     * @return an [Iterator] of the [constructor]'s values of the first row from the [input]. Returns null when
+     * no rows are returned from the [input].
+     * @throws TypeCheckException when more than one row is returned from the [input].
+     */
+    @OptIn(PartiQLValueExperimental::class)
+    fun getValues(record: Record): Iterator<PartiQLValue>? {
+        scopes.push(record)
+        input.open()
+        val firstRecord = input.next()
+        if (firstRecord == null) {
+            scopes.pop()
+            return null
+        }
+        val tuple = constructor.eval(firstRecord).check<StructValue<*>>()
+        val secondRecord = input.next()
+        scopes.pop()
+        if (secondRecord != null) {
+            throw TypeCheckException()
+        }
+        return tuple.values.iterator()
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSubquery.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSubquery.kt
@@ -1,5 +1,6 @@
 package org.partiql.eval.internal.operator.rex
 
+import org.partiql.errors.CardinalityViolation
 import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Environment
 import org.partiql.eval.internal.Record
@@ -10,14 +11,13 @@ import org.partiql.value.StructValue
 import org.partiql.value.check
 import org.partiql.value.listValue
 import org.partiql.value.nullValue
-import java.util.Stack
 
 /**
  * The PartiQL Specification talks about subqueries and how they are coerced. Specifically, subqueries are
  * modeled as a COLL_TO_SCALAR(SELECT VALUE <tuple> ...) where the SELECT VALUE must return a single row containing
  * a TUPLE.
  *
- * @see [getValues]
+ * @see [getFirst]
  */
 internal abstract class ExprSubquery : Operator.Expr {
 
@@ -30,9 +30,11 @@ internal abstract class ExprSubquery : Operator.Expr {
         override val input: Operator.Relation,
         override val env: Environment
     ) : ExprSubquery() {
+
         @PartiQLValueExperimental
         override fun eval(record: Record): PartiQLValue {
-            val values = getValues(record) ?: return nullValue()
+            val tuple = getFirst(record) ?: return nullValue()
+            val values = tuple.values.iterator()
             return listValue(values.asSequence().toList())
         }
     }
@@ -42,9 +44,11 @@ internal abstract class ExprSubquery : Operator.Expr {
         override val input: Operator.Relation,
         override val env: Environment
     ) : ExprSubquery() {
+
         @PartiQLValueExperimental
         override fun eval(record: Record): PartiQLValue {
-            val values = getValues(record) ?: return nullValue()
+            val tuple = getFirst(record) ?: return nullValue()
+            val values = tuple.values.iterator()
             if (values.hasNext().not()) {
                 throw TypeCheckException()
             }
@@ -57,28 +61,24 @@ internal abstract class ExprSubquery : Operator.Expr {
     }
 
     /**
-     * This grabs the first row of the [input], asserts that the [constructor] evaluates to a TUPLE, and returns an
-     * [Iterator] of the [constructor]'s values. These values are then used by [Scalar] and [Row].
+     * This grabs the first row of the [input], asserts that the [constructor] evaluates to a TUPLE, and returns the
+     * constructed value.
      *
-     * @return an [Iterator] of the [constructor]'s values of the first row from the [input]. Returns null when
-     * no rows are returned from the [input].
-     * @throws TypeCheckException when more than one row is returned from the [input].
+     * @return the constructed [constructor]. Returns null when no rows are returned from the [input].
+     * @throws CardinalityViolation when more than one row is returned from the [input].
+     * @throws TypeCheckException when the constructor is not a [StructValue].
      */
     @OptIn(PartiQLValueExperimental::class)
-    fun getValues(record: Record): Iterator<PartiQLValue>? {
-        env.push(record)
-        input.open()
-        val firstRecord = input.next()
-        if (firstRecord == null) {
-            env.pop()
-            return null
+    fun getFirst(record: Record): StructValue<*>? {
+        return env.scope(record) {
+            input.open()
+            val firstRecord = input.next() ?: return@scope null
+            val tuple = constructor.eval(firstRecord).check<StructValue<*>>()
+            val secondRecord = input.next()
+            if (secondRecord != null) {
+                throw CardinalityViolation()
+            }
+            tuple
         }
-        val tuple = constructor.eval(firstRecord).check<StructValue<*>>()
-        val secondRecord = input.next()
-        env.pop()
-        if (secondRecord != null) {
-            throw TypeCheckException()
-        }
-        return tuple.values.iterator()
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprUpvalue.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprUpvalue.kt
@@ -1,0 +1,22 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.eval.internal.Record
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import java.util.Stack
+
+/**
+ * Returns the appropriate value from the stack.
+ */
+internal class ExprUpvalue(
+    private val frameIndex: Int,
+    private val varIndex: Int,
+    private val scopes: Stack<Record>
+) : Operator.Expr {
+
+    @PartiQLValueExperimental
+    override fun eval(record: Record): PartiQLValue {
+        return scopes[frameIndex][varIndex]
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprVarGlobal.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprVarGlobal.kt
@@ -8,7 +8,7 @@ import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 
 @OptIn(PartiQLValueExperimental::class)
-internal class ExprGlobal(
+internal class ExprVarGlobal(
     private val path: ConnectorPath,
     private val bindings: ConnectorBindings,
 ) : Operator.Expr {

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprVarLocal.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprVarLocal.kt
@@ -4,19 +4,16 @@ import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
-import java.util.Stack
 
 /**
- * Returns the appropriate value from the stack.
+ * Returns the value in the given record index.
  */
-internal class ExprUpvalue(
-    private val frameIndex: Int,
-    private val varIndex: Int,
-    private val scopes: Stack<Record>
+internal class ExprVarLocal(
+    private val ref: Int,
 ) : Operator.Expr {
 
     @PartiQLValueExperimental
     override fun eval(record: Record): PartiQLValue {
-        return scopes[frameIndex][varIndex]
+        return record.values[ref]
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprVarOuter.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprVarOuter.kt
@@ -10,13 +10,13 @@ import org.partiql.value.PartiQLValueExperimental
  * Returns the appropriate value from the stack.
  */
 internal class ExprVarOuter(
-    private val depth: Int,
+    private val scope: Int,
     private val reference: Int,
     private val env: Environment
 ) : Operator.Expr {
 
     @PartiQLValueExperimental
     override fun eval(record: Record): PartiQLValue {
-        return env[depth][reference]
+        return env[scope][reference]
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprVarOuter.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprVarOuter.kt
@@ -10,13 +10,13 @@ import org.partiql.value.PartiQLValueExperimental
  * Returns the appropriate value from the stack.
  */
 internal class ExprVarOuter(
-    private val scope: Int,
+    private val depth: Int,
     private val reference: Int,
     private val env: Environment
 ) : Operator.Expr {
 
     @PartiQLValueExperimental
     override fun eval(record: Record): PartiQLValue {
-        return env[scope][reference]
+        return env[depth][reference]
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprVarOuter.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprVarOuter.kt
@@ -1,19 +1,22 @@
 package org.partiql.eval.internal.operator.rex
 
+import org.partiql.eval.internal.Environment
 import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
 
 /**
- * Returns the value in the given record index.
+ * Returns the appropriate value from the stack.
  */
-internal class ExprLocal(
-    private val ref: Int,
+internal class ExprVarOuter(
+    private val scope: Int,
+    private val reference: Int,
+    private val env: Environment
 ) : Operator.Expr {
 
     @PartiQLValueExperimental
     override fun eval(record: Record): PartiQLValue {
-        return record.values[ref]
+        return env[scope][reference]
     }
 }

--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -77,21 +77,16 @@ rex::{
       value: partiql_value,
     },
 
-    var::[
-      // Refers to a value coming from the input record.
-      local::{
-        ref: int
-      },
-      // Refers to a value defined in outer scopes.
-      outer::{
-        scope: int, // Scope reference. If the stack looks like [ < a, b >, < c, d > ], then scope 0 refers to < a, b >.
-        ref: int,    // Value reference within the scope
-      },
-      // Refers to a value in the database environment.
-      global::{
-        ref: ref,
-      },
-    ],
+    // Refers to a value in the variables environment.
+    var::{
+      depth: int, // A depth of 0 would indicate that the variable is coming from the current variable scope
+      ref: int,   // Value reference within the scope
+    },
+
+    // Refers to a value in the database environment.
+    global::{
+      ref: ref,
+    },
 
     path::[
       // The key MUST be an integer expression. Ex: a[0], a[1 + 1]

--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -77,13 +77,21 @@ rex::{
       value: partiql_value,
     },
 
-    var::{
-      ref: int,
-    },
-
-    global::{
-      ref: ref,
-    },
+    var::[
+      // Refers to a value coming from the input record.
+      local::{
+        ref: int
+      },
+      // Refers to a value defined in outer scopes. See https://craftinginterpreters.com/closures.html#upvalues .
+      upvalue::{
+        frameRef: int,
+        valueRef: int,
+      },
+      // Refers to a value in the database environment.
+      global::{
+        ref: ref,
+      },
+    ],
 
     path::[
       // The key MUST be an integer expression. Ex: a[0], a[1 + 1]
@@ -163,8 +171,9 @@ rex::{
     },
 
     subquery::{
-      select:   select,
-      coercion: [ SCALAR, ROW ],
+      constructor:  rex,
+      rel:          rel,
+      coercion:     [ SCALAR, ROW ],
     },
 
     select::{

--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -82,10 +82,10 @@ rex::{
       local::{
         ref: int
       },
-      // Refers to a value defined in outer scopes. See https://craftinginterpreters.com/closures.html#upvalues .
-      upvalue::{
-        frameRef: int,
-        valueRef: int,
+      // Refers to a value defined in outer scopes.
+      outer::{
+        scope: int, // Scope reference. If the stack looks like [ < a, b >, < c, d > ], then scope 0 refers to < a, b >.
+        ref: int,    // Value reference within the scope
       },
       // Refers to a value in the database environment.
       global::{

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Env.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Env.kt
@@ -13,7 +13,7 @@ import org.partiql.planner.internal.ir.rexOpCallDynamic
 import org.partiql.planner.internal.ir.rexOpCallDynamicCandidate
 import org.partiql.planner.internal.ir.rexOpCallStatic
 import org.partiql.planner.internal.ir.rexOpCastResolved
-import org.partiql.planner.internal.ir.rexOpGlobal
+import org.partiql.planner.internal.ir.rexOpVarGlobal
 import org.partiql.planner.internal.typer.TypeEnv.Companion.toPath
 import org.partiql.planner.internal.typer.toRuntimeType
 import org.partiql.planner.internal.typer.toStaticType
@@ -77,7 +77,7 @@ internal class Env(private val session: PartiQLPlanner.Session) {
             type = item.handle.entity.getType(),
         )
         // Rewrite as a path expression.
-        val root = rex(ref.type, rexOpGlobal(ref))
+        val root = rex(ref.type, rexOpVarGlobal(ref))
         val depth = calculateMatched(path, item.input, ref.path)
         val tail = path.steps.drop(depth)
         return if (tail.isEmpty()) root else root.toPath(tail)

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
@@ -64,8 +64,8 @@ import org.partiql.planner.internal.ir.builder.RexOpSubqueryBuilder
 import org.partiql.planner.internal.ir.builder.RexOpTupleUnionBuilder
 import org.partiql.planner.internal.ir.builder.RexOpVarGlobalBuilder
 import org.partiql.planner.internal.ir.builder.RexOpVarLocalBuilder
+import org.partiql.planner.internal.ir.builder.RexOpVarOuterBuilder
 import org.partiql.planner.internal.ir.builder.RexOpVarUnresolvedBuilder
-import org.partiql.planner.internal.ir.builder.RexOpVarUpvalueBuilder
 import org.partiql.planner.internal.ir.builder.StatementQueryBuilder
 import org.partiql.planner.internal.ir.visitor.PlanVisitor
 import org.partiql.spi.fn.AggSignature
@@ -291,7 +291,7 @@ internal data class Rex(
             public override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R = when (this) {
                 is Local -> visitor.visitRexOpVarLocal(this, ctx)
                 is Global -> visitor.visitRexOpVarGlobal(this, ctx)
-                is Upvalue -> visitor.visitRexOpVarUpvalue(this, ctx)
+                is Outer -> visitor.visitRexOpVarOuter(this, ctx)
                 is Unresolved -> visitor.visitRexOpVarUnresolved(this, ctx)
             }
 
@@ -299,18 +299,18 @@ internal data class Rex(
                 DEFAULT, LOCAL,
             }
 
-            internal data class Upvalue(
-                @JvmField internal val frameRef: Int,
-                @JvmField internal val valueRef: Int
+            internal data class Outer(
+                @JvmField internal val scope: Int,
+                @JvmField internal val ref: Int
             ) : Var() {
                 public override val children: List<PlanNode> = emptyList()
 
                 public override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
-                    visitor.visitRexOpVarUpvalue(this, ctx)
+                    visitor.visitRexOpVarOuter(this, ctx)
 
                 internal companion object {
                     @JvmStatic
-                    internal fun builder(): RexOpVarUpvalueBuilder = RexOpVarUpvalueBuilder()
+                    internal fun builder(): RexOpVarOuterBuilder = RexOpVarOuterBuilder()
                 }
             }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
@@ -64,7 +64,6 @@ import org.partiql.planner.internal.ir.builder.RexOpSubqueryBuilder
 import org.partiql.planner.internal.ir.builder.RexOpTupleUnionBuilder
 import org.partiql.planner.internal.ir.builder.RexOpVarGlobalBuilder
 import org.partiql.planner.internal.ir.builder.RexOpVarLocalBuilder
-import org.partiql.planner.internal.ir.builder.RexOpVarOuterBuilder
 import org.partiql.planner.internal.ir.builder.RexOpVarUnresolvedBuilder
 import org.partiql.planner.internal.ir.builder.StatementQueryBuilder
 import org.partiql.planner.internal.ir.visitor.PlanVisitor
@@ -291,7 +290,6 @@ internal data class Rex(
             public override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R = when (this) {
                 is Local -> visitor.visitRexOpVarLocal(this, ctx)
                 is Global -> visitor.visitRexOpVarGlobal(this, ctx)
-                is Outer -> visitor.visitRexOpVarOuter(this, ctx)
                 is Unresolved -> visitor.visitRexOpVarUnresolved(this, ctx)
             }
 
@@ -299,23 +297,9 @@ internal data class Rex(
                 DEFAULT, LOCAL,
             }
 
-            internal data class Outer(
-                @JvmField internal val scope: Int,
-                @JvmField internal val ref: Int
-            ) : Var() {
-                public override val children: List<PlanNode> = emptyList()
-
-                public override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
-                    visitor.visitRexOpVarOuter(this, ctx)
-
-                internal companion object {
-                    @JvmStatic
-                    internal fun builder(): RexOpVarOuterBuilder = RexOpVarOuterBuilder()
-                }
-            }
-
             internal data class Local(
-                @JvmField internal val ref: Int,
+                @JvmField internal val depth: Int,
+                @JvmField internal val ref: Int
             ) : Var() {
                 public override val children: List<PlanNode> = emptyList()
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -117,8 +117,8 @@ internal object PlanTransform {
             ref = visitRef(node.ref, ctx)
         )
 
-        override fun visitRexOpVarUpvalue(node: Rex.Op.Var.Upvalue, ctx: Unit): org.partiql.plan.Rex.Op {
-            return org.partiql.plan.Rex.Op.Var.Upvalue(node.frameRef, node.valueRef)
+        override fun visitRexOpVarOuter(node: Rex.Op.Var.Outer, ctx: Unit): org.partiql.plan.Rex.Op {
+            return org.partiql.plan.Rex.Op.Var.Outer(node.scope, node.ref)
         }
 
         override fun visitRexOpVarLocal(node: Rex.Op.Var.Local, ctx: Unit): org.partiql.plan.Rex.Op {
@@ -361,8 +361,8 @@ internal object PlanTransform {
 
             override fun visitRelOpExcludePath(node: Rel.Op.Exclude.Path, ctx: Unit): org.partiql.plan.Rel.Op.Exclude.Path {
                 val root = when (node.root) {
-                    is Rex.Op.Var.Upvalue -> visitRexOpVar(node.root, ctx) as org.partiql.plan.Rex.Op.Var
-                    is Rex.Op.Var.Unresolved -> org.partiql.plan.Rex.Op.Var.Upvalue(-1, -1) // unresolved in `PlanTyper` results in error
+                    is Rex.Op.Var.Outer -> visitRexOpVar(node.root, ctx) as org.partiql.plan.Rex.Op.Var
+                    is Rex.Op.Var.Unresolved -> org.partiql.plan.Rex.Op.Var.Outer(-1, -1) // unresolved in `PlanTyper` results in error
                     is Rex.Op.Var.Local -> visitRexOpVarLocal(node.root, ctx) as org.partiql.plan.Rex.Op.Var.Local
                     is Rex.Op.Var.Global -> visitRexOpVarGlobal(node.root, ctx)
                 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
@@ -101,7 +101,7 @@ internal object RelConverter {
                     "Expected SELECT VALUE's input to have a single binding. " +
                         "However, it contained: ${rel.type.schema.map { it.name }}."
                 }
-                val constructor = rex(StaticType.ANY, rexOpVarLocal(0))
+                val constructor = rex(StaticType.ANY, rexOpVarLocal(0, 0))
                 val op = rexOpSelect(constructor, rel)
                 val type = when (rel.type.props.contains(Rel.Prop.ORDERED)) {
                     true -> (StaticType.LIST)

--- a/partiql-planner/src/main/resources/partiql_plan_internal.ion
+++ b/partiql-planner/src/main/resources/partiql_plan_internal.ion
@@ -82,14 +82,10 @@ rex::{
     },
 
     var::[
-      // Refers to a value defined in outer scopes.
-      outer::{
-        scope: int, // Scope reference. If the stack looks like [ < a, b >, < c, d > ], then scope 0 refers to < a, b >.
-        ref: int,    // Value reference within the scope
-      },
-      // Refers to a value coming from the input record.
+      // Refers to a value in the variables environment.
       local::{
-        ref: int,
+        depth: int, // A depth of 0 would indicate that the variable is coming from the current variable scope
+        ref: int,   // Value reference within the scope
       },
       // Refers to a value in the database environment.
       global::{

--- a/partiql-planner/src/main/resources/partiql_plan_internal.ion
+++ b/partiql-planner/src/main/resources/partiql_plan_internal.ion
@@ -82,10 +82,10 @@ rex::{
     },
 
     var::[
-      // Refers to a value defined in outer scopes. See https://craftinginterpreters.com/closures.html#upvalues .
-      upvalue::{
-        frameRef: int,
-        valueRef: int
+      // Refers to a value defined in outer scopes.
+      outer::{
+        scope: int, // Scope reference. If the stack looks like [ < a, b >, < c, d > ], then scope 0 refers to < a, b >.
+        ref: int,    // Value reference within the scope
       },
       // Refers to a value coming from the input record.
       local::{

--- a/partiql-planner/src/main/resources/partiql_plan_internal.ion
+++ b/partiql-planner/src/main/resources/partiql_plan_internal.ion
@@ -82,8 +82,18 @@ rex::{
     },
 
     var::[
-      resolved::{
+      // Refers to a value defined in outer scopes. See https://craftinginterpreters.com/closures.html#upvalues .
+      upvalue::{
+        frameRef: int,
+        valueRef: int
+      },
+      // Refers to a value coming from the input record.
+      local::{
         ref: int,
+      },
+      // Refers to a value in the database environment.
+      global::{
+        ref: '.ref.obj',
       },
       unresolved::{
         identifier: identifier,
@@ -96,10 +106,6 @@ rex::{
         ],
       ],
     ],
-
-    global::{
-      ref: '.ref.obj',
-    },
 
     path::[
       // The key MUST be an integer expression. Ex: a[0], a[1 + 1]
@@ -185,8 +191,9 @@ rex::{
     },
 
     subquery::{
-      select:   select,
-      coercion: [ SCALAR, ROW ],
+      constructor:  rex,
+      rel:          rel,
+      coercion:     [ SCALAR, ROW ],
     },
 
     select::{

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/exclude/SubsumptionTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/exclude/SubsumptionTest.kt
@@ -18,7 +18,7 @@ import org.partiql.plan.relOpExcludeTypeCollWildcard
 import org.partiql.plan.relOpExcludeTypeStructKey
 import org.partiql.plan.relOpExcludeTypeStructSymbol
 import org.partiql.plan.relOpExcludeTypeStructWildcard
-import org.partiql.plan.rexOpVarLocal
+import org.partiql.plan.rexOpVar
 import org.partiql.planner.PartiQLPlanner
 import org.partiql.plugins.memory.MemoryConnector
 import org.partiql.spi.connector.ConnectorSession
@@ -75,7 +75,7 @@ class SubsumptionTest {
                 "s.a, t.a", // different roots
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(0),
+                        root = rexOpVar(0, 0),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(
@@ -86,7 +86,7 @@ class SubsumptionTest {
                         )
                     ),
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(
@@ -102,7 +102,7 @@ class SubsumptionTest {
                 "t.a, t.b", // different steps
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(
@@ -124,7 +124,7 @@ class SubsumptionTest {
                 "s.a, t.a, t.b, s.b", // different roots and steps
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(0),
+                        root = rexOpVar(0, 0),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"), substeps = emptyList()
@@ -135,7 +135,7 @@ class SubsumptionTest {
                         )
                     ),
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"), substeps = emptyList()
@@ -159,7 +159,7 @@ class SubsumptionTest {
                 """.trimIndent(),
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"), substeps = emptyList()
@@ -237,7 +237,7 @@ class SubsumptionTest {
                 """.trimIndent(),
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"), substeps = emptyList()
@@ -322,7 +322,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"),
@@ -351,7 +351,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"),
@@ -385,7 +385,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "foo"), substeps = emptyList()
@@ -410,7 +410,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"),
@@ -470,7 +470,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"),
@@ -521,7 +521,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"),
@@ -576,7 +576,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"), substeps = emptyList()
@@ -607,7 +607,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVarLocal(1),
+                        root = rexOpVar(0, 1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"),

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/exclude/SubsumptionTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/exclude/SubsumptionTest.kt
@@ -18,7 +18,7 @@ import org.partiql.plan.relOpExcludeTypeCollWildcard
 import org.partiql.plan.relOpExcludeTypeStructKey
 import org.partiql.plan.relOpExcludeTypeStructSymbol
 import org.partiql.plan.relOpExcludeTypeStructWildcard
-import org.partiql.plan.rexOpVar
+import org.partiql.plan.rexOpVarLocal
 import org.partiql.planner.PartiQLPlanner
 import org.partiql.plugins.memory.MemoryConnector
 import org.partiql.spi.connector.ConnectorSession
@@ -75,7 +75,7 @@ class SubsumptionTest {
                 "s.a, t.a", // different roots
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(0),
+                        root = rexOpVarLocal(0),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(
@@ -86,7 +86,7 @@ class SubsumptionTest {
                         )
                     ),
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(
@@ -102,7 +102,7 @@ class SubsumptionTest {
                 "t.a, t.b", // different steps
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(
@@ -124,7 +124,7 @@ class SubsumptionTest {
                 "s.a, t.a, t.b, s.b", // different roots and steps
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(0),
+                        root = rexOpVarLocal(0),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"), substeps = emptyList()
@@ -135,7 +135,7 @@ class SubsumptionTest {
                         )
                     ),
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"), substeps = emptyList()
@@ -159,7 +159,7 @@ class SubsumptionTest {
                 """.trimIndent(),
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"), substeps = emptyList()
@@ -237,7 +237,7 @@ class SubsumptionTest {
                 """.trimIndent(),
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"), substeps = emptyList()
@@ -322,7 +322,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"),
@@ -351,7 +351,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"),
@@ -385,7 +385,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "foo"), substeps = emptyList()
@@ -410,7 +410,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"),
@@ -470,7 +470,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"),
@@ -521,7 +521,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"),
@@ -576,7 +576,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"), substeps = emptyList()
@@ -607,7 +607,7 @@ class SubsumptionTest {
                 """,
                 listOf(
                     relOpExcludePath(
-                        root = rexOpVar(1),
+                        root = rexOpVarLocal(1),
                         steps = listOf(
                             relOpExcludeStep(
                                 type = relOpExcludeTypeStructSymbol(symbol = "a"),

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/transforms/NormalizeSelectTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/transforms/NormalizeSelectTest.kt
@@ -1,4 +1,4 @@
-package org.partiql.ast.normalize
+package org.partiql.planner.internal.transforms
 
 import org.junit.jupiter.api.Test
 import org.partiql.ast.Expr
@@ -38,7 +38,7 @@ class NormalizeSelectTest {
             "b" to variable("b"),
             "c" to variable("c"),
         )
-        val actual = NormalizeSelect.apply(input)
+        val actual = NormalizeSelect.normalize(input)
         assertEquals(expected, actual)
     }
 
@@ -63,7 +63,7 @@ class NormalizeSelectTest {
             "_2" to lit(2),
             "_3" to lit(3),
         )
-        val actual = NormalizeSelect.apply(input)
+        val actual = NormalizeSelect.normalize(input)
         assertEquals(expected, actual)
     }
 
@@ -88,7 +88,7 @@ class NormalizeSelectTest {
             "_1" to lit(2),
             "_2" to lit(3),
         )
-        val actual = NormalizeSelect.apply(input)
+        val actual = NormalizeSelect.normalize(input)
         assertEquals(expected, actual)
     }
 
@@ -113,7 +113,7 @@ class NormalizeSelectTest {
             "b" to lit(2),
             "c" to lit(3),
         )
-        val actual = NormalizeSelect.apply(input)
+        val actual = NormalizeSelect.normalize(input)
         assertEquals(expected, actual)
     }
 
@@ -128,43 +128,39 @@ class NormalizeSelectTest {
     )
 
     private fun select(vararg items: Select.Project.Item) = ast {
-        statementQuery {
-            expr = exprSFW {
-                select = selectProject {
-                    this.items += items
-                }
-                from = fromValue {
-                    expr = variable("T")
-                    type = From.Value.Type.SCAN
-                }
+        exprSFW {
+            select = selectProject {
+                this.items += items
+            }
+            from = fromValue {
+                expr = variable("T")
+                type = From.Value.Type.SCAN
             }
         }
     }
 
     @OptIn(PartiQLValueExperimental::class)
     private fun selectValue(vararg items: Pair<String, Expr>) = ast {
-        statementQuery {
-            expr = exprSFW {
-                select = selectValue {
-                    constructor = exprStruct {
-                        for ((k, v) in items) {
-                            fields += exprStructField {
-                                name = exprLit(stringValue(k))
-                                value = v
-                            }
+        exprSFW {
+            select = selectValue {
+                constructor = exprStruct {
+                    for ((k, v) in items) {
+                        fields += exprStructField {
+                            name = exprLit(stringValue(k))
+                            value = v
                         }
                     }
                 }
-                from = fromValue {
-                    expr = exprVar {
-                        identifier = identifierSymbol {
-                            symbol = "T"
-                            caseSensitivity = Identifier.CaseSensitivity.INSENSITIVE
-                        }
-                        scope = Expr.Var.Scope.DEFAULT
+            }
+            from = fromValue {
+                expr = exprVar {
+                    identifier = identifierSymbol {
+                        symbol = "T"
+                        caseSensitivity = Identifier.CaseSensitivity.INSENSITIVE
                     }
-                    type = From.Value.Type.SCAN
+                    scope = Expr.Var.Scope.DEFAULT
                 }
+                type = From.Value.Type.SCAN
             }
         }
     }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTest.kt
@@ -8,12 +8,12 @@ import org.partiql.planner.internal.ir.Rex
 import org.partiql.planner.internal.ir.identifierSymbol
 import org.partiql.planner.internal.ir.refObj
 import org.partiql.planner.internal.ir.rex
-import org.partiql.planner.internal.ir.rexOpGlobal
 import org.partiql.planner.internal.ir.rexOpLit
 import org.partiql.planner.internal.ir.rexOpPathKey
 import org.partiql.planner.internal.ir.rexOpPathSymbol
 import org.partiql.planner.internal.ir.rexOpStruct
 import org.partiql.planner.internal.ir.rexOpStructField
+import org.partiql.planner.internal.ir.rexOpVarGlobal
 import org.partiql.planner.internal.ir.rexOpVarUnresolved
 import org.partiql.planner.internal.ir.statementQuery
 import org.partiql.planner.util.ProblemCollector
@@ -379,7 +379,7 @@ class PlanTyperTest {
     private fun global(type: StaticType, path: List<String>): Rex {
         return rex(
             type,
-            rexOpGlobal(refObj(catalog = "pql", path = path, type))
+            rexOpVarGlobal(refObj(catalog = "pql", path = path, type))
         )
     }
 }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/TypeEnvTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/TypeEnvTest.kt
@@ -39,7 +39,8 @@ internal class TypeEnvTest {
                 relBinding("x", struct("Y" to BoolType(), open = true)),
                 relBinding("y", struct(open = true)),
                 relBinding("T", struct("x" to BoolType(), "x" to BoolType())),
-            )
+            ),
+            stack = emptyList()
         )
 
         private fun struct(vararg fields: Pair<String, StaticType>, open: Boolean = false): StructType {
@@ -89,7 +90,7 @@ internal class TypeEnvTest {
         }
         // For now, just traverse to the root
         var root = rex.op
-        while (root !is Rex.Op.Var.Resolved) {
+        while (root !is Rex.Op.Var.Local) {
             root = when (root) {
                 is Rex.Op.Path.Symbol -> root.root.op
                 is Rex.Op.Path.Key -> root.root.op

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/TypeEnvTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/TypeEnvTest.kt
@@ -40,7 +40,7 @@ internal class TypeEnvTest {
                 relBinding("y", struct(open = true)),
                 relBinding("T", struct("x" to BoolType(), "x" to BoolType())),
             ),
-            stack = emptyList()
+            outer = emptyList()
         )
 
         private fun struct(vararg fields: Pair<String, StaticType>, open: Boolean = false): StructType {

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/util/PlanNodeEquivalentVisitor.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/util/PlanNodeEquivalentVisitor.kt
@@ -44,9 +44,17 @@ class PlanNodeEquivalentVisitor : PlanBaseVisitor<Boolean, PlanNode>() {
         return true
     }
 
-    override fun visitRexOpVar(node: Rex.Op.Var, ctx: PlanNode): Boolean {
+    override fun visitRexOpVarUpvalue(node: Rex.Op.Var.Upvalue, ctx: PlanNode): Boolean {
         if (!super.visitRexOpVar(node, ctx)) return false
-        ctx as Rex.Op.Var
+        ctx as Rex.Op.Var.Upvalue
+        if (node.frameRef != ctx.frameRef) return false
+        if (node.valueRef != ctx.valueRef) return false
+        return true
+    }
+
+    override fun visitRexOpVarLocal(node: Rex.Op.Var.Local, ctx: PlanNode): Boolean {
+        if (!super.visitRexOpVarLocal(node, ctx)) return false
+        ctx as Rex.Op.Var.Local
         if (node.ref != ctx.ref) return false
         return true
     }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/util/PlanNodeEquivalentVisitor.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/util/PlanNodeEquivalentVisitor.kt
@@ -44,17 +44,10 @@ class PlanNodeEquivalentVisitor : PlanBaseVisitor<Boolean, PlanNode>() {
         return true
     }
 
-    override fun visitRexOpVarOuter(node: Rex.Op.Var.Outer, ctx: PlanNode): Boolean {
+    override fun visitRexOpVar(node: Rex.Op.Var, ctx: PlanNode): Boolean {
         if (!super.visitRexOpVar(node, ctx)) return false
-        ctx as Rex.Op.Var.Outer
-        if (node.scope != ctx.scope) return false
-        if (node.ref != ctx.ref) return false
-        return true
-    }
-
-    override fun visitRexOpVarLocal(node: Rex.Op.Var.Local, ctx: PlanNode): Boolean {
-        if (!super.visitRexOpVarLocal(node, ctx)) return false
-        ctx as Rex.Op.Var.Local
+        ctx as Rex.Op.Var
+        if (node.depth != ctx.depth) return false
         if (node.ref != ctx.ref) return false
         return true
     }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/util/PlanNodeEquivalentVisitor.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/util/PlanNodeEquivalentVisitor.kt
@@ -44,11 +44,11 @@ class PlanNodeEquivalentVisitor : PlanBaseVisitor<Boolean, PlanNode>() {
         return true
     }
 
-    override fun visitRexOpVarUpvalue(node: Rex.Op.Var.Upvalue, ctx: PlanNode): Boolean {
+    override fun visitRexOpVarOuter(node: Rex.Op.Var.Outer, ctx: PlanNode): Boolean {
         if (!super.visitRexOpVar(node, ctx)) return false
-        ctx as Rex.Op.Var.Upvalue
-        if (node.frameRef != ctx.frameRef) return false
-        if (node.valueRef != ctx.valueRef) return false
+        ctx as Rex.Op.Var.Outer
+        if (node.scope != ctx.scope) return false
+        if (node.ref != ctx.ref) return false
         return true
     }
 

--- a/partiql-types/src/main/kotlin/org/partiql/errors/TypeCheckException.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/errors/TypeCheckException.kt
@@ -9,3 +9,12 @@ public class TypeCheckException : RuntimeException()
  * A [DataException] represents an unrecoverable query runtime exception.
  */
 public class DataException(public override val message: String) : RuntimeException()
+
+/**
+ * A [CardinalityViolation] represents an invalid operation due to an unexpected cardinality of an argument.
+ *
+ * From SQL:1999:
+ * > If the cardinality of a <row subquery> is greater than 1 (one), then an exception condition is raised: cardinality violation.
+ * > If the cardinality of SS [[scalar subquery]] is greater than 1 (one), then an exception condition is raised: cardinality violation.
+ */
+public class CardinalityViolation : RuntimeException()

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/BagValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/BagValueImpl.kt
@@ -40,4 +40,8 @@ internal class BagValueImpl<T : PartiQLValue>(
     override fun withoutAnnotations(): BagValue<T> = _withoutAnnotations()
 
     override fun <R, C> accept(visitor: PartiQLValueVisitor<R, C>, ctx: C): R = visitor.visitBag(this, ctx)
+
+    override fun toString(): String {
+        return delegate?.joinToString(separator = ", ", prefix = "<< ", postfix = " >>") ?: "null.bag"
+    }
 }

--- a/partiql-types/src/main/kotlin/org/partiql/value/impl/StructValueImpl.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/impl/StructValueImpl.kt
@@ -67,6 +67,12 @@ internal class IterableStructValueImpl<T : PartiQLValue>(
     override fun withoutAnnotations(): StructValue<T> = _withoutAnnotations()
 
     override fun <R, C> accept(visitor: PartiQLValueVisitor<R, C>, ctx: C): R = visitor.visitStruct(this, ctx)
+
+    override fun toString(): String {
+        return delegate?.joinToString(separator = ", ", prefix = "{ ", postfix = " }") {
+            "'${it.first}': ${it.second}"
+        } ?: "null.struct"
+    }
 }
 
 /**


### PR DESCRIPTION
## Description
- This PR adds support for correlated subqueries and subquery coercions by:
  1. Introducing the concept of a stack to mimic the concept of a variables environment (see the PartiQL Spec).
- The stack keeps track of variables from outer scopes whenever a new scope is introduced. The `PlanTyper` now has the concept of a `Stack`, and the `Compiler` (along with the operator implementations) matches the functionality of the `PlanTyper`. The known instances of scope creation are:
  1. Top-level SFW queries (including PIVOTS)
  2. Subqueries (including PIVOTS)
  3. JOINs (according to the PartiQL Specification, a PartiQL JOIN's RHS can reference variables from the LHS).
- `Var`'s are just pointers to a location on our internal stack. Many SQL engines attempt to de-correlate all correlated subqueries during planning (to avoid using the stack), and therefore (almost) **all** data comes from the natural data flow of relational operators. Note that many engines do maintain a stack for variable resolution, but not all. PartiQL allows for referencing variables in many clauses where it is oftentimes disallowed in SQL. This implementation maintains the structure of our evaluator's use of the Volcano Model, however, we still allow accessing of the stack. This implementation of `Var` provides us with 4 benefits:
  1. It allows us to model what the PartiQL Specification says.
  2. It allows for quick access to bindings (with indexing).
  3. It helps us maintain the simplicity of the Volcano Model (using `Var`'s of depth 0) while also giving us flexibility to reference variables from outer variable environments (depths > 0).
  4. It allows us to KNOW which variables are coming from the outer variable environments **during** planning. Therefore, at planning time, we may attempt to remove these by de-correlating any correlated subqueries. I have a POC that does this.
- This PR also handles subquery coercion by modifying how we model subqueries. Now, instead of wrapping a `RexOpSelect`, the `RexOpSubquery` also has a constructor and input relation. This allows us the flexibility to call `next()` as we see fit to reduce any excess computation.

## Other (Small) Changes
- I've updated the PlanPrinter to be easier to read. No more printing of `Rel`'s and `Rex`'s. Though, we still print the types/schema.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **YES**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.