### PR TITLE
Adds performance optimizations for ExprCallDynamic

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -207,7 +207,8 @@ internal class Compiler(
     @OptIn(FnExperimental::class)
     override fun visitRexOpCallDynamic(node: Rex.Op.Call.Dynamic, ctx: StaticType?): Operator {
         val args = node.args.map { visitRex(it, ctx).modeHandled() }.toTypedArray()
-        val candidates = node.candidates.map { candidate ->
+        val candidates = Array(node.candidates.size) {
+            val candidate = node.candidates[it]
             val fn = symbols.getFn(candidate.fn)
             val coercions = candidate.coercions.toTypedArray()
             ExprCallDynamic.Candidate(fn, coercions)

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -204,7 +204,7 @@ internal class Compiler(
         }
     }
 
-    @OptIn(FnExperimental::class, PartiQLValueExperimental::class)
+    @OptIn(FnExperimental::class)
     override fun visitRexOpCallDynamic(node: Rex.Op.Call.Dynamic, ctx: StaticType?): Operator {
         val args = node.args.map { visitRex(it, ctx).modeHandled() }.toTypedArray()
         val candidates = node.candidates.map { candidate ->

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCast.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCast.kt
@@ -21,6 +21,7 @@ import org.partiql.value.Int64Value
 import org.partiql.value.Int8Value
 import org.partiql.value.IntValue
 import org.partiql.value.ListValue
+import org.partiql.value.NullValue
 import org.partiql.value.NumericValue
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
@@ -30,7 +31,13 @@ import org.partiql.value.StringValue
 import org.partiql.value.SymbolValue
 import org.partiql.value.TextValue
 import org.partiql.value.bagValue
+import org.partiql.value.binaryValue
+import org.partiql.value.blobValue
 import org.partiql.value.boolValue
+import org.partiql.value.byteValue
+import org.partiql.value.charValue
+import org.partiql.value.clobValue
+import org.partiql.value.dateValue
 import org.partiql.value.decimalValue
 import org.partiql.value.float32Value
 import org.partiql.value.float64Value
@@ -40,9 +47,13 @@ import org.partiql.value.int64Value
 import org.partiql.value.int8Value
 import org.partiql.value.intValue
 import org.partiql.value.listValue
+import org.partiql.value.missingValue
 import org.partiql.value.sexpValue
 import org.partiql.value.stringValue
+import org.partiql.value.structValue
 import org.partiql.value.symbolValue
+import org.partiql.value.timeValue
+import org.partiql.value.timestampValue
 import java.math.BigDecimal
 import java.math.BigInteger
 
@@ -79,11 +90,45 @@ internal class ExprCast(val arg: Operator.Expr, val cast: Ref.Cast) : Operator.E
                 PartiQLValueType.LIST -> castFromCollection(arg as ListValue<*>, cast.target)
                 PartiQLValueType.SEXP -> castFromCollection(arg as SexpValue<*>, cast.target)
                 PartiQLValueType.STRUCT -> TODO("CAST FROM STRUCT not yet implemented")
-                PartiQLValueType.NULL -> error("cast from NULL should be handled by Typer")
+                PartiQLValueType.NULL -> castFromNull(arg as NullValue, cast.target)
                 PartiQLValueType.MISSING -> error("cast from MISSING should be handled by Typer")
             }
         } catch (e: DataException) {
             throw TypeCheckException()
+        }
+    }
+
+    @OptIn(PartiQLValueExperimental::class)
+    private fun castFromNull(value: NullValue, t: PartiQLValueType): PartiQLValue {
+        return when (t) {
+            PartiQLValueType.ANY -> value
+            PartiQLValueType.BOOL -> boolValue(null)
+            PartiQLValueType.CHAR -> charValue(null)
+            PartiQLValueType.STRING -> stringValue(null)
+            PartiQLValueType.SYMBOL -> symbolValue(null)
+            PartiQLValueType.BINARY -> binaryValue(null)
+            PartiQLValueType.BYTE -> byteValue(null)
+            PartiQLValueType.BLOB -> blobValue(null)
+            PartiQLValueType.CLOB -> clobValue(null)
+            PartiQLValueType.DATE -> dateValue(null)
+            PartiQLValueType.TIME -> timeValue(null)
+            PartiQLValueType.TIMESTAMP -> timestampValue(null)
+            PartiQLValueType.INTERVAL -> TODO("Not yet supported")
+            PartiQLValueType.BAG -> bagValue<PartiQLValue>(null)
+            PartiQLValueType.LIST -> listValue<PartiQLValue>(null)
+            PartiQLValueType.SEXP -> sexpValue<PartiQLValue>(null)
+            PartiQLValueType.STRUCT -> structValue<PartiQLValue>(null)
+            PartiQLValueType.NULL -> value
+            PartiQLValueType.MISSING -> missingValue() // TODO: Os this allowed
+            PartiQLValueType.INT8 -> int8Value(null)
+            PartiQLValueType.INT16 -> int16Value(null)
+            PartiQLValueType.INT32 -> int32Value(null)
+            PartiQLValueType.INT64 -> int64Value(null)
+            PartiQLValueType.INT -> intValue(null)
+            PartiQLValueType.DECIMAL -> decimalValue(null)
+            PartiQLValueType.DECIMAL_ARBITRARY -> decimalValue(null)
+            PartiQLValueType.FLOAT32 -> float32Value(null)
+            PartiQLValueType.FLOAT64 -> float64Value(null)
         }
     }
 

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamicTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamicTest.kt
@@ -1,0 +1,135 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.partiql.eval.internal.Environment
+import org.partiql.spi.fn.Fn
+import org.partiql.spi.fn.FnExperimental
+import org.partiql.spi.fn.FnParameter
+import org.partiql.spi.fn.FnSignature
+import org.partiql.value.Int32Value
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.PartiQLValueType
+import org.partiql.value.bagValue
+import org.partiql.value.boolValue
+import org.partiql.value.check
+import org.partiql.value.int32Value
+import org.partiql.value.listValue
+import org.partiql.value.stringValue
+
+class ExprCallDynamicTest {
+
+    @ParameterizedTest
+    @MethodSource("sanityTestsCases")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun sanityTests(tc: DynamicTestCase) = tc.assert()
+
+    public class DynamicTestCase @OptIn(PartiQLValueExperimental::class) constructor(
+        val lhs: PartiQLValue,
+        val rhs: PartiQLValue,
+        val expectedIndex: Int,
+    ) {
+
+        @OptIn(PartiQLValueExperimental::class)
+        fun assert() {
+            val expr = ExprCallDynamic(candidates, args = arrayOf(ExprLiteral(lhs), ExprLiteral(rhs)))
+            val result = expr.eval(Environment.empty).check<Int32Value>()
+            assertEquals(expectedIndex, result.value)
+        }
+
+        companion object {
+
+            @OptIn(PartiQLValueExperimental::class)
+            private val params = listOf(
+                PartiQLValueType.LIST to PartiQLValueType.LIST, // Index 0
+                PartiQLValueType.BAG to PartiQLValueType.BAG, // Index 1
+                PartiQLValueType.INT8 to PartiQLValueType.INT8, // Index 2
+                PartiQLValueType.INT16 to PartiQLValueType.INT16, // Index 3
+                PartiQLValueType.INT32 to PartiQLValueType.INT32, // Index 4
+                PartiQLValueType.INT64 to PartiQLValueType.INT64, // Index 5
+                PartiQLValueType.STRING to PartiQLValueType.STRING, // Index 6
+                PartiQLValueType.ANY to PartiQLValueType.LIST, // Index 7
+                PartiQLValueType.BAG to PartiQLValueType.ANY, // Index 8
+                PartiQLValueType.INT32 to PartiQLValueType.STRING, // Index 9
+                PartiQLValueType.INT64 to PartiQLValueType.STRING, // Index 10
+                PartiQLValueType.LIST to PartiQLValueType.ANY, // Index 11
+                PartiQLValueType.ANY to PartiQLValueType.ANY, // Index 12
+            )
+
+            @OptIn(FnExperimental::class, PartiQLValueExperimental::class)
+            internal val candidates = params.mapIndexed { index, it ->
+                ExprCallDynamic.Candidate(
+                    fn = object : Fn {
+                        override val signature: FnSignature = FnSignature(
+                            name = "example_function",
+                            returns = PartiQLValueType.INT32,
+                            parameters = listOf(
+                                FnParameter("first", type = it.first),
+                                FnParameter("second", type = it.second),
+                            )
+                        )
+                        override fun invoke(args: Array<PartiQLValue>): PartiQLValue = int32Value(index)
+                    },
+                    coercions = arrayOf(null, null)
+                )
+            }.toTypedArray()
+        }
+    }
+
+    companion object {
+
+        @OptIn(PartiQLValueExperimental::class)
+        @JvmStatic
+        fun sanityTestsCases() = listOf(
+            DynamicTestCase(
+                lhs = int32Value(20),
+                rhs = int32Value(40),
+                expectedIndex = 4
+            ),
+            DynamicTestCase(
+                lhs = listValue(emptyList()),
+                rhs = listValue(emptyList()),
+                expectedIndex = 0
+            ),
+            DynamicTestCase(
+                lhs = bagValue(emptyList()),
+                rhs = bagValue(emptyList()),
+                expectedIndex = 1
+            ),
+            DynamicTestCase(
+                lhs = stringValue("hello"),
+                rhs = stringValue("world"),
+                expectedIndex = 6
+            ),
+            DynamicTestCase(
+                lhs = stringValue("hello"),
+                rhs = listValue(emptyList()),
+                expectedIndex = 7
+            ),
+            DynamicTestCase(
+                lhs = bagValue(emptyList()),
+                rhs = stringValue("world"),
+                expectedIndex = 8
+            ),
+            DynamicTestCase(
+                lhs = int32Value(20),
+                rhs = stringValue("world"),
+                expectedIndex = 9
+            ),
+            DynamicTestCase(
+                lhs = listValue(emptyList()),
+                rhs = stringValue("hello"),
+                expectedIndex = 11
+            ),
+            DynamicTestCase(
+                lhs = boolValue(true),
+                rhs = boolValue(false),
+                expectedIndex = 12
+            ),
+        )
+    }
+}

--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -41,6 +41,7 @@ ref::{
     cast::{
       input: partiql_value_type,
       target: partiql_value_type,
+      isNullable: bool
     }
   ]
 }
@@ -127,12 +128,10 @@ rex::{
           // ABS(INT32) -> INT32 or ABS(DEC) -> DEC. In this scenario, we maintain the two potential candidates.
           //
           // @param fn - represents the function to invoke (ex: ABS(INT32) -> INT32)
-          // @param parameters - represents the input type(s) to match. (ex: INT32)
           // @param coercions - represents the optional coercion to use on the argument(s). It will be NULL if no coercion
           //  is necessary.
           candidate::{
             fn: ref,
-            parameters: list::[partiql_value_type],
             coercions: list::[optional::'.ref.cast'],
           }
         ]

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Env.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Env.kt
@@ -105,9 +105,9 @@ internal class Env(private val session: PartiQLPlanner.Session) {
                         fn = refFn(
                             catalog = item.catalog,
                             path = item.handle.path.steps,
-                            signature = it.fn.signature,
+                            signature = it.signature,
                         ),
-                        coercions = it.fn.mapping.toList(),
+                        coercions = it.mapping.toList(),
                     )
                 }
                 // Rewrite as a dynamic call to be typed by PlanTyper

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Env.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Env.kt
@@ -107,7 +107,6 @@ internal class Env(private val session: PartiQLPlanner.Session) {
                             path = item.handle.path.steps,
                             signature = it.fn.signature,
                         ),
