### PR TITLE
Add additional APIs for async physical plan evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,23 @@ Thank you to all who have contributed!
 
 ### Added
 - Added constrained decimal as valid parameter type to functions that take in numeric parameters. 
+- Added async version of physical plan evaluator `PartiQLCompilerAsync`. The following related async APIs have been added:
+  - `org.partiql.lang.compiler` -- `PartiQLCompilerAsync`, `PartiQLCompilerAsyncBuilder`, `PartiQLCompilerAsyncDefault`, `PartiQLCompilerPipelineAsync`
+  - `org.partiql.lang.eval` -- `PartiQLStatementAsync`
+  - `org.partiql.lang.eval.physical` -- `VariableBindingAsync`
+  - `org.partiql.lang.eval.physical.operators` -- `AggregateOperatorFactoryAsync`, `CompiledGroupKeyAsync`, `CompiledAggregateFunctionAsync`, `FilterRelationalOperatorFactoryAsync`, `JoinRelationalOperatorFactoryAsync`, `LetRelationalOperatorFactoryAsync`, `LimitRelationalOperatorFactoryAsync`, `OffsetRelationalOperatorFactoryAsync`, `ProjectRelationalOperatorFactoryAsync`, `RelationExpressionAsync`, `ScanRelationalOperatorFactoryAsync`, `SortOperatorFactoryAsync`, `CompiledSortKeyAsync`, `UnpivotOperatorFactoryAsync`, `ValueExpressionAsync`, `WindowRelationalOperatorFactoryAsync`, `CompiledWindowFunctionAsync`
+  - `org.partiql.lang.eval.physical.window` -- `NavigationWindowFunctionAsync`, `WindowFunctionAsync`
 
 ### Changed
 - Function resolution logic: Now the function resolver would match all possible candidate(based on if the argument can be coerced to the Signature parameter type). If there are multiple match it will first attempt to pick the one requires the least cast, then pick the function with the highest precedence. 
 
 ### Deprecated
+- As part of the additions to make an async physical plan evaluator, the synchronous physical plan evaluator `PartiQLCompiler` has been deprecated. The following related APIs have been deprecated
+  - `org.partiql.lang.compiler` -- `PartiQLCompiler`, `PartiQLCompilerBuilder`, `PartiQLCompilerDefault`, `PartiQLCompilerPipeline`
+  - `org.partiql.lang.eval` -- `PartiQLStatement`
+  - `org.partiql.lang.eval.physical` -- `VariableBinding`
+  - `org.partiql.lang.eval.physical.operators` -- `AggregateOperatorFactory`, `CompiledGroupKey`, `CompiledAggregateFunction`, `FilterRelationalOperatorFactory`, `JoinRelationalOperatorFactory`, `LetRelationalOperatorFactory`, `LimitRelationalOperatorFactory`, `OffsetRelationalOperatorFactory`, `ProjectRelationalOperatorFactory`, `RelationExpression`, `ScanRelationalOperatorFactory`, `SortOperatorFactory`, `CompiledSortKey`, `UnpivotOperatorFactory`, `ValueExpression`, `WindowRelationalOperatorFactory`, `CompiledWindowFunction`
+  - `org.partiql.lang.eval.physical.window` -- `NavigationWindowFunction`, `WindowFunction`
 
 ### Fixed
 
@@ -43,7 +55,7 @@ Thank you to all who have contributed!
 
 ### Contributors
 Thank you to all who have contributed!
-- @<your-username>
+- @alancai98
 
 ## [0.14.3] - 2024-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Thank you to all who have contributed!
 
 ### Changed
 - Function resolution logic: Now the function resolver would match all possible candidate(based on if the argument can be coerced to the Signature parameter type). If there are multiple match it will first attempt to pick the one requires the least cast, then pick the function with the highest precedence. 
+- partiql-cli -- experimental version of CLI now uses the async physical plan evaluator
 
 ### Deprecated
 - As part of the additions to make an async physical plan evaluator, the synchronous physical plan evaluator `PartiQLCompiler` has been deprecated. The following related APIs have been deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,24 +29,28 @@ Thank you to all who have contributed!
 
 ### Added
 - Added constrained decimal as valid parameter type to functions that take in numeric parameters. 
-- Added async version of physical plan evaluator `PartiQLCompilerAsync`. The following related async APIs have been added:
-  - `org.partiql.lang.compiler` -- `PartiQLCompilerAsync`, `PartiQLCompilerAsyncBuilder`, `PartiQLCompilerAsyncDefault`, `PartiQLCompilerPipelineAsync`
-  - `org.partiql.lang.eval` -- `PartiQLStatementAsync`
-  - `org.partiql.lang.eval.physical` -- `VariableBindingAsync`
-  - `org.partiql.lang.eval.physical.operators` -- `AggregateOperatorFactoryAsync`, `CompiledGroupKeyAsync`, `CompiledAggregateFunctionAsync`, `FilterRelationalOperatorFactoryAsync`, `JoinRelationalOperatorFactoryAsync`, `LetRelationalOperatorFactoryAsync`, `LimitRelationalOperatorFactoryAsync`, `OffsetRelationalOperatorFactoryAsync`, `ProjectRelationalOperatorFactoryAsync`, `RelationExpressionAsync`, `ScanRelationalOperatorFactoryAsync`, `SortOperatorFactoryAsync`, `CompiledSortKeyAsync`, `UnpivotOperatorFactoryAsync`, `ValueExpressionAsync`, `WindowRelationalOperatorFactoryAsync`, `CompiledWindowFunctionAsync`
-  - `org.partiql.lang.eval.physical.window` -- `NavigationWindowFunctionAsync`, `WindowFunctionAsync`
+- Added async version of physical plan evaluator `PartiQLCompilerAsync`. 
+  - The following related async APIs have been added:
+    - `org.partiql.lang.compiler` -- `PartiQLCompilerAsync`, `PartiQLCompilerAsyncBuilder`, `PartiQLCompilerAsyncDefault`, `PartiQLCompilerPipelineAsync`
+    - `org.partiql.lang.eval` -- `PartiQLStatementAsync`
+    - `org.partiql.lang.eval.physical` -- `VariableBindingAsync`
+    - `org.partiql.lang.eval.physical.operators` -- `AggregateOperatorFactoryAsync`, `CompiledGroupKeyAsync`, `CompiledAggregateFunctionAsync`, `FilterRelationalOperatorFactoryAsync`, `JoinRelationalOperatorFactoryAsync`, `LetRelationalOperatorFactoryAsync`, `LimitRelationalOperatorFactoryAsync`, `OffsetRelationalOperatorFactoryAsync`, `ProjectRelationalOperatorFactoryAsync`, `RelationExpressionAsync`, `ScanRelationalOperatorFactoryAsync`, `SortOperatorFactoryAsync`, `CompiledSortKeyAsync`, `UnpivotOperatorFactoryAsync`, `ValueExpressionAsync`, `WindowRelationalOperatorFactoryAsync`, `CompiledWindowFunctionAsync`
+    - `org.partiql.lang.eval.physical.window` -- `NavigationWindowFunctionAsync`, `WindowFunctionAsync`
+  - Overall, we see about a 10-20% performance decline in running a single query on the synchronous vs async evaluator
+    - JMH benchmarks added to partiql-lang: `PartiQLCompilerPipelineBenchmark` and `PartiQLCompilerPipelineAsyncBenchmark`
 
 ### Changed
 - Function resolution logic: Now the function resolver would match all possible candidate(based on if the argument can be coerced to the Signature parameter type). If there are multiple match it will first attempt to pick the one requires the least cast, then pick the function with the highest precedence. 
 - partiql-cli -- experimental version of CLI now uses the async physical plan evaluator
 
 ### Deprecated
-- As part of the additions to make an async physical plan evaluator, the synchronous physical plan evaluator `PartiQLCompiler` has been deprecated. The following related APIs have been deprecated
-  - `org.partiql.lang.compiler` -- `PartiQLCompiler`, `PartiQLCompilerBuilder`, `PartiQLCompilerDefault`, `PartiQLCompilerPipeline`
-  - `org.partiql.lang.eval` -- `PartiQLStatement`
-  - `org.partiql.lang.eval.physical` -- `VariableBinding`
-  - `org.partiql.lang.eval.physical.operators` -- `AggregateOperatorFactory`, `CompiledGroupKey`, `CompiledAggregateFunction`, `FilterRelationalOperatorFactory`, `JoinRelationalOperatorFactory`, `LetRelationalOperatorFactory`, `LimitRelationalOperatorFactory`, `OffsetRelationalOperatorFactory`, `ProjectRelationalOperatorFactory`, `RelationExpression`, `ScanRelationalOperatorFactory`, `SortOperatorFactory`, `CompiledSortKey`, `UnpivotOperatorFactory`, `ValueExpression`, `WindowRelationalOperatorFactory`, `CompiledWindowFunction`
-  - `org.partiql.lang.eval.physical.window` -- `NavigationWindowFunction`, `WindowFunction`
+- As part of the additions to make an async physical plan evaluator, the synchronous physical plan evaluator `PartiQLCompiler` has been deprecated.
+  - The following related APIs have been deprecated
+    - `org.partiql.lang.compiler` -- `PartiQLCompiler`, `PartiQLCompilerBuilder`, `PartiQLCompilerDefault`, `PartiQLCompilerPipeline`
+    - `org.partiql.lang.eval` -- `PartiQLStatement`
+    - `org.partiql.lang.eval.physical` -- `VariableBinding`
+    - `org.partiql.lang.eval.physical.operators` -- `AggregateOperatorFactory`, `CompiledGroupKey`, `CompiledAggregateFunction`, `FilterRelationalOperatorFactory`, `JoinRelationalOperatorFactory`, `LetRelationalOperatorFactory`, `LimitRelationalOperatorFactory`, `OffsetRelationalOperatorFactory`, `ProjectRelationalOperatorFactory`, `RelationExpression`, `ScanRelationalOperatorFactory`, `SortOperatorFactory`, `CompiledSortKey`, `UnpivotOperatorFactory`, `ValueExpression`, `WindowRelationalOperatorFactory`, `CompiledWindowFunction`
+    - `org.partiql.lang.eval.physical.window` -- `NavigationWindowFunction`, `WindowFunction`
 
 ### Fixed
 

