### PR TITLE
Add EXCLUDE test for a new projection from subquery

### DIFF
--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerExcludeTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerExcludeTests.kt
@@ -22,6 +22,14 @@ class EvaluatingCompilerExcludeTests : EvaluatorTestBase() {
                 "SELECT t.* EXCLUDE t.a FROM <<{'a': {'b': 2}, 'foo': 'bar', 'foo2': 'bar2'}>> AS t",
                 """<<{'foo': 'bar', 'foo2': 'bar2'}>>"""
             ),
+            EvaluatorTestCase(
+                """
+                    SELECT tbl2.* EXCLUDE tbl2.derivedColumn FROM 
+                        (SELECT tbl1.*, tbl1.a.b + 2 AS derivedColumn FROM 
+                            <<{'a': {'b': 2}, 'foo': 'bar', 'foo2': 'bar2'}>> AS tbl1) 
+                            AS tbl2""",
+                " <<{'a': {'b': 2}, 'foo': 'bar', 'foo2': 'bar2'}>>"
+            ),
             EvaluatorTestCase( // EXCLUDE tuple attr using bracket syntax; same output as above
                 "SELECT t.* EXCLUDE t['a'] FROM <<{'a': {'b': 2}, 'foo': 'bar', 'foo2': 'bar2'}>> AS t",
                 """<<{'foo': 'bar', 'foo2': 'bar2'}>>"""


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
Adds a unit-test for excluding an attribute that is as a result of a new projection from a sub-query.

More details:
```
PartiQL> SELECT tbl2.* EXCLUDE tbl2.dervidedColumn FROM (SELECT tbl1.*, tbl1.a.b + 2 AS dervidedColumn FROM <<{'a': {'b': 2}, 'foo': 'bar', 'foo2': 'bar2'}>> AS tbl1) AS tbl2;
==='
<<
  {
    'a': {
      'b': 2
    },
    'foo': 'bar',
    'foo2': 'bar2'
  }
>>
---
OK!
PartiQL> SELECT tbl2.* FROM (SELECT tbl1.*, tbl1.a.b + 2 AS dervidedColumn FROM <<{'a': {'b': 2}, 'foo': 'bar', 'foo2': 'bar2'}>> AS tbl1) AS tbl2;
==='
<<
  {
    'a': {
      'b': 2
    },
    'foo': 'bar',
    'foo2': 'bar2',
    'dervidedColumn': 4
  }
>>
---
OK!
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No, this is just a uni-test addition.

- Any backward-incompatible changes? **[YES/NO]**
  - No.

- Any new external dependencies? **[YES/NO]**
  - No.

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.