-                        parameters = it.parameters,
                         coercions = it.fn.mapping.toList(),
                     )
                 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/FnMatch.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/FnMatch.kt
@@ -3,8 +3,6 @@ package org.partiql.planner.internal
 import org.partiql.planner.internal.ir.Ref
 import org.partiql.spi.fn.FnExperimental
 import org.partiql.spi.fn.FnSignature
-import org.partiql.value.PartiQLValueExperimental
-import org.partiql.value.PartiQLValueType
 
 /**
  * Result of matching an unresolved function.
@@ -18,7 +16,7 @@ internal sealed class FnMatch {
      * @property signature
      * @property mapping
      */
-    class Static(
+    data class Static(
         val signature: FnSignature,
         val mapping: Array<Ref.Cast?>,
     ) : FnMatch() {
@@ -29,11 +27,24 @@ internal sealed class FnMatch {
         val exact: Int = mapping.count { it != null }
 
         override fun equals(other: Any?): Boolean {
-            if (other !is Static) return false
-            return signature.equals(other.signature)
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as Static
+
+            if (signature != other.signature) return false
+            if (!mapping.contentEquals(other.mapping)) return false
+            if (exact != other.exact) return false
+
+            return true
         }
 
-        override fun hashCode(): Int = signature.hashCode()
+        override fun hashCode(): Int {
+            var result = signature.hashCode()
+            result = 31 * result + mapping.contentHashCode()
+            result = 31 * result + exact
+            return result
+        }
     }
 
     /**
@@ -51,11 +62,9 @@ internal sealed class FnMatch {
          * Represents a candidate of dynamic dispatch.
          *
          * @property fn             Function to invoke.
-         * @property parameters     Represents the input type(s) to match. (ex: INT32)
          */
-        data class Candidate @OptIn(PartiQLValueExperimental::class) constructor(
-            val fn: Static,
-            val parameters: List<PartiQLValueType>
+        data class Candidate(
+            val fn: Static
         )
     }
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/FnMatch.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/FnMatch.kt
@@ -54,17 +54,7 @@ internal sealed class FnMatch {
      * @property exhaustive     True if all argument permutations (branches) are matched.
      */
     data class Dynamic(
-        val candidates: List<Candidate>,
+        val candidates: List<Static>,
         val exhaustive: Boolean,
-    ) : FnMatch() {
-
-        /**
-         * Represents a candidate of dynamic dispatch.
-         *
-         * @property fn             Function to invoke.
-         */
-        data class Candidate(
-            val fn: Static
-        )
-    }
+    ) : FnMatch()
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/FnResolver.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/FnResolver.kt
@@ -68,14 +68,14 @@ internal object FnResolver {
         // Order based on original candidate function ordering
         val orderedUniqueMatches = matches.toSet().toList()
         val orderedCandidates = candidates.flatMap { candidate ->
-            orderedUniqueMatches.filter { it.fn.signature == candidate }
+            orderedUniqueMatches.filter { it.signature == candidate }
         }
 
         // Static call iff only one match for every branch
         val n = orderedCandidates.size
         return when {
             n == 0 -> null
-            n == 1 && exhaustive -> orderedCandidates.first().fn
+            n == 1 && exhaustive -> orderedCandidates.first()
             else -> FnMatch.Dynamic(orderedCandidates, exhaustive)
         }
     }
@@ -87,11 +87,11 @@ internal object FnResolver {
      * @param args
      * @return
      */
-    private fun match(candidates: List<FnSignature>, args: List<PartiQLValueType>): FnMatch.Dynamic.Candidate? {
+    private fun match(candidates: List<FnSignature>, args: List<PartiQLValueType>): FnMatch.Static? {
         // 1. Check for an exact match
         for (candidate in candidates) {
             if (candidate.matches(args)) {
-                return FnMatch.Dynamic.Candidate(fn = FnMatch.Static(candidate, arrayOfNulls(args.size)))
+                return FnMatch.Static(candidate, arrayOfNulls(args.size))
             }
         }
         // 2. Look for best match (for now, first match).
@@ -128,7 +128,7 @@ internal object FnResolver {
      * @param args
      * @return
      */
-    private fun FnSignature.match(args: List<PartiQLValueType>): FnMatch.Dynamic.Candidate? {
+    private fun FnSignature.match(args: List<PartiQLValueType>): FnMatch.Static? {
         val mapping = arrayOfNulls<Ref.Cast?>(args.size)
         for (i in args.indices) {
             val arg = args[i]
@@ -145,7 +145,7 @@ internal object FnResolver {
                 }
             }
         }
-        return FnMatch.Dynamic.Candidate(fn = FnMatch.Static(this, mapping))
+        return FnMatch.Static(this, mapping)
     }
 
     private fun buildArgumentPermutations(args: List<StaticType>): List<List<StaticType>> {

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/casts/CastTable.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/casts/CastTable.kt
@@ -1,7 +1,7 @@
 package org.partiql.planner.internal.casts
 
+import org.partiql.planner.internal.ir.Ref
 import org.partiql.planner.internal.ir.Ref.Cast
-import org.partiql.planner.internal.ir.refCast
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.PartiQLValueType
 import org.partiql.value.PartiQLValueType.ANY
@@ -107,7 +107,9 @@ internal class CastTable private constructor(
                 }
             }
             graph[NULL] = NULL.relationships {
-                coercion(NULL)
+                PartiQLValueType.values().filterNot { it == ANY || it == MISSING }.forEach {
+                    coercion(it, isNullable = true)
+                }
             }
             graph[MISSING] = MISSING.relationships {
                 coercion(MISSING)
@@ -312,16 +314,16 @@ internal class CastTable private constructor(
 
         fun build() = relationships
 
-        fun coercion(target: PartiQLValueType) {
-            relationships[target] = refCast(operand, target, Cast.Safety.COERCION)
+        fun coercion(target: PartiQLValueType, isNullable: Boolean = false) {
+            relationships[target] = Cast(operand, target, Ref.Cast.Safety.COERCION, isNullable)
         }
 
-        fun explicit(target: PartiQLValueType) {
-            relationships[target] = refCast(operand, target, Cast.Safety.EXPLICIT)
+        fun explicit(target: PartiQLValueType, isNullable: Boolean = false) {
+            relationships[target] = Cast(operand, target, Ref.Cast.Safety.EXPLICIT, isNullable)
         }
 
-        fun unsafe(target: PartiQLValueType) {
-            relationships[target] = refCast(operand, target, Cast.Safety.UNSAFE)
+        fun unsafe(target: PartiQLValueType, isNullable: Boolean = false) {
+            relationships[target] = Cast(operand, target, Ref.Cast.Safety.UNSAFE, isNullable)
         }
     }
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
@@ -158,6 +158,7 @@ internal sealed class Ref : PlanNode() {
         @JvmField internal val input: PartiQLValueType,
         @JvmField internal val target: PartiQLValueType,
         @JvmField internal val safety: Safety,
+        @JvmField internal val isNullable: Boolean,
     ) : PlanNode() {
         public override val children: List<PlanNode> = emptyList()
 
@@ -529,7 +530,6 @@ internal data class Rex(
 
                 internal data class Candidate(
                     @JvmField internal val fn: Ref.Fn,
-                    @JvmField internal val parameters: List<PartiQLValueType>,
                     @JvmField internal val coercions: List<Ref.Cast?>,
                 ) : PlanNode() {
                     public override val children: List<PlanNode> by lazy {

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -72,7 +72,7 @@ internal object PlanTransform {
         override fun visitRefAgg(node: Ref.Agg, ctx: Unit) = symbols.insert(node)
 
         @OptIn(PartiQLValueExperimental::class)
-        override fun visitRefCast(node: Ref.Cast, ctx: Unit) = org.partiql.plan.refCast(node.input, node.target)
+        override fun visitRefCast(node: Ref.Cast, ctx: Unit) = org.partiql.plan.refCast(node.input, node.target, node.isNullable)
 
         override fun visitStatement(node: Statement, ctx: Unit) =
             super.visitStatement(node, ctx) as org.partiql.plan.Statement
@@ -184,11 +184,10 @@ internal object PlanTransform {
             )
         }
 
-        @OptIn(PartiQLValueExperimental::class)
         override fun visitRexOpCallDynamicCandidate(node: Rex.Op.Call.Dynamic.Candidate, ctx: Unit): PlanNode {
             val fn = visitRef(node.fn, ctx)
             val coercions = node.coercions.map { it?.let { visitRefCast(it, ctx) } }
-            return org.partiql.plan.Rex.Op.Call.Dynamic.Candidate(fn, node.parameters, coercions)
+            return org.partiql.plan.Rex.Op.Call.Dynamic.Candidate(fn, coercions)
         }
 
         override fun visitRexOpCase(node: Rex.Op.Case, ctx: Unit) = org.partiql.plan.Rex.Op.Case(

--- a/partiql-planner/src/main/resources/partiql_plan_internal.ion
+++ b/partiql-planner/src/main/resources/partiql_plan_internal.ion
@@ -41,7 +41,8 @@ ref::[
         COERCION, // Lossless CAST(V AS T) -> T
         EXPLICIT, // Lossy    CAST(V AS T) -> T
         UNSAFE,   //          CAST(V AS T) -> T|MISSING
-      ]
+      ],
+      isNullable: bool
     }
   ]
 ]
@@ -141,7 +142,6 @@ rex::{
       // Represents a dynamic function call. If all candidates are exhausted, dynamic calls will return MISSING.
       //
       // args: represent the original typed arguments. These will eventually be wrapped by coercions from [candidates].
-      // parameters: represents the input type(s) to match. (ex: INT32)
       // candidates: represent the potentially applicable resolved functions with coercions. Each of these candidates
       //  should be overloaded functions of the same name and number of arguments.
       dynamic::{
@@ -151,7 +151,6 @@ rex::{
         _: [
           candidate::{
             fn: '.ref.fn',
-            parameters: list::[partiql_value_type],
             coercions: list::[optional::'.ref.cast'],
           }
         ]

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PartiQLTyperTestBase.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PartiQLTyperTestBase.kt
@@ -7,6 +7,7 @@ import org.partiql.parser.PartiQLParser
 import org.partiql.plan.Statement
 import org.partiql.plan.debug.PlanPrinter
 import org.partiql.planner.PartiQLPlanner
+import org.partiql.planner.PlanningProblemDetails
 import org.partiql.planner.test.PartiQLTest
 import org.partiql.planner.test.PartiQLTestProvider
 import org.partiql.planner.util.ProblemCollector
@@ -106,7 +107,11 @@ abstract class PartiQLTyperTestBase {
                                     PlanPrinter.append(this, result.plan)
                                 }
                             }
-                            assert(pc.problems.isEmpty()) {
+                            // We need to allow for the testing of null/missing
+                            val problemsWithoutNullMissing = pc.problems.filterNot {
+                                it.details is PlanningProblemDetails.ExpressionAlwaysReturnsNullOrMissing
+                            }
+                            assert(problemsWithoutNullMissing.isEmpty()) {
                                 buildString {
                                     this.appendLine("expected success Test case to have no problem")
                                     this.appendLine("actual problems are: ")

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -729,7 +729,7 @@ class PlanTyperTestsPorted {
             SuccessTestCase(
                 name = "BITWISE_AND_NULL_OPERAND",
                 query = "1 & NULL",
-                expected = StaticType.NULL,
+                expected = StaticType.unionOf(StaticType.INT4, StaticType.NULL),
             ),
             ErrorTestCase(
                 name = "BITWISE_AND_MISSING_OPERAND",

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/Utils.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/Utils.kt
@@ -1,0 +1,38 @@
+package org.partiql.planner.internal.typer
+
+import org.partiql.types.MissingType
+import org.partiql.types.NullType
+import org.partiql.types.StaticType
+
+/**
+ * In contrast to [set], this accumulates the passed-in [value] to the in-place value corresponding to [key].
+ * Note that this does not replace the value corresponding to [key]. The [MutableMap] is acting as a way to
+ * accumulate values, and this helper function aids in that.
+ *
+ * This function also checks whether any of the [value] is of type null. If so, it makes sure that the result
+ * is also nullable. If the [value] is of type MISSING, the result will be MISSING.
+ */
+internal fun MutableMap<PartiQLTyperTestBase.TestResult, Set<List<StaticType>>>.accumulateSuccess(
+    key: StaticType,
+    value: List<StaticType>,
+) {
+    val actualKey = when {
+        value.any { it is MissingType } -> StaticType.MISSING
+        value.any { it is NullType } -> key.asNullable()
+        else -> key
+    }
+    val result = PartiQLTyperTestBase.TestResult.Success(actualKey)
+    this[result] = setOf(value) + (this[result] ?: emptySet())
+}
+
+/**
+ * This runs [accumulateSuccess] over all elements of [value].
+ */
+internal fun MutableMap<PartiQLTyperTestBase.TestResult, Set<List<StaticType>>>.accumulateSuccesses(
+    key: StaticType,
+    value: Set<List<StaticType>>,
+) {
+    value.forEach {
+        accumulateSuccess(key, it)
+    }
+}

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/Utils.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/Utils.kt
@@ -1,6 +1,5 @@
 package org.partiql.planner.internal.typer
 
-import org.partiql.types.MissingType
 import org.partiql.types.NullType
 import org.partiql.types.StaticType
 
@@ -8,31 +7,40 @@ import org.partiql.types.StaticType
  * In contrast to [set], this accumulates the passed-in [value] to the in-place value corresponding to [key].
  * Note that this does not replace the value corresponding to [key]. The [MutableMap] is acting as a way to
  * accumulate values, and this helper function aids in that.
- *
- * This function also checks whether any of the [value] is of type null. If so, it makes sure that the result
- * is also nullable. If the [value] is of type MISSING, the result will be MISSING.
  */
+
 internal fun MutableMap<PartiQLTyperTestBase.TestResult, Set<List<StaticType>>>.accumulateSuccess(
     key: StaticType,
     value: List<StaticType>,
 ) {
-    val actualKey = when {
-        value.any { it is MissingType } -> StaticType.MISSING
-        value.any { it is NullType } -> key.asNullable()
-        else -> key
-    }
-    val result = PartiQLTyperTestBase.TestResult.Success(actualKey)
+    val result = PartiQLTyperTestBase.TestResult.Success(key)
     this[result] = setOf(value) + (this[result] ?: emptySet())
 }
 
 /**
- * This runs [accumulateSuccess] over all elements of [value].
+ * This internally calls [accumulateSuccess], however, this function also checks whether any of the [value] is of type
+ * null. If so, it makes sure that the result is also nullable. If the [value] is of type MISSING, the result will
+ * be MISSING.
+ */
+internal fun MutableMap<PartiQLTyperTestBase.TestResult, Set<List<StaticType>>>.accumulateSuccessNullCall(
+    key: StaticType,
+    value: List<StaticType>,
+) {
+    val actualKey = when {
+        value.any { it is NullType } -> key.asNullable()
+        else -> key
+    }
+    accumulateSuccess(actualKey, value)
+}
+
+/**
+ * This runs [accumulateSuccessNullCall] over all elements of [value].
  */
 internal fun MutableMap<PartiQLTyperTestBase.TestResult, Set<List<StaticType>>>.accumulateSuccesses(
     key: StaticType,
     value: Set<List<StaticType>>,
 ) {
     value.forEach {
-        accumulateSuccess(key, it)
+        accumulateSuccessNullCall(key, it)
     }
 }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpArithmeticTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpArithmeticTest.kt
@@ -3,11 +3,13 @@ package org.partiql.planner.internal.typer.operator
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
+import org.partiql.planner.internal.typer.accumulateSuccess
 import org.partiql.planner.util.CastType
 import org.partiql.planner.util.allNumberType
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.cartesianProduct
 import org.partiql.planner.util.castTable
+import org.partiql.types.NullType
 import org.partiql.types.StaticType
 import java.util.stream.Stream
 
@@ -35,24 +37,14 @@ class OpArithmeticTest : PartiQLTyperTestBase() {
             successArgs.forEach { args: List<StaticType> ->
                 val arg0 = args.first()
                 val arg1 = args[1]
-                if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
-                    }
-                } else if (arg0 == arg1) {
-                    (this[TestResult.Success(arg1)] ?: setOf(args)).let {
-                        put(TestResult.Success(arg1), it + setOf(args))
-                    }
-                } else if (castTable(arg1, arg0) == CastType.COERCION) {
-                    (this[TestResult.Success(arg0)] ?: setOf(args)).let {
-                        put(TestResult.Success(arg0), it + setOf(args))
-                    }
-                } else {
-                    (this[TestResult.Success(arg1)] ?: setOf(args)).let {
-                        put(TestResult.Success(arg1), it + setOf(args))
-                    }
+                val output = when {
+                    arg0 is NullType && arg1 is NullType -> StaticType.INT2
+                    arg0 == arg1 -> arg1
+                    castTable(arg1, arg0) == CastType.COERCION -> arg0
+                    castTable(arg0, arg1) == CastType.COERCION -> arg1
+                    else -> error("Arguments do not conform to parameters. Args: $args")
                 }
-                Unit
+                accumulateSuccess(output, args)
             }
 
             put(TestResult.Failure, failureArgs)

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpArithmeticTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpArithmeticTest.kt
@@ -3,7 +3,7 @@ package org.partiql.planner.internal.typer.operator
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
-import org.partiql.planner.internal.typer.accumulateSuccess
+import org.partiql.planner.internal.typer.accumulateSuccessNullCall
 import org.partiql.planner.util.CastType
 import org.partiql.planner.util.allNumberType
 import org.partiql.planner.util.allSupportedType
@@ -44,7 +44,7 @@ class OpArithmeticTest : PartiQLTyperTestBase() {
                     castTable(arg0, arg1) == CastType.COERCION -> arg1
                     else -> error("Arguments do not conform to parameters. Args: $args")
                 }
-                accumulateSuccess(output, args)
+                accumulateSuccessNullCall(output, args)
             }
 
             put(TestResult.Failure, failureArgs)

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpBitwiseAndTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpBitwiseAndTest.kt
@@ -3,11 +3,13 @@ package org.partiql.planner.internal.typer.operator
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
+import org.partiql.planner.internal.typer.accumulateSuccess
 import org.partiql.planner.util.CastType
 import org.partiql.planner.util.allIntType
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.cartesianProduct
 import org.partiql.planner.util.castTable
+import org.partiql.types.NullType
 import org.partiql.types.StaticType
 import java.util.stream.Stream
 
@@ -18,7 +20,7 @@ class OpBitwiseAndTest : PartiQLTyperTestBase() {
             "expr-36"
         ).map { inputs.get("basics", it)!! }
 
-        val argsMap = buildMap {
+        val argsMap: Map<TestResult, Set<List<StaticType>>> = buildMap {
             val successArgs = (allIntType + listOf(StaticType.NULL))
                 .let { cartesianProduct(it, it) }
             val failureArgs = cartesianProduct(
@@ -31,24 +33,14 @@ class OpBitwiseAndTest : PartiQLTyperTestBase() {
             successArgs.forEach { args: List<StaticType> ->
                 val arg0 = args.first()
                 val arg1 = args[1]
-                if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
-                    }
-                } else if (arg0 == arg1) {
-                    (this[TestResult.Success(arg1)] ?: setOf(args)).let {
-                        put(TestResult.Success(arg1), it + setOf(args))
-                    }
-                } else if (castTable(arg1, arg0) == CastType.COERCION) {
-                    (this[TestResult.Success(arg0)] ?: setOf(args)).let {
-                        put(TestResult.Success(arg0), it + setOf(args))
-                    }
-                } else {
-                    (this[TestResult.Success(arg1)] ?: setOf(args)).let {
-                        put(TestResult.Success(arg1), it + setOf(args))
-                    }
+                val output = when {
+                    arg0 is NullType && arg1 is NullType -> StaticType.INT2
+                    arg0 == arg1 -> arg1
+                    castTable(arg1, arg0) == CastType.COERCION -> arg0
+                    castTable(arg0, arg1) == CastType.COERCION -> arg1
+                    else -> error("Arguments do not conform to parameters. Args: $args")
                 }
-                Unit
+                accumulateSuccess(output, args)
             }
             put(TestResult.Failure, failureArgs)
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpBitwiseAndTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpBitwiseAndTest.kt
@@ -3,7 +3,7 @@ package org.partiql.planner.internal.typer.operator
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
-import org.partiql.planner.internal.typer.accumulateSuccess
+import org.partiql.planner.internal.typer.accumulateSuccessNullCall
 import org.partiql.planner.util.CastType
 import org.partiql.planner.util.allIntType
 import org.partiql.planner.util.allSupportedType
@@ -40,7 +40,7 @@ class OpBitwiseAndTest : PartiQLTyperTestBase() {
                     castTable(arg0, arg1) == CastType.COERCION -> arg1
                     else -> error("Arguments do not conform to parameters. Args: $args")
                 }
-                accumulateSuccess(output, args)
+                accumulateSuccessNullCall(output, args)
             }
             put(TestResult.Failure, failureArgs)
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpConcatTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpConcatTest.kt
@@ -3,7 +3,7 @@ package org.partiql.planner.internal.typer.operator
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
-import org.partiql.planner.internal.typer.accumulateSuccess
+import org.partiql.planner.internal.typer.accumulateSuccessNullCall
 import org.partiql.planner.util.CastType
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.allTextType
@@ -48,7 +48,7 @@ class OpConcatTest : PartiQLTyperTestBase() {
                     castTable(arg0, arg1) == CastType.COERCION -> arg1
                     else -> error("Arguments do not conform to parameters. Args: $args")
                 }
-                accumulateSuccess(output, args)
+                accumulateSuccessNullCall(output, args)
             }
             put(TestResult.Failure, failureArgs)
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpBetweenTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpBetweenTest.kt
@@ -3,7 +3,7 @@ package org.partiql.planner.internal.typer.predicate
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
-import org.partiql.planner.internal.typer.accumulateSuccess
+import org.partiql.planner.internal.typer.accumulateSuccessNullCall
 import org.partiql.planner.util.allNumberType
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.cartesianProduct
@@ -52,7 +52,7 @@ class OpBetweenTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                accumulateSuccess(StaticType.BOOL, args)
+                accumulateSuccessNullCall(StaticType.BOOL, args)
             }
             put(TestResult.Failure, failureArgs)
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpBetweenTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpBetweenTest.kt
@@ -3,6 +3,7 @@ package org.partiql.planner.internal.typer.predicate
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
+import org.partiql.planner.internal.typer.accumulateSuccess
 import org.partiql.planner.util.allNumberType
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.cartesianProduct
@@ -51,19 +52,7 @@ class OpBetweenTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                val arg0 = args.first()
-                val arg1 = args[1]
-                val arg2 = args[2]
-                if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
-                    }
-                } else {
-                    (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.BOOL), it + setOf(args))
-                    }
-                }
-                Unit
+                accumulateSuccess(StaticType.BOOL, args)
             }
             put(TestResult.Failure, failureArgs)
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpComparisonTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpComparisonTest.kt
@@ -4,9 +4,11 @@ import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
 import org.partiql.planner.internal.typer.accumulateSuccess
+import org.partiql.planner.internal.typer.accumulateSuccessNullCall
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.cartesianProduct
 import org.partiql.types.MissingType
+import org.partiql.types.NullType
 import org.partiql.types.StaticType
 import java.util.stream.Stream
 
@@ -20,12 +22,12 @@ class OpComparisonTest : PartiQLTyperTestBase() {
             "expr-08", // Not Equal !=
             "expr-09", // Not Equal <>
         ).map { inputs.get("basics", it)!! }
-        val argsMap = buildMap {
+        val argsMap: Map<TestResult, Set<List<StaticType>>> = buildMap {
             val successArgs = cartesianProduct(allSupportedType, allSupportedType)
             successArgs.forEach { args: List<StaticType> ->
-                when (args.any { it is MissingType }) {
-                    true -> accumulateSuccess(StaticType.MISSING, args)
-                    false -> accumulateSuccess(StaticType.BOOL, args)
+                when {
+                    args.any { it is MissingType } && args.any { it is NullType } -> accumulateSuccess(StaticType.BOOL, args)
+                    args.any { it is MissingType } && args.any { it is NullType } -> accumulateSuccess(StaticType.BOOL, args)
                 }
             }
         }
@@ -76,7 +78,7 @@ class OpComparisonTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                accumulateSuccess(StaticType.BOOL, args)
+                accumulateSuccessNullCall(StaticType.BOOL, args)
             }
             put(TestResult.Failure, failureArgs)
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpComparisonTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpComparisonTest.kt
@@ -3,8 +3,10 @@ package org.partiql.planner.internal.typer.predicate
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
+import org.partiql.planner.internal.typer.accumulateSuccess
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.cartesianProduct
+import org.partiql.types.MissingType
 import org.partiql.types.StaticType
 import java.util.stream.Stream
 
@@ -20,22 +22,11 @@ class OpComparisonTest : PartiQLTyperTestBase() {
         ).map { inputs.get("basics", it)!! }
         val argsMap = buildMap {
             val successArgs = cartesianProduct(allSupportedType, allSupportedType)
-
             successArgs.forEach { args: List<StaticType> ->
-                if (args.contains(StaticType.MISSING)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
-                    }
-                } else if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
-                    }
-                } else {
-                    (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.BOOL), it + setOf(args))
-                    }
+                when (args.any { it is MissingType }) {
+                    true -> accumulateSuccess(StaticType.MISSING, args)
+                    false -> accumulateSuccess(StaticType.BOOL, args)
                 }
-                put(TestResult.Failure, emptySet<List<StaticType>>())
             }
         }
 
@@ -85,16 +76,7 @@ class OpComparisonTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
-                    }
-                } else {
-                    (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.BOOL), it + setOf(args))
-                    }
-                }
-                Unit
+                accumulateSuccess(StaticType.BOOL, args)
             }
             put(TestResult.Failure, failureArgs)
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpInTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpInTest.kt
@@ -3,7 +3,7 @@ package org.partiql.planner.internal.typer.predicate
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
-import org.partiql.planner.internal.typer.accumulateSuccess
+import org.partiql.planner.internal.typer.accumulateSuccessNullCall
 import org.partiql.planner.util.allCollectionType
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.cartesianProduct
@@ -27,7 +27,7 @@ class OpInTest : PartiQLTyperTestBase() {
                     .toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                accumulateSuccess(StaticType.BOOL, args)
+                accumulateSuccessNullCall(StaticType.BOOL, args)
             }
             put(TestResult.Failure, emptySet<List<StaticType>>())
         }
@@ -54,7 +54,7 @@ class OpInTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                accumulateSuccess(StaticType.BOOL, args)
+                accumulateSuccessNullCall(StaticType.BOOL, args)
             }
             put(TestResult.Failure, failureArgs)
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpInTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpInTest.kt
@@ -3,6 +3,7 @@ package org.partiql.planner.internal.typer.predicate
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
+import org.partiql.planner.internal.typer.accumulateSuccess
 import org.partiql.planner.util.allCollectionType
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.cartesianProduct
@@ -26,16 +27,7 @@ class OpInTest : PartiQLTyperTestBase() {
                     .toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
-                    }
-                } else {
-                    (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.BOOL), it + setOf(args))
-                    }
-                }
-                Unit
+                accumulateSuccess(StaticType.BOOL, args)
             }
             put(TestResult.Failure, emptySet<List<StaticType>>())
         }
