### PR TITLE
Fix Join Hang

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinNestedLoop.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinNestedLoop.kt
@@ -54,6 +54,8 @@ internal abstract class RelJoinNestedLoop : Operator.Relation {
                 val result = condition.eval(input)
                 toReturn = join(result.isTrue(), lhsRecord!!, rhsRecord!!)
             }
+            // Move the pointer to the next row for the RHS
+            if (toReturn == null) rhsRecord = rhs.next()
         }
         while (toReturn == null)
         return toReturn

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/Symbols.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/Symbols.kt
@@ -49,7 +49,8 @@ internal class Symbols private constructor() {
         var j = 0
         while (j < c.items.size) {
             if (c.items[j] == item) {
-                break
+                // Found existing item in catalog, return the ref
+                return CatalogRef(i, j)
             }
             j++
         }


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
- Joins previously would hang if condition is false. 
- This is because we missed moving the pointer for the RHS record to the next one. 
- Also, small fix on the logic to insert ref into symbol. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - < If NO, why? >

- Any backward-incompatible changes? **[YES/NO]**
  - < If YES, why? >
  - < For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base. >

- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.