### PR TITLE
Flatten case when branch result type in PlanTyper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Thank you to all who have contributed!
 
 ### Fixed
 - Return type of `partiql-ast`'s `SqlDialect` for `defaultReturn` to be a `SqlBlock` rather than `Nothing`
+- Flatten `CASE WHEN` branch type in `PlanTyper`
 
 ### Removed
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -796,7 +796,7 @@ internal class PlanTyper(
                     }
 
                     // Replace the result's type
-                    val type = AnyOfType(ref.type.allTypes.filterIsInstance<StructType>().toSet())
+                    val type = AnyOfType(ref.type.allTypes.filterIsInstance<StructType>().toSet()).flatten()
                     val replacementVal = ref.copy(type = type)
                     val rex = when (ref.op is Rex.Op.Var.Resolved) {
                         true -> RexReplacer.replace(result, ref, replacementVal)


### PR DESCRIPTION
## Description
Typing of a `CASE WHEN` branch does not flatten the type in certain circumstances. Noticed this when I called `SELECT <table>.<struct>.* FROM <table>` and the an argument of the `TUPLEUNION` was an `AnyOfType` containing a single `STRUCT`.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[Yes]**

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.