@@ -62,16 +54,7 @@ class OpInTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
-                    }
-                } else {
-                    (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.BOOL), it + setOf(args))
-                    }
-                }
-                Unit
+                accumulateSuccess(StaticType.BOOL, args)
             }
             put(TestResult.Failure, failureArgs)
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpLikeTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpLikeTest.kt
@@ -3,7 +3,7 @@ package org.partiql.planner.internal.typer.predicate
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
-import org.partiql.planner.internal.typer.accumulateSuccess
+import org.partiql.planner.internal.typer.accumulateSuccessNullCall
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.allTextType
 import org.partiql.planner.util.cartesianProduct
@@ -28,7 +28,7 @@ class OpLikeTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                accumulateSuccess(StaticType.BOOL, args)
+                accumulateSuccessNullCall(StaticType.BOOL, args)
             }
             put(TestResult.Failure, failureArgs)
         }
@@ -54,7 +54,7 @@ class OpLikeTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                accumulateSuccess(StaticType.BOOL, args)
+                accumulateSuccessNullCall(StaticType.BOOL, args)
             }
             put(TestResult.Failure, failureArgs)
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpLikeTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpLikeTest.kt
@@ -3,6 +3,7 @@ package org.partiql.planner.internal.typer.predicate
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
+import org.partiql.planner.internal.typer.accumulateSuccess
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.allTextType
 import org.partiql.planner.util.cartesianProduct
