### PR TITLE
Fixes `SqlDialect` output for unary ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Thank you to all who have contributed!
 ### Deprecated
 
 ### Fixed
+- partiql-ast: `SqlDialect` will wrap unary ops (`NOT`, `+`, `-`) in parens
 
 ### Removed
 

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/sql/SqlDialect.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/sql/SqlDialect.kt
@@ -230,13 +230,15 @@ public abstract class SqlDialect : AstBaseVisitor<SqlBlock, SqlBlock>() {
 
     override fun visitExprUnary(node: Expr.Unary, head: SqlBlock): SqlBlock {
         val op = when (node.op) {
-            Expr.Unary.Op.NOT -> "NOT "
-            Expr.Unary.Op.POS -> "+"
-            Expr.Unary.Op.NEG -> "-"
+            Expr.Unary.Op.NOT -> "NOT ("
+            Expr.Unary.Op.POS -> "+("
+            Expr.Unary.Op.NEG -> "-("
         }
         var h = head
         h = h concat r(op)
-        return visitExprWrapped(node.expr, h)
+        h = visitExprWrapped(node.expr, h)
+        h = h concat r(")")
+        return h
     }
 
     override fun visitExprBinary(node: Expr.Binary, head: SqlBlock): SqlBlock {

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
@@ -227,22 +227,61 @@ class SqlDialectTest {
 
         @JvmStatic
         fun exprOperators() = listOf(
-            expect("NOT NULL") {
+            expect("NOT (NULL)") {
                 exprUnary {
                     op = Expr.Unary.Op.NOT
                     expr = NULL
                 }
             },
-            expect("+NULL") {
+            expect("+(NULL)") {
                 exprUnary {
                     op = Expr.Unary.Op.POS
                     expr = NULL
                 }
             },
-            expect("-NULL") {
+            expect("-(NULL)") {
                 exprUnary {
                     op = Expr.Unary.Op.NEG
                     expr = NULL
+                }
+            },
+            expect("NOT (NOT (NULL))") {
+                exprUnary {
+                    op = Expr.Unary.Op.NOT
+                    expr = exprUnary {
+                        op = Expr.Unary.Op.NOT
+                        expr = NULL
+                    }
+                }
+            },
+            expect("+(+(NULL))") {
+                exprUnary {
+                    op = Expr.Unary.Op.POS
+                    expr = exprUnary {
+                        op = Expr.Unary.Op.POS
+                        expr = NULL
+                    }
+                }
+            },
+            expect("-(-(NULL))") {
+                exprUnary {
+                    op = Expr.Unary.Op.NEG
+                    expr = exprUnary {
+                        op = Expr.Unary.Op.NEG
+                        expr = NULL
+                    }
+                }
+            },
+            expect("+(-(+(NULL)))") {
+                exprUnary {
+                    op = Expr.Unary.Op.POS
+                    expr = exprUnary {
+                        op = Expr.Unary.Op.NEG
+                        expr = exprUnary {
+                            op = Expr.Unary.Op.POS
+                            expr = NULL
+                        }
+                    }
                 }
             },
             expect("NULL + NULL") {


### PR DESCRIPTION
## Description
Applies fix to SqlDialect output for unary ops from https://github.com/partiql/partiql-scribe/pull/22.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.