### PR TITLE
roll back PVT <> ST mapping

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeUtils.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeUtils.kt
@@ -121,10 +121,11 @@ private fun StaticType.asRuntimeType(): PartiQLValueType = when (this) {
     is ListType -> PartiQLValueType.LIST
     is SexpType -> PartiQLValueType.SEXP
     is DateType -> PartiQLValueType.DATE
-    is DecimalType -> when (this.precisionScaleConstraint) {
-        is DecimalType.PrecisionScaleConstraint.Constrained -> PartiQLValueType.DECIMAL
-        DecimalType.PrecisionScaleConstraint.Unconstrained -> PartiQLValueType.DECIMAL_ARBITRARY
-    }
+    // TODO: Run time decimal type does not model precision scale constraint yet
+    //  even though we can match to Decimal vs Decimal_ARBITRARY (PVT) here
+    //  but when mapping it back to Static Type, (i.e, mapping function return type to Value Type)
+    //  we can only map to Unconstrained decimal (Static Type)
+    is DecimalType -> PartiQLValueType.DECIMAL_ARBITRARY
     is FloatType -> PartiQLValueType.FLOAT64
     is GraphType -> error("Graph type missing from runtime types")
     is IntType -> when (this.rangeConstraint) {


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
- Roll back the PVT to ST mapping. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No. Internal. 

- Any backward-incompatible changes? **[YES/NO]**
  -  N/A
 
- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >
No.

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
  Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.