@@ -27,16 +28,7 @@ class OpLikeTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
-                    }
-                } else {
-                    (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.BOOL), it + setOf(args))
-                    }
-                }
-                Unit
+                accumulateSuccess(StaticType.BOOL, args)
             }
             put(TestResult.Failure, failureArgs)
         }
@@ -62,16 +54,7 @@ class OpLikeTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
-                    }
-                } else {
-                    (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.BOOL), it + setOf(args))
-                    }
-                }
-                Unit
+                accumulateSuccess(StaticType.BOOL, args)
             }
             put(TestResult.Failure, failureArgs)
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpTypeAssertionTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpTypeAssertionTest.kt
@@ -3,7 +3,7 @@ package org.partiql.planner.internal.typer.predicate
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
-import org.partiql.planner.internal.typer.accumulateSuccess
+import org.partiql.planner.internal.typer.accumulateSuccessNullCall
 import org.partiql.planner.internal.typer.accumulateSuccesses
 import org.partiql.planner.util.allSupportedType
 import org.partiql.types.MissingType
@@ -28,7 +28,7 @@ class OpTypeAssertionTest : PartiQLTyperTestBase() {
             }.toSet()
             val failureArgs = setOf(listOf(MissingType))
             accumulateSuccesses(StaticType.BOOL, successArgs)
