### PR TITLE
Change StaticType.AnyOfType's .toString to not perform .flatten()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Thank you to all who have contributed!
 ### Added
 
 ### Changed
+- Change `StaticType.AnyOfType`'s `.toString` to not perform `.flatten()`
 
 ### Deprecated
 
@@ -164,6 +165,7 @@ Thank you to all who have contributed!
 - **BREAKING** Changed modeling of `EXCLUDE` in `partiql-ast`
 
 ### Deprecated
+
 
 ### Fixed
 - Fixes the CLI hanging on invalid queries. See issue #1230.

--- a/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
@@ -642,21 +642,10 @@ public data class AnyOfType(val types: Set<StaticType>, override val metas: Map<
         }
     }
 
-    override fun toString(): String =
-        when (val flattenedType = flatten()) {
-            is AnyOfType -> {
-                val unionedTypes = flattenedType.types
-                when (unionedTypes.size) {
-                    0 -> "\$null"
-                    1 -> unionedTypes.first().toString()
-                    else -> {
-                        val types = unionedTypes.joinToString { it.toString() }
-                        "union($types)"
-                    }
-                }
-            }
-            else -> flattenedType.toString()
-        }
+    override fun toString(): String {
+        val types = types.joinToString { it.toString() }
+        return "union($types)"
+    }
 
     override val allTypes: List<StaticType>
         get() = this.types.map { it.flatten() }


### PR DESCRIPTION
## Description
Change the `StaticType.AnyOfType`'s `.toString` method to not perform a `.flatten()` call. This can make things clearer when debugging `StaticType.AnyOfType` strings.

Previously,
`StaticType.unionOf(StaticType.STRING, StaticType.NULL)` and `StaticType.unionOf(unionOf(StaticType.STRING, StaticType.NULL))` would output the same string, which made debugging confusing.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.