### PR TITLE
Partiql eval limit offset

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -10,6 +10,7 @@ import org.partiql.eval.internal.operator.rel.RelJoinLeft
 import org.partiql.eval.internal.operator.rel.RelJoinOuterFull
 import org.partiql.eval.internal.operator.rel.RelJoinRight
 import org.partiql.eval.internal.operator.rel.RelLimit
+import org.partiql.eval.internal.operator.rel.RelOffset
 import org.partiql.eval.internal.operator.rel.RelProject
 import org.partiql.eval.internal.operator.rel.RelScan
 import org.partiql.eval.internal.operator.rel.RelScanIndexed
@@ -216,7 +217,7 @@ internal class Compiler(
     override fun visitRelOpOffset(node: Rel.Op.Offset, ctx: StaticType?): Operator {
         val input = visitRel(node.input, ctx)
         val offset = visitRex(node.offset, ctx)
-        return RelLimit(input, offset)
+        return RelOffset(input, offset)
     }
 
     override fun visitRexOpTupleUnion(node: Rex.Op.TupleUnion, ctx: StaticType?): Operator {

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelLimit.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelLimit.kt
@@ -5,6 +5,7 @@ import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.value.NumericValue
 import org.partiql.value.PartiQLValueExperimental
+import java.math.BigInteger
 
 @OptIn(PartiQLValueExperimental::class)
 internal class RelLimit(
@@ -12,17 +13,17 @@ internal class RelLimit(
     private val limit: Operator.Expr,
 ) : Operator.Relation {
 
-    private var _seen: Long = 0
-    private var _limit: Long = 0
+    private var _seen: BigInteger = BigInteger.ZERO
+    private var _limit: BigInteger = BigInteger.ZERO
 
     override fun open() {
         input.open()
-        _seen = 0
+        _seen = BigInteger.ZERO
 
         // TODO pass outer scope to limit expression
         val l = limit.eval(Record.empty)
         if (l is NumericValue<*>) {
-            _limit = l.toInt64().value ?: 0L
+            _limit = l.toInt().value!!
         } else {
             throw TypeCheckException()
         }
@@ -31,7 +32,7 @@ internal class RelLimit(
     override fun next(): Record? {
         if (_seen < _limit) {
             val row = input.next() ?: return null
-            _seen += 1
+            _seen = _seen.add(BigInteger.ONE)
             return row
         }
         return null

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOffset.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOffset.kt
@@ -5,6 +5,7 @@ import org.partiql.eval.internal.Record
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.value.NumericValue
 import org.partiql.value.PartiQLValueExperimental
+import java.math.BigInteger
 
 @OptIn(PartiQLValueExperimental::class)
 internal class RelOffset(
@@ -13,18 +14,18 @@ internal class RelOffset(
 ) : Operator.Relation {
 
     private var init = false
-    private var _seen: Long = 0
-    private var _offset: Long = 0
+    private var _seen: BigInteger = BigInteger.ZERO
+    private var _offset: BigInteger = BigInteger.ZERO
 
     override fun open() {
         input.open()
         init = false
-        _seen = 0
+        _seen = BigInteger.ZERO
 
         // TODO pass outer scope to offset expression
         val o = offset.eval(Record.empty)
         if (o is NumericValue<*>) {
-            _offset = o.toInt64().value ?: 0L
+            _offset = o.toInt().value!!
         } else {
             throw TypeCheckException()
         }
@@ -34,7 +35,7 @@ internal class RelOffset(
         if (!init) {
             while (_seen < _offset) {
                 input.next() ?: return null
-                _seen += 1
+                _seen = _seen.add(BigInteger.ONE)
             }
             init = true
         }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
@@ -147,8 +147,9 @@ internal object RelConverter {
             rel = convertHaving(rel, sel.having)
             rel = convertSetOp(rel, sel.setOp)
             rel = convertOrderBy(rel, sel.orderBy)
-            rel = convertLimit(rel, sel.limit)
+            // offset should precede limit
             rel = convertOffset(rel, sel.offset)
+            rel = convertLimit(rel, sel.limit)
             rel = convertExclude(rel, sel.exclude)
             // append SQL projection if present
             rel = when (val projection = sel.select) {


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
- Remodel Limit / Offset

~~If limit is 0 or null, the query should behavior as the same as if there were no limit clause.~~
If offset is 0 or null, the query should behavior as the same as if there were no offset clause. 
If limit and offset clause both exist, the offset should get executed first. 

Update: 
When converting from AST to Plan, append the offset node first then the limit node. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - < If NO, why? >

- Any backward-incompatible changes? **[YES/NO]**
  - < If YES, why? >
  - < For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base. >

- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.