-            accumulateSuccess(StaticType.BOOL, listOf(StaticType.NULL))
+            accumulateSuccessNullCall(StaticType.BOOL, listOf(StaticType.NULL))
             put(TestResult.Failure, failureArgs)
         }
 

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpTypeAssertionTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpTypeAssertionTest.kt
@@ -3,10 +3,11 @@ package org.partiql.planner.internal.typer.predicate
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.TestFactory
 import org.partiql.planner.internal.typer.PartiQLTyperTestBase
+import org.partiql.planner.internal.typer.accumulateSuccess
+import org.partiql.planner.internal.typer.accumulateSuccesses
 import org.partiql.planner.util.allSupportedType
 import org.partiql.types.MissingType
 import org.partiql.types.NullType
-import org.partiql.types.SingleType
 import org.partiql.types.StaticType
 import java.util.stream.Stream
 
@@ -26,8 +27,8 @@ class OpTypeAssertionTest : PartiQLTyperTestBase() {
                 setOf(listOf(t))
             }.toSet()
             val failureArgs = setOf(listOf(MissingType))
-            put(TestResult.Success(StaticType.BOOL), successArgs)
-            put(TestResult.Success(StaticType.NULL), setOf(listOf<SingleType>(StaticType.NULL)))
+            accumulateSuccesses(StaticType.BOOL, successArgs)
+            accumulateSuccess(StaticType.BOOL, listOf(StaticType.NULL))
             put(TestResult.Failure, failureArgs)
         }
 

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/util/Utils.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/util/Utils.kt
@@ -184,9 +184,11 @@ val castTable: ((StaticType, StaticType) -> CastType) = { from, to ->
             is MissingType -> CastType.COERCION
             else -> CastType.UNSAFE
         }
