### PR TITLE
Fixes aggregations of attribute references to values of union types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Thank you to all who have contributed!
 
 ### Deprecated
 - The current SqlBlock, SqlDialect, and SqlLayout are marked as deprecated and will be slightly changed in the next release. 
+- Deprecates constructor and properties `variableName` and `caseSensitive` of `org.partiql.planner.PlanningProblemDetails.UndefinedVariable`
+  in favor of newly added constructor and properties `name` and `inScopeVariables`.
 
 ### Fixed
 - `StaticType.flatten()` on an `AnyOfType` with `AnyType` will return `AnyType`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Thank you to all who have contributed!
 ### Changed
 - Change `StaticType.AnyOfType`'s `.toString` to not perform `.flatten()`
 - Change modeling of `COALESCE` and `NULLIF` to dedicated nodes in logical plan
+- Function resolution logic: Now the function resolver would match all possible candidate (based on if the argument can be coerced to the Signature parameter type). If there are multiple match it will first attempt to pick the one requires the least cast, then pick the function with the highest precedence.
+- **Behavioral change**: The COUNT aggregate function now returns INT64.
 
 ### Deprecated
 - The current SqlBlock, SqlDialect, and SqlLayout are marked as deprecated and will be slightly changed in the next release. 
@@ -40,7 +42,7 @@ Thank you to all who have contributed!
 ### Fixed
 - `StaticType.flatten()` on an `AnyOfType` with `AnyType` will return `AnyType`
 - Updates the default `.sql()` method to use a more efficient (internal) printer implementation.
-
+- Fixes aggregations of attribute references to values of union types. This fix also allows for proper error handling by passing the UnknownAggregateFunction problem to the ProblemCallback. Please note that, with this change, the planner will no longer immediately throw an IllegalStateException for this exact scenario.
 
 ### Removed
 
@@ -51,6 +53,7 @@ Thank you to all who have contributed!
 - @<your-username>
 - @rchowell
 - @alancai98
+- @johnedquinn
 
 ## [0.14.4]
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/Errors.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/Errors.kt
@@ -94,6 +94,14 @@ public sealed class PlanningProblemDetails(
         "Unknown function `$identifier($types)"
     })
 
