### PR TITLE
Fix StaticType.flatten() on AnyOfType containing AnyType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Thank you to all who have contributed!
 ### Deprecated
 
 ### Fixed
+- `StaticType.flatten()` on an `AnyOfType` with `AnyType` will return `AnyType`
 
 ### Removed
 

--- a/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
@@ -630,7 +630,7 @@ public data class AnyOfType(val types: Set<StaticType>, override val metas: Map<
         types = this.types.flatMap {
             when (it) {
                 is SingleType -> listOf(it)
-                is AnyType -> listOf(it)
+                is AnyType -> return@flatten it // if `AnyType`, return `AnyType`
                 is AnyOfType -> it.types
             }
         }.toSet()


### PR DESCRIPTION
## Description
Fixes some previous buggy behavior when flattening an `AnyOfType` containing `AnyType`:

```
AnyOfType(setOf(StaticType.INT, StaticType.ANY))           // union(int, any)
AnyOfType(setOf(StaticType.INT, StaticType.ANY)).flatten() // union(int, any)
```

With this change, the above will now be:
```
AnyOfType(setOf(StaticType.INT, StaticType.ANY))           // union(int, any)
AnyOfType(setOf(StaticType.INT, StaticType.ANY)).flatten() // any
```


## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.