### PR TITLE
Func resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,10 @@ Thank you to all who have contributed!
 ## [Unreleased]
 
 ### Added
+- Added constrained decimal as valid parameter type to functions that take in numeric parameters. 
 
 ### Changed
+- Function resolution logic: Now the function resolver would match all possible candidate(based on if the argument can be coerced to the Signature parameter type). If there are multiple match it will first attempt to pick the one requires the least cast, then pick the function with the highest precedence. 
 
 ### Deprecated
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeLattice.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeLattice.kt
@@ -86,6 +86,7 @@ internal class TypeLattice private constructor(
         INT32,
         INT64,
         INT,
+        DECIMAL,
         DECIMAL_ARBITRARY,
         FLOAT32,
         FLOAT64,

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeUtils.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeUtils.kt
@@ -121,9 +121,15 @@ private fun StaticType.asRuntimeType(): PartiQLValueType = when (this) {
     is ListType -> PartiQLValueType.LIST
     is SexpType -> PartiQLValueType.SEXP
     is DateType -> PartiQLValueType.DATE
-    is DecimalType -> when (this.precisionScaleConstraint) {
-        is DecimalType.PrecisionScaleConstraint.Constrained -> PartiQLValueType.DECIMAL
-        DecimalType.PrecisionScaleConstraint.Unconstrained -> PartiQLValueType.DECIMAL_ARBITRARY
+    // TODO: Run time decimal type does not model precision scale constraint yet
+    //  despite that we match to Decimal vs Decimal_ARBITRARY (PVT) here
+    //  but when mapping it back to Static Type, (i.e, mapping function return type to Value Type)
+    //  we can only map to Unconstrained decimal (Static Type)
+    is DecimalType -> {
+        when (this.precisionScaleConstraint) {
+            is DecimalType.PrecisionScaleConstraint.Constrained -> PartiQLValueType.DECIMAL
+            DecimalType.PrecisionScaleConstraint.Unconstrained -> PartiQLValueType.DECIMAL_ARBITRARY
+        }
     }
     is FloatType -> PartiQLValueType.FLOAT64
     is GraphType -> error("Graph type missing from runtime types")


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
- Changed Function Match logic.
    -  Previously we assumed that if all the args require coercion to match the function signature, then the function match should failed, as there should be another function signature that requires no coercion. Such transitive coercion model is not correct. 
    -  Change the matching logic to gather all possible candidate, then sort them first based on number of coercion and then the function Precedence. 

- Also, added the constrained decimal as a valid numeric type when generating function signature. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - Yes. 

- Any backward-incompatible changes? **[YES/NO]**
  - No API changes. 
  
- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >
  - No. 

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.