-        is NullType -> when (to) {
-            is NullType -> CastType.COERCION
-            else -> CastType.UNSAFE
+        is NullType -> {
+            when (to) {
+                is MissingType -> CastType.UNSAFE
+                else -> CastType.COERCION
+            }
         }
         is StringType ->
             when (to) {

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/sql/builtins/FnAnd.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/sql/builtins/FnAnd.kt
@@ -32,10 +32,14 @@ internal object Fn_AND__BOOL_BOOL__BOOL : Fn {
     )
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
-        val lhs = args[0].check<BoolValue>().value!!
-        val rhs = args[1].check<BoolValue>().value!!
+        val lhs = args[0].check<BoolValue>()
+        val rhs = args[1].check<BoolValue>()
+        // SQL:1999 Section 6.30 Table 13
         val toReturn = when {
-            !lhs || !rhs -> false
+            lhs.isNull && rhs.isNull -> null
+            lhs.value == true && rhs.isNull -> null
+            rhs.value == true && lhs.isNull -> null
+            lhs.value == false || rhs.value == false -> false
             else -> true
         }
         return boolValue(toReturn)

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/sql/builtins/FnEq.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/sql/builtins/FnEq.kt
@@ -69,6 +69,7 @@ internal object Fn_EQ__ANY_ANY__BOOL : Fn {
 
     private val comparator = PartiQLValue.comparator()
 
+    // Since the ANY_ANY function is the catch-all, we must be able to take in nulls. Therefore, isNullCall must be false.
     override val signature = FnSignature(
         name = "eq",
         returns = BOOL,
@@ -77,19 +78,16 @@ internal object Fn_EQ__ANY_ANY__BOOL : Fn {
             FnParameter("rhs", ANY),
         ),
         isNullable = false,
-        isNullCall = true,
+        isNullCall = false,
         isMissable = false,
-        isMissingCall = false,
+        isMissingCall = true,
     )
 
     // TODO ANY, ANY equals not clearly defined at the moment.
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
         val lhs = args[0]
         val rhs = args[1]
-        return when {
-            lhs.type == MISSING || rhs.type == MISSING -> boolValue(lhs == rhs)
-            else -> boolValue(comparator.compare(lhs, rhs) == 0)
-        }
+        return boolValue(comparator.compare(lhs, rhs) == 0)
     }
 }
 
@@ -686,9 +684,8 @@ internal object Fn_EQ__NULL_NULL__BOOL : Fn {
 
     // TODO how does null comparison work? ie null.null == null.null or int8.null == null.null ??
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
-        val lhs = args[0]
-        val rhs = args[1]
-        return boolValue(lhs.isNull == rhs.isNull)
+        // According to the conformance tests, NULL = NULL -> NULL
+        return boolValue(null)
     }
 }
 
