### PR TITLE
Prepare v0.14.4 release; move internal, top-level functions back to original file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,24 @@ Thank you to all who have contributed!
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
+### Contributors
+Thank you to all who have contributed!
+- @<your-username>
+
+## [0.14.4]
+
+### Added
 - Added constrained decimal as valid parameter type to functions that take in numeric parameters. 
 - Added async version of physical plan evaluator `PartiQLCompilerAsync`. 
   - The following related async APIs have been added:
@@ -61,6 +79,7 @@ Thank you to all who have contributed!
 
 ### Contributors
 Thank you to all who have contributed!
+- @yliuuuu
 - @alancai98
 
 ## [0.14.3] - 2024-02-14
@@ -1020,7 +1039,8 @@ breaking changes if migrating from v0.9.2. The breaking changes accidentally int
 ### Added
 Initial alpha release of PartiQL.
 
-[Unreleased]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.3...HEAD
+[Unreleased]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.4...HEAD
+[0.14.4]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.0-alpha...v0.14.1

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID      | Artifact ID           | Recommended Version |
 |---------------|-----------------------|---------------------|
-| `org.partiql` | `partiql-lang-kotlin` | `0.14.3`            |
+| `org.partiql` | `partiql-lang-kotlin` | `0.14.4`            |
 
 
 For Maven builds, add the following to your `pom.xml`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=0.14.4-SNAPSHOT
+version=0.14.4
 
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerAsyncImpl.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerAsyncImpl.kt
@@ -32,7 +32,6 @@ import org.partiql.errors.Property
 import org.partiql.errors.PropertyValueMap
 import org.partiql.lang.ast.IsOrderedMeta
 import org.partiql.lang.ast.SourceLocationMeta
-import org.partiql.lang.ast.UNKNOWN_SOURCE_LOCATION
 import org.partiql.lang.ast.sourceLocation
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.domains.staticType
@@ -1872,14 +1871,6 @@ internal class PhysicalPlanCompilerAsyncImpl(
             },
             ordering
         )
-}
-
-internal val MetaContainer.sourceLocationMeta get() = this[SourceLocationMeta.TAG] as? SourceLocationMeta
-internal val MetaContainer.sourceLocationMetaOrUnknown get() = this.sourceLocationMeta ?: UNKNOWN_SOURCE_LOCATION
-
-internal fun StaticType.getTypes() = when (val flattened = this.flatten()) {
-    is AnyOfType -> flattened.types
-    else -> listOf(this)
 }
 
 /**

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/physical/PhysicalPlanCompilerImpl.kt
@@ -26,6 +26,7 @@ import org.partiql.errors.Property
 import org.partiql.errors.PropertyValueMap
 import org.partiql.lang.ast.IsOrderedMeta
 import org.partiql.lang.ast.SourceLocationMeta
+import org.partiql.lang.ast.UNKNOWN_SOURCE_LOCATION
 import org.partiql.lang.ast.sourceLocation
 import org.partiql.lang.domains.PartiqlPhysical
 import org.partiql.lang.domains.staticType
@@ -1883,6 +1884,14 @@ internal class PhysicalPlanCompilerImpl(
             },
             ordering
         )
+}
+
+internal val MetaContainer.sourceLocationMeta get() = this[SourceLocationMeta.TAG] as? SourceLocationMeta
+internal val MetaContainer.sourceLocationMetaOrUnknown get() = this.sourceLocationMeta ?: UNKNOWN_SOURCE_LOCATION
+
+internal fun StaticType.getTypes() = when (val flattened = this.flatten()) {
+    is AnyOfType -> flattened.types
+    else -> listOf(this)
 }
 
 /**


### PR DESCRIPTION
## Description
- Prepares v0.14.4 minor release
- Running the Java API compliance checker showed that moving the `internal`, top-level functions to a different file in #1382 is a "breaking change" from Java perspective (since Java can call `internal` Kotlin functions). Choosing the conservative approach to move back the `internal`, top-level functions back to the original file until #1387 is resolved.
  - Following this reversion, I reran the compliance checker, which found no breaking changes.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.