+    public data class UnknownAggregateFunction(
+        val identifier: String,
+        val args: List<StaticType>,
+    ) : PlanningProblemDetails(ProblemSeverity.ERROR, {
+        val types = args.joinToString { "<${it.toString().lowercase()}>" }
+        "Unknown aggregate function `$identifier($types)"
+    })
+
     public object ExpressionAlwaysReturnsNullOrMissing : PlanningProblemDetails(
         severity = ProblemSeverity.ERROR,
         messageFormatter = { "Expression always returns null or missing." }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PartiQLHeader.kt
@@ -702,13 +702,13 @@ internal object PartiQLHeader : Header() {
     private fun count() = listOf(
         FunctionSignature.Aggregation(
             name = "count",
-            returns = INT32,
+            returns = INT64,
             parameters = listOf(FunctionParameter("value", ANY)),
             isNullable = false,
         ),
         FunctionSignature.Aggregation(
             name = "count_star",
-            returns = INT32,
+            returns = INT64,
             parameters = listOf(),
             isNullable = false,
         ),
@@ -741,6 +741,15 @@ internal object PartiQLHeader : Header() {
         )
     }
 
+    /**
+     * According to SQL:1999 Section 6.16 Syntax Rule 14.c and Rule 14.d:
+     * > If AVG is specified and DT is exact numeric, then the declared type of the result is exact
+     * numeric with implementation-defined precision not less than the precision of DT and
+     * implementation-defined scale not less than the scale of DT.
+     *
+     * > If DT is approximate numeric, then the declared type of the result is approximate numeric
+     * with implementation-defined precision not less than the precision of DT.
+     */
     private fun avg() = types.numeric.map {
         FunctionSignature.Aggregation(
             name = "avg",

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -1268,8 +1268,8 @@ internal class PlanTyper(
         fun resolveAgg(agg: Agg.Unresolved, arguments: List<Rex>): Pair<Rel.Op.Aggregate.Call, StaticType> {
             var missingArg = false
             val args = arguments.map {
-                val arg = visitRex(it, null)
-                if (arg.type.isMissable()) missingArg = true
+                val arg = visitRex(it, it.type)
+                if (arg.type is MissingType) missingArg = true
                 arg
             }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeEnv.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeEnv.kt
@@ -10,6 +10,8 @@ import org.partiql.planner.internal.ir.rexOpVarResolved
 import org.partiql.spi.BindingCase
 import org.partiql.spi.BindingName
 import org.partiql.spi.BindingPath
+import org.partiql.types.AnyOfType
+import org.partiql.types.AnyType
 import org.partiql.types.StaticType
 import org.partiql.types.StructType
 import org.partiql.types.TupleConstraint
@@ -85,30 +87,28 @@ internal class TypeEnv(public val schema: List<Rel.Binding>) {
         for (i in schema.indices) {
             val local = schema[i]
             val type = local.type
-            if (type is StructType) {
-                when (type.containsKey(name)) {
-                    true -> {
-                        if (c != null && known) {
-                            // TODO root was already definitively matched, emit ambiguous error.
+            when (type.containsKey(name)) {
+                true -> {
+                    if (c != null && known) {
+                        // TODO root was already definitively matched, emit ambiguous error.
+                        return null
+                    }
+                    c = rex(type, rexOpVarResolved(i))
+                    known = true
+                }
+                null -> {
+                    if (c != null) {
+                        if (known) {
+                            continue
+                        } else {
+                            // TODO we have more than one possible match, emit ambiguous error.
                             return null
                         }
-                        c = rex(type, rexOpVarResolved(i))
-                        known = true
                     }
-                    null -> {
-                        if (c != null) {
-                            if (known) {
-                                continue
-                            } else {
-                                // TODO we have more than one possible match, emit ambiguous error.
-                                return null
-                            }
-                        }
-                        c = rex(type, rexOpVarResolved(i))
-                        known = false
-                    }
-                    false -> continue
+                    c = rex(type, rexOpVarResolved(i))
+                    known = false
                 }
+                false -> continue
             }
         }
         return c
@@ -151,5 +151,40 @@ internal class TypeEnv(public val schema: List<Rel.Binding>) {
         }
         val closed = constraints.contains(TupleConstraint.Open(false))
         return if (closed) false else null
+    }
+
+    /**
+     * Searches for the [BindingName] within the given [StaticType].
+     *
+     * Returns
+     *  - true  iff known to contain key
+     *  - false iff known to NOT contain key
+     *  - null  iff NOT known to contain key
+     *
+     * @param name
+     * @return
+     */
+    private fun StaticType.containsKey(name: BindingName): Boolean? {
+        return when (val type = this.flatten()) {
+            is StructType -> type.containsKey(name)
+            is AnyOfType -> {
+                val anyKnownToContainKey = type.allTypes.any { it.containsKey(name) == true }
+                val anyKnownToNotContainKey = type.allTypes.any { it.containsKey(name) == false }
+                val anyNotKnownToContainKey = type.allTypes.any { it.containsKey(name) == null }
+                when {
+                    // There are:
+                    // - No subtypes that are known to not contain the key
+                    // - No subtypes that are not known to contain the key
+                    anyKnownToNotContainKey.not() && anyNotKnownToContainKey.not() -> true
+                    // There are:
+                    // - No subtypes that are known to contain the key
+                    // - No subtypes that are not known to contain the key
+                    anyKnownToContainKey.not() && anyNotKnownToContainKey.not() -> false
+                    else -> null
+                }
+            }
+            is AnyType -> null
+            else -> false
+        }
     }
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeEnv.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeEnv.kt
@@ -168,9 +168,15 @@ internal class TypeEnv(public val schema: List<Rel.Binding>) {
         return when (val type = this.flatten()) {
             is StructType -> type.containsKey(name)
             is AnyOfType -> {
-                val anyKnownToContainKey = type.allTypes.any { it.containsKey(name) == true }
-                val anyKnownToNotContainKey = type.allTypes.any { it.containsKey(name) == false }
-                val anyNotKnownToContainKey = type.allTypes.any { it.containsKey(name) == null }
+                var anyKnownToContainKey = false
+                var anyKnownToNotContainKey = false
+                var anyNotKnownToContainKey = false
+                for (t in type.allTypes) {
+                    val containsKey = t.containsKey(name)
+                    anyKnownToContainKey = anyKnownToContainKey || (containsKey == true)
+                    anyKnownToNotContainKey = anyKnownToNotContainKey || (containsKey == false)
+                    anyNotKnownToContainKey = anyNotKnownToContainKey || (containsKey == null)
+                }
                 when {
                     // There are:
                     // - No subtypes that are known to not contain the key

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeUtils.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeUtils.kt
@@ -93,7 +93,7 @@ internal fun StaticType.toRuntimeType(): PartiQLValueType {
         // handle anyOf(null, T) cases
         val t = types.filter { it !is NullType && it !is MissingType }
         return if (t.size != 1) {
-            error("Cannot have a UNION runtime type: $this")
+            PartiQLValueType.ANY
         } else {
             t.first().asRuntimeType()
         }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/utils/PlanUtils.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/utils/PlanUtils.kt
@@ -1,0 +1,26 @@
+package org.partiql.planner.internal.utils
+
+import org.partiql.plan.Identifier
+
+internal object PlanUtils {
+
+    /**
+     * Transforms an identifier to a human-readable string.
+     *
+     * Example output: aCaseInsensitiveCatalog."aCaseSensitiveSchema".aCaseInsensitiveTable
+     */
+    fun identifierToString(node: Identifier): String = when (node) {
+        is Identifier.Symbol -> identifierSymbolToString(node)
+        is Identifier.Qualified -> {
+            val toJoin = listOf(node.root) + node.steps
+            toJoin.joinToString(separator = ".") { ident ->
+                identifierSymbolToString(ident)
+            }
+        }
+    }
+
+    private fun identifierSymbolToString(node: Identifier.Symbol) = when (node.caseSensitivity) {
+        Identifier.CaseSensitivity.SENSITIVE -> "\"${node.symbol}\""
+        Identifier.CaseSensitivity.INSENSITIVE -> node.symbol
+    }
+}

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -1,6 +1,8 @@
 package org.partiql.planner.internal.typer
 
 import com.amazon.ionelement.api.loadSingleElement
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.parallel.Execution
@@ -129,6 +131,7 @@ class PlanTyperTestsPorted {
                 }
             }
             map.entries.map {
+                println("Map Entry: ${it.key} to ${it.value}")
                 it.key to MemoryConnector.Metadata.of(*it.value.toTypedArray())
             }
         }
@@ -3063,14 +3066,16 @@ class PlanTyperTestsPorted {
         fun aggregationCases() = listOf(
             SuccessTestCase(
                 name = "AGGREGATE over INTS, without alias",
-                query = "SELECT a, COUNT(*), SUM(a), MIN(b) FROM << {'a': 1, 'b': 2} >> GROUP BY a",
+                query = "SELECT a, COUNT(*), COUNT(a), SUM(a), MIN(b), MAX(a) FROM << {'a': 1, 'b': 2} >> GROUP BY a",
                 expected = BagType(
                     StructType(
                         fields = mapOf(
                             "a" to StaticType.INT4,
-                            "_1" to StaticType.INT4,
-                            "_2" to StaticType.INT4.asNullable(),
+                            "_1" to StaticType.INT8,
+                            "_2" to StaticType.INT8,
                             "_3" to StaticType.INT4.asNullable(),
+                            "_4" to StaticType.INT4.asNullable(),
+                            "_5" to StaticType.INT4.asNullable(),
                         ),
                         contentClosed = true,
                         constraints = setOf(
@@ -3083,12 +3088,13 @@ class PlanTyperTestsPorted {
             ),
             SuccessTestCase(
                 name = "AGGREGATE over INTS, with alias",
-                query = "SELECT a, COUNT(*) AS c, SUM(a) AS s, MIN(b) AS m FROM << {'a': 1, 'b': 2} >> GROUP BY a",
+                query = "SELECT a, COUNT(*) AS c_s, COUNT(a) AS c, SUM(a) AS s, MIN(b) AS m FROM << {'a': 1, 'b': 2} >> GROUP BY a",
                 expected = BagType(
                     StructType(
                         fields = mapOf(
                             "a" to StaticType.INT4,
-                            "c" to StaticType.INT4,
+                            "c_s" to StaticType.INT8,
+                            "c" to StaticType.INT8,
                             "s" to StaticType.INT4.asNullable(),
                             "m" to StaticType.INT4.asNullable(),
                         ),
@@ -3108,9 +3114,90 @@ class PlanTyperTestsPorted {
                     StructType(
                         fields = mapOf(
                             "a" to StaticType.DECIMAL,
-                            "c" to StaticType.INT4,
+                            "c" to StaticType.INT8,
                             "s" to StaticType.DECIMAL.asNullable(),
                             "m" to StaticType.DECIMAL.asNullable(),
+                        ),
+                        contentClosed = true,
+                        constraints = setOf(
+                            TupleConstraint.Open(false),
+                            TupleConstraint.UniqueAttrs(true),
+                            TupleConstraint.Ordered
+                        )
+                    )
+                )
+            ),
+            SuccessTestCase(
+                name = "AGGREGATE over nullable integers",
+                query = """
+                    SELECT
+                        a AS a,
+                        COUNT(*) AS count_star,
+                        COUNT(a) AS count_a,
+                        COUNT(b) AS count_b,
+                        SUM(a) AS sum_a,
+                        SUM(b) AS sum_b,
+                        MIN(a) AS min_a,
+                        MIN(b) AS min_b,
+                        MAX(a) AS max_a,
+                        MAX(b) AS max_b,
+                        AVG(a) AS avg_a,
+                        AVG(b) AS avg_b
+                    FROM <<
+                        { 'a': 1, 'b': 2 },
+                        { 'a': 3, 'b': 4 },
+                        { 'a': 5, 'b': NULL }
+                    >> GROUP BY a
+                """.trimIndent(),
+                expected = BagType(
+                    StructType(
+                        fields = mapOf(
+                            "a" to StaticType.INT4,
+                            "count_star" to StaticType.INT8,
+                            "count_a" to StaticType.INT8,
+                            "count_b" to StaticType.INT8,
+                            "sum_a" to StaticType.INT4.asNullable(),
+                            "sum_b" to StaticType.INT4.asNullable(),
+                            "min_a" to StaticType.INT4.asNullable(),
+                            "min_b" to StaticType.INT4.asNullable(),
+                            "max_a" to StaticType.INT4.asNullable(),
+                            "max_b" to StaticType.INT4.asNullable(),
+                            "avg_a" to StaticType.INT4.asNullable(),
+                            "avg_b" to StaticType.INT4.asNullable(),
+                        ),
+                        contentClosed = true,
+                        constraints = setOf(
+                            TupleConstraint.Open(false),
+                            TupleConstraint.UniqueAttrs(true),
+                            TupleConstraint.Ordered
+                        )
+                    )
+                )
+            ),
+            SuccessTestCase(
+                name = "AGGREGATE over nullable integers",
+                query = """
+                    SELECT
+                        COUNT(a) AS count_a
+                    FROM <<
+                        { 'a': 1, 'b': 2 }
+                    >> t1 INNER JOIN <<
+                        { 'c': 1, 'd': 3 }
+                    >> t2
+                        ON t1.a = t1.c
+                        AND (
+                            1 = (
+                            SELECT COUNT(e) AS count_e
+                            FROM <<
+                                { 'e': 10 }
+                            >> t3
+                            )
+                        );
+                """.trimIndent(),
+                expected = BagType(
+                    StructType(
+                        fields = mapOf(
+                            "count_a" to StaticType.INT8
                         ),
                         contentClosed = true,
                         constraints = setOf(
@@ -3371,6 +3458,101 @@ class PlanTyperTestsPorted {
     //
     // Parameterized Tests
     //
+
+    @Test
+    fun failingAggTest() {
+        val tc = SuccessTestCase(
+            name = "AGGREGATE over nullable integers",
+            query = """
+                SELECT T1.a
+                FROM T1
+                    LEFT JOIN T2 AS T2_1
+                        ON T2_1.d =
+                            (
+                                SELECT
+                                    CASE WHEN COUNT(f) = 1 THEN MAX(f) ELSE 0 END AS e
+                                FROM T3 AS T3_mapping
+                            )
+                    LEFT JOIN T2 AS T2_2
+                        ON T2_2.d =
+                            (
+                                SELECT
+                                    CASE WHEN COUNT(f) = 1 THEN MAX(f) ELSE 0 END AS e
+                                FROM T3 AS T3_mapping
+                            )
+                        ;
+            """.trimIndent(),
+            expected = BagType(
+                StructType(
+                    fields = mapOf(
+                        "a" to StaticType.BOOL
+                    ),
+                    contentClosed = true,
+                    constraints = setOf(
+                        TupleConstraint.Open(false),
+                        TupleConstraint.UniqueAttrs(true),
+                        TupleConstraint.Ordered
+                    )
+                )
+            ),
+            catalog = "aggregations"
+        )
+        runTest(tc)
+    }
+
+    @Test
+    @Disabled("The planner doesn't support heterogeneous input to aggregation functions (yet?).")
+    fun failingTest() {
+        val tc = SuccessTestCase(
+            name = "AGGREGATE over heterogeneous data",
+            query = """
+                    SELECT
+                        a AS a,
+                        COUNT(*) AS count_star,
+                        COUNT(a) AS count_a,
+                        COUNT(b) AS count_b,
+                        SUM(a) AS sum_a,
+                        SUM(b) AS sum_b,
+                        MIN(a) AS min_a,
+                        MIN(b) AS min_b,
+                        MAX(a) AS max_a,
+                        MAX(b) AS max_b,
+                        AVG(a) AS avg_a,
+                        AVG(b) AS avg_b
+                    FROM <<
+                        { 'a': 1.0, 'b': 2.0 },
+                        { 'a': 3, 'b': 4 },
+                        { 'a': 5, 'b': NULL }
+                    >> GROUP BY a
+            """.trimIndent(),
+            expected = BagType(
+                StructType(
+                    fields = mapOf(
+                        "a" to StaticType.DECIMAL,
+                        "count_star" to StaticType.INT8,
+                        "count_a" to StaticType.INT8,
+                        "count_b" to StaticType.INT8,
+                        "sum_a" to StaticType.DECIMAL.asNullable(),
+                        "sum_b" to StaticType.DECIMAL.asNullable(),
+                        "min_a" to StaticType.DECIMAL.asNullable(),
+                        "min_b" to StaticType.DECIMAL.asNullable(),
+                        "max_a" to StaticType.DECIMAL.asNullable(),
+                        "max_b" to StaticType.DECIMAL.asNullable(),
+                        "avg_a" to StaticType.DECIMAL.asNullable(),
+                        "avg_b" to StaticType.DECIMAL.asNullable(),
+                    ),
+                    contentClosed = true,
+                    constraints = setOf(
+                        TupleConstraint.Open(false),
+                        TupleConstraint.UniqueAttrs(true),
+                        TupleConstraint.Ordered
+                    )
+                )
+            )
+        )
+        runTest(tc)
+    }
+
     @ParameterizedTest
     @ArgumentsSource(TestProvider::class)
     fun test(tc: TestCase) = runTest(tc)

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/aggregations/T1.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/aggregations/T1.ion
@@ -1,0 +1,17 @@
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed ],
+    fields: [
+      {
+        name: "a",
+        type: "bool",
+      },
+      {
+        name: "b",
+        type: "int32",
+      },
+    ]
+  }
+}

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/aggregations/T2.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/aggregations/T2.ion
@@ -1,0 +1,17 @@
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed ],
+    fields: [
+      {
+        name: "c",
+        type: "bool",
+      },
+      {
+        name: "d",
+        type: "int32",
+      },
+    ]
+  }
+}

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/aggregations/T3.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/aggregations/T3.ion
@@ -1,0 +1,17 @@
+{
+  type: "bag",
+  items: {
+    type: "struct",
+    constraints: [ closed ],
+    fields: [
+      {
+        name: "e",
+        type: "bool",
+      },
+      {
+        name: "f",
+        type: "int32",
+      },
+    ]
+  }
+}

--- a/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
@@ -599,9 +599,10 @@ public data class StructType(
         get() = listOf(this)
 
     override fun toString(): String {
-        val firstSeveral = fields.take(3).joinToString { "${it.key}: ${it.value}" }
+        val firstFieldsSize = 15
+        val firstSeveral = fields.take(firstFieldsSize).joinToString { "${it.key}: ${it.value}" }
         return when {
-            fields.size <= 3 -> "struct($firstSeveral, $constraints)"
+            fields.size <= firstFieldsSize -> "struct($firstSeveral, $constraints)"
             else -> "struct($firstSeveral, ... and ${fields.size - 3} other field(s), $constraints)"
         }
     }


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Fixes aggregations of attribute references to values of union types
- Before, in `TypeEnv`, we would assert, when looking up an attribute on a value, that the value were a `StructType` -- even though it could be a union of StructTypes. Or a union of other types. This PR handles this scenario.
- This PR does NOT handle heterogeneous data for aggregation functions. See the new, disabled test in PlanTyperTestsPorted.
- For the purposes of better error reporting, modified the definition of UndefinedVariable. See the CHANGELOG.

## Open Questions (Not addressed in this PR)
- What should `AVG` return? I've pasted a snippet from SQL:1999 which shows that we are conformant, however, I'm not sold.

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **YES**
  - Yes, but not API incompatible changes. See the CHANGELOG.
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.