@@ -705,7 +702,7 @@ internal object Fn_EQ__MISSING_MISSING__BOOL : Fn {
         isNullable = false,
         isNullCall = true,
         isMissable = false,
-        isMissingCall = false,
+        isMissingCall = true,
     )
 
     // TODO how does `=` work with MISSING? As of now, always false.

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/sql/builtins/FnEq.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/sql/builtins/FnEq.kt
@@ -80,14 +80,17 @@ internal object Fn_EQ__ANY_ANY__BOOL : Fn {
         isNullable = false,
         isNullCall = false,
         isMissable = false,
-        isMissingCall = true,
+        isMissingCall = false,
     )
 
     // TODO ANY, ANY equals not clearly defined at the moment.
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
         val lhs = args[0]
         val rhs = args[1]
-        return boolValue(comparator.compare(lhs, rhs) == 0)
+        return when {
+            lhs.type == MISSING || rhs.type == MISSING -> boolValue(lhs == rhs)
+            else -> boolValue(comparator.compare(lhs, rhs) == 0)
+        }
     }
 }
 
@@ -700,9 +703,9 @@ internal object Fn_EQ__MISSING_MISSING__BOOL : Fn {
             FnParameter("rhs", MISSING),
         ),
         isNullable = false,
-        isNullCall = true,
+        isNullCall = false,
         isMissable = false,
-        isMissingCall = true,
+        isMissingCall = false,
     )
 
     // TODO how does `=` work with MISSING? As of now, always false.

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/sql/builtins/FnNot.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/sql/builtins/FnNot.kt
@@ -40,16 +40,15 @@ internal object Fn_NOT__MISSING__BOOL : Fn {
 
     override val signature = FnSignature(
         name = "not",
-        returns = MISSING,
+        returns = BOOL,
         parameters = listOf(FnParameter("value", MISSING)),
-        isNullable = false,
+        isNullable = true,
         isNullCall = true,
-        isMissable = true,
-        isMissingCall = true,
+        isMissable = false,
+        isMissingCall = false,
     )
 
-    // TODO: determine what this behavior should be
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
-        throw TypeCheckException()
+        return boolValue(null)
     }
 }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/sql/builtins/FnNot.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/sql/builtins/FnNot.kt
