### PR TITLE
resolve nullable type causes a dynamic call

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/FnResolver.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/FnResolver.kt
@@ -5,6 +5,8 @@ import org.partiql.planner.internal.ir.Agg
 import org.partiql.planner.internal.ir.Fn
 import org.partiql.planner.internal.ir.Identifier
 import org.partiql.planner.internal.ir.Rex
+import org.partiql.types.AnyOfType
+import org.partiql.types.NullType
 import org.partiql.types.StaticType
 import org.partiql.types.function.FunctionParameter
 import org.partiql.types.function.FunctionSignature
@@ -192,7 +194,13 @@ internal class FnResolver(private val header: Header) {
     }
 
     private fun buildArgumentPermutations(args: List<StaticType>): List<List<StaticType>> {
-        val flattenedArgs = args.map { it.flatten().allTypes }
+        val flattenedArgs = args.map {
+            if (it is AnyOfType) {
+                it.flatten().allTypes.filter { it !is NullType }
+            } else {
+                it.flatten().allTypes
+            }
+        }
         return buildArgumentPermutations(flattenedArgs, accumulator = emptyList())
     }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeUtils.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeUtils.kt
@@ -121,7 +121,10 @@ private fun StaticType.asRuntimeType(): PartiQLValueType = when (this) {
     is ListType -> PartiQLValueType.LIST
     is SexpType -> PartiQLValueType.SEXP
     is DateType -> PartiQLValueType.DATE
-    is DecimalType -> PartiQLValueType.DECIMAL_ARBITRARY
+    is DecimalType -> when (this.precisionScaleConstraint) {
+        is DecimalType.PrecisionScaleConstraint.Constrained -> PartiQLValueType.DECIMAL
+        DecimalType.PrecisionScaleConstraint.Unconstrained -> PartiQLValueType.DECIMAL_ARBITRARY
+    }
     is FloatType -> PartiQLValueType.FLOAT64
     is GraphType -> error("Graph type missing from runtime types")
     is IntType -> when (this.rangeConstraint) {


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
Consider if we have `a : StaticType.UnionOf(INT4, NULL)`
The query `a + a` would be routed to a dynamic call, because the `buildArgumentPermutations` would attempts to match signatures with args `INT4, INT4`, `NULL, INT4`, `INT4, NULL`, `NULL, NULL`. 

See example Plan: 
```
⚬ PartiQLPlan[tag=Plan-36809b3]
   ├──Catalog[name=test, tag=Plan-c9b14412]
   │  └──Symbol[type=union(null, int4), tag=Plan-fdf51022]
   └──Query[tag=Plan-439af0a1]
      └──Rex[type=union(int2, null, int4), tag=Plan-ecb47ef3]
         └──Dynamic[tag=Plan-32394b25]
            ├──Rex[type=union(null, int4), tag=Plan-3b304cd]
            │  └──Global[tag=Plan-b7513a12]
            │     └──Ref[catalog=0, symbol=0, tag=Plan-eaf2e03d]
            ├──Rex[type=union(null, int4), tag=Plan-2be5e6ab]
            │  └──Global[tag=Plan-7faea094]
            │     └──Ref[catalog=0, symbol=0, tag=Plan-664cc400]
            ├──Candidate[tag=Plan-e083537]
            │  └──Fn[signature=PLUS__INT8_INT8__INT8, tag=Plan-440fa4c]
            └──Candidate[tag=Plan-215c0857]
               └──Fn[signature=PLUS__INT32_INT32__INT32, tag=Plan-d4d5c34b]
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - NO. Not released. 
  
- Any backward-incompatible changes? **[YES/NO]**
  -  No. Not released. 

- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >
  No. 

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
  Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.