--- a/buildSrc/src/main/kotlin/partiql.versions.kt
+++ b/buildSrc/src/main/kotlin/partiql.versions.kt
@@ -36,7 +36,10 @@ object Versions {
     const val jansi = "2.4.0"
     const val jgenhtml = "1.6"
     const val jline = "3.21.0"
-    const val jmh = "0.5.3"
+    const val jmhGradlePlugin = "0.5.3"
+    const val jmhCore = "1.37"
+    const val jmhGeneratorAnnprocess = "1.37"
+    const val jmhGeneratorBytecode = "1.37"
     const val joda = "2.12.1"
     const val kotlinPoet = "1.11.0"
     const val kotlinxCollections = "0.3.5"
@@ -103,6 +106,11 @@ object Deps {
     const val mockito = "org.mockito:mockito-junit-jupiter:${Versions.mockito}"
     const val mockk = "io.mockk:mockk:${Versions.mockk}"
     const val kotlinxCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinxCoroutinesTest}"
+
+    // JMH Benchmarking
+    const val jmhCore = "org.openjdk.jmh:jmh-core:${Versions.jmhCore}"
+    const val jmhGeneratorAnnprocess = "org.openjdk.jmh:jmh-core:${Versions.jmhGeneratorAnnprocess}"
+    const val jmhGeneratorBytecode = "org.openjdk.jmh:jmh-core:${Versions.jmhGeneratorBytecode}"
 }
 
 object Plugins {

--- a/buildSrc/src/main/kotlin/partiql.versions.kt
+++ b/buildSrc/src/main/kotlin/partiql.versions.kt
@@ -44,6 +44,8 @@ object Versions {
     const val kasechange = "1.3.0"
     const val ktlint = "11.6.0"
     const val pig = "0.6.2"
+    const val kotlinxCoroutines = "1.6.0"
+    const val kotlinxCoroutinesJdk8 = "1.6.0"
 
     // Testing
     const val assertj = "3.11.0"
@@ -54,6 +56,7 @@ object Versions {
     const val junit4Params = "1.1.1"
     const val mockito = "4.5.0"
     const val mockk = "1.11.0"
+    const val kotlinxCoroutinesTest = "1.6.0"
 }
 
 object Deps {
@@ -84,6 +87,8 @@ object Deps {
     const val picoCli = "info.picocli:picocli:${Versions.picoCli}"
     const val pig = "org.partiql:partiql-ir-generator:${Versions.pig}"
     const val pigRuntime = "org.partiql:partiql-ir-generator-runtime:${Versions.pig}"
+    const val kotlinxCoroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinxCoroutines}"
+    const val kotlinxCoroutinesJdk8 = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:${Versions.kotlinxCoroutinesJdk8}"
 
     // Testing
     const val assertj = "org.assertj:assertj-core:${Versions.assertj}"
@@ -97,6 +102,7 @@ object Deps {
     const val kotlinTestJunit = "org.jetbrains.kotlin:kotlin-test-junit5:${Versions.kotlin}"
     const val mockito = "org.mockito:mockito-junit-jupiter:${Versions.mockito}"
     const val mockk = "io.mockk:mockk:${Versions.mockk}"
+    const val kotlinxCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinxCoroutinesTest}"
 }
 
 object Plugins {

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -25,6 +25,8 @@ application {
 dependencies {
     implementation(project(":partiql-lang"))
     implementation(project(":partiql-types"))
+    implementation(Deps.kotlinxCoroutines)
+    implementation(Deps.kotlinxCoroutinesJdk8)
     implementation(Deps.awsSdkS3)
 }
 

--- a/examples/src/main/java/org/partiql/examples/PartiQLCompilerPipelineAsyncJavaExample.java
+++ b/examples/src/main/java/org/partiql/examples/PartiQLCompilerPipelineAsyncJavaExample.java
@@ -35,7 +35,7 @@ import java.io.PrintStream;
 /**
  * This is an example of using PartiQLCompilerPipelineAsync in Java.
  * It is an experimental feature and is marked as such, with @OptIn, in this example.
- * Unfortunately, it seems like the Java does not recognize the Optin annotation specified in Kotlin.
+ * Unfortunately, it seems like the Java does not recognize the OptIn annotation specified in Kotlin.
  * Java users will be able to access the experimental APIs freely, and not be warned at all.
  */
 public class PartiQLCompilerPipelineAsyncJavaExample extends Example {
@@ -57,10 +57,7 @@ public class PartiQLCompilerPipelineAsyncJavaExample extends Example {
                 "{name: \"mary\", age: 19}" +
                 "]";
 
-        final Bindings<ExprValue> globalVariables = Bindings.<ExprValue>lazyBindingsBuilder().addBinding("myTable", () -> {
-            ExprValue exprValue = ExprValue.of(ion.singleValue(myTable));
-            return exprValue;
-        }).build();
+        final Bindings<ExprValue> globalVariables = Bindings.<ExprValue>lazyBindingsBuilder().addBinding("myTable", () -> ExprValue.of(ion.singleValue(myTable))).build();
 
         final EvaluationSession session = EvaluationSession.builder()
                 .globals(globalVariables)
@@ -97,6 +94,11 @@ public class PartiQLCompilerPipelineAsyncJavaExample extends Example {
         String query = "SELECT t.name FROM myTable AS t WHERE t.age > 20";
 
         print("PartiQL query:", query);
+
+        // Calling Kotlin coroutines from Java requires some additional libraries from `kotlinx.coroutines.future`
+        // to return a `java.util.concurrent.CompletableFuture`. If a use case arises to call the
+        // `PartiQLCompilerPipelineAsync` APIs directly from Java, we can add Kotlin functions that directly return
+        // Java's async libraries (e.g. in https://stackoverflow.com/a/52887677).
         CompletableFuture<PartiQLStatementAsync> statementFuture = FutureKt.future(
                 CoroutineScopeKt.CoroutineScope(EmptyCoroutineContext.INSTANCE),
                 EmptyCoroutineContext.INSTANCE,

--- a/examples/src/main/java/org/partiql/examples/PartiQLCompilerPipelineAsyncJavaExample.java
+++ b/examples/src/main/java/org/partiql/examples/PartiQLCompilerPipelineAsyncJavaExample.java
@@ -2,17 +2,25 @@ package org.partiql.examples;
 
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.system.IonSystemBuilder;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import kotlin.OptIn;
+import kotlin.coroutines.EmptyCoroutineContext;
+import kotlinx.coroutines.CoroutineScopeKt;
+import kotlinx.coroutines.CoroutineStart;
+import kotlinx.coroutines.future.FutureKt;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline;
 import org.partiql.examples.util.Example;
-import org.partiql.lang.compiler.PartiQLCompiler;
-import org.partiql.lang.compiler.PartiQLCompilerBuilder;
-import org.partiql.lang.compiler.PartiQLCompilerPipeline;
+import org.partiql.lang.compiler.PartiQLCompilerAsync;
+import org.partiql.lang.compiler.PartiQLCompilerAsyncBuilder;
+import org.partiql.lang.compiler.PartiQLCompilerPipelineAsync;
 import org.partiql.lang.eval.Bindings;
 import org.partiql.lang.eval.EvaluationSession;
 import org.partiql.lang.eval.ExprValue;
 import org.partiql.lang.eval.PartiQLResult;
+import org.partiql.lang.eval.PartiQLStatementAsync;
 import org.partiql.lang.eval.ProjectionIterationBehavior;
 import org.partiql.lang.planner.EvaluatorOptions;
 import org.partiql.lang.planner.GlobalResolutionResult;
@@ -25,14 +33,14 @@ import org.partiql.lang.syntax.PartiQLParserBuilder;
 import java.io.PrintStream;
 
 /**
- * This is an example of using PartiQLCompilerPipeline in Java.
+ * This is an example of using PartiQLCompilerPipelineAsync in Java.
  * It is an experimental feature and is marked as such, with @OptIn, in this example.
  * Unfortunately, it seems like the Java does not recognize the Optin annotation specified in Kotlin.
  * Java users will be able to access the experimental APIs freely, and not be warned at all.
  */
-public class PartiQLCompilerPipelineJavaExample extends Example {
+public class PartiQLCompilerPipelineAsyncJavaExample extends Example {
 
-    public PartiQLCompilerPipelineJavaExample(@NotNull PrintStream out) {
+    public PartiQLCompilerPipelineAsyncJavaExample(@NotNull PrintStream out) {
         super(out);
     }
 
@@ -79,17 +87,36 @@ public class PartiQLCompilerPipelineJavaExample extends Example {
         final PartiQLPlanner planner = PartiQLPlannerBuilder.standard().globalVariableResolver(globalVariableResolver).build();
 
         @OptIn(markerClass = ExperimentalPartiQLCompilerPipeline.class)
-        final PartiQLCompiler compiler = PartiQLCompilerBuilder.standard().options(evaluatorOptions).build();
+        final PartiQLCompilerAsync compiler = PartiQLCompilerAsyncBuilder.standard().options(evaluatorOptions).build();
 
         @OptIn(markerClass = ExperimentalPartiQLCompilerPipeline.class)
-        final PartiQLCompilerPipeline pipeline = new PartiQLCompilerPipeline(
+        final PartiQLCompilerPipelineAsync pipeline = new PartiQLCompilerPipelineAsync(
                 parser, planner, compiler
         );
 
         String query = "SELECT t.name FROM myTable AS t WHERE t.age > 20";
 
         print("PartiQL query:", query);
-        PartiQLResult result = pipeline.compile(query).eval(session);
+        CompletableFuture<PartiQLStatementAsync> statementFuture = FutureKt.future(
+                CoroutineScopeKt.CoroutineScope(EmptyCoroutineContext.INSTANCE),
+                EmptyCoroutineContext.INSTANCE,
+                CoroutineStart.DEFAULT,
+                (scope, continuation) -> pipeline.compile(query, continuation)
+        );
+
+        PartiQLResult result;
+        try {
+            PartiQLStatementAsync statement = statementFuture.get();
+            CompletableFuture<PartiQLResult> resultFuture = FutureKt.future(
+                    CoroutineScopeKt.CoroutineScope(EmptyCoroutineContext.INSTANCE),
+                    EmptyCoroutineContext.INSTANCE,
+                    CoroutineStart.DEFAULT,
+                    (scope, continuation) -> statement.eval(session, continuation)
+            );
+            result = resultFuture.get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
         ExprValue exprValue = null;
         if (result instanceof PartiQLResult.Value) {
             exprValue = ((PartiQLResult.Value) result).getValue();

--- a/examples/src/main/kotlin/org/partiql/examples/PartiQLCompilerPipelineAsyncExample.kt
+++ b/examples/src/main/kotlin/org/partiql/examples/PartiQLCompilerPipelineAsyncExample.kt
@@ -21,7 +21,7 @@ import java.io.PrintStream
  * One way to do so is to add the `Optin(Experimental<X>::class) before the class. where <X> is the feature name.
  * Also see: https://kotlinlang.org/docs/opt-in-requirements.html#module-wide-opt-in
  */
-class PartiQLCompilerPipelineExample(out: PrintStream) : Example(out) {
+class PartiQLCompilerPipelineAsyncExample(out: PrintStream) : Example(out) {
 
     private val myIonSystem = IonSystemBuilder.standard().build()
 

--- a/examples/src/main/kotlin/org/partiql/examples/PartiQLCompilerPipelineExample.kt
+++ b/examples/src/main/kotlin/org/partiql/examples/PartiQLCompilerPipelineExample.kt
@@ -1,6 +1,7 @@
 package org.partiql.examples
 
 import com.amazon.ion.system.IonSystemBuilder
+import kotlinx.coroutines.runBlocking
 import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
 import org.partiql.examples.util.Example
 import org.partiql.lang.compiler.PartiQLCompilerPipelineAsync
@@ -13,7 +14,6 @@ import org.partiql.lang.planner.EvaluatorOptions
 import org.partiql.lang.planner.GlobalResolutionResult
 import org.partiql.lang.planner.GlobalVariableResolver
 import java.io.PrintStream
-import kotlinx.coroutines.runBlocking
 
 /**
  * This example demonstrate how to use PartiQLCompilerPipeline. This feature is currently in experimental stage.

--- a/examples/src/main/kotlin/org/partiql/examples/PartiQLCompilerPipelineExample.kt
+++ b/examples/src/main/kotlin/org/partiql/examples/PartiQLCompilerPipelineExample.kt
@@ -3,7 +3,7 @@ package org.partiql.examples
 import com.amazon.ion.system.IonSystemBuilder
 import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
 import org.partiql.examples.util.Example
-import org.partiql.lang.compiler.PartiQLCompilerPipeline
+import org.partiql.lang.compiler.PartiQLCompilerPipelineAsync
 import org.partiql.lang.eval.Bindings
 import org.partiql.lang.eval.EvaluationSession
 import org.partiql.lang.eval.ExprValue
@@ -13,6 +13,7 @@ import org.partiql.lang.planner.EvaluatorOptions
 import org.partiql.lang.planner.GlobalResolutionResult
 import org.partiql.lang.planner.GlobalVariableResolver
 import java.io.PrintStream
+import kotlinx.coroutines.runBlocking
 
 /**
  * This example demonstrate how to use PartiQLCompilerPipeline. This feature is currently in experimental stage.
@@ -59,7 +60,7 @@ class PartiQLCompilerPipelineExample(out: PrintStream) : Example(out) {
         .build()
 
     @OptIn(ExperimentalPartiQLCompilerPipeline::class)
-    private val partiQLCompilerPipeline = PartiQLCompilerPipeline.build {
+    private val partiQLCompilerPipeline = PartiQLCompilerPipelineAsync.build {
         planner
             .globalVariableResolver(globalVariableResolver)
         compiler
@@ -71,7 +72,10 @@ class PartiQLCompilerPipelineExample(out: PrintStream) : Example(out) {
 
         print("PartiQL query:", query)
         @OptIn(ExperimentalPartiQLCompilerPipeline::class)
-        val exprValue = when (val result = partiQLCompilerPipeline.compile(query).eval(session)) {
+        val result = runBlocking {
+            partiQLCompilerPipeline.compile(query).eval(session)
+        }
+        val exprValue = when (result) {
             is PartiQLResult.Value -> result.value
             is PartiQLResult.Delete,
             is PartiQLResult.Explain.Domain,

--- a/examples/src/main/kotlin/org/partiql/examples/util/Main.kt
+++ b/examples/src/main/kotlin/org/partiql/examples/util/Main.kt
@@ -12,8 +12,8 @@ import org.partiql.examples.EvaluationWithLazyBindings
 import org.partiql.examples.ParserErrorExample
 import org.partiql.examples.ParserExample
 import org.partiql.examples.ParserJavaExample
-import org.partiql.examples.PartiQLCompilerPipelineExample
 import org.partiql.examples.PartiQLCompilerPipelineAsyncJavaExample
+import org.partiql.examples.PartiQLCompilerPipelineExample
 import org.partiql.examples.PartialEvaluationVisitorTransformExample
 import org.partiql.examples.PreventJoinVisitorExample
 import org.partiql.examples.S3JavaExample

--- a/examples/src/main/kotlin/org/partiql/examples/util/Main.kt
+++ b/examples/src/main/kotlin/org/partiql/examples/util/Main.kt
@@ -12,8 +12,8 @@ import org.partiql.examples.EvaluationWithLazyBindings
 import org.partiql.examples.ParserErrorExample
 import org.partiql.examples.ParserExample
 import org.partiql.examples.ParserJavaExample
+import org.partiql.examples.PartiQLCompilerPipelineAsyncExample
 import org.partiql.examples.PartiQLCompilerPipelineAsyncJavaExample
-import org.partiql.examples.PartiQLCompilerPipelineExample
 import org.partiql.examples.PartialEvaluationVisitorTransformExample
 import org.partiql.examples.PreventJoinVisitorExample
 import org.partiql.examples.S3JavaExample
@@ -41,7 +41,7 @@ private val examples = mapOf(
     PartialEvaluationVisitorTransformExample::class.java.simpleName to PartialEvaluationVisitorTransformExample(System.out),
     PreventJoinVisitorExample::class.java.simpleName to PreventJoinVisitorExample(System.out),
     SimpleExpressionEvaluation::class.java.simpleName to SimpleExpressionEvaluation(System.out),
-    PartiQLCompilerPipelineExample::class.java.simpleName to PartiQLCompilerPipelineExample(System.out)
+    PartiQLCompilerPipelineAsyncExample::class.java.simpleName to PartiQLCompilerPipelineAsyncExample(System.out)
 )
 
 fun main(args: Array<String>) {

--- a/examples/src/main/kotlin/org/partiql/examples/util/Main.kt
+++ b/examples/src/main/kotlin/org/partiql/examples/util/Main.kt
@@ -13,7 +13,7 @@ import org.partiql.examples.ParserErrorExample
 import org.partiql.examples.ParserExample
 import org.partiql.examples.ParserJavaExample
 import org.partiql.examples.PartiQLCompilerPipelineExample
-import org.partiql.examples.PartiQLCompilerPipelineJavaExample
+import org.partiql.examples.PartiQLCompilerPipelineAsyncJavaExample
 import org.partiql.examples.PartialEvaluationVisitorTransformExample
 import org.partiql.examples.PreventJoinVisitorExample
 import org.partiql.examples.S3JavaExample
@@ -26,7 +26,9 @@ private val examples = mapOf(
     S3JavaExample::class.java.simpleName to S3JavaExample(System.out),
     EvaluationJavaExample::class.java.simpleName to EvaluationJavaExample(System.out),
     ParserJavaExample::class.java.simpleName to ParserJavaExample(System.out),
-    PartiQLCompilerPipelineJavaExample::class.java.simpleName to PartiQLCompilerPipelineJavaExample(System.out),
+    PartiQLCompilerPipelineAsyncJavaExample::class.java.simpleName to PartiQLCompilerPipelineAsyncJavaExample(
+        System.out
+    ),
 
     // Kotlin Examples
     CsvExprValueExample::class.java.simpleName to CsvExprValueExample(System.out),

--- a/examples/src/test/kotlin/org/partiql/examples/PartiQLCompilerPipelineAsyncExampleTest.kt
+++ b/examples/src/test/kotlin/org/partiql/examples/PartiQLCompilerPipelineAsyncExampleTest.kt
@@ -3,8 +3,8 @@ package org.partiql.examples
 import org.partiql.examples.util.Example
 import java.io.PrintStream
 
-class PartiQLCompilerPipelineExampleTest : BaseExampleTest() {
-    override fun example(out: PrintStream): Example = PartiQLCompilerPipelineExample(out)
+class PartiQLCompilerPipelineAsyncExampleTest : BaseExampleTest() {
+    override fun example(out: PrintStream): Example = PartiQLCompilerPipelineAsyncExample(out)
 
     override val expected = """
         |PartiQL query:

--- a/examples/src/test/kotlin/org/partiql/examples/PartiQLCompilerPipelineAsyncJavaExampleTest.kt
+++ b/examples/src/test/kotlin/org/partiql/examples/PartiQLCompilerPipelineAsyncJavaExampleTest.kt
@@ -3,8 +3,9 @@ package org.partiql.examples
 import org.partiql.examples.util.Example
 import java.io.PrintStream
 
-class PartiQLCompilerPipelineJavaExampleTest : BaseExampleTest() {
-    override fun example(out: PrintStream): Example = PartiQLCompilerPipelineJavaExample(out)
+class PartiQLCompilerPipelineAsyncJavaExampleTest : BaseExampleTest() {
+    override fun example(out: PrintStream): Example =
+        PartiQLCompilerPipelineAsyncJavaExample(out)
 
     override val expected = """
         |PartiQL query:

--- a/partiql-cli/build.gradle.kts
+++ b/partiql-cli/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation(Deps.joda)
     implementation(Deps.picoCli)
     implementation(Deps.kotlinReflect)
+    implementation(Deps.kotlinxCoroutines)
     testImplementation(Deps.mockito)
 }
 

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/pipeline/AbstractPipeline.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/pipeline/AbstractPipeline.kt
@@ -20,6 +20,7 @@ import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.ionString
 import com.amazon.ionelement.api.ionStructOf
 import com.amazon.ionelement.api.toIonValue
+import kotlinx.coroutines.runBlocking
 import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
 import org.partiql.cli.Debug
 import org.partiql.cli.functions.QueryDDB
@@ -48,7 +49,6 @@ import org.partiql.lang.syntax.Parser
 import org.partiql.lang.syntax.PartiQLParserBuilder
 import java.nio.file.Path
 import java.time.ZoneOffset
-import kotlinx.coroutines.runBlocking
 
 /**
  * A means by which we can run both the EvaluatingCompiler and [PartiQLCompilerPipelineAsync].

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -15,7 +15,7 @@
 
 plugins {
     id(Plugins.conventions)
-    id(Plugins.jmh) version Versions.jmh
+    id(Plugins.jmh) version Versions.jmhGradlePlugin
     id(Plugins.library)
     id(Plugins.publish)
 }
@@ -52,11 +52,16 @@ dependencies {
     testImplementation(Deps.mockk)
     testImplementation(Deps.kotlinxCoroutinesTest)
 
-    // jmh use newer version
+    // The JMH gradle plugin that we currently use is 0.5.3, which uses JMH version 1.25. The JMH gradle plugin has a
+    // newer version (see https://github.com/melix/jmh-gradle-plugin/releases) which upgrades the JMH version. We can't
+    // use that newer plugin version until we upgrade our gradle version to 8.0+. JMH version 1.25 does not support
+    // creating CPU flamegraphs using the JMH benchmarks, hence why the newer version dependency is specified here.
+    //
+    // When we upgrade gradle to 8.0+, we can upgrade the gradle plugin to the latest and remove this dependency block
     dependencies {
-        jmh("org.openjdk.jmh:jmh-core:1.37")
-        jmh("org.openjdk.jmh:jmh-generator-annprocess:1.37")
-        jmh("org.openjdk.jmh:jmh-generator-bytecode:1.37")
+        jmh(Deps.jmhCore)
+        jmh(Deps.jmhGeneratorAnnprocess)
+        jmh(Deps.jmhGeneratorBytecode)
     }
 }
 

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
     implementation(Deps.csv)
     implementation(Deps.kotlinReflect)
     implementation(Deps.kotlinxCoroutines)
-    implementation(Deps.kotlinxCoroutinesJdk8)
 
     testImplementation(testFixtures(project(":partiql-planner")))
     testImplementation(project(":plugins:partiql-memory"))

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -39,6 +39,8 @@ dependencies {
     implementation(Deps.antlrRuntime)
     implementation(Deps.csv)
     implementation(Deps.kotlinReflect)
+    implementation(Deps.kotlinxCoroutines)
+    implementation(Deps.kotlinxCoroutinesJdk8)
 
     testImplementation(testFixtures(project(":partiql-planner")))
     testImplementation(project(":plugins:partiql-memory"))
@@ -48,6 +50,14 @@ dependencies {
     testImplementation(Deps.junit4Params)
     testImplementation(Deps.junitVintage) // Enables JUnit4
     testImplementation(Deps.mockk)
+    testImplementation(Deps.kotlinxCoroutinesTest)
+
+    // jmh use newer version
+    dependencies {
+        jmh("org.openjdk.jmh:jmh-core:1.37")
+        jmh("org.openjdk.jmh:jmh-generator-annprocess:1.37")
+        jmh("org.openjdk.jmh:jmh-generator-bytecode:1.37")
+    }
 }
 
 publish {

--- a/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineAsyncBenchmark.kt
+++ b/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineAsyncBenchmark.kt
@@ -27,7 +27,7 @@ import org.partiql.lang.planner.GlobalResolutionResult
 import org.partiql.lang.syntax.PartiQLParserBuilder
 import java.util.concurrent.TimeUnit
 
-@BenchmarkMode(Mode.All)
+@BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 open class PartiQLCompilerPipelineAsyncBenchmark {
     companion object {

--- a/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineAsyncBenchmark.kt
+++ b/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineAsyncBenchmark.kt
@@ -1,5 +1,6 @@
 package org.partiql.jmh.benchmarks
 
+import com.amazon.ion.IonSystem
 import com.amazon.ion.system.IonSystemBuilder
 import kotlinx.coroutines.runBlocking
 import org.openjdk.jmh.annotations.Benchmark
@@ -41,10 +42,10 @@ open class PartiQLCompilerPipelineAsyncBenchmark {
     @State(Scope.Thread)
     @OptIn(ExperimentalPartiQLCompilerPipeline::class)
     open class MyState {
-        val parser = PartiQLParserBuilder.standard().build()
-        val myIonSystem = IonSystemBuilder.standard().build()
+        private val parser = PartiQLParserBuilder.standard().build()
+        private val myIonSystem: IonSystem = IonSystemBuilder.standard().build()
 
-        fun tableWithRows(numRows: Int): ExprValue {
+        private fun tableWithRows(numRows: Int): ExprValue {
             val allRows = (1..numRows).joinToString { index ->
                 """
                     {
@@ -62,7 +63,7 @@ open class PartiQLCompilerPipelineAsyncBenchmark {
             )
         }
 
-        val bindings = Bindings.ofMap(
+        private val bindings = Bindings.ofMap(
             mapOf(
                 "t1" to tableWithRows(1),
                 "t10" to tableWithRows(10),
@@ -73,7 +74,7 @@ open class PartiQLCompilerPipelineAsyncBenchmark {
             )
         )
 
-        val parameters = listOf(
+        private val parameters = listOf(
             ExprValue.newInt(5), // WHERE `id` > 5
             ExprValue.newInt(1000000), // LIMIT 1000000
             ExprValue.newInt(3), // OFFSET 3 * 2

--- a/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineAsyncBenchmark.kt
+++ b/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineAsyncBenchmark.kt
@@ -1,0 +1,379 @@
+package org.partiql.jmh.benchmarks
+
+import com.amazon.ion.system.IonSystemBuilder
+import kotlinx.coroutines.runBlocking
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
+import org.partiql.jmh.utils.FORK_VALUE_RECOMMENDED
+import org.partiql.jmh.utils.MEASUREMENT_ITERATION_VALUE_RECOMMENDED
+import org.partiql.jmh.utils.MEASUREMENT_TIME_VALUE_RECOMMENDED
+import org.partiql.jmh.utils.WARMUP_ITERATION_VALUE_RECOMMENDED
+import org.partiql.jmh.utils.WARMUP_TIME_VALUE_RECOMMENDED
+import org.partiql.lang.compiler.PartiQLCompilerPipelineAsync
+import org.partiql.lang.eval.Bindings
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.PartiQLResult
+import org.partiql.lang.planner.GlobalResolutionResult
+import org.partiql.lang.syntax.PartiQLParserBuilder
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Mode.All)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+open class PartiQLCompilerPipelineAsyncBenchmark {
+    companion object {
+        private const val FORK_VALUE: Int = FORK_VALUE_RECOMMENDED
+        private const val MEASUREMENT_ITERATION_VALUE: Int = MEASUREMENT_ITERATION_VALUE_RECOMMENDED
+        private const val MEASUREMENT_TIME_VALUE: Int = MEASUREMENT_TIME_VALUE_RECOMMENDED
+        private const val WARMUP_ITERATION_VALUE: Int = WARMUP_ITERATION_VALUE_RECOMMENDED
+        private const val WARMUP_TIME_VALUE: Int = WARMUP_TIME_VALUE_RECOMMENDED
+    }
+
+    @State(Scope.Thread)
+    @OptIn(ExperimentalPartiQLCompilerPipeline::class)
+    open class MyState {
+        val parser = PartiQLParserBuilder.standard().build()
+        val myIonSystem = IonSystemBuilder.standard().build()
+
+        fun tableWithRows(numRows: Int): ExprValue {
+            val allRows = (1..numRows).joinToString { index ->
+                """
+                    {
+                        "id": $index,
+                        "someString": "some string foo $index",
+                        "someDecimal": $index.00,
+                        "someBlob": {{ dHdvIHBhZGRpbmcgY2hhcmFjdGVycw== }},
+                        "someTimestamp": 2007-02-23T12:14:15.${index}Z
+                    }
+                """.trimIndent()
+            }
+            val data = "[ $allRows ]"
+            return ExprValue.of(
+                myIonSystem.singleValue(data)
+            )
+        }
+
+        val bindings = Bindings.ofMap(
+            mapOf(
+                "t1" to tableWithRows(1),
+                "t10" to tableWithRows(10),
+                "t100" to tableWithRows(100),
+                "t1000" to tableWithRows(1000),
+                "t10000" to tableWithRows(10000),
+                "t100000" to tableWithRows(100000),
+            )
+        )
+
+        val parameters = listOf(
+            ExprValue.newInt(5), // WHERE `id` > 5
+            ExprValue.newInt(1000000), // LIMIT 1000000
+            ExprValue.newInt(3), // OFFSET 3 * 2
+            ExprValue.newInt(2), // ------------^
+        )
+        val session = EvaluationSession.build {
+            globals(bindings)
+            parameters(parameters)
+        }
+
+        val pipeline = PartiQLCompilerPipelineAsync.build {
+            planner.globalVariableResolver {
+                val value = session.globals[it]
+                if (value != null) {
+                    GlobalResolutionResult.GlobalVariable(it.name)
+                } else {
+                    GlobalResolutionResult.Undefined
+                }
+            }
+        }
+
+        val query1 = parser.parseAstStatement(
+            """
+            SELECT * FROM t100000
+            """.trimIndent()
+        )
+        val query2 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t100000
+            WHERE t100000.someTimestamp < UTCNOW()
+            """.trimIndent()
+        )
+        val query3 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t100000
+            WHERE t100000.someTimestamp < UTCNOW()
+            LIMIT ${Int.MAX_VALUE}
+            """.trimIndent()
+        )
+        val query4 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t100000
+            WHERE t100000.someTimestamp < UTCNOW()
+            ORDER BY t100000.id DESC
+            """.trimIndent()
+        )
+        val query5 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t100000
+            WHERE t100000.someTimestamp < UTCNOW() AND t100000.id > ?
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+        val query6 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t100000
+            WHERE t100000.someTimestamp < UTCNOW() AND t100000.id > ?
+            ORDER BY t100000.id DESC
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+        val query7 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t10000
+            WHERE t10000.someTimestamp < UTCNOW() AND t10000.id > ?
+            ORDER BY t10000.id DESC
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+        val query8 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t1000
+            WHERE t1000.someTimestamp < UTCNOW() AND t1000.id > ?
+            ORDER BY t1000.id DESC
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+        val query9 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t100
+            WHERE t100.someTimestamp < UTCNOW() AND t100.id > ?
+            ORDER BY t100.id DESC
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+        val query10 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t10
+            WHERE t10.someTimestamp < UTCNOW() AND t10.id > ?
+            ORDER BY t10.id DESC
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+        val query11 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t1
+            WHERE t1.someTimestamp < UTCNOW() AND t1.id > ?
+            ORDER BY t1.id DESC
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+
+        val statement1 = runBlocking { pipeline.compile(query1) }
+        val statement2 = runBlocking { pipeline.compile(query2) }
+        val statement3 = runBlocking { pipeline.compile(query3) }
+        val statement4 = runBlocking { pipeline.compile(query4) }
+        val statement5 = runBlocking { pipeline.compile(query5) }
+        val statement6 = runBlocking { pipeline.compile(query6) }
+        val statement7 = runBlocking { pipeline.compile(query7) }
+        val statement8 = runBlocking { pipeline.compile(query8) }
+        val statement9 = runBlocking { pipeline.compile(query9) }
+        val statement10 = runBlocking { pipeline.compile(query10) }
+        val statement11 = runBlocking { pipeline.compile(query11) }
+    }
+
+    @OptIn(ExperimentalPartiQLCompilerPipeline::class)
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testCompileQuery1(state: MyState, blackhole: Blackhole) = runBlocking {
+        val statement = state.pipeline.compile(state.query1)
+        blackhole.consume(statement)
+    }
+
+    @OptIn(ExperimentalPartiQLCompilerPipeline::class)
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testCompileQuery2(state: MyState, blackhole: Blackhole) = runBlocking {
+        val statement = state.pipeline.compile(state.query2)
+        blackhole.consume(statement)
+    }
+
+    @OptIn(ExperimentalPartiQLCompilerPipeline::class)
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testCompileQuery3(state: MyState, blackhole: Blackhole) = runBlocking {
+        val statement = state.pipeline.compile(state.query3)
+        blackhole.consume(statement)
+    }
+
+    @OptIn(ExperimentalPartiQLCompilerPipeline::class)
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testCompileQuery4(state: MyState, blackhole: Blackhole) = runBlocking {
+        val statement = state.pipeline.compile(state.query4)
+        blackhole.consume(statement)
+    }
+
+    @OptIn(ExperimentalPartiQLCompilerPipeline::class)
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testCompileQuery5(state: MyState, blackhole: Blackhole) = runBlocking {
+        val statement = state.pipeline.compile(state.query5)
+        blackhole.consume(statement)
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery1(state: MyState, blackhole: Blackhole) = runBlocking {
+        val result = state.statement1.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery2(state: MyState, blackhole: Blackhole) = runBlocking {
+        val result = state.statement2.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery3(state: MyState, blackhole: Blackhole) = runBlocking {
+        val result = state.statement3.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery4(state: MyState, blackhole: Blackhole) = runBlocking {
+        val result = state.statement4.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery5(state: MyState, blackhole: Blackhole) = runBlocking {
+        val result = state.statement5.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery6(state: MyState, blackhole: Blackhole) = runBlocking {
+        val result = state.statement6.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery7(state: MyState, blackhole: Blackhole) = runBlocking {
+        val result = state.statement7.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery8(state: MyState, blackhole: Blackhole) = runBlocking {
+        val result = state.statement8.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery9(state: MyState, blackhole: Blackhole) = runBlocking {
+        val result = state.statement9.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery10(state: MyState, blackhole: Blackhole) = runBlocking {
+        val result = state.statement10.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery11(state: MyState, blackhole: Blackhole) = runBlocking {
+        val result = state.statement11.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+}

--- a/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineBenchmark.kt
+++ b/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineBenchmark.kt
@@ -1,0 +1,379 @@
+package org.partiql.jmh.benchmarks
+
+import com.amazon.ion.system.IonSystemBuilder
+import kotlinx.coroutines.runBlocking
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
+import org.partiql.jmh.utils.FORK_VALUE_RECOMMENDED
+import org.partiql.jmh.utils.MEASUREMENT_ITERATION_VALUE_RECOMMENDED
+import org.partiql.jmh.utils.MEASUREMENT_TIME_VALUE_RECOMMENDED
+import org.partiql.jmh.utils.WARMUP_ITERATION_VALUE_RECOMMENDED
+import org.partiql.jmh.utils.WARMUP_TIME_VALUE_RECOMMENDED
+import org.partiql.lang.compiler.PartiQLCompilerPipeline
+import org.partiql.lang.eval.Bindings
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.PartiQLResult
+import org.partiql.lang.planner.GlobalResolutionResult
+import org.partiql.lang.syntax.PartiQLParserBuilder
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Mode.All)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+open class PartiQLCompilerPipelineBenchmark {
+    companion object {
+        private const val FORK_VALUE: Int = FORK_VALUE_RECOMMENDED
+        private const val MEASUREMENT_ITERATION_VALUE: Int = MEASUREMENT_ITERATION_VALUE_RECOMMENDED
+        private const val MEASUREMENT_TIME_VALUE: Int = MEASUREMENT_TIME_VALUE_RECOMMENDED
+        private const val WARMUP_ITERATION_VALUE: Int = WARMUP_ITERATION_VALUE_RECOMMENDED
+        private const val WARMUP_TIME_VALUE: Int = WARMUP_TIME_VALUE_RECOMMENDED
+    }
+
+    @State(Scope.Thread)
+    @OptIn(ExperimentalPartiQLCompilerPipeline::class)
+    open class MyState {
+        val parser = PartiQLParserBuilder.standard().build()
+        val myIonSystem = IonSystemBuilder.standard().build()
+
+        fun tableWithRows(numRows: Int): ExprValue {
+            val allRows = (1..numRows).joinToString { index ->
+                """
+                    {
+                        "id": $index,
+                        "someString": "some string foo $index",
+                        "someDecimal": $index.00,
+                        "someBlob": {{ dHdvIHBhZGRpbmcgY2hhcmFjdGVycw== }},
+                        "someTimestamp": 2007-02-23T12:14:15.${index}Z
+                    }
+                """.trimIndent()
+            }
+            val data = "[ $allRows ]"
+            return ExprValue.of(
+                myIonSystem.singleValue(data)
+            )
+        }
+
+        val bindings = Bindings.ofMap(
+            mapOf(
+                "t1" to tableWithRows(1),
+                "t10" to tableWithRows(10),
+                "t100" to tableWithRows(100),
+                "t1000" to tableWithRows(1000),
+                "t10000" to tableWithRows(10000),
+                "t100000" to tableWithRows(100000),
+            )
+        )
+
+        val parameters = listOf(
+            ExprValue.newInt(5), // WHERE `id` > 5
+            ExprValue.newInt(1000000), // LIMIT 1000000
+            ExprValue.newInt(3), // OFFSET 3 * 2
+            ExprValue.newInt(2), // ------------^
+        )
+        val session = EvaluationSession.build {
+            globals(bindings)
+            parameters(parameters)
+        }
+
+        val pipeline = PartiQLCompilerPipeline.build {
+            planner.globalVariableResolver {
+                val value = session.globals[it]
+                if (value != null) {
+                    GlobalResolutionResult.GlobalVariable(it.name)
+                } else {
+                    GlobalResolutionResult.Undefined
+                }
+            }
+        }
+
+        val query1 = parser.parseAstStatement(
+            """
+            SELECT * FROM t100000
+            """.trimIndent()
+        )
+        val query2 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t100000
+            WHERE t100000.someTimestamp < UTCNOW()
+            """.trimIndent()
+        )
+        val query3 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t100000
+            WHERE t100000.someTimestamp < UTCNOW()
+            LIMIT ${Int.MAX_VALUE}
+            """.trimIndent()
+        )
+        val query4 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t100000
+            WHERE t100000.someTimestamp < UTCNOW()
+            ORDER BY t100000.id DESC
+            """.trimIndent()
+        )
+        val query5 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t100000
+            WHERE t100000.someTimestamp < UTCNOW() AND t100000.id > ?
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+        val query6 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t100000
+            WHERE t100000.someTimestamp < UTCNOW() AND t100000.id > ?
+            ORDER BY t100000.id DESC
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+        val query7 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t10000
+            WHERE t10000.someTimestamp < UTCNOW() AND t10000.id > ?
+            ORDER BY t10000.id DESC
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+        val query8 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t1000
+            WHERE t1000.someTimestamp < UTCNOW() AND t1000.id > ?
+            ORDER BY t1000.id DESC
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+        val query9 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t100
+            WHERE t100.someTimestamp < UTCNOW() AND t100.id > ?
+            ORDER BY t100.id DESC
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+        val query10 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t10
+            WHERE t10.someTimestamp < UTCNOW() AND t10.id > ?
+            ORDER BY t10.id DESC
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+        val query11 = parser.parseAstStatement(
+            """
+            SELECT *
+            FROM t1
+            WHERE t1.someTimestamp < UTCNOW() AND t1.id > ?
+            ORDER BY t1.id DESC
+            LIMIT ?
+            OFFSET ? * ?
+            """.trimIndent()
+        )
+
+        val statement1 = pipeline.compile(query1)
+        val statement2 = pipeline.compile(query2)
+        val statement3 = pipeline.compile(query3)
+        val statement4 = pipeline.compile(query4)
+        val statement5 = pipeline.compile(query5)
+        val statement6 = pipeline.compile(query6)
+        val statement7 = pipeline.compile(query7)
+        val statement8 = pipeline.compile(query8)
+        val statement9 = pipeline.compile(query9)
+        val statement10 = pipeline.compile(query10)
+        val statement11 = pipeline.compile(query11)
+    }
+
+    @OptIn(ExperimentalPartiQLCompilerPipeline::class)
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testCompileQuery1(state: MyState, blackhole: Blackhole) = runBlocking {
+        val statement = state.pipeline.compile(state.query1)
+        blackhole.consume(statement)
+    }
+
+    @OptIn(ExperimentalPartiQLCompilerPipeline::class)
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testCompileQuery2(state: MyState, blackhole: Blackhole) = runBlocking {
+        val statement = state.pipeline.compile(state.query2)
+        blackhole.consume(statement)
+    }
+
+    @OptIn(ExperimentalPartiQLCompilerPipeline::class)
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testCompileQuery3(state: MyState, blackhole: Blackhole) = runBlocking {
+        val statement = state.pipeline.compile(state.query3)
+        blackhole.consume(statement)
+    }
+
+    @OptIn(ExperimentalPartiQLCompilerPipeline::class)
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testCompileQuery4(state: MyState, blackhole: Blackhole) {
+        val statement = state.pipeline.compile(state.query4)
+        blackhole.consume(statement)
+    }
+
+    @OptIn(ExperimentalPartiQLCompilerPipeline::class)
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testCompileQuery5(state: MyState, blackhole: Blackhole) {
+        val statement = state.pipeline.compile(state.query5)
+        blackhole.consume(statement)
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery1(state: MyState, blackhole: Blackhole) {
+        val result = state.statement1.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery2(state: MyState, blackhole: Blackhole) {
+        val result = state.statement2.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery3(state: MyState, blackhole: Blackhole) {
+        val result = state.statement3.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery4(state: MyState, blackhole: Blackhole) {
+        val result = state.statement4.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery5(state: MyState, blackhole: Blackhole) {
+        val result = state.statement5.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery6(state: MyState, blackhole: Blackhole) {
+        val result = state.statement6.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery7(state: MyState, blackhole: Blackhole) {
+        val result = state.statement7.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery8(state: MyState, blackhole: Blackhole) {
+        val result = state.statement8.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery9(state: MyState, blackhole: Blackhole) {
+        val result = state.statement9.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery10(state: MyState, blackhole: Blackhole) {
+        val result = state.statement10.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+
+    @Benchmark
+    @Fork(value = FORK_VALUE)
+    @Measurement(iterations = MEASUREMENT_ITERATION_VALUE, time = MEASUREMENT_TIME_VALUE)
+    @Warmup(iterations = WARMUP_ITERATION_VALUE, time = WARMUP_TIME_VALUE)
+    fun testEvalQuery11(state: MyState, blackhole: Blackhole) {
+        val result = state.statement11.eval(state.session)
+        val exprValue = (result as PartiQLResult.Value).value
+        blackhole.consume(exprValue)
+        blackhole.consume(exprValue.iterator().forEach { })
+    }
+}

--- a/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineBenchmark.kt
+++ b/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineBenchmark.kt
@@ -1,5 +1,6 @@
 package org.partiql.jmh.benchmarks
 
+import com.amazon.ion.IonSystem
 import com.amazon.ion.system.IonSystemBuilder
 import kotlinx.coroutines.runBlocking
 import org.openjdk.jmh.annotations.Benchmark
@@ -42,10 +43,10 @@ open class PartiQLCompilerPipelineBenchmark {
     @State(Scope.Thread)
     @OptIn(ExperimentalPartiQLCompilerPipeline::class)
     open class MyState {
-        val parser = PartiQLParserBuilder.standard().build()
-        val myIonSystem = IonSystemBuilder.standard().build()
+        private val parser = PartiQLParserBuilder.standard().build()
+        private val myIonSystem: IonSystem = IonSystemBuilder.standard().build()
 
-        fun tableWithRows(numRows: Int): ExprValue {
+        private fun tableWithRows(numRows: Int): ExprValue {
             val allRows = (1..numRows).joinToString { index ->
                 """
                     {
@@ -63,7 +64,7 @@ open class PartiQLCompilerPipelineBenchmark {
             )
         }
 
-        val bindings = Bindings.ofMap(
+        private val bindings = Bindings.ofMap(
             mapOf(
                 "t1" to tableWithRows(1),
                 "t10" to tableWithRows(10),
@@ -74,7 +75,7 @@ open class PartiQLCompilerPipelineBenchmark {
             )
         )
 
-        val parameters = listOf(
+        private val parameters = listOf(
             ExprValue.newInt(5), // WHERE `id` > 5
             ExprValue.newInt(1000000), // LIMIT 1000000
             ExprValue.newInt(3), // OFFSET 3 * 2
@@ -133,7 +134,7 @@ open class PartiQLCompilerPipelineBenchmark {
             OFFSET ? * ?
             """.trimIndent()
         )
-        val query6 = parser.parseAstStatement(
+        private val query6 = parser.parseAstStatement(
             """
             SELECT *
             FROM t100000
@@ -143,7 +144,7 @@ open class PartiQLCompilerPipelineBenchmark {
             OFFSET ? * ?
             """.trimIndent()
         )
-        val query7 = parser.parseAstStatement(
+        private val query7 = parser.parseAstStatement(
             """
             SELECT *
             FROM t10000
@@ -153,7 +154,7 @@ open class PartiQLCompilerPipelineBenchmark {
             OFFSET ? * ?
             """.trimIndent()
         )
-        val query8 = parser.parseAstStatement(
+        private val query8 = parser.parseAstStatement(
             """
             SELECT *
             FROM t1000
@@ -163,7 +164,7 @@ open class PartiQLCompilerPipelineBenchmark {
             OFFSET ? * ?
             """.trimIndent()
         )
-        val query9 = parser.parseAstStatement(
+        private val query9 = parser.parseAstStatement(
             """
             SELECT *
             FROM t100
@@ -173,7 +174,7 @@ open class PartiQLCompilerPipelineBenchmark {
             OFFSET ? * ?
             """.trimIndent()
         )
-        val query10 = parser.parseAstStatement(
+        private val query10 = parser.parseAstStatement(
             """
             SELECT *
             FROM t10
@@ -183,7 +184,7 @@ open class PartiQLCompilerPipelineBenchmark {
             OFFSET ? * ?
             """.trimIndent()
         )
-        val query11 = parser.parseAstStatement(
+        private val query11 = parser.parseAstStatement(
             """
             SELECT *
             FROM t1

--- a/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineBenchmark.kt
+++ b/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineBenchmark.kt
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Deprecated("To be removed in the next major version once the synchronous physical plan compiler is removed.")
 open class PartiQLCompilerPipelineBenchmark {
     companion object {
         private const val FORK_VALUE: Int = FORK_VALUE_RECOMMENDED

--- a/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineBenchmark.kt
+++ b/partiql-lang/src/jmh/kotlin/org/partiql/jmh/benchmarks/PartiQLCompilerPipelineBenchmark.kt
@@ -27,7 +27,7 @@ import org.partiql.lang.planner.GlobalResolutionResult
 import org.partiql.lang.syntax.PartiQLParserBuilder
 import java.util.concurrent.TimeUnit
 
-@BenchmarkMode(Mode.All)
+@BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 open class PartiQLCompilerPipelineBenchmark {
     companion object {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompiler.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompiler.kt
@@ -23,15 +23,18 @@ import org.partiql.lang.planner.PartiQLPlanner
  * [PartiQLCompiler] is responsible for transforming a [PartiqlPhysical.Plan] into an executable [PartiQLStatement].
  */
 @ExperimentalPartiQLCompilerPipeline
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerAsync"))
 interface PartiQLCompiler {
 
     /**
      * Compiles the [PartiqlPhysical.Plan] to an executable [PartiQLStatement].
      */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerAsync.compile"))
     fun compile(statement: PartiqlPhysical.Plan): PartiQLStatement
 
     /**
      * Compiles the [PartiqlPhysical.Statement.Explain] with the details provided in [details]
      */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerAsync.compile"))
     fun compile(statement: PartiqlPhysical.Plan, details: PartiQLPlanner.PlanningDetails): PartiQLStatement
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsync.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.compiler
+
+import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.PartiQLStatementAsync
+import org.partiql.lang.planner.PartiQLPlanner
+
+/**
+ * [PartiQLCompilerAsync] is responsible for transforming a [PartiqlPhysical.Plan] into an executable [PartiQLStatementAsync].
+ */
+@ExperimentalPartiQLCompilerPipeline
+interface PartiQLCompilerAsync {
+
+    /**
+     * Compiles the [PartiqlPhysical.Plan] to an executable [PartiQLStatementAsync].
+     */
+    suspend fun compile(statement: PartiqlPhysical.Plan): PartiQLStatementAsync
+
+    /**
+     * Compiles the [PartiqlPhysical.Statement.Explain] with the details provided in [details]
+     */
+    suspend fun compile(statement: PartiqlPhysical.Plan, details: PartiQLPlanner.PlanningDetails): PartiQLStatementAsync
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsyncBuilder.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsyncBuilder.kt
@@ -137,8 +137,7 @@ class PartiQLCompilerAsyncBuilder private constructor() {
     private fun allFunctions(typingMode: TypingMode): List<ExprFunction> {
         val definitionalBuiltins = definitionalBuiltins(typingMode)
         val builtins = SCALAR_BUILTINS_DEFAULT
-        val allFunctions = definitionalBuiltins + builtins + customFunctions + DynamicLookupExprFunction()
-        return allFunctions
+        return definitionalBuiltins + builtins + customFunctions + DynamicLookupExprFunction()
     }
 
     private fun allOperatorFactories() = (DEFAULT_RELATIONAL_OPERATOR_FACTORIES + customOperatorFactories).apply {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsyncBuilder.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsyncBuilder.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.compiler
+
+import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
+import org.partiql.annotations.ExperimentalWindowFunctions
+import org.partiql.lang.eval.ExprFunction
+import org.partiql.lang.eval.ThunkReturnTypeAssertions
+import org.partiql.lang.eval.TypingMode
+import org.partiql.lang.eval.builtins.DynamicLookupExprFunction
+import org.partiql.lang.eval.builtins.SCALAR_BUILTINS_DEFAULT
+import org.partiql.lang.eval.builtins.definitionalBuiltins
+import org.partiql.lang.eval.builtins.storedprocedure.StoredProcedure
+import org.partiql.lang.eval.physical.operators.AggregateOperatorFactoryDefaultAsync
+import org.partiql.lang.eval.physical.operators.FilterRelationalOperatorFactoryDefaultAsync
+import org.partiql.lang.eval.physical.operators.JoinRelationalOperatorFactoryDefaultAsync
+import org.partiql.lang.eval.physical.operators.LetRelationalOperatorFactoryDefaultAsync
+import org.partiql.lang.eval.physical.operators.LimitRelationalOperatorFactoryDefaultAsync
+import org.partiql.lang.eval.physical.operators.OffsetRelationalOperatorFactoryDefaultAsync
+import org.partiql.lang.eval.physical.operators.RelationalOperatorFactory
+import org.partiql.lang.eval.physical.operators.ScanRelationalOperatorFactoryDefaultAsync
+import org.partiql.lang.eval.physical.operators.SortOperatorFactoryDefaultAsync
+import org.partiql.lang.eval.physical.operators.UnpivotOperatorFactoryDefaultAsync
+import org.partiql.lang.eval.physical.operators.WindowRelationalOperatorFactoryDefaultAsync
+import org.partiql.lang.planner.EvaluatorOptions
+import org.partiql.lang.types.CustomType
+
+/**
+ * Builder class to instantiate a [PartiQLCompiler].
+ *
+ * Example usages:
+ *
+ * ```
+ * // Default
+ * val compiler = PartiQLCompilerBuilder.standard().build()
+ *
+ * // Fluent builder
+ * val compiler = PartiQLCompilerBuilder.standard()
+ *                                      .customFunctions(myCustomFunctionList)
+ *                                      .build()
+ * ```
+ */
+
+@ExperimentalPartiQLCompilerPipeline
+class PartiQLCompilerAsyncBuilder private constructor() {
+
+    private var options: EvaluatorOptions = EvaluatorOptions.standard()
+    private var customTypes: List<CustomType> = emptyList()
+    private var customFunctions: List<ExprFunction> = emptyList()
+    private var customProcedures: List<StoredProcedure> = emptyList()
+    private var customOperatorFactories: List<RelationalOperatorFactory> = emptyList()
+
+    companion object {
+
+        /**
+         * A collection of all the default relational operator implementations provided by PartiQL.
+         *
+         * By default, the query planner will select these as the implementations for all relational operators, but
+         * alternate implementations may be provided and chosen by physical plan passes.
+         *
+         * @see [org.partiql.lang.planner.PlannerPipeline.Builder.addPhysicalPlanPass]
+         * @see [org.partiql.lang.planner.PlannerPipeline.Builder.addRelationalOperatorFactory]
+         */
+
+        private val DEFAULT_RELATIONAL_OPERATOR_FACTORIES = listOf(
+            AggregateOperatorFactoryDefaultAsync,
+            SortOperatorFactoryDefaultAsync,
+            UnpivotOperatorFactoryDefaultAsync,
+            FilterRelationalOperatorFactoryDefaultAsync,
+            ScanRelationalOperatorFactoryDefaultAsync,
+            JoinRelationalOperatorFactoryDefaultAsync,
+            OffsetRelationalOperatorFactoryDefaultAsync,
+            LimitRelationalOperatorFactoryDefaultAsync,
+            LetRelationalOperatorFactoryDefaultAsync,
+            // Notice here we will not propagate the optin requirement to the user
+            @OptIn(ExperimentalWindowFunctions::class)
+            WindowRelationalOperatorFactoryDefaultAsync,
+        )
+
+        @JvmStatic
+        fun standard() = PartiQLCompilerAsyncBuilder()
+    }
+
+    fun build(): PartiQLCompilerAsync {
+        if (options.thunkOptions.thunkReturnTypeAssertions == ThunkReturnTypeAssertions.ENABLED) {
+            TODO("ThunkReturnTypeAssertions.ENABLED requires a static type pass")
+        }
+        return PartiQLCompilerAsyncDefault(
+            evaluatorOptions = options,
+            customTypedOpParameters = customTypes.associateBy(
+                keySelector = { it.name },
+                valueTransform = { it.typedOpParameter }
+            ),
+            functions = allFunctions(options.typingMode),
+            procedures = customProcedures.associateBy(
+                keySelector = { it.signature.name },
+                valueTransform = { it }
+            ),
+            operatorFactories = allOperatorFactories()
+        )
+    }
+
+    fun options(options: EvaluatorOptions) = this.apply {
+        this.options = options
+    }
+
+    fun customFunctions(customFunctions: List<ExprFunction>) = this.apply {
+        this.customFunctions = customFunctions
+    }
+
+    fun customTypes(customTypes: List<CustomType>) = this.apply {
+        this.customTypes = customTypes
+    }
+
+    fun customProcedures(customProcedures: List<StoredProcedure>) = this.apply {
+        this.customProcedures = customProcedures
+    }
+
+    fun customOperatorFactories(customOperatorFactories: List<RelationalOperatorFactory>) = this.apply {
+        this.customOperatorFactories = customOperatorFactories
+    }
+
+    // --- Internal ----------------------------------
+
+    private fun allFunctions(typingMode: TypingMode): List<ExprFunction> {
+        val definitionalBuiltins = definitionalBuiltins(typingMode)
+        val builtins = SCALAR_BUILTINS_DEFAULT
+        val allFunctions = definitionalBuiltins + builtins + customFunctions + DynamicLookupExprFunction()
+        return allFunctions
+    }
+
+    private fun allOperatorFactories() = (DEFAULT_RELATIONAL_OPERATOR_FACTORIES + customOperatorFactories).apply {
+        groupBy { it.key }.entries.firstOrNull { it.value.size > 1 }?.let {
+            error(
+                "More than one BindingsOperatorFactory for ${it.key.operator} named '${it.value}' was specified."
+            )
+        }
+    }.associateBy { it.key }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsyncBuilder.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsyncBuilder.kt
@@ -38,16 +38,16 @@ import org.partiql.lang.planner.EvaluatorOptions
 import org.partiql.lang.types.CustomType
 
 /**
- * Builder class to instantiate a [PartiQLCompiler].
+ * Builder class to instantiate a [PartiQLCompilerAsync].
  *
  * Example usages:
  *
  * ```
  * // Default
- * val compiler = PartiQLCompilerBuilder.standard().build()
+ * val compiler = PartiQLCompilerAsyncBuilder.standard().build()
  *
  * // Fluent builder
- * val compiler = PartiQLCompilerBuilder.standard()
+ * val compiler = PartiQLCompilerAsyncBuilder.standard()
  *                                      .customFunctions(myCustomFunctionList)
  *                                      .build()
  * ```

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsyncDefault.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsyncDefault.kt
@@ -36,11 +36,11 @@ import org.partiql.lang.types.TypedOpParameter
 
 @ExperimentalPartiQLCompilerPipeline
 internal class PartiQLCompilerAsyncDefault(
-    private val evaluatorOptions: EvaluatorOptions,
-    private val customTypedOpParameters: Map<String, TypedOpParameter>,
-    private val functions: List<ExprFunction>,
-    private val procedures: Map<String, StoredProcedure>,
-    private val operatorFactories: Map<RelationalOperatorFactoryKey, RelationalOperatorFactory>
+    evaluatorOptions: EvaluatorOptions,
+    customTypedOpParameters: Map<String, TypedOpParameter>,
+    functions: List<ExprFunction>,
+    procedures: Map<String, StoredProcedure>,
+    operatorFactories: Map<RelationalOperatorFactoryKey, RelationalOperatorFactory>
 ) : PartiQLCompilerAsync {
 
     private lateinit var exprConverter: PhysicalPlanCompilerAsyncImpl
@@ -113,7 +113,7 @@ internal class PartiQLCompilerAsyncDefault(
 
     private fun compileExplainDomain(statement: PartiqlPhysical.ExplainTarget.Domain, details: PartiQLPlanner.PlanningDetails): PartiQLResult.Explain.Domain {
         val format = statement.format?.text
-        val type = statement.type?.text?.toUpperCase() ?: ExplainDomains.AST.name
+        val type = statement.type?.text?.uppercase() ?: ExplainDomains.AST.name
         val domain = try {
             ExplainDomains.valueOf(type)
         } catch (ex: IllegalArgumentException) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsyncDefault.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsyncDefault.kt
@@ -21,7 +21,6 @@ import org.partiql.lang.domains.PartiqlLogicalResolved
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.errors.PartiQLException
 import org.partiql.lang.eval.ExprFunction
-import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.PartiQLResult
 import org.partiql.lang.eval.PartiQLStatementAsync
 import org.partiql.lang.eval.builtins.storedprocedure.StoredProcedure
@@ -157,6 +156,4 @@ internal class PartiQLCompilerAsyncDefault(
             }
         }
     }
-
-    private fun ExprValue.toValue(): PartiQLResult = PartiQLResult.Value(this)
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsyncDefault.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerAsyncDefault.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.compiler
+
+import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
+import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.PartiqlLogical
+import org.partiql.lang.domains.PartiqlLogicalResolved
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.errors.PartiQLException
+import org.partiql.lang.eval.ExprFunction
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.PartiQLResult
+import org.partiql.lang.eval.PartiQLStatementAsync
+import org.partiql.lang.eval.builtins.storedprocedure.StoredProcedure
+import org.partiql.lang.eval.physical.PhysicalBexprToThunkConverterAsync
+import org.partiql.lang.eval.physical.PhysicalPlanCompilerAsync
+import org.partiql.lang.eval.physical.PhysicalPlanCompilerAsyncImpl
+import org.partiql.lang.eval.physical.PhysicalPlanThunkAsync
+import org.partiql.lang.eval.physical.operators.RelationalOperatorFactory
+import org.partiql.lang.eval.physical.operators.RelationalOperatorFactoryKey
+import org.partiql.lang.planner.EvaluatorOptions
+import org.partiql.lang.planner.PartiQLPlanner
+import org.partiql.lang.types.TypedOpParameter
+
+@ExperimentalPartiQLCompilerPipeline
+internal class PartiQLCompilerAsyncDefault(
+    private val evaluatorOptions: EvaluatorOptions,
+    private val customTypedOpParameters: Map<String, TypedOpParameter>,
+    private val functions: List<ExprFunction>,
+    private val procedures: Map<String, StoredProcedure>,
+    private val operatorFactories: Map<RelationalOperatorFactoryKey, RelationalOperatorFactory>
+) : PartiQLCompilerAsync {
+
+    private lateinit var exprConverter: PhysicalPlanCompilerAsyncImpl
+    private val bexprConverter = PhysicalBexprToThunkConverterAsync(
+        exprConverter = object : PhysicalPlanCompilerAsync {
+            override suspend fun convert(expr: PartiqlPhysical.Expr): PhysicalPlanThunkAsync = exprConverter.convert(expr)
+        },
+        relationalOperatorFactory = operatorFactories
+    )
+
+    init {
+        exprConverter = PhysicalPlanCompilerAsyncImpl(
+            functions = functions,
+            customTypedOpParameters = customTypedOpParameters,
+            procedures = procedures,
+            evaluatorOptions = evaluatorOptions,
+            bexperConverter = bexprConverter
+        )
+    }
+
+    override suspend fun compile(statement: PartiqlPhysical.Plan): PartiQLStatementAsync {
+        return when (val stmt = statement.stmt) {
+            is PartiqlPhysical.Statement.Dml -> compileDml(stmt, statement.locals.size)
+            is PartiqlPhysical.Statement.Exec,
+            is PartiqlPhysical.Statement.Query -> {
+                val expression = exprConverter.compile(statement)
+                PartiQLStatementAsync { expression.eval(it) }
+            }
+            is PartiqlPhysical.Statement.Explain -> throw PartiQLException("Unable to compile EXPLAIN without details.")
+        }
+    }
+
+    override suspend fun compile(statement: PartiqlPhysical.Plan, details: PartiQLPlanner.PlanningDetails): PartiQLStatementAsync {
+        return when (val stmt = statement.stmt) {
+            is PartiqlPhysical.Statement.Dml -> compileDml(stmt, statement.locals.size)
+            is PartiqlPhysical.Statement.Exec,
+            is PartiqlPhysical.Statement.Query -> compile(statement)
+            is PartiqlPhysical.Statement.Explain -> PartiQLStatementAsync { compileExplain(stmt, details) }
+        }
+    }
+
+    // --- INTERNAL -------------------
+
+    private enum class ExplainDomains {
+        AST,
+        AST_NORMALIZED,
+        LOGICAL,
+        LOGICAL_RESOLVED,
+        PHYSICAL,
+        PHYSICAL_TRANSFORMED
+    }
+
+    private suspend fun compileDml(dml: PartiqlPhysical.Statement.Dml, localsSize: Int): PartiQLStatementAsync {
+        val rows = exprConverter.compile(dml.rows, localsSize)
+        return PartiQLStatementAsync { session ->
+            when (dml.operation) {
+                is PartiqlPhysical.DmlOperation.DmlReplace -> PartiQLResult.Replace(dml.uniqueId.text, (rows.eval(session) as PartiQLResult.Value).value)
+                is PartiqlPhysical.DmlOperation.DmlInsert -> PartiQLResult.Insert(dml.uniqueId.text, (rows.eval(session) as PartiQLResult.Value).value)
+                is PartiqlPhysical.DmlOperation.DmlDelete -> PartiQLResult.Delete(dml.uniqueId.text, (rows.eval(session) as PartiQLResult.Value).value)
+                is PartiqlPhysical.DmlOperation.DmlUpdate -> TODO("DML Update compilation not supported yet.")
+            }
+        }
+    }
+
+    private fun compileExplain(statement: PartiqlPhysical.Statement.Explain, details: PartiQLPlanner.PlanningDetails): PartiQLResult.Explain.Domain {
+        return when (val target = statement.target) {
+            is PartiqlPhysical.ExplainTarget.Domain -> compileExplainDomain(target, details)
+        }
+    }
+
+    private fun compileExplainDomain(statement: PartiqlPhysical.ExplainTarget.Domain, details: PartiQLPlanner.PlanningDetails): PartiQLResult.Explain.Domain {
+        val format = statement.format?.text
+        val type = statement.type?.text?.toUpperCase() ?: ExplainDomains.AST.name
+        val domain = try {
+            ExplainDomains.valueOf(type)
+        } catch (ex: IllegalArgumentException) {
+            throw PartiQLException("Illegal argument: $type")
+        }
+        return when (domain) {
+            ExplainDomains.AST -> {
+                val explain = details.ast!! as PartiqlAst.Statement.Explain
+                val target = explain.target as PartiqlAst.ExplainTarget.Domain
+                PartiQLResult.Explain.Domain(target.statement, format)
+            }
+            ExplainDomains.AST_NORMALIZED -> {
+                val explain = details.astNormalized!! as PartiqlAst.Statement.Explain
+                val target = explain.target as PartiqlAst.ExplainTarget.Domain
+                PartiQLResult.Explain.Domain(target.statement, format)
+            }
+            ExplainDomains.LOGICAL -> {
+                val explain = details.logical!!.stmt as PartiqlLogical.Statement.Explain
+                val target = explain.target as PartiqlLogical.ExplainTarget.Domain
+                val plan = details.logical.copy(stmt = target.statement)
+                PartiQLResult.Explain.Domain(plan, format)
+            }
+            ExplainDomains.LOGICAL_RESOLVED -> {
+                val explain = details.logicalResolved!!.stmt as PartiqlLogicalResolved.Statement.Explain
+                val target = explain.target as PartiqlLogicalResolved.ExplainTarget.Domain
+                val plan = details.logicalResolved.copy(stmt = target.statement)
+                PartiQLResult.Explain.Domain(plan, format)
+            }
+            ExplainDomains.PHYSICAL -> {
+                val explain = details.physical!!.stmt as PartiqlPhysical.Statement.Explain
+                val target = explain.target as PartiqlPhysical.ExplainTarget.Domain
+                val plan = details.physical.copy(stmt = target.statement)
+                PartiQLResult.Explain.Domain(plan, format)
+            }
+            ExplainDomains.PHYSICAL_TRANSFORMED -> {
+                val explain = details.physicalTransformed!!.stmt as PartiqlPhysical.Statement.Explain
+                val target = explain.target as PartiqlPhysical.ExplainTarget.Domain
+                val plan = details.physicalTransformed.copy(stmt = target.statement)
+                PartiQLResult.Explain.Domain(plan, format)
+            }
+        }
+    }
+
+    private fun ExprValue.toValue(): PartiQLResult = PartiQLResult.Value(this)
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerBuilder.kt
@@ -54,6 +54,7 @@ import org.partiql.lang.types.CustomType
  */
 
 @ExperimentalPartiQLCompilerPipeline
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerAsyncBuilder"))
 class PartiQLCompilerBuilder private constructor() {
 
     private var options: EvaluatorOptions = EvaluatorOptions.standard()
@@ -90,9 +91,11 @@ class PartiQLCompilerBuilder private constructor() {
         )
 
         @JvmStatic
+        @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerAsyncBuilder.standard"))
         fun standard() = PartiQLCompilerBuilder()
     }
 
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerAsyncBuilder.build"))
     fun build(): PartiQLCompiler {
         if (options.thunkOptions.thunkReturnTypeAssertions == ThunkReturnTypeAssertions.ENABLED) {
             TODO("ThunkReturnTypeAssertions.ENABLED requires a static type pass")
@@ -112,22 +115,27 @@ class PartiQLCompilerBuilder private constructor() {
         )
     }
 
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerAsyncBuilder.options"))
     fun options(options: EvaluatorOptions) = this.apply {
         this.options = options
     }
 
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerAsyncBuilder.customFunctions"))
     fun customFunctions(customFunctions: List<ExprFunction>) = this.apply {
         this.customFunctions = customFunctions
     }
 
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerAsyncBuilder.customTypes"))
     fun customTypes(customTypes: List<CustomType>) = this.apply {
         this.customTypes = customTypes
     }
 
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerAsyncBuilder.customProcedures"))
     fun customProcedures(customProcedures: List<StoredProcedure>) = this.apply {
         this.customProcedures = customProcedures
     }
 
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerAsyncBuilder.customOperatorFactories"))
     fun customOperatorFactories(customOperatorFactories: List<RelationalOperatorFactory>) = this.apply {
         this.customOperatorFactories = customOperatorFactories
     }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerDefault.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerDefault.kt
@@ -36,6 +36,7 @@ import org.partiql.lang.planner.PartiQLPlanner
 import org.partiql.lang.types.TypedOpParameter
 
 @ExperimentalPartiQLCompilerPipeline
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerAsyncDefault"))
 internal class PartiQLCompilerDefault(
     private val evaluatorOptions: EvaluatorOptions,
     private val customTypedOpParameters: Map<String, TypedOpParameter>,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerPipeline.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerPipeline.kt
@@ -42,6 +42,7 @@ import org.partiql.lang.syntax.PartiQLParserBuilder
  * ```
  */
 @ExperimentalPartiQLCompilerPipeline
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerPipelineAsync"))
 class PartiQLCompilerPipeline(
     private val parser: Parser,
     private val planner: PartiQLPlanner,
@@ -54,6 +55,7 @@ class PartiQLCompilerPipeline(
          * Returns a [PartiQLCompilerPipeline] with default parser, planner, and compiler configurations.
          */
         @JvmStatic
+        @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerPipelineAsync.standard"))
         fun standard() = PartiQLCompilerPipeline(
             parser = PartiQLParserBuilder.standard().build(),
             planner = PartiQLPlannerBuilder.standard().build(),
@@ -75,6 +77,7 @@ class PartiQLCompilerPipeline(
          * }
          * ```
          */
+        @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerPipelineAsync.build"))
         fun build(block: Builder.() -> Unit): PartiQLCompilerPipeline {
             val builder = Builder()
             block.invoke(builder)
@@ -89,6 +92,7 @@ class PartiQLCompilerPipeline(
     /**
      * Compiles a PartiQL query into an executable [PartiQLStatement].
      */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerPipelineAsync.compile"))
     fun compile(statement: String): PartiQLStatement {
         val ast = parser.parseAstStatement(statement)
         return compile(ast)
@@ -97,6 +101,7 @@ class PartiQLCompilerPipeline(
     /**
      * Compiles a [PartiqlAst.Statement] representation of a query into an executable [PartiQLStatement].
      */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerPipelineAsync.compile"))
     fun compile(statement: PartiqlAst.Statement): PartiQLStatement {
         val result = planner.plan(statement)
         if (result is PartiQLPlanner.Result.Error) {
@@ -110,10 +115,12 @@ class PartiQLCompilerPipeline(
      * Compiles a [PartiqlPhysical.Plan] representation of a query into an executable [PartiQLStatement].
      */
     @JvmOverloads
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerPipelineAsync.compile"))
     fun compile(statement: PartiqlPhysical.Plan, details: PartiQLPlanner.PlanningDetails = PartiQLPlanner.PlanningDetails()): PartiQLStatement {
         return compiler.compile(statement, details)
     }
 
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLCompilerPipelineAsync.Builder"))
     class Builder internal constructor() {
         var parser = PartiQLParserBuilder.standard()
         var planner = PartiQLPlannerBuilder.standard()

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerPipelineAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerPipelineAsync.kt
@@ -25,12 +25,12 @@ import org.partiql.lang.syntax.Parser
 import org.partiql.lang.syntax.PartiQLParserBuilder
 
 /**
- * TODO ALAN update usage
  * [PartiQLCompilerPipelineAsync] is the top-level class for embedded usage of PartiQL.
  *
  * Example usage:
  * ```
- * val pipeline = PartiQLCompilerPipeline.standard()
+ * // Within a coroutine scope or `suspend fun`
+ * val pipeline = PartiQLCompilerPipelineAsync.standard()
  * val session = // session bindings
  * val statement = pipeline.compile("-- some PartiQL query!")
  * val result = statement.eval(session)
@@ -66,7 +66,7 @@ class PartiQLCompilerPipelineAsync(
          *
          * Example usage:
          * ```
-         * val pipeline = PartiQLCompilerPipeline.build {
+         * val pipeline = PartiQLCompilerPipelineAsync.build {
          *    planner.options(plannerOptions)
          *           .globalVariableResolver(globalVariableResolver)
          *    compiler.ionSystem(ION)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerPipelineAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/compiler/PartiQLCompilerPipelineAsync.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.compiler
+
+import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
+import org.partiql.lang.domains.PartiqlAst
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.errors.PartiQLException
+import org.partiql.lang.eval.PartiQLStatementAsync
+import org.partiql.lang.planner.PartiQLPlanner
+import org.partiql.lang.planner.PartiQLPlannerBuilder
+import org.partiql.lang.syntax.Parser
+import org.partiql.lang.syntax.PartiQLParserBuilder
+
+/**
+ * TODO ALAN update usage
+ * [PartiQLCompilerPipelineAsync] is the top-level class for embedded usage of PartiQL.
+ *
+ * Example usage:
+ * ```
+ * val pipeline = PartiQLCompilerPipeline.standard()
+ * val session = // session bindings
+ * val statement = pipeline.compile("-- some PartiQL query!")
+ * val result = statement.eval(session)
+ * when (result) {
+ *   is PartiQLResult.Value -> handle(result)  // Query Result
+ *   is PartiQLResult.Insert -> handle(result) // DML `Insert`
+ *   is PartiQLResult.Delete -> handle(result) // DML `Delete`
+ *   ...
+ * }
+ * ```
+ */
+@ExperimentalPartiQLCompilerPipeline
+class PartiQLCompilerPipelineAsync(
+    private val parser: Parser,
+    private val planner: PartiQLPlanner,
+    private val compiler: PartiQLCompilerAsync
+) {
+
+    companion object {
+
+        /**
+         * Returns a [PartiQLCompilerPipelineAsync] with default parser, planner, and compiler configurations.
+         */
+        @JvmStatic
+        fun standard() = PartiQLCompilerPipelineAsync(
+            parser = PartiQLParserBuilder.standard().build(),
+            planner = PartiQLPlannerBuilder.standard().build(),
+            compiler = PartiQLCompilerAsyncBuilder.standard().build()
+        )
+
+        /**
+         * Builder utility for pipeline creation.
+         *
+         * Example usage:
+         * ```
+         * val pipeline = PartiQLCompilerPipeline.build {
+         *    planner.options(plannerOptions)
+         *           .globalVariableResolver(globalVariableResolver)
+         *    compiler.ionSystem(ION)
+         *            .options(evaluatorOptions)
+         *            .customTypes(myCustomTypes)
+         *            .customFunctions(myCustomFunctions)
+         * }
+         * ```
+         */
+        fun build(block: Builder.() -> Unit): PartiQLCompilerPipelineAsync {
+            val builder = Builder()
+            block.invoke(builder)
+            return PartiQLCompilerPipelineAsync(
+                parser = builder.parser.build(),
+                planner = builder.planner.build(),
+                compiler = builder.compiler.build(),
+            )
+        }
+    }
+
+    /**
+     * Compiles a PartiQL query into an executable [PartiQLStatementAsync].
+     */
+    suspend fun compile(statement: String): PartiQLStatementAsync {
+        val ast = parser.parseAstStatement(statement)
+        return compile(ast)
+    }
+
+    /**
+     * Compiles a [PartiqlAst.Statement] representation of a query into an executable [PartiQLStatementAsync].
+     */
+    suspend fun compile(statement: PartiqlAst.Statement): PartiQLStatementAsync {
+        val result = planner.plan(statement)
+        if (result is PartiQLPlanner.Result.Error) {
+            throw PartiQLException(result.problems.toString())
+        }
+        val plan = (result as PartiQLPlanner.Result.Success).plan
+        return compile(plan, result.details)
+    }
+
+    /**
+     * Compiles a [PartiqlPhysical.Plan] representation of a query into an executable [PartiQLStatementAsync].
+     */
+    @JvmOverloads
+    suspend fun compile(statement: PartiqlPhysical.Plan, details: PartiQLPlanner.PlanningDetails = PartiQLPlanner.PlanningDetails()): PartiQLStatementAsync {
+        return compiler.compile(statement, details)
+    }
+
+    class Builder internal constructor() {
+        var parser = PartiQLParserBuilder.standard()
+        var planner = PartiQLPlannerBuilder.standard()
+        var compiler = PartiQLCompilerAsyncBuilder.standard()
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/ExpressionAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/ExpressionAsync.kt
@@ -19,7 +19,7 @@ package org.partiql.lang.eval
  */
 internal interface ExpressionAsync {
     /**
-     * TODO ALAN
+     * Evaluates the [ExpressionAsync] with the given Session
      */
     suspend fun eval(session: EvaluationSession): PartiQLResult
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/ExpressionAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/ExpressionAsync.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.eval
+
+/**
+ * An expression that can be evaluated to [ExprValue].
+ */
+internal interface ExpressionAsync {
+    /**
+     * TODO ALAN
+     */
+    suspend fun eval(session: EvaluationSession): PartiQLResult
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/PartiQLStatement.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/PartiQLStatement.kt
@@ -17,7 +17,8 @@ package org.partiql.lang.eval
 /**
  * A compiled PartiQL statement
  */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("PartiQLStatementAsync"))
 fun interface PartiQLStatement {
-
+    @Deprecated("To be removed in next major version.", replaceWith = ReplaceWith("PartiQLStatementAsync.eval"))
     fun eval(session: EvaluationSession): PartiQLResult
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/PartiQLStatementAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/PartiQLStatementAsync.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at:
+ *
+ *       http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.eval
+
+/**
+ * A compiled PartiQL statement
+ */
+fun interface PartiQLStatementAsync {
+
+    suspend fun eval(session: EvaluationSession): PartiQLResult
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/PartiQLStatementAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/PartiQLStatementAsync.kt
@@ -15,7 +15,7 @@
 package org.partiql.lang.eval
 
 /**
- * A compiled PartiQL statement
+ * A compiled PartiQL statement intended to be evaluated from a Kotlin coroutine.
  */
 fun interface PartiQLStatementAsync {
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/Thunk.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/Thunk.kt
@@ -107,6 +107,25 @@ data class ThunkOptions private constructor(
     }
 }
 
+internal val DEFAULT_EXCEPTION_HANDLER_FOR_LEGACY_MODE: ThunkExceptionHandlerForLegacyMode = { e, sourceLocation ->
+    val message = e.message ?: "<NO MESSAGE>"
+    throw EvaluationException(
+        "Internal error, $message",
+        errorCode = (e as? EvaluationException)?.errorCode ?: ErrorCode.EVALUATOR_GENERIC_EXCEPTION,
+        errorContext = errorContextFrom(sourceLocation),
+        cause = e,
+        internal = true
+    )
+}
+
+internal val DEFAULT_EXCEPTION_HANDLER_FOR_PERMISSIVE_MODE: ThunkExceptionHandlerForPermissiveMode = { e, _ ->
+    when (e) {
+        is InterruptedException -> { throw e }
+        is StackOverflowError -> { throw e }
+        else -> {}
+    }
+}
+
 /**
  * An extension method for creating [ThunkFactory] based on the type of [TypingMode]
  *  - when [TypingMode] is [TypingMode.LEGACY], creates [LegacyThunkFactory]

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalBexprToThunkConverterAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalBexprToThunkConverterAsync.kt
@@ -34,7 +34,7 @@ import org.partiql.lang.eval.physical.window.createBuiltinWindowFunctionAsync
 import org.partiql.lang.util.toIntExact
 
 /** Converts instances of [PartiqlPhysical.Bexpr] to any [T]. */
-interface Converter<T> {
+internal interface Converter<T> {
     suspend fun convert(node: PartiqlPhysical.Bexpr): T = when (node) {
         is PartiqlPhysical.Bexpr.Project -> convertProject(node)
         is PartiqlPhysical.Bexpr.Scan -> convertScan(node)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerAsync.kt
@@ -1,0 +1,13 @@
+package org.partiql.lang.eval.physical
+
+import org.partiql.lang.domains.PartiqlPhysical
+
+/**
+ * Simple API that defines a method to convert a [PartiqlPhysical.Expr] to a [PhysicalPlanThunkAsync].
+ *
+ * Intended to prevent [PhysicalBexprToThunkConverterAsync] from having to take a direct dependency on
+ * [org.partiql.lang.eval.EvaluatingCompiler].
+ */
+internal interface PhysicalPlanCompilerAsync {
+    suspend fun convert(expr: PartiqlPhysical.Expr): PhysicalPlanThunkAsync
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerAsyncImpl.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerAsyncImpl.kt
@@ -855,7 +855,7 @@ internal class PhysicalPlanCompilerAsyncImpl(
             try {
                 val func = functionManager.get(name = name, arity = arity, args = argTypes)
                 val computeThunk = when (func.signature.unknownArguments) {
-                    UnknownArguments.PROPAGATE -> thunkFactory.thunkEnvOperands(metas, funcArgThunks) { env, values ->
+                    UnknownArguments.PROPAGATE -> thunkFactory.thunkEnvOperands(metas, funcArgThunks) { env, _ ->
                         func.call(env.session, args)
                     }
                     UnknownArguments.PASS_THRU -> thunkFactory.thunkEnvAsync(metas) { env ->
@@ -1679,7 +1679,7 @@ internal class PhysicalPlanCompilerAsyncImpl(
         escape?.let {
             val escapeCharString = checkEscapeChar(escape, escapeLocationMeta)
             val escapeCharCodePoint = escapeCharString.codePointAt(0) // escape is a string of length 1
-            val validEscapedChars = setOf('_'.toInt(), '%'.toInt(), escapeCharCodePoint)
+            val validEscapedChars = setOf('_'.code, '%'.code, escapeCharCodePoint)
             val iter = pattern.codePointSequence().iterator()
 
             while (iter.hasNext()) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/RelationThunk.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/RelationThunk.kt
@@ -11,6 +11,7 @@ import org.partiql.lang.eval.fillErrorContext
 import org.partiql.lang.eval.relation.RelationIterator
 
 /** A thunk that returns a [RelationIterator], which is the result of evaluating a relational operator. */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("RelationThunkEnvAsync"))
 internal typealias RelationThunkEnv = (EvaluatorState) -> RelationIterator
 
 /**
@@ -19,6 +20,7 @@ internal typealias RelationThunkEnv = (EvaluatorState) -> RelationIterator
  * This function is not currently in [ThunkFactory] to avoid complicating it further.  If a need arises, it could be
  * moved.
  */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("relationThunkAsync"))
 internal inline fun relationThunk(metas: MetaContainer, crossinline t: RelationThunkEnv): RelationThunkEnv {
     val sourceLocationMeta = metas[SourceLocationMeta.TAG] as? SourceLocationMeta
     return { env: EvaluatorState ->

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/RelationThunkAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/RelationThunkAsync.kt
@@ -1,0 +1,45 @@
+package org.partiql.lang.eval.physical
+
+import com.amazon.ionelement.api.MetaContainer
+import org.partiql.errors.ErrorCode
+import org.partiql.errors.Property
+import org.partiql.lang.ast.SourceLocationMeta
+import org.partiql.lang.eval.EvaluationException
+import org.partiql.lang.eval.ThunkFactory
+import org.partiql.lang.eval.errorContextFrom
+import org.partiql.lang.eval.fillErrorContext
+import org.partiql.lang.eval.relation.RelationIterator
+
+/** A thunk that returns a [RelationIterator], which is the result of evaluating a relational operator. */
+internal typealias RelationThunkEnvAsync = suspend (EvaluatorState) -> RelationIterator
+
+/**
+ * Invokes [t] with error handling like is supplied by [ThunkFactory].
+ *
+ * This function is not currently in [ThunkFactory] to avoid complicating it further.  If a need arises, it could be
+ * moved.
+ */
+internal suspend inline fun relationThunkAsync(metas: MetaContainer, crossinline t: RelationThunkEnvAsync): RelationThunkEnvAsync {
+    val sourceLocationMeta = metas[SourceLocationMeta.TAG] as? SourceLocationMeta
+    return { env: EvaluatorState ->
+        try {
+            t(env)
+        } catch (e: EvaluationException) {
+            // Only add source location data to the error context if it doesn't already exist
+            // in [errorContext].
+            if (!e.errorContext.hasProperty(Property.LINE_NUMBER)) {
+                sourceLocationMeta?.let { fillErrorContext(e.errorContext, sourceLocationMeta) }
+            }
+            throw e
+        } catch (e: Exception) {
+            val message = e.message ?: "<NO MESSAGE>"
+            throw EvaluationException(
+                "Generic exception, $message",
+                errorCode = ErrorCode.EVALUATOR_GENERIC_EXCEPTION,
+                errorContext = errorContextFrom(sourceLocationMeta),
+                cause = e,
+                internal = true
+            )
+        }
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/VariableBinding.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/VariableBinding.kt
@@ -8,6 +8,7 @@ import org.partiql.lang.eval.physical.operators.ValueExpression
  * @property setFunc The function to be invoked at evaluation-time to set the value of the variable.
  * @property expr The function to be invoked at evaluation-time to compute the value of the variable.
  */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("VariableBindingAsync"))
 class VariableBinding(
     val setFunc: SetVariableFunc,
     val expr: ValueExpression

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/VariableBindingAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/VariableBindingAsync.kt
@@ -1,0 +1,14 @@
+package org.partiql.lang.eval.physical
+
+import org.partiql.lang.eval.physical.operators.ValueExpressionAsync
+
+/**
+ * A compiled variable binding.
+ *
+ * @property setFunc The function to be invoked at evaluation-time to set the value of the variable.
+ * @property expr The function to be invoked at evaluation-time to compute the value of the variable.
+ */
+class VariableBindingAsync(
+    val setFunc: SetVariableFunc,
+    val expr: ValueExpressionAsync
+)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/AggregateOperatorFactory.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/AggregateOperatorFactory.kt
@@ -31,10 +31,12 @@ import java.util.TreeMap
  *
  * @param name
  */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("AggregateOperatorFactoryAsync"))
 public abstract class AggregateOperatorFactory(name: String) : RelationalOperatorFactory {
 
     public override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.AGGREGATE, name)
 
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("AggregateOperatorFactoryAsync.create"))
     public abstract fun create(
         source: RelationExpression,
         strategy: PartiqlPhysical.GroupingStrategy,
@@ -43,12 +45,14 @@ public abstract class AggregateOperatorFactory(name: String) : RelationalOperato
     ): RelationExpression
 }
 
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("CompiledGroupKeyAsync"))
 public class CompiledGroupKey(
     val setGroupKeyVal: SetVariableFunc,
     val value: ValueExpression,
     val variable: PartiqlPhysical.VarDecl
 )
 
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("CompiledAggregateFunctionAsync"))
 public class CompiledAggregateFunction(
     val name: String,
     val setAggregateVal: SetVariableFunc,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/AggregateOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/AggregateOperatorFactoryAsync.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.DEFAULT_COMPARATOR
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.physical.SetVariableFunc
+import org.partiql.lang.eval.relation.RelationIterator
+import org.partiql.lang.eval.relation.RelationType
+import org.partiql.lang.eval.relation.relation
+import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
+import java.util.TreeMap
+
+/**
+ * Provides an implementation of the [PartiqlPhysical.Bexpr.Aggregate] operator.
+ *
+ * @constructor
+ *
+ * @param name
+ */
+public abstract class AggregateOperatorFactoryAsync(name: String) : RelationalOperatorFactory {
+
+    public override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.AGGREGATE, name)
+
+    public abstract fun create(
+        source: RelationExpressionAsync,
+        strategy: PartiqlPhysical.GroupingStrategy,
+        keys: List<CompiledGroupKeyAsync>,
+        functions: List<CompiledAggregateFunctionAsync>
+    ): RelationExpressionAsync
+}
+
+public class CompiledGroupKeyAsync(
+    val setGroupKeyVal: SetVariableFunc,
+    val value: ValueExpressionAsync,
+    val variable: PartiqlPhysical.VarDecl
+)
+
+public class CompiledAggregateFunctionAsync(
+    val name: String,
+    val setAggregateVal: SetVariableFunc,
+    val value: ValueExpressionAsync,
+    val quantifier: PartiqlPhysical.SetQuantifier,
+)
+
+internal object AggregateOperatorFactoryDefaultAsync : AggregateOperatorFactoryAsync(DEFAULT_IMPL_NAME) {
+    override fun create(
+        source: RelationExpressionAsync,
+        strategy: PartiqlPhysical.GroupingStrategy,
+        keys: List<CompiledGroupKeyAsync>,
+        functions: List<CompiledAggregateFunctionAsync>
+    ): RelationExpressionAsync = AggregateOperatorDefaultAsync(source, keys, functions)
+}
+
+internal class AggregateOperatorDefaultAsync(
+    val source: RelationExpressionAsync,
+    val keys: List<CompiledGroupKeyAsync>,
+    val functions: List<CompiledAggregateFunctionAsync>
+) : RelationExpressionAsync {
+    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator = relation(RelationType.BAG) {
+        val aggregationMap = TreeMap<ExprValue, List<Accumulator>>(DEFAULT_COMPARATOR)
+
+        val sourceIter = source.evaluateAsync(state)
+        while (sourceIter.nextRow()) {
+
+            // Initialize the AggregationMap
+            val evaluatedGroupByKeys =
+                keys.map { it.value.invoke(state) }.let { ExprValue.newList(it) }
+            val accumulators = aggregationMap.getOrPut(evaluatedGroupByKeys) {
+                functions.map { function ->
+                    Accumulator.create(function.name, function.quantifier)
+                }
+            }
+
+            // Aggregate Values in Aggregation State
+            functions.forEachIndexed { index, function ->
+                val valueToAggregate = function.value(state)
+                accumulators[index].next(valueToAggregate)
+            }
+        }
+
+        // No Aggregations Created
+        if (keys.isEmpty() && aggregationMap.isEmpty()) {
+            functions.forEach { function ->
+                val accumulator = Accumulator.create(function.name, function.quantifier)
+                function.setAggregateVal(state, accumulator.compute())
+            }
+            yield()
+            return@relation
+        }
+
+        // Place Aggregated Values into Result State
+        aggregationMap.forEach { (exprList, accumulators) ->
+            exprList.forEachIndexed { index, exprValue -> keys[index].setGroupKeyVal(state, exprValue) }
+            accumulators.forEachIndexed { index, acc -> functions[index].setAggregateVal(state, acc.compute()) }
+            yield()
+        }
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/AggregateOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/AggregateOperatorFactoryAsync.kt
@@ -70,10 +70,10 @@ internal class AggregateOperatorDefaultAsync(
     val keys: List<CompiledGroupKeyAsync>,
     val functions: List<CompiledAggregateFunctionAsync>
 ) : RelationExpressionAsync {
-    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator = relation(RelationType.BAG) {
+    override suspend fun evaluate(state: EvaluatorState): RelationIterator = relation(RelationType.BAG) {
         val aggregationMap = TreeMap<ExprValue, List<Accumulator>>(DEFAULT_COMPARATOR)
 
-        val sourceIter = source.evaluateAsync(state)
+        val sourceIter = source.evaluate(state)
         while (sourceIter.nextRow()) {
 
             // Initialize the AggregationMap

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/FilterRelationalOperatorFactory.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/FilterRelationalOperatorFactory.kt
@@ -16,6 +16,7 @@ import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
  *
  * @param name
  */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("FilterRelationalOperatorFactoryAsync"))
 abstract class FilterRelationalOperatorFactory(name: String) : RelationalOperatorFactory {
 
     final override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.FILTER, name)
@@ -28,6 +29,7 @@ abstract class FilterRelationalOperatorFactory(name: String) : RelationalOperato
      * @param sourceBexpr
      * @return
      */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("FilterRelationalOperatorFactoryAsync.create"))
     abstract fun create(
         impl: PartiqlPhysical.Impl,
         predicate: ValueExpression,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/FilterRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/FilterRelationalOperatorFactoryAsync.kt
@@ -51,8 +51,8 @@ internal class SelectOperatorDefaultAsync(
     val predicate: ValueExpressionAsync,
 ) : RelationExpressionAsync {
 
-    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
-        val input = input.evaluateAsync(state)
+    override suspend fun evaluate(state: EvaluatorState): RelationIterator {
+        val input = input.evaluate(state)
         return relation(RelationType.BAG) {
             while (true) {
                 if (!input.nextRow()) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/FilterRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/FilterRelationalOperatorFactoryAsync.kt
@@ -1,0 +1,69 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.booleanValue
+import org.partiql.lang.eval.isNotUnknown
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.relation.RelationIterator
+import org.partiql.lang.eval.relation.RelationType
+import org.partiql.lang.eval.relation.relation
+import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
+
+/**
+ * Provides an implementation of the [PartiqlPhysical.Bexpr.Filter] operator.
+ *
+ * @constructor
+ *
+ * @param name
+ */
+abstract class FilterRelationalOperatorFactoryAsync(name: String) : RelationalOperatorFactory {
+
+    final override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.FILTER, name)
+
+    /**
+     * Creates a [RelationExpressionAsync] instance for [PartiqlPhysical.Bexpr.Filter].
+     *
+     * @param impl
+     * @param predicate
+     * @param sourceBexpr
+     * @return
+     */
+    abstract fun create(
+        impl: PartiqlPhysical.Impl,
+        predicate: ValueExpressionAsync,
+        sourceBexpr: RelationExpressionAsync
+    ): RelationExpressionAsync
+}
+
+internal object FilterRelationalOperatorFactoryDefaultAsync : FilterRelationalOperatorFactoryAsync(DEFAULT_IMPL_NAME) {
+    override fun create(
+        impl: PartiqlPhysical.Impl,
+        predicate: ValueExpressionAsync,
+        sourceBexpr: RelationExpressionAsync
+    ) = SelectOperatorDefaultAsync(
+        input = sourceBexpr,
+        predicate = predicate
+    )
+}
+
+internal class SelectOperatorDefaultAsync(
+    val input: RelationExpressionAsync,
+    val predicate: ValueExpressionAsync,
+) : RelationExpressionAsync {
+
+    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+        val input = input.evaluateAsync(state)
+        return relation(RelationType.BAG) {
+            while (true) {
+                if (!input.nextRow()) {
+                    break
+                } else {
+                    val matches = predicate.invoke(state)
+                    if (matches.isNotUnknown() && matches.booleanValue()) {
+                        yield()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/JoinRelationalOperatorFactory.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/JoinRelationalOperatorFactory.kt
@@ -15,6 +15,7 @@ import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
  *
  * @param name
  */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("JoinRelationalOperatorFactoryAsync"))
 abstract class JoinRelationalOperatorFactory(name: String) : RelationalOperatorFactory {
 
     final override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.JOIN, name)
@@ -31,6 +32,7 @@ abstract class JoinRelationalOperatorFactory(name: String) : RelationalOperatorF
      * @param setRightSideVariablesToNull
      * @return
      */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("JoinRelationalOperatorFactoryAsync.create"))
     abstract fun create(
         impl: PartiqlPhysical.Impl,
         joinType: PartiqlPhysical.JoinType,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/JoinRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/JoinRelationalOperatorFactoryAsync.kt
@@ -93,10 +93,10 @@ private class InnerJoinOperatorAsync(
     private val condition: suspend (EvaluatorState) -> Boolean
 ) : RelationExpressionAsync {
 
-    override suspend fun evaluateAsync(state: EvaluatorState) = relation(RelationType.BAG) {
-        val leftItr = lhs.evaluateAsync(state)
+    override suspend fun evaluate(state: EvaluatorState) = relation(RelationType.BAG) {
+        val leftItr = lhs.evaluate(state)
         while (leftItr.nextRow()) {
-            val rightItr = rhs.evaluateAsync(state)
+            val rightItr = rhs.evaluate(state)
             while (rightItr.nextRow()) {
                 if (condition(state)) {
                     yield()
@@ -116,10 +116,10 @@ private class LeftJoinOperatorAsync(
     private val setRightSideVariablesToNull: (EvaluatorState) -> Unit
 ) : RelationExpressionAsync {
 
-    override suspend fun evaluateAsync(state: EvaluatorState) = relation(RelationType.BAG) {
-        val leftItr = lhs.evaluateAsync(state)
+    override suspend fun evaluate(state: EvaluatorState) = relation(RelationType.BAG) {
+        val leftItr = lhs.evaluate(state)
         while (leftItr.nextRow()) {
-            val rightItr = rhs.evaluateAsync(state)
+            val rightItr = rhs.evaluate(state)
             var yieldedSomething = false
             while (rightItr.nextRow()) {
                 if (condition(state)) {
@@ -145,10 +145,10 @@ private class RightJoinOperatorAsync(
     private val setLeftSideVariablesToNull: (EvaluatorState) -> Unit
 ) : RelationExpressionAsync {
 
-    override suspend fun evaluateAsync(state: EvaluatorState) = relation(RelationType.BAG) {
-        val rightItr = rhs.evaluateAsync(state)
+    override suspend fun evaluate(state: EvaluatorState) = relation(RelationType.BAG) {
+        val rightItr = rhs.evaluate(state)
         while (rightItr.nextRow()) {
-            val leftItr = lhs.evaluateAsync(state)
+            val leftItr = lhs.evaluate(state)
             var yieldedSomething = false
             while (leftItr.nextRow()) {
                 if (condition(state)) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LetRelationalOperatorFactory.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LetRelationalOperatorFactory.kt
@@ -14,6 +14,7 @@ import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
  *
  * @param name
  */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("LetRelationalOperatorFactoryAsync"))
 abstract class LetRelationalOperatorFactory(name: String) : RelationalOperatorFactory {
 
     final override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.LET, name)
@@ -26,6 +27,7 @@ abstract class LetRelationalOperatorFactory(name: String) : RelationalOperatorFa
      * @param bindings list of [VariableBinding]s in the `LET` clause
      * @return
      */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("LetRelationalOperatorFactoryAsync.create"))
     abstract fun create(
         impl: PartiqlPhysical.Impl,
         sourceBexpr: RelationExpression,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LetRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LetRelationalOperatorFactoryAsync.kt
@@ -2,7 +2,6 @@ package org.partiql.lang.eval.physical.operators
 
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.eval.physical.EvaluatorState
-import org.partiql.lang.eval.physical.VariableBinding
 import org.partiql.lang.eval.physical.VariableBindingAsync
 import org.partiql.lang.eval.relation.RelationIterator
 import org.partiql.lang.eval.relation.relation
@@ -24,7 +23,7 @@ abstract class LetRelationalOperatorFactoryAsync(name: String) : RelationalOpera
      *
      * @param impl
      * @param sourceBexpr
-     * @param bindings list of [VariableBinding]s in the `LET` clause
+     * @param bindings list of [VariableBindingAsync]s in the `LET` clause
      * @return
      */
     abstract fun create(
@@ -51,8 +50,8 @@ internal class LetOperatorAsync(
     private val bindings: List<VariableBindingAsync>
 ) : RelationExpressionAsync {
 
-    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
-        val rows = input.evaluateAsync(state)
+    override suspend fun evaluate(state: EvaluatorState): RelationIterator {
+        val rows = input.evaluate(state)
         return relation(rows.relType) {
             while (rows.nextRow()) {
                 bindings.forEach {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LetRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LetRelationalOperatorFactoryAsync.kt
@@ -1,0 +1,65 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.physical.VariableBinding
+import org.partiql.lang.eval.physical.VariableBindingAsync
+import org.partiql.lang.eval.relation.RelationIterator
+import org.partiql.lang.eval.relation.relation
+import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
+
+/**
+ * Provides an implementation of the [PartiqlPhysical.Bexpr.Let] operator.
+ *
+ * @constructor
+ *
+ * @param name
+ */
+abstract class LetRelationalOperatorFactoryAsync(name: String) : RelationalOperatorFactory {
+
+    final override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.LET, name)
+
+    /**
+     * Creates a [RelationExpressionAsync] instance for [PartiqlPhysical.Bexpr.Let].
+     *
+     * @param impl
+     * @param sourceBexpr
+     * @param bindings list of [VariableBinding]s in the `LET` clause
+     * @return
+     */
+    abstract fun create(
+        impl: PartiqlPhysical.Impl,
+        sourceBexpr: RelationExpressionAsync,
+        bindings: List<VariableBindingAsync>
+    ): RelationExpressionAsync
+}
+
+internal object LetRelationalOperatorFactoryDefaultAsync : LetRelationalOperatorFactoryAsync(DEFAULT_IMPL_NAME) {
+
+    override fun create(
+        impl: PartiqlPhysical.Impl,
+        sourceBexpr: RelationExpressionAsync,
+        bindings: List<VariableBindingAsync>
+    ) = LetOperatorAsync(
+        input = sourceBexpr,
+        bindings = bindings,
+    )
+}
+
+internal class LetOperatorAsync(
+    private val input: RelationExpressionAsync,
+    private val bindings: List<VariableBindingAsync>
+) : RelationExpressionAsync {
+
+    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+        val rows = input.evaluateAsync(state)
+        return relation(rows.relType) {
+            while (rows.nextRow()) {
+                bindings.forEach {
+                    it.setFunc(state, it.expr(state))
+                }
+                yield()
+            }
+        }
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LimitRelationalOperatorFactory.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LimitRelationalOperatorFactory.kt
@@ -32,6 +32,7 @@ abstract class LimitRelationalOperatorFactory(name: String) : RelationalOperator
      * @param sourceBexpr
      * @return
      */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("LimitRelationalOperatorFactoryAsync.create"))
     abstract fun create(
         impl: PartiqlPhysical.Impl,
         rowCountExpr: ValueExpression,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LimitRelationalOperatorFactory.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LimitRelationalOperatorFactory.kt
@@ -19,6 +19,7 @@ import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
  *
  * @param name
  */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("LimitRelationalOperatorFactoryAsync"))
 abstract class LimitRelationalOperatorFactory(name: String) : RelationalOperatorFactory {
 
     final override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.LIMIT, name)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LimitRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LimitRelationalOperatorFactoryAsync.kt
@@ -1,0 +1,105 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.errors.ErrorCode
+import org.partiql.errors.Property
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.ExprValueType
+import org.partiql.lang.eval.err
+import org.partiql.lang.eval.errorContextFrom
+import org.partiql.lang.eval.numberValue
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.relation.RelationIterator
+import org.partiql.lang.eval.relation.relation
+import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
+
+/**
+ * Provides an implementation of the [PartiqlPhysical.Bexpr.Limit] operator.
+ *
+ * @constructor
+ *
+ * @param name
+ */
+abstract class LimitRelationalOperatorFactoryAsync(name: String) : RelationalOperatorFactory {
+
+    final override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.LIMIT, name)
+
+    /**
+     * Creates a [RelationExpressionAsync] instance for [PartiqlPhysical.Bexpr.Limit].
+     *
+     * @param impl
+     * @param rowCountExpr
+     * @param sourceBexpr
+     * @return
+     */
+    abstract fun create(
+        impl: PartiqlPhysical.Impl,
+        rowCountExpr: ValueExpressionAsync,
+        sourceBexpr: RelationExpressionAsync
+    ): RelationExpressionAsync
+}
+
+internal object LimitRelationalOperatorFactoryDefaultAsync : LimitRelationalOperatorFactoryAsync(DEFAULT_IMPL_NAME) {
+
+    override fun create(
+        impl: PartiqlPhysical.Impl,
+        rowCountExpr: ValueExpressionAsync,
+        sourceBexpr: RelationExpressionAsync
+    ) = LimitOperatorAsync(
+        input = sourceBexpr,
+        limit = rowCountExpr
+    )
+}
+
+internal class LimitOperatorAsync(
+    private val input: RelationExpressionAsync,
+    private val limit: ValueExpressionAsync,
+) : RelationExpressionAsync {
+
+    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+        val limit = evalLimitRowCount(limit, state)
+        val rows = input.evaluateAsync(state)
+        return relation(rows.relType) {
+            var rowCount = 0L
+            while (rowCount++ < limit && rows.nextRow()) {
+                yield()
+            }
+        }
+    }
+
+    private suspend fun evalLimitRowCount(rowCountExpr: ValueExpressionAsync, env: EvaluatorState): Long {
+        val limitExprValue = rowCountExpr(env)
+        if (limitExprValue.type != ExprValueType.INT) {
+            err(
+                "LIMIT value was not an integer",
+                ErrorCode.EVALUATOR_NON_INT_LIMIT_VALUE,
+                errorContextFrom(rowCountExpr.sourceLocation).also {
+                    it[Property.ACTUAL_TYPE] = limitExprValue.type.toString()
+                },
+                internal = false
+            )
+        }
+
+        val originalLimitValue = limitExprValue.numberValue()
+        val limitValue = originalLimitValue.toLong()
+        if (originalLimitValue != limitValue as Number) { // Make sure `Number.toLong()` is a lossless transformation
+            err(
+                "Integer exceeds Long.MAX_VALUE provided as LIMIT value",
+                ErrorCode.INTERNAL_ERROR,
+                errorContextFrom(rowCountExpr.sourceLocation),
+                internal = true
+            )
+        }
+
+        if (limitValue < 0) {
+            err(
+                "negative LIMIT",
+                ErrorCode.EVALUATOR_NEGATIVE_LIMIT,
+                errorContextFrom(rowCountExpr.sourceLocation),
+                internal = false
+            )
+        }
+        // we can't use the Kotlin's Sequence<T>.take(n) for this since it accepts only an integer.
+        // this references [Sequence<T>.take(count: Long): Sequence<T>] defined in [org.partiql.util].
+        return limitValue
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LimitRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/LimitRelationalOperatorFactoryAsync.kt
@@ -55,9 +55,9 @@ internal class LimitOperatorAsync(
     private val limit: ValueExpressionAsync,
 ) : RelationExpressionAsync {
 
-    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+    override suspend fun evaluate(state: EvaluatorState): RelationIterator {
         val limit = evalLimitRowCount(limit, state)
-        val rows = input.evaluateAsync(state)
+        val rows = input.evaluate(state)
         return relation(rows.relType) {
             var rowCount = 0L
             while (rowCount++ < limit && rows.nextRow()) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/OffsetRelationalOperatorFactory.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/OffsetRelationalOperatorFactory.kt
@@ -19,6 +19,7 @@ import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
  *
  * @param name
  */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("OffsetRelationalOperatorFactoryAsync"))
 abstract class OffsetRelationalOperatorFactory(name: String) : RelationalOperatorFactory {
 
     final override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.OFFSET, name)
@@ -31,6 +32,7 @@ abstract class OffsetRelationalOperatorFactory(name: String) : RelationalOperato
      * @param sourceBexpr
      * @return
      */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("OffsetRelationalOperatorFactoryAsync.create"))
     abstract fun create(
         impl: PartiqlPhysical.Impl,
         rowCountExpr: ValueExpression,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/OffsetRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/OffsetRelationalOperatorFactoryAsync.kt
@@ -1,0 +1,107 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.errors.ErrorCode
+import org.partiql.errors.Property
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.ExprValueType
+import org.partiql.lang.eval.err
+import org.partiql.lang.eval.errorContextFrom
+import org.partiql.lang.eval.numberValue
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.relation.RelationIterator
+import org.partiql.lang.eval.relation.relation
+import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
+
+/**
+ * Provides an implementation of the [PartiqlPhysical.Bexpr.Offset] operator.
+ *
+ * @constructor
+ *
+ * @param name
+ */
+abstract class OffsetRelationalOperatorFactoryAsync(name: String) : RelationalOperatorFactory {
+
+    final override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.OFFSET, name)
+
+    /**
+     * Creates a [RelationExpressionAsync] instance for [PartiqlPhysical.Bexpr.Offset].
+     *
+     * @param impl
+     * @param rowCountExpr
+     * @param sourceBexpr
+     * @return
+     */
+    abstract fun create(
+        impl: PartiqlPhysical.Impl,
+        rowCountExpr: ValueExpressionAsync,
+        sourceBexpr: RelationExpressionAsync
+    ): RelationExpressionAsync
+}
+
+internal object OffsetRelationalOperatorFactoryDefaultAsync : OffsetRelationalOperatorFactoryAsync(DEFAULT_IMPL_NAME) {
+
+    override fun create(
+        impl: PartiqlPhysical.Impl,
+        rowCountExpr: ValueExpressionAsync,
+        sourceBexpr: RelationExpressionAsync
+    ) = OffsetOperatorAsync(
+        input = sourceBexpr,
+        offset = rowCountExpr,
+    )
+}
+
+internal class OffsetOperatorAsync(
+    private val input: RelationExpressionAsync,
+    private val offset: ValueExpressionAsync,
+) : RelationExpressionAsync {
+
+    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+        val skipCount: Long = evalOffsetRowCount(offset, state)
+        val rows = input.evaluateAsync(state)
+        return relation(rows.relType) {
+            var rowCount = 0L
+            while (rowCount++ < skipCount) {
+                // stop iterating if we run out of rows before we hit the offset.
+                if (!rows.nextRow()) {
+                    return@relation
+                }
+            }
+            yieldAll(rows)
+        }
+    }
+
+    private suspend fun evalOffsetRowCount(rowCountExpr: ValueExpressionAsync, state: EvaluatorState): Long {
+        val offsetExprValue = rowCountExpr(state)
+        if (offsetExprValue.type != ExprValueType.INT) {
+            err(
+                "OFFSET value was not an integer",
+                ErrorCode.EVALUATOR_NON_INT_OFFSET_VALUE,
+                errorContextFrom(rowCountExpr.sourceLocation).also {
+                    it[Property.ACTUAL_TYPE] = offsetExprValue.type.toString()
+                },
+                internal = false
+            )
+        }
+
+        val originalOffsetValue = offsetExprValue.numberValue()
+        val offsetValue = originalOffsetValue.toLong()
+        if (originalOffsetValue != offsetValue as Number) { // Make sure `Number.toLong()` is a lossless transformation
+            err(
+                "Integer exceeds Long.MAX_VALUE provided as OFFSET value",
+                ErrorCode.INTERNAL_ERROR,
+                errorContextFrom(rowCountExpr.sourceLocation),
+                internal = true
+            )
+        }
+
+        if (offsetValue < 0) {
+            err(
+                "negative OFFSET",
+                ErrorCode.EVALUATOR_NEGATIVE_OFFSET,
+                errorContextFrom(rowCountExpr.sourceLocation),
+                internal = false
+            )
+        }
+        return offsetValue
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/OffsetRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/OffsetRelationalOperatorFactoryAsync.kt
@@ -55,9 +55,9 @@ internal class OffsetOperatorAsync(
     private val offset: ValueExpressionAsync,
 ) : RelationExpressionAsync {
 
-    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+    override suspend fun evaluate(state: EvaluatorState): RelationIterator {
         val skipCount: Long = evalOffsetRowCount(offset, state)
-        val rows = input.evaluateAsync(state)
+        val rows = input.evaluate(state)
         return relation(rows.relType) {
             var rowCount = 0L
             while (rowCount++ < skipCount) {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ProjectRelationalOperatorFactory.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ProjectRelationalOperatorFactory.kt
@@ -4,10 +4,12 @@ import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.eval.physical.SetVariableFunc
 
 /** Provides an implementation of the [PartiqlPhysical.Bexpr.Project] operator.*/
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("ProjectRelationalOperatorFactoryAsync"))
 abstract class ProjectRelationalOperatorFactory(name: String) : RelationalOperatorFactory {
     final override val key: RelationalOperatorFactoryKey = RelationalOperatorFactoryKey(RelationalOperatorKind.PROJECT, name)
 
     /** Creates a [RelationExpression] instance for [PartiqlPhysical.Bexpr.Project]. */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("ProjectRelationalOperatorFactoryAsync.create"))
     abstract fun create(
         /**
          * Contains any static arguments needed by the operator implementation that were supplied by the planner

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ProjectRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ProjectRelationalOperatorFactoryAsync.kt
@@ -1,0 +1,22 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.physical.SetVariableFunc
+
+/** Provides an implementation of the [PartiqlPhysical.Bexpr.Project] operator.*/
+abstract class ProjectRelationalOperatorFactoryAsync(name: String) : RelationalOperatorFactory {
+    final override val key: RelationalOperatorFactoryKey = RelationalOperatorFactoryKey(RelationalOperatorKind.PROJECT, name)
+
+    /** Creates a [RelationExpressionAsync] instance for [PartiqlPhysical.Bexpr.Project]. */
+    abstract fun create(
+        /**
+         * Contains any static arguments needed by the operator implementation that were supplied by the planner
+         * pass which specified the operator implementation.
+         */
+        impl: PartiqlPhysical.Impl,
+        /** Invoke to set the binding for the current row. */
+        setVar: SetVariableFunc,
+        /** Invoke to obtain evaluation-time arguments. */
+        args: List<ValueExpressionAsync>
+    ): RelationExpressionAsync
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/RelationExpression.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/RelationExpression.kt
@@ -14,6 +14,8 @@ import org.partiql.lang.eval.relation.RelationIterator
  * Like [ValueExpression], this is public API that is supported long term and is intended to avoid exposing
  * implementation details such as [org.partiql.lang.eval.physical.RelationThunkEnv].
  */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("RelationExpressionAsync"))
 fun interface RelationExpression {
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("RelationExpressionAsync.evaluate"))
     fun evaluate(state: EvaluatorState): RelationIterator
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/RelationExpressionAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/RelationExpressionAsync.kt
@@ -15,5 +15,5 @@ import org.partiql.lang.eval.relation.RelationIterator
  * implementation details such as [org.partiql.lang.eval.physical.RelationThunkEnv].
  */
 fun interface RelationExpressionAsync {
-    suspend fun evaluateAsync(state: EvaluatorState): RelationIterator
+    suspend fun evaluate(state: EvaluatorState): RelationIterator
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/RelationExpressionAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/RelationExpressionAsync.kt
@@ -1,0 +1,19 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.relation.RelationIterator
+
+/**
+ * An implementation of a physical plan relational operator.
+ *
+ * PartiQL's relational algebra is based on
+ * [E.F. Codd's Relational Algebra](https://en.wikipedia.org/wiki/Relational_algebra), but to better support
+ * semi-structured, schemaless data, our "relations" are actually logical collections of bindings.  Still, the term
+ * "relation" has remained, as well as most other concepts from E.F. Codd's relational algebra.
+ *
+ * Like [ValueExpression], this is public API that is supported long term and is intended to avoid exposing
+ * implementation details such as [org.partiql.lang.eval.physical.RelationThunkEnv].
+ */
+fun interface RelationExpressionAsync {
+    suspend fun evaluateAsync(state: EvaluatorState): RelationIterator
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ScanRelationalOperatorFactory.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ScanRelationalOperatorFactory.kt
@@ -20,6 +20,7 @@ import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
  *
  * @param name
  */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("ScanRelationalOperatorFactoryAsync"))
 abstract class ScanRelationalOperatorFactory(name: String) : RelationalOperatorFactory {
 
     final override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.SCAN, name)
@@ -34,6 +35,7 @@ abstract class ScanRelationalOperatorFactory(name: String) : RelationalOperatorF
      * @param setByVar BY variable binding, if non-null
      * @return
      */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("ScanRelationalOperatorFactoryAsync.create"))
     abstract fun create(
         impl: PartiqlPhysical.Impl,
         expr: ValueExpression,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ScanRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ScanRelationalOperatorFactoryAsync.kt
@@ -1,0 +1,82 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueType
+import org.partiql.lang.eval.address
+import org.partiql.lang.eval.name
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.physical.SetVariableFunc
+import org.partiql.lang.eval.relation.RelationIterator
+import org.partiql.lang.eval.relation.RelationType
+import org.partiql.lang.eval.relation.relation
+import org.partiql.lang.eval.unnamedValue
+import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
+
+/**
+ * Provides an implementation of the [PartiqlPhysical.Bexpr.Scan] operator.
+ *
+ * @constructor
+ *
+ * @param name
+ */
+abstract class ScanRelationalOperatorFactoryAsync(name: String) : RelationalOperatorFactory {
+
+    final override val key = RelationalOperatorFactoryKey(RelationalOperatorKind.SCAN, name)
+
+    /**
+     * Creates a [RelationExpressionAsync] instance for [PartiqlPhysical.Bexpr.Scan].
+     *
+     * @param impl static arguments
+     * @param expr invoked to obtain an iterable value
+     * @param setAsVar AS variable binding
+     * @param setAtVar AT variable binding, if non-null
+     * @param setByVar BY variable binding, if non-null
+     * @return
+     */
+    abstract fun create(
+        impl: PartiqlPhysical.Impl,
+        expr: ValueExpressionAsync,
+        setAsVar: SetVariableFunc,
+        setAtVar: SetVariableFunc?,
+        setByVar: SetVariableFunc?
+    ): RelationExpressionAsync
+}
+
+internal object ScanRelationalOperatorFactoryDefaultAsync : ScanRelationalOperatorFactoryAsync(DEFAULT_IMPL_NAME) {
+    override fun create(
+        impl: PartiqlPhysical.Impl,
+        expr: ValueExpressionAsync,
+        setAsVar: SetVariableFunc,
+        setAtVar: SetVariableFunc?,
+        setByVar: SetVariableFunc?
+    ) = ScanOperatorAsync(expr, setAsVar, setAtVar, setByVar)
+}
+
+internal class ScanOperatorAsync(
+    private val expr: ValueExpressionAsync,
+    private val setAsVar: SetVariableFunc,
+    private val setAtVar: SetVariableFunc?,
+    private val setByVar: SetVariableFunc?
+) : RelationExpressionAsync {
+
+    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+        val value = expr(state)
+        val sequence: Sequence<ExprValue> = when (value.type) {
+            ExprValueType.LIST,
+            ExprValueType.BAG -> value.asSequence()
+            else -> sequenceOf(value)
+        }
+        return relation(RelationType.BAG) {
+            val rows: Iterator<ExprValue> = sequence.iterator()
+            while (rows.hasNext()) {
+                val item = rows.next()
+                // .unnamedValue() removes any ordinal that might exist on item
+                setAsVar(state, item.unnamedValue())
+                setAtVar?.let { it(state, item.name ?: ExprValue.missingValue) }
+                setByVar?.let { it(state, item.address ?: ExprValue.missingValue) }
+                yield()
+            }
+        }
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ScanRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ScanRelationalOperatorFactoryAsync.kt
@@ -60,7 +60,7 @@ internal class ScanOperatorAsync(
     private val setByVar: SetVariableFunc?
 ) : RelationExpressionAsync {
 
-    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+    override suspend fun evaluate(state: EvaluatorState): RelationIterator {
         val value = expr(state)
         val sequence: Sequence<ExprValue> = when (value.type) {
             ExprValueType.LIST,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/SortOperatorFactory.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/SortOperatorFactory.kt
@@ -4,12 +4,15 @@ import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.eval.NaturalExprValueComparators
 
 /** Provides an implementation of the [PartiqlPhysical.Bexpr.Order] operator.*/
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("SortOperatorFactoryAsync"))
 public abstract class SortOperatorFactory(name: String) : RelationalOperatorFactory {
     public final override val key: RelationalOperatorFactoryKey = RelationalOperatorFactoryKey(RelationalOperatorKind.SORT, name)
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("SortOperatorFactoryAsync.create"))
     public abstract fun create(
         sortKeys: List<CompiledSortKey>,
         sourceRelation: RelationExpression
     ): RelationExpression
 }
 
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("CompiledSortKeyAsync"))
 public class CompiledSortKey(val comparator: NaturalExprValueComparators, val value: ValueExpression)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/SortOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/SortOperatorFactoryAsync.kt
@@ -3,7 +3,7 @@ package org.partiql.lang.eval.physical.operators
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.eval.NaturalExprValueComparators
 
-/** Provides an implementation of the [PartiqlPhysical.Bexpr.Order] operator.*/
+/** Provides an implementation of the [PartiqlPhysical.Bexpr.Sort] operator.*/
 public abstract class SortOperatorFactoryAsync(name: String) : RelationalOperatorFactory {
     public final override val key: RelationalOperatorFactoryKey = RelationalOperatorFactoryKey(RelationalOperatorKind.SORT, name)
     public abstract fun create(

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/SortOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/SortOperatorFactoryAsync.kt
@@ -1,0 +1,15 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.NaturalExprValueComparators
+
+/** Provides an implementation of the [PartiqlPhysical.Bexpr.Order] operator.*/
+public abstract class SortOperatorFactoryAsync(name: String) : RelationalOperatorFactory {
+    public final override val key: RelationalOperatorFactoryKey = RelationalOperatorFactoryKey(RelationalOperatorKind.SORT, name)
+    public abstract fun create(
+        sortKeys: List<CompiledSortKeyAsync>,
+        sourceRelation: RelationExpressionAsync
+    ): RelationExpressionAsync
+}
+
+public class CompiledSortKeyAsync(val comparator: NaturalExprValueComparators, val value: ValueExpressionAsync)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/SortOperatorFactoryDefaultAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/SortOperatorFactoryDefaultAsync.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.NaturalExprValueComparators
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.relation.RelationIterator
+import org.partiql.lang.eval.relation.RelationType
+import org.partiql.lang.eval.relation.relation
+import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
+
+internal object SortOperatorFactoryDefaultAsync : SortOperatorFactoryAsync(DEFAULT_IMPL_NAME) {
+    override fun create(
+        sortKeys: List<CompiledSortKeyAsync>,
+        sourceRelation: RelationExpressionAsync
+    ): RelationExpressionAsync = SortOperatorDefaultAsync(sortKeys, sourceRelation)
+}
+
+internal class SortOperatorDefaultAsync(private val sortKeys: List<CompiledSortKeyAsync>, private val sourceRelation: RelationExpressionAsync) : RelationExpressionAsync {
+    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+        val source = sourceRelation.evaluateAsync(state)
+        return relation(RelationType.LIST) {
+            val rows = mutableListOf<Array<ExprValue>>()
+
+            // Consume Input
+            while (source.nextRow()) {
+                rows.add(state.registers.clone())
+            }
+
+            val rowWithValues = rows.map { row ->
+                state.load(row)
+                row to sortKeys.map { sk ->
+                    sk.value(state)
+                }
+            }.toMutableList()
+            val comparator = getSortingComparator(sortKeys.map { it.comparator })
+
+            // Perform Sort
+            val sortedRows = rowWithValues.sortedWith(comparator)
+
+            // Yield Sorted Rows
+            val iterator = sortedRows.iterator()
+            while (iterator.hasNext()) {
+                state.load(iterator.next().first)
+                yield()
+            }
+        }
+    }
+}
+
+/**
+ * Returns a [Comparator] that compares arrays of registers by using un-evaluated sort keys. It does this by modifying
+ * the [state] to allow evaluation of the [sortKeys]
+ */
+internal fun getSortingComparator(sortKeys: List<NaturalExprValueComparators>): Comparator<Pair<Array<ExprValue>, List<ExprValue>>> {
+    return object : Comparator<Pair<Array<ExprValue>, List<ExprValue>>> {
+        override fun compare(
+            l: Pair<Array<ExprValue>, List<ExprValue>>,
+            r: Pair<Array<ExprValue>, List<ExprValue>>
+        ): Int {
+            val valsToCompare = l.second.zip(r.second)
+            sortKeys.zip(valsToCompare).map {
+                val comp = it.first
+                val cmpResult = comp.compare(it.second.first, it.second.second)
+                if (cmpResult != 0) {
+                    return cmpResult
+                }
+            }
+            return 0
+        }
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/SortOperatorFactoryDefaultAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/SortOperatorFactoryDefaultAsync.kt
@@ -30,8 +30,8 @@ internal object SortOperatorFactoryDefaultAsync : SortOperatorFactoryAsync(DEFAU
 }
 
 internal class SortOperatorDefaultAsync(private val sortKeys: List<CompiledSortKeyAsync>, private val sourceRelation: RelationExpressionAsync) : RelationExpressionAsync {
-    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
-        val source = sourceRelation.evaluateAsync(state)
+    override suspend fun evaluate(state: EvaluatorState): RelationIterator {
+        val source = sourceRelation.evaluate(state)
         return relation(RelationType.LIST) {
             val rows = mutableListOf<Array<ExprValue>>()
 
@@ -63,7 +63,7 @@ internal class SortOperatorDefaultAsync(private val sortKeys: List<CompiledSortK
 
 /**
  * Returns a [Comparator] that compares arrays of registers by using un-evaluated sort keys. It does this by modifying
- * the [state] to allow evaluation of the [sortKeys]
+ * the [EvaluatorState] to allow evaluation of the [sortKeys].
  */
 internal fun getSortingComparator(sortKeys: List<NaturalExprValueComparators>): Comparator<Pair<Array<ExprValue>, List<ExprValue>>> {
     return object : Comparator<Pair<Array<ExprValue>, List<ExprValue>>> {

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/UnpivotOperatorFactory.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/UnpivotOperatorFactory.kt
@@ -4,10 +4,12 @@ import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.eval.physical.SetVariableFunc
 
 /** Provides an implementation of the [PartiqlPhysical.Bexpr.Scan] operator.*/
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("UnpivotOperatorFactoryAsync"))
 public abstract class UnpivotOperatorFactory(name: String) : RelationalOperatorFactory {
     public final override val key: RelationalOperatorFactoryKey = RelationalOperatorFactoryKey(RelationalOperatorKind.UNPIVOT, name)
 
     /** Creates a [RelationExpression] instance for [PartiqlPhysical.Bexpr.Scan]. */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("UnpivotOperatorFactoryAsync.create"))
     public abstract fun create(
         /** Invoke to obtain the value to be iterated over.*/
         expr: ValueExpression,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/UnpivotOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/UnpivotOperatorFactoryAsync.kt
@@ -1,0 +1,21 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.physical.SetVariableFunc
+
+/** Provides an implementation of the [PartiqlPhysical.Bexpr.Scan] operator.*/
+public abstract class UnpivotOperatorFactoryAsync(name: String) : RelationalOperatorFactory {
+    public final override val key: RelationalOperatorFactoryKey = RelationalOperatorFactoryKey(RelationalOperatorKind.UNPIVOT, name)
+
+    /** Creates a [RelationExpressionAsync] instance for [PartiqlPhysical.Bexpr.Scan]. */
+    public abstract fun create(
+        /** Invoke to obtain the value to be iterated over.*/
+        expr: ValueExpressionAsync,
+        /** Invoke to set the `AS` variable binding. */
+        setAsVar: SetVariableFunc,
+        /** Invoke to set the `AT` variable binding, if non-null */
+        setAtVar: SetVariableFunc?,
+        /** Invoke to set the `BY` variable binding, if non-null. */
+        setByVar: SetVariableFunc?
+    ): RelationExpressionAsync
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/UnpivotOperatorFactoryDefaultAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/UnpivotOperatorFactoryDefaultAsync.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.ExprValueType
+import org.partiql.lang.eval.address
+import org.partiql.lang.eval.name
+import org.partiql.lang.eval.namedValue
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.physical.SetVariableFunc
+import org.partiql.lang.eval.relation.RelationIterator
+import org.partiql.lang.eval.relation.RelationType
+import org.partiql.lang.eval.relation.relation
+import org.partiql.lang.eval.syntheticColumnName
+import org.partiql.lang.eval.unnamedValue
+import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
+
+internal object UnpivotOperatorFactoryDefaultAsync : UnpivotOperatorFactoryAsync(DEFAULT_IMPL_NAME) {
+    override fun create(
+        expr: ValueExpressionAsync,
+        setAsVar: SetVariableFunc,
+        setAtVar: SetVariableFunc?,
+        setByVar: SetVariableFunc?
+    ): RelationExpressionAsync = UnpivotOperatorDefaultAsync(expr, setAsVar, setAtVar, setByVar)
+}
+
+internal class UnpivotOperatorDefaultAsync(
+    private val expr: ValueExpressionAsync,
+    private val setAsVar: SetVariableFunc,
+    private val setAtVar: SetVariableFunc?,
+    private val setByVar: SetVariableFunc?
+) : RelationExpressionAsync {
+    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+        val originalValue = expr(state)
+        val unpivot = originalValue.unpivot()
+
+        return relation(RelationType.BAG) {
+            val iter = unpivot.iterator()
+            while (iter.hasNext()) {
+                val item = iter.next()
+                setAsVar(state, item.unnamedValue())
+                setAtVar?.let { it(state, item.name ?: ExprValue.missingValue) }
+                setByVar?.let { it(state, item.address ?: ExprValue.missingValue) }
+                yield()
+            }
+        }
+    }
+
+    private fun ExprValue.unpivot(): ExprValue = when (type) {
+        ExprValueType.STRUCT, ExprValueType.MISSING -> this
+        else -> ExprValue.newBag(
+            listOf(
+                this.namedValue(ExprValue.newString(syntheticColumnName(0)))
+            )
+        )
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/UnpivotOperatorFactoryDefaultAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/UnpivotOperatorFactoryDefaultAsync.kt
@@ -43,7 +43,7 @@ internal class UnpivotOperatorDefaultAsync(
     private val setAtVar: SetVariableFunc?,
     private val setByVar: SetVariableFunc?
 ) : RelationExpressionAsync {
-    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+    override suspend fun evaluate(state: EvaluatorState): RelationIterator {
         val originalValue = expr(state)
         val unpivot = originalValue.unpivot()
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ValueExpression.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ValueExpression.kt
@@ -11,11 +11,14 @@ import org.partiql.lang.eval.physical.EvaluatorState
  * avoid exposing implementation details (i.e. [org.partiql.lang.eval.physical.PhysicalPlanThunk]) of the evaluator.
  * This implementation accomplishes that and is intended as a publicly usable API that is supported long term.
  */
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("ValueExpressionAsync"))
 interface ValueExpression {
     /** Evaluates the expression. */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("ValueExpressionAsync.invoke"))
     operator fun invoke(state: EvaluatorState): ExprValue
 
     /** Provides the source location (line & column) of the expression, for error reporting purposes. */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("ValueExpressionAsync.sourceLocation"))
     val sourceLocation: SourceLocationMeta?
 }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ValueExpressionAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/ValueExpressionAsync.kt
@@ -1,0 +1,30 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.lang.ast.SourceLocationMeta
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.physical.EvaluatorState
+
+/**
+ * Evaluates a PartiQL expression returning an [ExprValue].
+ *
+ * [RelationExpression] implementations need a mechanism to evaluate such expressions, and said mechanism should
+ * avoid exposing implementation details (i.e. [org.partiql.lang.eval.physical.PhysicalPlanThunk]) of the evaluator.
+ * This implementation accomplishes that and is intended as a publicly usable API that is supported long term.
+ */
+interface ValueExpressionAsync {
+    /** Evaluates the expression. */
+    suspend operator fun invoke(state: EvaluatorState): ExprValue
+
+    /** Provides the source location (line & column) of the expression, for error reporting purposes. */
+    val sourceLocation: SourceLocationMeta?
+}
+
+/** Convenience constructor for [ValueExpression]. */
+internal inline fun valueExpressionAsync(
+    sourceLocation: SourceLocationMeta?,
+    crossinline invoke: suspend (EvaluatorState) -> ExprValue
+) =
+    object : ValueExpressionAsync {
+        override suspend fun invoke(state: EvaluatorState): ExprValue = invoke(state)
+        override val sourceLocation: SourceLocationMeta? get() = sourceLocation
+    }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/WindowRelationalOperatorFactory.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/WindowRelationalOperatorFactory.kt
@@ -6,11 +6,13 @@ import org.partiql.lang.eval.physical.SetVariableFunc
 import org.partiql.lang.eval.physical.window.WindowFunction
 
 @ExperimentalWindowFunctions
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("WindowRelationalOperatorFactoryAsync"))
 abstract class WindowRelationalOperatorFactory(name: String) : RelationalOperatorFactory {
 
     final override val key: RelationalOperatorFactoryKey = RelationalOperatorFactoryKey(RelationalOperatorKind.WINDOW, name)
 
     /** Creates a [RelationExpression] instance for [PartiqlPhysical.Bexpr.Window]. */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("WindowRelationalOperatorFactoryAsync.create"))
     abstract fun create(
         source: RelationExpression,
         windowPartitionList: List<ValueExpression>,
@@ -21,6 +23,7 @@ abstract class WindowRelationalOperatorFactory(name: String) : RelationalOperato
 }
 
 @ExperimentalWindowFunctions
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("CompiledWindowFunctionAsync"))
 class CompiledWindowFunction(
     val func: WindowFunction,
     val parameters: List<ValueExpression>,

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/WindowRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/WindowRelationalOperatorFactoryAsync.kt
@@ -1,0 +1,32 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.annotations.ExperimentalWindowFunctions
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.physical.SetVariableFunc
+import org.partiql.lang.eval.physical.window.NavigationWindowFunctionAsync
+
+@ExperimentalWindowFunctions
+abstract class WindowRelationalOperatorFactoryAsync(name: String) : RelationalOperatorFactory {
+
+    final override val key: RelationalOperatorFactoryKey = RelationalOperatorFactoryKey(RelationalOperatorKind.WINDOW, name)
+
+    /** Creates a [RelationExpressionAsync] instance for [PartiqlPhysical.Bexpr.Window]. */
+    abstract fun create(
+        source: RelationExpressionAsync,
+        windowPartitionList: List<ValueExpressionAsync>,
+        windowSortSpecList: List<CompiledSortKeyAsync>,
+        compiledWindowFunctions: List<CompiledWindowFunctionAsync>
+
+    ): RelationExpressionAsync
+}
+
+@ExperimentalWindowFunctions
+class CompiledWindowFunctionAsync(
+    val func: NavigationWindowFunctionAsync,
+    val parameters: List<ValueExpressionAsync>,
+    /**
+     * This is [PartiqlPhysical.VarDecl] instead of [SetVariableFunc] because we would like to access the index of variable in the register
+     * when processing rows within the partition.
+     */
+    val windowVarDecl: PartiqlPhysical.VarDecl
+)

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/WindowRelationalOperatorFactoryDefaultAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/WindowRelationalOperatorFactoryDefaultAsync.kt
@@ -34,9 +34,9 @@ internal class WindowOperatorDefaultAsync(
     private val windowSortSpecList: List<CompiledSortKeyAsync>,
     private val compiledWindowFunctions: List<CompiledWindowFunctionAsync>
 ) : RelationExpressionAsync {
-    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+    override suspend fun evaluate(state: EvaluatorState): RelationIterator {
         // the following corresponding to materialization process
-        val sourceIter = source.evaluateAsync(state)
+        val sourceIter = source.evaluate(state)
         val registers = sequence {
             while (sourceIter.nextRow()) {
                 yield(state.registers.clone())
@@ -59,7 +59,7 @@ internal class WindowOperatorDefaultAsync(
         val sortedRegisters = newRegisters.sortedWith(getSortingComparator(sortKeys.map { it.comparator })).map { it.first }
 
         // create the partition here
-        var partition = mutableListOf<List<Array<ExprValue>>>()
+        val partition = mutableListOf<List<Array<ExprValue>>>()
 
         // entire partition
         if (windowPartitionList.isEmpty()) {
@@ -68,7 +68,7 @@ internal class WindowOperatorDefaultAsync(
         // need to be partitioned
         else {
             val iter = sortedRegisters.iterator()
-            var rowInPartition = mutableListOf<Array<ExprValue>>()
+            val rowInPartition = mutableListOf<Array<ExprValue>>()
             var previousPartition: ExprValue? = null
             while (iter.hasNext()) {
                 val currentRow = iter.next()

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/WindowRelationalOperatorFactoryDefaultAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/operators/WindowRelationalOperatorFactoryDefaultAsync.kt
@@ -1,0 +1,119 @@
+package org.partiql.lang.eval.physical.operators
+
+import org.partiql.annotations.ExperimentalWindowFunctions
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.NaturalExprValueComparators
+import org.partiql.lang.eval.exprEquals
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.relation.RelationIterator
+import org.partiql.lang.eval.relation.RelationType
+import org.partiql.lang.eval.relation.relation
+import org.partiql.lang.planner.transforms.DEFAULT_IMPL_NAME
+
+/**
+ * This is an experimental implementation of the window operator
+ *
+ * The general concept here is to sort the input relation, first by partition keys (if not null) then by sort keys (if not null).
+ * After sorting, we do a sequence scan to create partition and materialize all the element in the same partition
+ *
+ */
+@ExperimentalWindowFunctions
+internal object WindowRelationalOperatorFactoryDefaultAsync : WindowRelationalOperatorFactoryAsync(DEFAULT_IMPL_NAME) {
+    override fun create(
+        source: RelationExpressionAsync,
+        windowPartitionList: List<ValueExpressionAsync>,
+        windowSortSpecList: List<CompiledSortKeyAsync>,
+        compiledWindowFunctions: List<CompiledWindowFunctionAsync>
+    ): RelationExpressionAsync = WindowOperatorDefaultAsync(source, windowPartitionList, windowSortSpecList, compiledWindowFunctions)
+}
+
+@ExperimentalWindowFunctions
+internal class WindowOperatorDefaultAsync(
+    private val source: RelationExpressionAsync,
+    private val windowPartitionList: List<ValueExpressionAsync>,
+    private val windowSortSpecList: List<CompiledSortKeyAsync>,
+    private val compiledWindowFunctions: List<CompiledWindowFunctionAsync>
+) : RelationExpressionAsync {
+    override suspend fun evaluateAsync(state: EvaluatorState): RelationIterator {
+        // the following corresponding to materialization process
+        val sourceIter = source.evaluateAsync(state)
+        val registers = sequence {
+            while (sourceIter.nextRow()) {
+                yield(state.registers.clone())
+            }
+        }
+
+        val partitionSortSpec = windowPartitionList.map {
+            CompiledSortKeyAsync(NaturalExprValueComparators.NULLS_FIRST_ASC, it)
+        }
+
+        val sortKeys = partitionSortSpec + windowSortSpecList
+
+        val newRegisters = registers.toList().map { row ->
+            state.load(row)
+            row to sortKeys.map { sk ->
+                sk.value(state)
+            }
+        }.toMutableList()
+
+        val sortedRegisters = newRegisters.sortedWith(getSortingComparator(sortKeys.map { it.comparator })).map { it.first }
+
+        // create the partition here
+        var partition = mutableListOf<List<Array<ExprValue>>>()
+
+        // entire partition
+        if (windowPartitionList.isEmpty()) {
+            partition.add(sortedRegisters.toList())
+        }
+        // need to be partitioned
+        else {
+            val iter = sortedRegisters.iterator()
+            var rowInPartition = mutableListOf<Array<ExprValue>>()
+            var previousPartition: ExprValue? = null
+            while (iter.hasNext()) {
+                val currentRow = iter.next()
+                state.load(currentRow)
+                val currentPartition = ExprValue.newSexp(
+                    windowPartitionList.map {
+                        it.invoke(state)
+                    }
+                )
+                // for the first time,
+                if (previousPartition == null) {
+                    rowInPartition.add(currentRow)
+                    previousPartition = currentPartition
+                } else if (previousPartition.exprEquals(currentPartition)) {
+                    rowInPartition.add(currentRow)
+                } else {
+                    partition.add(rowInPartition.toList())
+                    rowInPartition.clear()
+                    previousPartition = currentPartition
+                    rowInPartition.add(currentRow)
+                }
+            }
+            // finish up
+            partition.add(rowInPartition.toList())
+            rowInPartition.clear()
+        }
+
+        return relation(RelationType.BAG) {
+            partition.forEach { rowsInPartition ->
+                compiledWindowFunctions.forEach {
+                    val windowFunc = it.func
+                    // set the window function partition to the current partition
+                    windowFunc.reset(rowsInPartition)
+                }
+
+                rowsInPartition.forEach {
+                    // process current row
+                    compiledWindowFunctions.forEach { compiledWindowFunction ->
+                        compiledWindowFunction.func.processRow(state, compiledWindowFunction.parameters, compiledWindowFunction.windowVarDecl)
+                    }
+
+                    // yield the result
+                    yield()
+                }
+            }
+        }
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/BuiltInWindowFunction.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/BuiltInWindowFunction.kt
@@ -9,3 +9,11 @@ internal fun createBuiltinWindowFunction(name: String) =
         "lead" -> Lead()
         else -> error("Window function $name has not been implemented")
     }
+
+@ExperimentalWindowFunctions
+internal fun createBuiltinWindowFunctionAsync(name: String) =
+    when (name) {
+        "lag" -> LagAsync()
+        "lead" -> LeadAsync()
+        else -> error("Window function $name has not been implemented")
+    }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/LagAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/LagAsync.kt
@@ -1,0 +1,45 @@
+package org.partiql.lang.eval.physical.window
+
+import org.partiql.annotations.ExperimentalWindowFunctions
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.numberValue
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.physical.operators.ValueExpressionAsync
+
+// TODO: Decide if we should reduce the code duplication by combining lead and lag function
+@ExperimentalWindowFunctions
+internal class LagAsync : NavigationWindowFunctionAsync() {
+    override val name = "lag"
+
+    companion object {
+        const val DEFAULT_OFFSET_VALUE = 1L
+    }
+
+    override suspend fun processRow(state: EvaluatorState, arguments: List<ValueExpressionAsync>, currentPos: Int): ExprValue {
+        val (target, offset, default) = when (arguments.size) {
+            1 -> listOf(arguments[0], null, null)
+            2 -> listOf(arguments[0], arguments[1], null)
+            3 -> listOf(arguments[0], arguments[1], arguments[2])
+            else -> error("Wrong number of Parameter for Lag Function")
+        }
+
+        val offsetValue = offset?.let {
+            val numberValue = it.invoke(state).numberValue().toLong()
+            if (numberValue >= 0) {
+                numberValue
+            } else {
+                error("offset need to be non-negative integer")
+            }
+        } ?: DEFAULT_OFFSET_VALUE
+        val defaultValue = default?.invoke(state) ?: ExprValue.nullValue
+        val targetIndex = currentPos - offsetValue
+
+        if (targetIndex >= 0 && targetIndex <= currentPartition.lastIndex) {
+            val targetRow = currentPartition[targetIndex.toInt()]
+            state.load(targetRow)
+            return target!!.invoke(state)
+        } else {
+            return defaultValue
+        }
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/LagAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/LagAsync.kt
@@ -34,12 +34,12 @@ internal class LagAsync : NavigationWindowFunctionAsync() {
         val defaultValue = default?.invoke(state) ?: ExprValue.nullValue
         val targetIndex = currentPos - offsetValue
 
-        if (targetIndex >= 0 && targetIndex <= currentPartition.lastIndex) {
+        return if (targetIndex >= 0 && targetIndex <= currentPartition.lastIndex) {
             val targetRow = currentPartition[targetIndex.toInt()]
             state.load(targetRow)
-            return target!!.invoke(state)
+            target!!.invoke(state)
         } else {
-            return defaultValue
+            defaultValue
         }
     }
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/LeadAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/LeadAsync.kt
@@ -1,0 +1,46 @@
+package org.partiql.lang.eval.physical.window
+
+import org.partiql.annotations.ExperimentalWindowFunctions
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.numberValue
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.physical.operators.ValueExpressionAsync
+
+// TODO: Decide if we should reduce the code duplication by combining lead and lag function.
+@ExperimentalWindowFunctions
+internal class LeadAsync : NavigationWindowFunctionAsync() {
+
+    override val name = "lead"
+
+    companion object {
+        const val DEFAULT_OFFSET_VALUE = 1L
+    }
+
+    override suspend fun processRow(state: EvaluatorState, arguments: List<ValueExpressionAsync>, currentPos: Int): ExprValue {
+        val (target, offset, default) = when (arguments.size) {
+            1 -> listOf(arguments[0], null, null)
+            2 -> listOf(arguments[0], arguments[1], null)
+            3 -> listOf(arguments[0], arguments[1], arguments[2])
+            else -> error("Wrong number of Parameter for Lag Function")
+        }
+
+        val offsetValue = offset?.let {
+            val numberValue = it.invoke(state).numberValue().toLong()
+            if (numberValue >= 0) {
+                numberValue
+            } else {
+                error("offset need to be non-negative integer")
+            }
+        } ?: DEFAULT_OFFSET_VALUE
+        val defaultValue = default?.invoke(state) ?: ExprValue.nullValue
+        val targetIndex = currentPos + offsetValue
+
+        if (targetIndex <= currentPartition.lastIndex) {
+            val targetRow = currentPartition[targetIndex.toInt()]
+            state.load(targetRow)
+            return target!!.invoke(state)
+        } else {
+            return defaultValue
+        }
+    }
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/LeadAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/LeadAsync.kt
@@ -35,12 +35,12 @@ internal class LeadAsync : NavigationWindowFunctionAsync() {
         val defaultValue = default?.invoke(state) ?: ExprValue.nullValue
         val targetIndex = currentPos + offsetValue
 
-        if (targetIndex <= currentPartition.lastIndex) {
+        return if (targetIndex <= currentPartition.lastIndex) {
             val targetRow = currentPartition[targetIndex.toInt()]
             state.load(targetRow)
-            return target!!.invoke(state)
+            target!!.invoke(state)
         } else {
-            return defaultValue
+            defaultValue
         }
     }
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/NavigationWindowFunction.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/NavigationWindowFunction.kt
@@ -12,6 +12,7 @@ import org.partiql.lang.eval.physical.toSetVariableFunc
  * TODO: When we support FIRST_VALUE, etc, we probably need to modify the process row function, since those function requires frame
  */
 @ExperimentalWindowFunctions
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("NavigationWindowFunctionAsync"))
 abstract class NavigationWindowFunction() : WindowFunction {
 
     lateinit var currentPartition: List<Array<ExprValue>>
@@ -38,5 +39,6 @@ abstract class NavigationWindowFunction() : WindowFunction {
         currentPos += 1
     }
 
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("NavigationWindowFunctionAsync.processRow"))
     abstract fun processRow(state: EvaluatorState, arguments: List<ValueExpression>, currentPos: Int): ExprValue
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/NavigationWindowFunctionAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/NavigationWindowFunctionAsync.kt
@@ -1,0 +1,42 @@
+package org.partiql.lang.eval.physical.window
+
+import org.partiql.annotations.ExperimentalWindowFunctions
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.physical.operators.ValueExpressionAsync
+import org.partiql.lang.eval.physical.toSetVariableFunc
+
+/**
+ * This abstract class holds some common logic for navigation window function, i.e., LAG, LEAD
+ * TODO: When we support FIRST_VALUE, etc, we probably need to modify the process row function, since those function requires frame
+ */
+@ExperimentalWindowFunctions
+abstract class NavigationWindowFunctionAsync : WindowFunctionAsync {
+
+    lateinit var currentPartition: List<Array<ExprValue>>
+    private var currentPos: Int = 0
+
+    override fun reset(partition: List<Array<ExprValue>>) {
+        currentPartition = partition
+        currentPos = 0
+    }
+
+    override suspend fun processRow(
+        state: EvaluatorState,
+        arguments: List<ValueExpressionAsync>,
+        windowVarDecl: PartiqlPhysical.VarDecl
+    ) {
+        state.load(currentPartition[currentPos])
+        val value = processRow(state, arguments, currentPos)
+        // before we declare the window function result, we need to go back to the current row
+        state.load(currentPartition[currentPos])
+        windowVarDecl.toSetVariableFunc().invoke(state, value)
+        // make sure the change of state is reflected in the partition
+        // so the result of the current window function won't get removed by the time we process the next window function at the same row level.
+        currentPartition[currentPos][windowVarDecl.index.value.toInt()] = value
+        currentPos += 1
+    }
+
+    abstract suspend fun processRow(state: EvaluatorState, arguments: List<ValueExpressionAsync>, currentPos: Int): ExprValue
+}

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/WindowFunction.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/WindowFunction.kt
@@ -7,6 +7,7 @@ import org.partiql.lang.eval.physical.EvaluatorState
 import org.partiql.lang.eval.physical.operators.ValueExpression
 
 @ExperimentalWindowFunctions
+@Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("WindowFunctionAsync"))
 interface WindowFunction {
 
     val name: String
@@ -17,10 +18,12 @@ interface WindowFunction {
      * For now, a partition is represented by list<Array<ExprValue>>.
      * We could potentially benefit from further abstraction of partition.
      */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("WindowFunctionAsync.reset"))
     fun reset(partition: List<Array<ExprValue>>)
 
     /**
      * Process a row by outputting the result of the window function.
      */
+    @Deprecated("To be removed in the next major version.", replaceWith = ReplaceWith("WindowFunctionAsync.processRow"))
     fun processRow(state: EvaluatorState, arguments: List<ValueExpression>, windowVarDecl: PartiqlPhysical.VarDecl)
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/WindowFunctionAsync.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/window/WindowFunctionAsync.kt
@@ -1,0 +1,26 @@
+package org.partiql.lang.eval.physical.window
+
+import org.partiql.annotations.ExperimentalWindowFunctions
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.physical.EvaluatorState
+import org.partiql.lang.eval.physical.operators.ValueExpressionAsync
+
+@ExperimentalWindowFunctions
+interface WindowFunctionAsync {
+
+    val name: String
+
+    /**
+     * The reset function should be called before enter a new partition ( including the first one).
+     *
+     * For now, a partition is represented by list<Array<ExprValue>>.
+     * We could potentially benefit from further abstraction of partition.
+     */
+    fun reset(partition: List<Array<ExprValue>>)
+
+    /**
+     * Process a row by outputting the result of the window function.
+     */
+    suspend fun processRow(state: EvaluatorState, arguments: List<ValueExpressionAsync>, windowVarDecl: PartiqlPhysical.VarDecl)
+}

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/PartiQLCompilerPipelineExplainTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/PartiQLCompilerPipelineExplainTests.kt
@@ -34,7 +34,7 @@ import org.partiql.lang.util.ArgumentsProviderBase
 class PartiQLCompilerPipelineExplainTests {
 
     val compiler = PartiQLCompilerPipeline.standard()
-    val compilerAsync = PartiQLCompilerPipelineAsync.standard()
+    private val compilerAsync = PartiQLCompilerPipelineAsync.standard()
 
     data class ExplainTestCase(
         val description: String? = null,

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/PartiQLCompilerPipelineExplainTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/PartiQLCompilerPipelineExplainTests.kt
@@ -15,6 +15,8 @@
 package org.partiql.lang.compiler
 
 import com.amazon.ionelement.api.ionInt
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
@@ -32,6 +34,7 @@ import org.partiql.lang.util.ArgumentsProviderBase
 class PartiQLCompilerPipelineExplainTests {
 
     val compiler = PartiQLCompilerPipeline.standard()
+    val compilerAsync = PartiQLCompilerPipelineAsync.standard()
 
     data class ExplainTestCase(
         val description: String? = null,
@@ -44,8 +47,19 @@ class PartiQLCompilerPipelineExplainTests {
     @ParameterizedTest
     fun successTests(tc: ExplainTestCase) = runSuccessTest(tc)
 
+    @ArgumentsSource(SuccessTestProvider::class)
+    @ParameterizedTest
+    fun successTestsAsync(tc: ExplainTestCase) = runSuccessTestAsync(tc)
+
     private fun runSuccessTest(tc: ExplainTestCase) {
         val statement = compiler.compile(tc.query)
+        val result = statement.eval(tc.session)
+        assertEquals(tc.expected, result)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun runSuccessTestAsync(tc: ExplainTestCase) = runTest {
+        val statement = compilerAsync.compile(tc.query)
         val result = statement.eval(tc.session)
         assertEquals(tc.expected, result)
     }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/async/AsyncOperatorTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/async/AsyncOperatorTests.kt
@@ -1,0 +1,106 @@
+package org.partiql.lang.compiler.async
+
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.ionString
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
+import org.partiql.lang.compiler.PartiQLCompilerPipelineAsync
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.PartiQLResult
+import org.partiql.lang.eval.booleanValue
+import org.partiql.lang.eval.isNotUnknown
+import org.partiql.lang.eval.physical.operators.FilterRelationalOperatorFactoryAsync
+import org.partiql.lang.eval.physical.operators.RelationExpressionAsync
+import org.partiql.lang.eval.physical.operators.ValueExpressionAsync
+import org.partiql.lang.eval.relation.RelationType
+import org.partiql.lang.eval.relation.relation
+import org.partiql.lang.planner.litTrue
+import org.partiql.lang.planner.transforms.DEFAULT_IMPL
+import org.partiql.lang.planner.transforms.PLAN_VERSION_NUMBER
+
+private const val FAKE_IMPL_NAME = "test_async_fake"
+private val FAKE_IMPL_NODE = PartiqlPhysical.build { impl(FAKE_IMPL_NAME) }
+
+@OptIn(ExperimentalPartiQLCompilerPipeline::class)
+class AsyncOperatorTests {
+    private val fakeOperatorFactories = listOf(
+        object : FilterRelationalOperatorFactoryAsync(FAKE_IMPL_NAME) {
+            override fun create(
+                impl: PartiqlPhysical.Impl,
+                predicate: ValueExpressionAsync,
+                sourceBexpr: RelationExpressionAsync
+            ): RelationExpressionAsync = RelationExpressionAsync { state ->
+                // If `RelationExpression`'s `evaluate` was NOT a `suspend fun`, then `runBlocking` would be required
+//                runBlocking {
+                println("Calling")
+                someAsyncOp()
+//                }
+                val input = sourceBexpr.evaluateAsync(state)
+
+                relation(RelationType.BAG) {
+                    while (true) {
+                        if (!input.nextRow()) {
+                            break
+                        } else {
+                            val matches = predicate.invoke(state)
+                            if (matches.isNotUnknown() && matches.booleanValue()) {
+                                yield()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+    private suspend fun someAsyncOp() {
+        println("sleeping")
+        delay(2000L)
+        println("done sleeping")
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun compilePlan() = runTest {
+        val pipeline = PartiQLCompilerPipelineAsync.build {
+            compiler
+                .customOperatorFactories(
+                    fakeOperatorFactories.map { it }
+                )
+        }
+        val plan = PartiqlPhysical.build {
+            plan(
+                stmt = query(
+                    bindingsToValues(
+                        exp = lit(ionInt(42)),
+                        query = filter(
+                            i = FAKE_IMPL_NODE,
+                            predicate = litTrue(),
+                            source = scan(
+                                i = DEFAULT_IMPL,
+                                expr = bag(struct(listOf(structField(fieldName = lit(ionString("a")), value = lit(ionInt(1)))))),
+                                asDecl = varDecl(0)
+                            )
+                        )
+                    )
+                ),
+                version = PLAN_VERSION_NUMBER,
+                locals = listOf(localVariable("_1", 0))
+            )
+        }
+        val statement = pipeline.compile(plan)
+        repeat(10) { index ->
+            launch {
+                print("\nCompiling $index. ")
+                val result = statement.eval(EvaluationSession.standard()) as PartiQLResult.Value
+                println("About to print value; $index")
+                println(result.value)
+            }
+        }
+    }
+}

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/memorydb/QueryEngine.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/memorydb/QueryEngine.kt
@@ -39,7 +39,7 @@ internal const val DB_CONTEXT_VAR = "in-memory-database"
  */
 @OptIn(ExperimentalPartiQLCompilerPipeline::class)
 class QueryEngine(val db: MemoryDatabase) {
-    var enableDebugOutput = false
+    private var enableDebugOutput = false
 
     /** Given a [BindingName], inform the planner the unique identifier of the global variable (usually a table). */
     private val globalVariableResolver = GlobalVariableResolver { bindingName ->
@@ -63,7 +63,7 @@ class QueryEngine(val db: MemoryDatabase) {
                 // TODO: nothing in the planner uses the contentClosed property yet, but "technically" do have open
                 // content since nothing is constraining the fields in the table.
                 contentClosed = false,
-                // The FilterScanTokeyLookup pass does use this.
+                // The FilterScanToKeyLookup pass does use this.
                 primaryKeyFields = tableMetadata.primaryKeyFields
             )
         )

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/memorydb/QueryEngine.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/memorydb/QueryEngine.kt
@@ -4,7 +4,9 @@ import com.amazon.ionelement.api.toIonValue
 import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
 import org.partiql.lang.ION
 import org.partiql.lang.compiler.PartiQLCompilerPipeline
+import org.partiql.lang.compiler.PartiQLCompilerPipelineAsync
 import org.partiql.lang.compiler.memorydb.operators.GetByKeyProjectRelationalOperatorFactory
+import org.partiql.lang.compiler.memorydb.operators.GetByKeyProjectRelationalOperatorFactoryAsync
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.eval.BindingCase
 import org.partiql.lang.eval.BindingName
@@ -17,6 +19,7 @@ import org.partiql.lang.eval.namedValue
 import org.partiql.lang.planner.GlobalResolutionResult
 import org.partiql.lang.planner.GlobalVariableResolver
 import org.partiql.lang.planner.PartiQLPhysicalPass
+import org.partiql.lang.planner.PartiQLPlannerBuilder
 import org.partiql.lang.planner.StaticTypeResolver
 import org.partiql.lang.planner.transforms.optimizations.createConcatWindowFunctionPass
 import org.partiql.lang.planner.transforms.optimizations.createFilterScanToKeyLookupPass
@@ -92,75 +95,85 @@ class QueryEngine(val db: MemoryDatabase) {
         }
     }
 
-    private val compilerPipeline = PartiQLCompilerPipeline.build {
-        planner
-            .callback {
-                fun prettyPrint(label: String, data: Any) {
-                    val padding = 10
-                    when (data) {
-                        is DomainNode -> {
-                            println("$label:")
-                            val sexpElement = data.toIonElement()
-                            println(SexpAstPrettyPrinter.format(sexpElement.asAnyElement().toIonValue(ION)))
-                        }
-                        else ->
-                            println("$label:".padEnd(padding) + data.toString())
+    // session data
+    val session = EvaluationSession.build {
+        globals(bindings)
+        // Please note that the context here is immutable once the call to .build above
+        // returns, (Hopefully that will reduce the chances of it being abused.)
+        withContextVariable("in-memory-database", db)
+    }
+
+    private fun PartiQLPlannerBuilder.plannerBlock() = this
+        .callback {
+            fun prettyPrint(label: String, data: Any) {
+                val padding = 10
+                when (data) {
+                    is DomainNode -> {
+                        println("$label:")
+                        val sexpElement = data.toIonElement()
+                        println(SexpAstPrettyPrinter.format(sexpElement.asAnyElement().toIonValue(ION)))
                     }
-                }
-                if (this@QueryEngine.enableDebugOutput) {
-                    prettyPrint("event", it.eventName)
-                    prettyPrint("duration", it.duration)
-                    if (it.eventName == "parse_sql") prettyPrint("input", it.input)
-                    prettyPrint("output", it.output)
+                    else ->
+                        println("$label:".padEnd(padding) + data.toString())
                 }
             }
-            .globalVariableResolver(globalVariableResolver)
-            .physicalPlannerPasses(
-                listOf(
-                    // TODO: push-down filters on top of scans before this pass.
-                    PartiQLPhysicalPass { plan, problemHandler ->
-                        createFilterScanToKeyLookupPass(
-                            customProjectOperatorName = GET_BY_KEY_PROJECT_IMPL_NAME,
-                            staticTypeResolver = staticTypeResolver,
-                            createKeyValueConstructor = { recordType, keyFieldEqualityPredicates ->
-                                require(recordType.primaryKeyFields.size == keyFieldEqualityPredicates.size)
-                                PartiqlPhysical.build {
-                                    list(
-                                        // Key values are expressed to the in-memory storage engine as ordered list. Therefore, we need
-                                        // to ensure that the list we pass in as an argument to the custom_get_by_key project operator
-                                        // impl is in the right order.
-                                        recordType.primaryKeyFields.map { keyFieldName ->
-                                            keyFieldEqualityPredicates.single { it.keyFieldName == keyFieldName }.equivalentValue
-                                        }
-                                    )
-                                }
+            if (this@QueryEngine.enableDebugOutput) {
+                prettyPrint("event", it.eventName)
+                prettyPrint("duration", it.duration)
+                if (it.eventName == "parse_sql") prettyPrint("input", it.input)
+                prettyPrint("output", it.output)
+            }
+        }
+        .globalVariableResolver(globalVariableResolver)
+        .physicalPlannerPasses(
+            listOf(
+                // TODO: push-down filters on top of scans before this pass.
+                PartiQLPhysicalPass { plan, problemHandler ->
+                    createFilterScanToKeyLookupPass(
+                        customProjectOperatorName = GET_BY_KEY_PROJECT_IMPL_NAME,
+                        staticTypeResolver = staticTypeResolver,
+                        createKeyValueConstructor = { recordType, keyFieldEqualityPredicates ->
+                            require(recordType.primaryKeyFields.size == keyFieldEqualityPredicates.size)
+                            PartiqlPhysical.build {
+                                list(
+                                    // Key values are expressed to the in-memory storage engine as ordered list. Therefore, we need
+                                    // to ensure that the list we pass in as an argument to the custom_get_by_key project operator
+                                    // impl is in the right order.
+                                    recordType.primaryKeyFields.map { keyFieldName ->
+                                        keyFieldEqualityPredicates.single { it.keyFieldName == keyFieldName }.equivalentValue
+                                    }
+                                )
                             }
-                        ).apply(plan, problemHandler)
-                    },
-                    // Note that the order of the following plans is relevant--the "remove useless filters" pass
-                    // will not work correctly if "remove useless ands" pass is not executed first.
+                        }
+                    ).apply(plan, problemHandler)
+                },
+                // Note that the order of the following plans is relevant--the "remove useless filters" pass
+                // will not work correctly if "remove useless ands" pass is not executed first.
 
-                    // After the filter-scan-to-key-lookup pass above, we may be left with some `(and ...)` expressions
-                    // whose operands were replaced with `(lit true)`. This pass removes `(lit true)` operands from `and`
-                    // expressions, and replaces any `and` expressions with only `(lit true)` operands with `(lit true)`.
-                    // This happens recursively, so an entire tree of useless `(and ...)` expressions will be replaced
-                    // with a single `(lit true)`.
-                    // A constant folding pass might one day eliminate the need for this, but that is not within the current scope.
-                    PartiQLPhysicalPass { plan, problemHandler ->
-                        createRemoveUselessAndsPass().apply(plan, problemHandler)
-                    },
+                // After the filter-scan-to-key-lookup pass above, we may be left with some `(and ...)` expressions
+                // whose operands were replaced with `(lit true)`. This pass removes `(lit true)` operands from `and`
+                // expressions, and replaces any `and` expressions with only `(lit true)` operands with `(lit true)`.
+                // This happens recursively, so an entire tree of useless `(and ...)` expressions will be replaced
+                // with a single `(lit true)`.
+                // A constant folding pass might one day eliminate the need for this, but that is not within the current scope.
+                PartiQLPhysicalPass { plan, problemHandler ->
+                    createRemoveUselessAndsPass().apply(plan, problemHandler)
+                },
 
-                    // After the previous pass, we may have some `(filter ... )` nodes with `(lit true)` as a predicate.
-                    // This pass removes these useless filter nodes.
-                    PartiQLPhysicalPass { plan, problemHandler ->
-                        createRemoveUselessFiltersPass().apply(plan, problemHandler)
-                    },
+                // After the previous pass, we may have some `(filter ... )` nodes with `(lit true)` as a predicate.
+                // This pass removes these useless filter nodes.
+                PartiQLPhysicalPass { plan, problemHandler ->
+                    createRemoveUselessFiltersPass().apply(plan, problemHandler)
+                },
 
-                    PartiQLPhysicalPass { plan, problemHandler ->
-                        createConcatWindowFunctionPass().apply(plan, problemHandler)
-                    },
-                )
+                PartiQLPhysicalPass { plan, problemHandler ->
+                    createConcatWindowFunctionPass().apply(plan, problemHandler)
+                },
             )
+        )
+
+    private val compilerPipeline = PartiQLCompilerPipeline.build {
+        planner.plannerBlock()
         compiler
             .customOperatorFactories(
                 listOf(
@@ -169,23 +182,38 @@ class QueryEngine(val db: MemoryDatabase) {
             )
     }
 
+    private val compilerPipelineAsync = PartiQLCompilerPipelineAsync.build {
+        planner.plannerBlock()
+        compiler
+            .customOperatorFactories(
+                listOf(
+                    GetByKeyProjectRelationalOperatorFactoryAsync() // using async version here
+                )
+            )
+    }
+
     fun executeQuery(sql: String): ExprValue {
-
-        // session data
-        val session = EvaluationSession.build {
-            globals(bindings)
-            // Please note that the context here is immutable once the call to .build above
-            // returns, (Hopefully that will reduce the chances of it being abused.)
-            withContextVariable("in-memory-database", db)
-        }
-
         // compile query to statement
         val statement = compilerPipeline.compile(sql)
 
         // First step is to plan the query.
         // This parses the query and runs it through all the planner passes:
         // AST -> logical plan -> resolved logical plan -> default physical plan -> custom physical plan
-        return when (val result = statement.eval(session)) {
+        return convertResultToExprValue(statement.eval(session))
+    }
+
+    suspend fun executeQueryAsync(sql: String): ExprValue {
+        // compile query to statement
+        val statement = compilerPipelineAsync.compile(sql)
+
+        // First step is to plan the query.
+        // This parses the query and runs it through all the planner passes:
+        // AST -> logical plan -> resolved logical plan -> default physical plan -> custom physical plan
+        return convertResultToExprValue(statement.eval(session))
+    }
+
+    private fun convertResultToExprValue(result: PartiQLResult): ExprValue =
+        when (result) {
             is PartiQLResult.Value -> result.value
             is PartiQLResult.Delete -> {
                 val targetTableId = UUID.fromString(result.target)
@@ -220,5 +248,4 @@ class QueryEngine(val db: MemoryDatabase) {
             is PartiQLResult.Replace -> TODO("Not implemented yet")
             is PartiQLResult.Explain.Domain -> TODO("Not implemented yet")
         }
-    }
 }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/memorydb/operators/GetByKeyProjectRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/memorydb/operators/GetByKeyProjectRelationalOperatorFactoryAsync.kt
@@ -54,7 +54,7 @@ class GetByKeyProjectRelationalOperatorFactoryAsync : ProjectRelationalOperatorF
         // Extract the key value constructor
         val keyValueExpressionAsync = args.single()
 
-        // Parse the tableId so we don't have to at evaluation-time
+        // Parse the tableId, so we don't have to at evaluation-time
         val tableId = UUID.fromString(impl.staticArgs.single().textValue)
 
         var exhausted = false

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/memorydb/operators/GetByKeyProjectRelationalOperatorFactoryAsync.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/memorydb/operators/GetByKeyProjectRelationalOperatorFactoryAsync.kt
@@ -1,0 +1,108 @@
+package org.partiql.lang.compiler.memorydb.operators
+
+import org.partiql.lang.compiler.memorydb.DB_CONTEXT_VAR
+import org.partiql.lang.compiler.memorydb.GET_BY_KEY_PROJECT_IMPL_NAME
+import org.partiql.lang.compiler.memorydb.MemoryDatabase
+import org.partiql.lang.domains.PartiqlPhysical
+import org.partiql.lang.eval.physical.SetVariableFunc
+import org.partiql.lang.eval.physical.operators.ProjectRelationalOperatorFactoryAsync
+import org.partiql.lang.eval.physical.operators.RelationExpressionAsync
+import org.partiql.lang.eval.physical.operators.ValueExpressionAsync
+import org.partiql.lang.eval.relation.RelationIterator
+import org.partiql.lang.eval.relation.RelationScope
+import org.partiql.lang.eval.relation.RelationType
+import org.partiql.lang.eval.relation.relation
+import java.util.UUID
+
+/**
+ * A `project` operator implementation that performs a lookup of a single record stored in a [MemoryDatabase] given its
+ * primary key.
+ *
+ * Operator implementations comprise two phases:
+ *
+ * - A compile phase, where one-time computation can be performed and stored in a [RelationExpressionAsync], which
+ * is essentially a closure.
+ *- An evaluation phase, where the closure is invoked. The closure returns a [RelationIterator], which is a
+ * coroutine created by the [relation] function.
+ *
+ * In general, the `project` operator implementations must fetch the next row from the data store, call the provided
+ * [SetVariableFunc] to set the variable, and then call [RelationScope.yield].
+ */
+
+class GetByKeyProjectRelationalOperatorFactoryAsync : ProjectRelationalOperatorFactoryAsync(GET_BY_KEY_PROJECT_IMPL_NAME) {
+    /**
+     * This function is called at compile-time to create an instance of the operator [RelationExpressionAsync]
+     * that will be invoked at evaluation-time.
+     */
+    override fun create(
+        impl: PartiqlPhysical.Impl,
+        setVar: SetVariableFunc,
+        args: List<ValueExpressionAsync>
+    ): RelationExpressionAsync {
+        // Compile phase starts here.  We should do as much pre-computation as possible to avoid repeating during the
+        // evaluation phase.
+
+        // Sanity check the static and dynamic arguments of this operator. If either of these checks fail, it would
+        // indicate a bug in the rewrite which created this (project ...) operator.
+        require(impl.staticArgs.size == 1) {
+            "Expected one static argument to $GET_BY_KEY_PROJECT_IMPL_NAME but found ${args.size}"
+        }
+        require(args.size == 1) {
+            "Expected one argument to $GET_BY_KEY_PROJECT_IMPL_NAME but found ${args.size}"
+        }
+
+        // Extract the key value constructor
+        val keyValueExpressionAsync = args.single()
+
+        // Parse the tableId so we don't have to at evaluation-time
+        val tableId = UUID.fromString(impl.staticArgs.single().textValue)
+
+        var exhausted = false
+
+        // Finally, return a RelationExpressionAsync which evaluates the key value expression and returns a
+        // RelationIterator containing a single row corresponding to the key (or no rows if nothing matches)
+        return RelationExpressionAsync { state ->
+            // this code runs at evaluation-time.
+
+            if (exhausted) {
+                throw IllegalStateException("Exhausted result set")
+            }
+
+            // Get the current database from the EvaluationSession context.
+            // Please note that the state.session.context map is immutable, therefore it is not possible
+            // for custom operators or functions to put stuff in there. (Hopefully that will reduce the
+            // chances of it being abused.)
+            val db = state.session.context[DB_CONTEXT_VAR] as MemoryDatabase
+
+            // Compute the value of the key using the keyValueExpressionAsync
+            val keyValue = keyValueExpressionAsync.invoke(state)
+
+            // get the record requested.
+            val record = db.getRecordByKey(tableId, keyValue)
+
+            exhausted = true
+
+            // if the record was not found, return an empty relation:
+            if (record == null)
+                relation(RelationType.BAG) {
+                    // this relation is empty because there is no call to yield()
+                }
+            else {
+                // Return the relation which is Kotlin-coroutine that simply projects the single record we
+                // found above into the one variable allowed by the project operator, yields, and then returns.
+                relation(RelationType.BAG) {
+                    // `state` is sacrosanct and should not be modified outside PartiQL.  PartiQL
+                    // provides the setVar function so that embedders can safely set the value of the
+                    // variable from within the relation without clobbering anything else.
+                    // It is important to call setVar *before* the yield since otherwise the value
+                    // of the variable will not be assigned before it is accessed.
+                    setVar(state, record)
+                    yield()
+
+                    // also note that in this case there is only one record--to return multiple records we would
+                    // iterate over each record normally, calling `setVar` and `yield` once for each record.
+                }
+            }
+        }
+    }
+}

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/operators/CustomOperatorFactoryTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/operators/CustomOperatorFactoryTests.kt
@@ -1,6 +1,7 @@
 package org.partiql.lang.compiler.operators
 
 import com.amazon.ionelement.api.ionBool
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
@@ -186,6 +187,7 @@ class CustomOperatorFactoryTests {
         assertEquals(tc.expectedThrownFromOperator, ex.thrownFromOperator)
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @ParameterizedTest
     @ArgumentsSource(CustomOperatorCases::class)
     fun `make sure custom async operator implementations are called`(tc: CustomOperatorCases.TestCase) = runTest {
@@ -207,7 +209,7 @@ class CustomOperatorFactoryTests {
         class TestCase(val expectedThrownFromOperator: RelationalOperatorKind, val plan: PartiqlPhysical.Plan)
         override fun getParameters() = listOf(
             // The key parts of the cases below are the setting of FAKE_IMPL_NODE which causes the custom operator
-            // factories to be called.  The rest is the minimum gibberish needed to make complete PartiqlPhsyical.Bexpr
+            // factories to be called.  The rest is the minimum gibberish needed to make complete PartiqlPhysical.Bexpr
             // nodes.  There must only be one FAKE_IMPL_NODE per plan otherwise the CreateFunctionWasCalledException
             // might be called for an operator other than the one intended.
             createTestCase(RelationalOperatorKind.PROJECT) { project(FAKE_IMPL_NODE, varDecl(0)) },

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/operators/CustomOperatorFactoryTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/compiler/operators/CustomOperatorFactoryTests.kt
@@ -1,26 +1,38 @@
 package org.partiql.lang.compiler.operators
 
 import com.amazon.ionelement.api.ionBool
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
 import org.partiql.lang.compiler.PartiQLCompilerPipeline
+import org.partiql.lang.compiler.PartiQLCompilerPipelineAsync
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.eval.physical.EvaluatorState
 import org.partiql.lang.eval.physical.SetVariableFunc
 import org.partiql.lang.eval.physical.VariableBinding
+import org.partiql.lang.eval.physical.VariableBindingAsync
 import org.partiql.lang.eval.physical.operators.FilterRelationalOperatorFactory
+import org.partiql.lang.eval.physical.operators.FilterRelationalOperatorFactoryAsync
 import org.partiql.lang.eval.physical.operators.JoinRelationalOperatorFactory
+import org.partiql.lang.eval.physical.operators.JoinRelationalOperatorFactoryAsync
 import org.partiql.lang.eval.physical.operators.LetRelationalOperatorFactory
+import org.partiql.lang.eval.physical.operators.LetRelationalOperatorFactoryAsync
 import org.partiql.lang.eval.physical.operators.LimitRelationalOperatorFactory
+import org.partiql.lang.eval.physical.operators.LimitRelationalOperatorFactoryAsync
 import org.partiql.lang.eval.physical.operators.OffsetRelationalOperatorFactory
+import org.partiql.lang.eval.physical.operators.OffsetRelationalOperatorFactoryAsync
 import org.partiql.lang.eval.physical.operators.ProjectRelationalOperatorFactory
+import org.partiql.lang.eval.physical.operators.ProjectRelationalOperatorFactoryAsync
 import org.partiql.lang.eval.physical.operators.RelationExpression
+import org.partiql.lang.eval.physical.operators.RelationExpressionAsync
 import org.partiql.lang.eval.physical.operators.RelationalOperatorKind
 import org.partiql.lang.eval.physical.operators.ScanRelationalOperatorFactory
+import org.partiql.lang.eval.physical.operators.ScanRelationalOperatorFactoryAsync
 import org.partiql.lang.eval.physical.operators.ValueExpression
+import org.partiql.lang.eval.physical.operators.ValueExpressionAsync
 import org.partiql.lang.planner.transforms.DEFAULT_IMPL
 import org.partiql.lang.planner.transforms.PLAN_VERSION_NUMBER
 import org.partiql.lang.util.ArgumentsProviderBase
@@ -96,6 +108,67 @@ class CustomOperatorFactoryTests {
         }
     )
 
+    private val fakeAsyncOperatorFactories = listOf(
+        object : ProjectRelationalOperatorFactoryAsync(FAKE_IMPL_NAME) {
+            override fun create(
+                impl: PartiqlPhysical.Impl,
+                setVar: SetVariableFunc,
+                args: List<ValueExpressionAsync>
+            ): RelationExpressionAsync =
+                throw CreateFunctionWasCalledException(RelationalOperatorKind.PROJECT)
+        },
+        object : ScanRelationalOperatorFactoryAsync(FAKE_IMPL_NAME) {
+            override fun create(
+                impl: PartiqlPhysical.Impl,
+                expr: ValueExpressionAsync,
+                setAsVar: SetVariableFunc,
+                setAtVar: SetVariableFunc?,
+                setByVar: SetVariableFunc?
+            ): RelationExpressionAsync =
+                throw CreateFunctionWasCalledException(RelationalOperatorKind.SCAN)
+        },
+        object : FilterRelationalOperatorFactoryAsync(FAKE_IMPL_NAME) {
+            override fun create(impl: PartiqlPhysical.Impl, predicate: ValueExpressionAsync, sourceBexpr: RelationExpressionAsync) =
+                throw CreateFunctionWasCalledException(RelationalOperatorKind.FILTER)
+        },
+        object : JoinRelationalOperatorFactoryAsync(FAKE_IMPL_NAME) {
+            override fun create(
+                impl: PartiqlPhysical.Impl,
+                joinType: PartiqlPhysical.JoinType,
+                leftBexpr: RelationExpressionAsync,
+                rightBexpr: RelationExpressionAsync,
+                predicateExpr: ValueExpressionAsync?,
+                setLeftSideVariablesToNull: (EvaluatorState) -> Unit,
+                setRightSideVariablesToNull: (EvaluatorState) -> Unit
+            ): RelationExpressionAsync =
+                throw CreateFunctionWasCalledException(RelationalOperatorKind.JOIN)
+        },
+        object : OffsetRelationalOperatorFactoryAsync(FAKE_IMPL_NAME) {
+            override fun create(
+                impl: PartiqlPhysical.Impl,
+                rowCountExpr: ValueExpressionAsync,
+                sourceBexpr: RelationExpressionAsync
+            ): RelationExpressionAsync =
+                throw CreateFunctionWasCalledException(RelationalOperatorKind.OFFSET)
+        },
+        object : LimitRelationalOperatorFactoryAsync(FAKE_IMPL_NAME) {
+            override fun create(
+                impl: PartiqlPhysical.Impl,
+                rowCountExpr: ValueExpressionAsync,
+                sourceBexpr: RelationExpressionAsync
+            ): RelationExpressionAsync =
+                throw CreateFunctionWasCalledException(RelationalOperatorKind.LIMIT)
+        },
+        object : LetRelationalOperatorFactoryAsync(FAKE_IMPL_NAME) {
+            override fun create(
+                impl: PartiqlPhysical.Impl,
+                sourceBexpr: RelationExpressionAsync,
+                bindings: List<VariableBindingAsync>
+            ) =
+                throw CreateFunctionWasCalledException(RelationalOperatorKind.LET)
+        }
+    )
+
     @ParameterizedTest
     @ArgumentsSource(CustomOperatorCases::class)
     fun `make sure custom operator implementations are called`(tc: CustomOperatorCases.TestCase) {
@@ -103,6 +176,23 @@ class CustomOperatorFactoryTests {
             compiler
                 .customOperatorFactories(
                     fakeOperatorFactories.map {
+                        it
+                    }
+                )
+        }
+        val ex = assertThrows<CreateFunctionWasCalledException> {
+            pipeline.compile(tc.plan)
+        }
+        assertEquals(tc.expectedThrownFromOperator, ex.thrownFromOperator)
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(CustomOperatorCases::class)
+    fun `make sure custom async operator implementations are called`(tc: CustomOperatorCases.TestCase) = runTest {
+        val pipeline = PartiQLCompilerPipelineAsync.build {
+            compiler
+                .customOperatorFactories(
+                    fakeAsyncOperatorFactories.map {
                         it
                     }
                 )

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerCollectionAggregationsTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerCollectionAggregationsTest.kt
@@ -52,9 +52,23 @@ internal class EvaluatingCompilerCollectionAggregationsTest : EvaluatorTestBase(
     }
 
     @ParameterizedTest
+    @ArgumentsSource(ValidTestArguments::class)
+    fun validTestsAsync(tc: EvaluatorTestCase) {
+        val newTc = tc.copy(targetPipeline = EvaluatorTestTarget.PARTIQL_PIPELINE_ASYNC)
+        runEvaluatorTestCase(newTc, SESSION)
+    }
+
+    @ParameterizedTest
     @ArgumentsSource(ErrorTestArguments::class)
     fun errorTests(tc: EvaluatorErrorTestCase) {
         val newTc = tc.copy(targetPipeline = EvaluatorTestTarget.PARTIQL_PIPELINE)
+        runEvaluatorErrorTestCase(newTc, SESSION)
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ErrorTestArguments::class)
+    fun errorTestsAsync(tc: EvaluatorErrorTestCase) {
+        val newTc = tc.copy(targetPipeline = EvaluatorTestTarget.PARTIQL_PIPELINE_ASYNC)
         runEvaluatorErrorTestCase(newTc, SESSION)
     }
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerFromLetTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerFromLetTests.kt
@@ -73,6 +73,11 @@ class EvaluatingCompilerFromLetTests : EvaluatorTestBase() {
                 """<< { 'id': 1 }>>""",
                 target = EvaluatorTestTarget.PARTIQL_PIPELINE
             ),
+            EvaluatorTestCase(
+                "SELECT * FROM A LET 100 AS A",
+                """<< { 'id': 1 }>>""",
+                target = EvaluatorTestTarget.PARTIQL_PIPELINE_ASYNC
+            ),
 
             // LET using other variables
             EvaluatorTestCase(

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatorTestBase.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatorTestBase.kt
@@ -30,6 +30,7 @@ import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestTarget
 import org.partiql.lang.eval.evaluatortestframework.ExpectedResultFormat
 import org.partiql.lang.eval.evaluatortestframework.MultipleTestAdapter
 import org.partiql.lang.eval.evaluatortestframework.PartiQLCompilerPipelineFactory
+import org.partiql.lang.eval.evaluatortestframework.PartiQLCompilerPipelineFactoryAsync
 import org.partiql.lang.eval.evaluatortestframework.PipelineEvaluatorTestAdapter
 import org.partiql.lang.eval.evaluatortestframework.VisitorTransformBaseTestAdapter
 import org.partiql.lang.graph.ExternalGraphReader
@@ -45,6 +46,7 @@ abstract class EvaluatorTestBase : TestBase() {
         listOf(
             PipelineEvaluatorTestAdapter(CompilerPipelineFactory()),
             PipelineEvaluatorTestAdapter(PartiQLCompilerPipelineFactory()),
+            PipelineEvaluatorTestAdapter(PartiQLCompilerPipelineFactoryAsync()),
             VisitorTransformBaseTestAdapter()
         )
     )

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatorTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatorTests.kt
@@ -114,4 +114,8 @@ class EvaluatorTests {
     @ParameterizedTest
     @MethodSource("planEvaluatorTests")
     fun planEvaluatorTests(tc: IonResultTestCase) = tc.runTestCase(mockDb, EvaluatorTestTarget.PARTIQL_PIPELINE)
+
+    @ParameterizedTest
+    @MethodSource("planEvaluatorTests")
+    fun planEvaluatorTestsAsync(tc: IonResultTestCase) = tc.runTestCase(mockDb, EvaluatorTestTarget.PARTIQL_PIPELINE_ASYNC)
 }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/DynamicLookupExprFunctionTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/functions/DynamicLookupExprFunctionTest.kt
@@ -111,7 +111,7 @@ class DynamicLookupExprFunctionTest : EvaluatorTestBase() {
 
     class MismatchCaseSensitiveCases : ArgumentsProviderBase() {
         override fun getParameters(): List<Any> = listOf(
-            // Can't find these variables due to case mismatch when perform case sensitive lookup
+            // Can't find these variables due to case mismatch when perform case-sensitive lookup
             EvaluatorErrorTestCase(
                 query = "\"$DYNAMIC_LOOKUP_FUNCTION_NAME\"(`fOo`, `case_sensitive`, `locals_then_globals`, [f, b])",
                 expectedErrorCode = ErrorCode.EVALUATOR_QUOTED_BINDING_DOES_NOT_EXIST,

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/windowFunctions/WindowFunctionTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/builtins/windowFunctions/WindowFunctionTests.kt
@@ -25,6 +25,14 @@ class WindowFunctionTests : EvaluatorTestBase() {
         tc = tc.copy(targetPipeline = EvaluatorTestTarget.PARTIQL_PIPELINE),
         session = session
     )
+
+    @ParameterizedTest
+    @ArgumentsSource(LagFunctionTestsProvider::class)
+    fun lagFunctionTestsAsync(tc: EvaluatorTestCase) = runEvaluatorTestCase(
+        tc = tc.copy(targetPipeline = EvaluatorTestTarget.PARTIQL_PIPELINE_ASYNC),
+        session = session
+    )
+
     class LagFunctionTestsProvider : ArgumentsProviderBase() {
         override fun getParameters() = listOf(
             // Lag Function with PARTITION BY AND ORDER BY
@@ -205,6 +213,13 @@ class WindowFunctionTests : EvaluatorTestBase() {
         session = session
     )
 
+    @ParameterizedTest
+    @ArgumentsSource(LeadFunctionTestsProvider::class)
+    fun leadFunctionTestsAsync(tc: EvaluatorTestCase) = runEvaluatorTestCase(
+        tc = tc.copy(targetPipeline = EvaluatorTestTarget.PARTIQL_PIPELINE_ASYNC),
+        session = session
+    )
+
     class LeadFunctionTestsProvider : ArgumentsProviderBase() {
         override fun getParameters() = listOf(
             EvaluatorTestCase(
@@ -378,6 +393,14 @@ class WindowFunctionTests : EvaluatorTestBase() {
         tc = tc.copy(targetPipeline = EvaluatorTestTarget.PARTIQL_PIPELINE),
         session = session,
     )
+
+    @ParameterizedTest
+    @ArgumentsSource(MultipleFunctionTestsProvider::class)
+    fun multipleFunctionTestsAsync(tc: EvaluatorTestCase) = runEvaluatorTestCase(
+        tc = tc.copy(targetPipeline = EvaluatorTestTarget.PARTIQL_PIPELINE_ASYNC),
+        session = session,
+    )
+
     class MultipleFunctionTestsProvider : ArgumentsProviderBase() {
         override fun getParameters() = listOf(
             EvaluatorTestCase(

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/AbstractPipeline.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/AbstractPipeline.kt
@@ -4,8 +4,9 @@ import org.partiql.lang.eval.ExprValue
 import org.partiql.lang.eval.TypingMode
 
 /**
- * Represents an abstract pipeline (either [org.partiql.lang.CompilerPipeline] or
- * [org.partiql.lang.compiler.PartiQLCompilerPipeline]) so that [PipelineEvaluatorTestAdapter] can work with either.
+ * Represents an abstract pipeline (one of [org.partiql.lang.CompilerPipeline],
+ * [org.partiql.lang.compiler.PartiQLCompilerPipeline], or [org.partiql.lang.compiler.PartiQLCompilerPipelineAsync])
+ * so that [PipelineEvaluatorTestAdapter] can work on any of them.
  *
  * Includes only those properties and methods that are required for testing purposes.
  */

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/EvaluatorErrorTestCase.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/EvaluatorErrorTestCase.kt
@@ -5,6 +5,7 @@ import org.partiql.errors.PropertyValueMap
 import org.partiql.lang.CompilerPipeline
 import org.partiql.lang.SqlException
 import org.partiql.lang.compiler.PartiQLCompilerPipeline
+import org.partiql.lang.compiler.PartiQLCompilerPipelineAsync
 import org.partiql.lang.eval.CompileOptions
 
 /**
@@ -56,8 +57,8 @@ data class EvaluatorErrorTestCase(
     val additionalExceptionAssertBlock: (SqlException) -> Unit = { },
 
     /**
-     * Determines which pipeline this test should run against; the [CompilerPipeline],
-     * [PartiQLCompilerPipeline] or both.
+     * Determines which pipeline this test should run against; the [CompilerPipeline], [PartiQLCompilerPipeline],
+     * [PartiQLCompilerPipelineAsync], or all of them.
      */
     override val targetPipeline: EvaluatorTestTarget = EvaluatorTestTarget.ALL_PIPELINES,
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestCase.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestCase.kt
@@ -1,6 +1,8 @@
 package org.partiql.lang.eval.evaluatortestframework
 
 import org.partiql.lang.CompilerPipeline
+import org.partiql.lang.compiler.PartiQLCompilerPipeline
+import org.partiql.lang.compiler.PartiQLCompilerPipelineAsync
 import org.partiql.lang.eval.CompileOptions
 import org.partiql.lang.eval.ExprValue
 
@@ -55,8 +57,8 @@ data class EvaluatorTestCase(
     override val implicitPermissiveModeTest: Boolean = true,
 
     /**
-     * Determines which pipeline this test should run against; the [CompilerPipeline],
-     * [org.partiql.lang.compiler.PartiQLCompilerPipeline] or both.
+     * Determines which pipeline this test should run against; the [CompilerPipeline], [PartiQLCompilerPipeline],
+     * [PartiQLCompilerPipelineAsync], or all of them.
      */
     override val targetPipeline: EvaluatorTestTarget = EvaluatorTestTarget.ALL_PIPELINES,
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestDefinition.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestDefinition.kt
@@ -1,6 +1,8 @@
 package org.partiql.lang.eval.evaluatortestframework
 
 import org.partiql.lang.CompilerPipeline
+import org.partiql.lang.compiler.PartiQLCompilerPipeline
+import org.partiql.lang.compiler.PartiQLCompilerPipelineAsync
 import org.partiql.lang.eval.CompileOptions
 
 /**
@@ -32,8 +34,8 @@ interface EvaluatorTestDefinition {
     val implicitPermissiveModeTest: Boolean
 
     /**
-     * Determines which pipeline this test should run against; the [CompilerPipeline],
-     * [org.partiql.lang.compiler.PartiQLCompilerPipeline] or both.
+     * Determines which pipeline this test should run against; the [CompilerPipeline], [PartiQLCompilerPipeline],
+     * [PartiQLCompilerPipelineAsync], or all of them.
      */
     val targetPipeline: EvaluatorTestTarget
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestTarget.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestTarget.kt
@@ -23,4 +23,9 @@ enum class EvaluatorTestTarget {
      * supported by [org.partiql.lang.CompilerPipeline], or when testing features unique to the former.
      */
     PARTIQL_PIPELINE,
+
+    /**
+     * TODO ALAN
+     */
+    PARTIQL_PIPELINE_ASYNC
 }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestTarget.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/EvaluatorTestTarget.kt
@@ -21,11 +21,17 @@ enum class EvaluatorTestTarget {
     /**
      * Run the test on [org.partiql.lang.compiler.PartiQLCompilerPipeline]. Set this when the test case covers features not
      * supported by [org.partiql.lang.CompilerPipeline], or when testing features unique to the former.
+     *
+     * Since [org.partiql.lang.compiler.PartiQLCompilerPipeline] is deprecated and will be removed in favor of
+     * [org.partiql.lang.compiler.PartiQLCompilerPipelineAsync], opt to use [PARTIQL_PIPELINE_ASYNC] or [ALL_PIPELINES].
      */
     PARTIQL_PIPELINE,
 
     /**
-     * TODO ALAN
+     * Run the test on [org.partiql.lang.compiler.PartiQLCompilerPipelineAsync]. Set this when the test case covers
+     * features not supported by [org.partiql.lang.CompilerPipeline], or when testing features unique to the former.
+     *
+     * This is the async version of [PARTIQL_PIPELINE].
      */
     PARTIQL_PIPELINE_ASYNC
 }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactoryAsync.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactoryAsync.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertNull
  * TODO delete this once evaluator tests are replaced by `partiql-tests`
  */
 @OptIn(ExperimentalPartiQLCompilerPipeline::class)
-internal class PartiQLCompilerPipelineFactoryAsync() : PipelineFactory {
+internal class PartiQLCompilerPipelineFactoryAsync : PipelineFactory {
 
     override val pipelineName: String = "PartiQLCompilerPipelineAsync"
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactoryAsync.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PartiQLCompilerPipelineFactoryAsync.kt
@@ -1,0 +1,108 @@
+package org.partiql.lang.eval.evaluatortestframework
+
+import kotlinx.coroutines.runBlocking
+import org.partiql.annotations.ExperimentalPartiQLCompilerPipeline
+import org.partiql.lang.compiler.PartiQLCompilerAsyncBuilder
+import org.partiql.lang.compiler.PartiQLCompilerPipelineAsync
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.lang.eval.ExprValue
+import org.partiql.lang.eval.PartiQLResult
+import org.partiql.lang.eval.TypingMode
+import org.partiql.lang.eval.UndefinedVariableBehavior
+import org.partiql.lang.planner.EvaluatorOptions
+import org.partiql.lang.planner.GlobalResolutionResult
+import org.partiql.lang.planner.GlobalVariableResolver
+import org.partiql.lang.planner.PartiQLPlanner
+import org.partiql.lang.planner.PartiQLPlannerBuilder
+import org.partiql.lang.syntax.PartiQLParserBuilder
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+/**
+ * TODO delete this once evaluator tests are replaced by `partiql-tests`
+ */
+@OptIn(ExperimentalPartiQLCompilerPipeline::class)
+internal class PartiQLCompilerPipelineFactoryAsync() : PipelineFactory {
+
+    override val pipelineName: String = "PartiQLCompilerPipelineAsync"
+
+    override val target: EvaluatorTestTarget = EvaluatorTestTarget.PARTIQL_PIPELINE_ASYNC
+
+    override fun createPipeline(
+        evaluatorTestDefinition: EvaluatorTestDefinition,
+        session: EvaluationSession,
+        forcePermissiveMode: Boolean
+    ): AbstractPipeline {
+
+        // Construct a legacy CompilerPipeline
+        val legacyPipeline = evaluatorTestDefinition.createCompilerPipeline(forcePermissiveMode)
+        val co = legacyPipeline.compileOptions
+
+        assertNotEquals(
+            co.undefinedVariable, UndefinedVariableBehavior.MISSING,
+            "The planner and physical plan evaluator do not support UndefinedVariableBehavior.MISSING. " +
+                "Please set target = EvaluatorTestTarget.COMPILER_PIPELINE for this test.\n" +
+                "Test groupName: ${evaluatorTestDefinition.groupName}"
+        )
+
+        assertNull(
+            legacyPipeline.globalTypeBindings,
+            "The planner and evaluator do not currently support globalTypeBindings" +
+                "Please set target = EvaluatorTestTarget.COMPILER_PIPELINE for this test."
+        )
+
+        val evaluatorOptions = EvaluatorOptions.build {
+            typingMode(co.typingMode)
+            thunkOptions(co.thunkOptions)
+            defaultTimezoneOffset(co.defaultTimezoneOffset)
+            typedOpBehavior(co.typedOpBehavior)
+            projectionIteration(co.projectionIteration)
+        }
+
+        val globalVariableResolver = GlobalVariableResolver {
+            val value = session.globals[it]
+            if (value != null) {
+                GlobalResolutionResult.GlobalVariable(it.name)
+            } else {
+                GlobalResolutionResult.Undefined
+            }
+        }
+
+        val plannerOptions = PartiQLPlanner.Options(
+            allowedUndefinedVariables = true,
+            typedOpBehavior = evaluatorOptions.typedOpBehavior
+        )
+
+        val pipeline = PartiQLCompilerPipelineAsync(
+            parser = PartiQLParserBuilder().customTypes(legacyPipeline.customDataTypes).build(),
+            planner = PartiQLPlannerBuilder.standard()
+                .options(plannerOptions)
+                .globalVariableResolver(globalVariableResolver)
+                .build(),
+            compiler = PartiQLCompilerAsyncBuilder.standard()
+                .options(evaluatorOptions)
+                .customTypes(legacyPipeline.customDataTypes)
+                .customFunctions(legacyPipeline.functions.values.toList())
+                .customProcedures(legacyPipeline.procedures.values.toList())
+                .build()
+        )
+
+        return object : AbstractPipeline {
+
+            override val typingMode: TypingMode = evaluatorOptions.typingMode
+
+            override fun evaluate(query: String): ExprValue {
+                return runBlocking {
+                    val statement = pipeline.compile(query)
+                    when (val result = statement.eval(session)) {
+                        is PartiQLResult.Delete,
+                        is PartiQLResult.Insert,
+                        is PartiQLResult.Replace -> error("DML is not supported by test suite")
+                        is PartiQLResult.Value -> result.value
+                        is PartiQLResult.Explain -> error("EXPLAIN is not supported by test suite")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PipelineFactory.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/evaluatortestframework/PipelineFactory.kt
@@ -4,8 +4,8 @@ import org.partiql.lang.eval.EvaluationSession
 
 /**
  * The implementation of this interface is passed to the constructor of [PipelineEvaluatorTestAdapter].  Determines
- * which pipeline (either [org.partiql.lang.CompilerPipeline] or [org.partiql.lang.compiler.PartiQLCompilerPipeline]) will be
- * tested.
+ * which pipeline (either [org.partiql.lang.CompilerPipeline], [org.partiql.lang.CompilerPipelineAsync],
+ * [org.partiql.lang.compiler.PartiQLCompilerPipeline]) will be tested.
  */
 internal interface PipelineFactory {
     val pipelineName: String

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/util/testdsl/IonResultTestCase.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/util/testdsl/IonResultTestCase.kt
@@ -12,6 +12,7 @@ import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestCase
 import org.partiql.lang.eval.evaluatortestframework.EvaluatorTestTarget
 import org.partiql.lang.eval.evaluatortestframework.ExpectedResultFormat
 import org.partiql.lang.eval.evaluatortestframework.PartiQLCompilerPipelineFactory
+import org.partiql.lang.eval.evaluatortestframework.PartiQLCompilerPipelineFactoryAsync
 import org.partiql.lang.eval.evaluatortestframework.PipelineEvaluatorTestAdapter
 import org.partiql.lang.mockdb.MockDb
 import org.partiql.lang.syntax.PartiQLParserBuilder
@@ -77,6 +78,7 @@ internal fun IonResultTestCase.runTestCase(
         when (target) {
             EvaluatorTestTarget.COMPILER_PIPELINE -> CompilerPipelineFactory()
             EvaluatorTestTarget.PARTIQL_PIPELINE -> PartiQLCompilerPipelineFactory()
+            EvaluatorTestTarget.PARTIQL_PIPELINE_ASYNC -> PartiQLCompilerPipelineFactoryAsync()
             // We don't support ALL_PIPELINES here because each pipeline needs a separate skip list, which
             // is decided by the caller of this function.
             EvaluatorTestTarget.ALL_PIPELINES -> error("May only test one pipeline at a time with IonResultTestCase")


### PR DESCRIPTION
## Description
Creates an asynchronous version of the existing physical plan evaluator APIs. This PR differs from the other attempt to make the physical plan evaluator async (https://github.com/partiql/partiql-lang-kotlin/compare/main...plan-eval-async-make-statement-eval-async), which had **changed** the existing synchronous APIs to be async. Performance-wise, we see about a 10-20% drop in performance when using the async APIs on a single query.

This PR chooses to have both APIs to be compatible with semver. Due to the performance drop, we choose to not just wrap the async evaluator w/ a `runBlocking` call. Including both versions also makes it easier to test the synchronous and asynchronous API performance more easily. The previous synchronous versions have been marked as deprecated and are expected to be removed in the next major version.

For reviewers, I recommend starting to look at
1. [AsyncOperatorTests.kt](https://github.com/partiql/partiql-lang-kotlin/pull/1382/files/4a1a79c5b2d1c5c59e019322dfe4328a9859850a#diff-d5434bdafbfc181054b7cfe03f0ec30e2fd96b28603276cfea815a7a13e4fde2) -- shows the use case for the async evaluator
2. [PartiQLCompilerAsync.kt](https://github.com/partiql/partiql-lang-kotlin/pull/1382/files/4a1a79c5b2d1c5c59e019322dfe4328a9859850a#diff-3c8489d73a91e103ecbc89990f0d3c7337ab6df512bb0860dd85fc55b90fac53) -- shows the public API for calling the async evaluator

The remaining changes were pretty straightforward (other than what's noted in the self-review comments). Essentially they were
- Creating an async version (usually w/ `Async` added to the end of the previous class/interface)
- Making the functions within the classes/interfaces `suspend fun`

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**

- Any backward-incompatible changes? **[NO]**
  - No. Previous synchronized physical plan evaluator APIs are the same but have been marked as deprecated. In a future major version, all of these deprecated APIs will be removed.

- Any new external dependencies? **[YES]**
  - Kotlin co-routine libraries to enable async
    - partiql-lang
      - implementation dep on org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0
      - test dep on org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0
    - partiql-examples
      - implementation dep on org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0
      - implementation dep on org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.0 (for converting coroutine to Java's `CompletableFuture`)
      - test dep on org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0
    - partiql-cli
      - implementation dep on org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.