@@ -26,7 +26,7 @@ internal object Fn_NOT__BOOL__BOOL : Fn {
         isNullable = false,
         isNullCall = true,
         isMissable = false,
-        isMissingCall = false,
+        isMissingCall = true,
     )
 
     override fun invoke(args: Array<PartiQLValue>): PartiQLValue {
@@ -40,12 +40,12 @@ internal object Fn_NOT__MISSING__BOOL : Fn {
 
     override val signature = FnSignature(
         name = "not",
-        returns = BOOL,
+        returns = MISSING,
         parameters = listOf(FnParameter("value", MISSING)),
         isNullable = false,
         isNullCall = true,
-        isMissable = false,
-        isMissingCall = false,
+        isMissable = true,
+        isMissingCall = true,
     )
 
     // TODO: determine what this behavior should be

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/connector/sql/builtins/FnNot.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/connector/sql/builtins/FnNot.kt
@@ -3,7 +3,6 @@
 
 package org.partiql.spi.connector.sql.builtins
 
-import org.partiql.errors.TypeCheckException
 import org.partiql.spi.fn.Fn
 import org.partiql.spi.fn.FnExperimental
 import org.partiql.spi.fn.FnParameter

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/fn/FnSignature.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/fn/FnSignature.kt
@@ -21,7 +21,7 @@ import org.partiql.value.PartiQLValueType
  */
 @FnExperimental
 @OptIn(PartiQLValueExperimental::class)
-public class FnSignature(
+public data class FnSignature(
     @JvmField public val name: String,
     @JvmField public val returns: PartiQLValueType,
     @JvmField public val parameters: List<FnParameter>,
@@ -50,38 +50,6 @@ public class FnSignature(
      * @return
      */
     override fun toString(): String = specific
-
-    override fun equals(other: Any?): Boolean {
-        if (other !is FnSignature) return false
-        if (
-            other.name != name ||
-            other.returns != returns ||
-            other.parameters.size != parameters.size ||
-            other.isDeterministic != isDeterministic ||
-            other.isNullCall != isNullCall ||
-            other.isNullable != isNullable
-        ) {
-            return false
-        }
-        // all other parts equal, compare parameters (ignore names)
-        for (i in parameters.indices) {
-            val p1 = parameters[i]
-            val p2 = other.parameters[i]
-            if (p1.type != p2.type) return false
-        }
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = name.hashCode()
-        result = 31 * result + returns.hashCode()
-        result = 31 * result + parameters.hashCode()
-        result = 31 * result + isDeterministic.hashCode()
-        result = 31 * result + isNullCall.hashCode()
-        result = 31 * result + isNullable.hashCode()
-        result = 31 * result + (description?.hashCode() ?: 0)
-        return result
-    }
 
     // Logic for writing a [FunctionSignature] using SQL `CREATE FUNCTION` syntax.
 

--- a/partiql-types/src/main/kotlin/org/partiql/errors/TypeCheckException.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/errors/TypeCheckException.kt
@@ -3,12 +3,24 @@ package org.partiql.errors
 /**
  * A [TypeCheckException] represents an invalid operation due to argument types.
  */
-public class TypeCheckException(message: String? = null) : RuntimeException(message)
+public class TypeCheckException(message: String? = null) : RuntimeException(message) {
+
+    /**
+     * This does not provide the stack trace, as this is very expensive in permissive mode.
+     */
+    override fun fillInStackTrace(): Throwable = this
+}
 
 /**
  * A [DataException] represents an unrecoverable query runtime exception.
  */
-public class DataException(public override val message: String) : RuntimeException()
+public class DataException(public override val message: String) : RuntimeException() {
+
+    /**
+     * This does not provide the stack trace, as this is very expensive in permissive mode.
+     */
+    override fun fillInStackTrace(): Throwable = this
+}
 
 /**
  * A [CardinalityViolation] represents an invalid operation due to an unexpected cardinality of an argument.
@@ -17,4 +29,10 @@ public class DataException(public override val message: String) : RuntimeExcepti
  * > If the cardinality of a <row subquery> is greater than 1 (one), then an exception condition is raised: cardinality violation.
  * > If the cardinality of SS [[scalar subquery]] is greater than 1 (one), then an exception condition is raised: cardinality violation.
  */
-public class CardinalityViolation : RuntimeException()
+public class CardinalityViolation : RuntimeException() {
+
+    /**
+     * This does not provide the stack trace, as this is very expensive in permissive mode.
+     */
+    override fun fillInStackTrace(): Throwable = this
+}


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds performance optimizations for ExprCallDynamic
  - Creates a `CandidateIndex.All` that preserves the initial order of the candidate functions, however, it internally wraps a list of `CandidateIndex.Direct` and `CandidateIndex.Indirect`. `CandidateIndex.Direct` holds a map between runtime parameter types and the associated candidate to invoke. `CandidateIndex.Indirect` holds an ordered list of any non-runtime parameter types (aka `ANY`). With this, `CandidateIndex.All` can reduce the number of checks by taking advantage of these two subclasses.
  - Fixes ordering of the dynamic candidates. Before, we would lose the original ordering of candidates, and for some functions, it would cause extremely expensive computation. For example, when profiling `SELECT ... WHERE <ANY> = 2`, the lack of ordering would for some reason **always** place `EQ(ANY, ANY)` first -- which would invoke PartiQL's comparator -- which is seemingly very slow (taking up 25% of the entire test's CPU usage). By re-ordering the candidates, it significantly impacted our performance for the better (the matched `EQ` function did not even show up on the profiler, indicating that it took up less than 1% of the CPU usage).
- Since CASTs are really function calls in SQL:1999, I've updated the definition of `Ref.Cast` to contain `isNullable` -- at least until we truly represent casts with function calls.
```
<user-defined cast definition> ::=
    CREATE CAST <left paren> <source data type> AS <target data type> <right paren>
    WITH <cast function>
    [ AS ASSIGNMENT ]
```
- I needed to update the tests since the typing of functions like `ADD(NULL, INT)` were initially returning the type `NULL`, but it really should have been returning `INT?`. This is modeled slightly different in SQL:1999 since types are nullable, but until we add this, we'll need to support this.
- By examining the profiler, in permissive mode, our runtime exceptions that get converted to `MISSINGs` are extremely expensive (causing up to 33.2% of our CPU usage for evaluation) due to the `fillInStackTrace` method. Since we are programming a language, we can/should be architecting our own error messaging system.

## Note
- The conformance tests that now fail are from `NULL = MISSING`. See the Summary. I think these tests are wrong. See PartiQL Spec: "Equality never fails in the type-checking mode and never returns MISSING in the permissive mode."

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **YES** -- the `isNullable` flag, which is required
- Any new external dependencies? **NO**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.