### PR TITLE
Add `COALESCE` and `NULLIF` to the logical plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Thank you to all who have contributed!
 
 ### Changed
 - Change `StaticType.AnyOfType`'s `.toString` to not perform `.flatten()`
+- Change modeling of `COALESCE` and `NULLIF` to dedicated nodes in logical plan
 
 ### Deprecated
 
@@ -43,7 +44,7 @@ Thank you to all who have contributed!
 
 ### Contributors
 Thank you to all who have contributed!
-- @<your-username>
+- @alancai98
 
 ## [0.14.4]
 

--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -135,6 +135,15 @@ rex::{
       ],
     },
 
+    nullif::{
+      v1: rex,
+      v2: rex
+    },
+
+    coalesce::{
+      args: list::[rex]
+    },
+
     collection::{
       values: list::[rex],
     },

--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -136,8 +136,8 @@ rex::{
     },
 
     nullif::{
-      v1: rex,
-      v2: rex
+      value: rex,
+      nullifier: rex
     },
 
     coalesce::{

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
@@ -51,10 +51,12 @@ import org.partiql.planner.internal.ir.builder.RexOpCallDynamicCandidateBuilder
 import org.partiql.planner.internal.ir.builder.RexOpCallStaticBuilder
 import org.partiql.planner.internal.ir.builder.RexOpCaseBranchBuilder
 import org.partiql.planner.internal.ir.builder.RexOpCaseBuilder
+import org.partiql.planner.internal.ir.builder.RexOpCoalesceBuilder
 import org.partiql.planner.internal.ir.builder.RexOpCollectionBuilder
 import org.partiql.planner.internal.ir.builder.RexOpErrBuilder
 import org.partiql.planner.internal.ir.builder.RexOpGlobalBuilder
 import org.partiql.planner.internal.ir.builder.RexOpLitBuilder
+import org.partiql.planner.internal.ir.builder.RexOpNullifBuilder
 import org.partiql.planner.internal.ir.builder.RexOpPathIndexBuilder
 import org.partiql.planner.internal.ir.builder.RexOpPathKeyBuilder
 import org.partiql.planner.internal.ir.builder.RexOpPathSymbolBuilder
@@ -312,6 +314,8 @@ internal data class Rex(
             is Path -> visitor.visitRexOpPath(this, ctx)
             is Call -> visitor.visitRexOpCall(this, ctx)
             is Case -> visitor.visitRexOpCase(this, ctx)
+            is Nullif -> visitor.visitRexOpNullif(this, ctx)
+            is Coalesce -> visitor.visitRexOpCoalesce(this, ctx)
             is Collection -> visitor.visitRexOpCollection(this, ctx)
             is Struct -> visitor.visitRexOpStruct(this, ctx)
             is Pivot -> visitor.visitRexOpPivot(this, ctx)
@@ -564,6 +568,47 @@ internal data class Rex(
             internal companion object {
                 @JvmStatic
                 internal fun builder(): RexOpCaseBuilder = RexOpCaseBuilder()
+            }
+        }
+
+        internal data class Nullif(
+            @JvmField
+            internal val v1: Rex,
+            @JvmField
+            internal val v2: Rex,
+        ) : Op() {
+            internal override val children: List<PlanNode> by lazy {
+                val kids = mutableListOf<PlanNode?>()
+                kids.add(v1)
+                kids.add(v2)
+                kids.filterNotNull()
+            }
+
+            internal override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
+                visitor.visitRexOpNullif(this, ctx)
+
+            internal companion object {
+                @JvmStatic
+                internal fun builder(): RexOpNullifBuilder = RexOpNullifBuilder()
+            }
+        }
+
+        internal data class Coalesce(
+            @JvmField
+            internal val args: List<Rex>,
+        ) : Op() {
+            override val children: List<PlanNode> by lazy {
+                val kids = mutableListOf<PlanNode?>()
+                kids.addAll(args)
+                kids.filterNotNull()
+            }
+
+            override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
+                visitor.visitRexOpCoalesce(this, ctx)
+
+            internal companion object {
+                @JvmStatic
+                internal fun builder(): RexOpCoalesceBuilder = RexOpCoalesceBuilder()
             }
         }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
@@ -573,14 +573,14 @@ internal data class Rex(
 
         internal data class Nullif(
             @JvmField
-            internal val v1: Rex,
+            internal val value: Rex,
             @JvmField
-            internal val v2: Rex,
+            internal val nullifier: Rex,
         ) : Op() {
             internal override val children: List<PlanNode> by lazy {
                 val kids = mutableListOf<PlanNode?>()
-                kids.add(v1)
-                kids.add(v2)
+                kids.add(value)
+                kids.add(nullifier)
                 kids.filterNotNull()
             }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -182,8 +182,8 @@ internal object PlanTransform : PlanBaseVisitor<PlanNode, ProblemCallback>() {
 
         override fun visitRexOpNullif(node: Rex.Op.Nullif, ctx: ProblemCallback) =
             org.partiql.plan.Rex.Op.Nullif(
-                v1 = visitRex(node.v1, ctx),
-                v2 = visitRex(node.v2, ctx),
+                value = visitRex(node.value, ctx),
+                nullifier = visitRex(node.nullifier, ctx),
             )
 
         override fun visitRexOpCoalesce(node: Rex.Op.Coalesce, ctx: ProblemCallback) =

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -180,6 +180,17 @@ internal object PlanTransform : PlanBaseVisitor<PlanNode, ProblemCallback>() {
         branches = node.branches.map { visitRexOpCaseBranch(it, ctx) }, default = visitRex(node.default, ctx)
         )
 
+        override fun visitRexOpNullif(node: Rex.Op.Nullif, ctx: ProblemCallback) =
+            org.partiql.plan.Rex.Op.Nullif(
+                v1 = visitRex(node.v1, ctx),
+                v2 = visitRex(node.v2, ctx),
+            )
+
+        override fun visitRexOpCoalesce(node: Rex.Op.Coalesce, ctx: ProblemCallback) =
+            org.partiql.plan.Rex.Op.Coalesce(
+                args = node.args.map { visitRex(it, ctx) }
+            )
+
         override fun visitRexOpCaseBranch(node: Rex.Op.Case.Branch, ctx: ProblemCallback) =
             org.partiql.plan.Rex.Op.Case.Branch(
                 condition = visitRex(node.condition, ctx), rex = visitRex(node.rex, ctx)

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
@@ -30,8 +30,10 @@ import org.partiql.planner.internal.ir.identifierQualified
 import org.partiql.planner.internal.ir.identifierSymbol
 import org.partiql.planner.internal.ir.rex
 import org.partiql.planner.internal.ir.rexOpCallStatic
+import org.partiql.planner.internal.ir.rexOpCoalesce
 import org.partiql.planner.internal.ir.rexOpCollection
 import org.partiql.planner.internal.ir.rexOpLit
+import org.partiql.planner.internal.ir.rexOpNullif
 import org.partiql.planner.internal.ir.rexOpPathIndex
 import org.partiql.planner.internal.ir.rexOpPathKey
 import org.partiql.planner.internal.ir.rexOpPathSymbol
@@ -107,7 +109,7 @@ internal object RexConverter {
         private fun visitExprCoerce(node: Expr, ctx: Env, coercion: Rex.Op.Subquery.Coercion = Rex.Op.Subquery.Coercion.SCALAR): Rex {
             val rex = super.visitExpr(node, ctx)
             return when (rex.op is Rex.Op.Select) {
-                true -> rex(StaticType.ANY, rexOpSubquery(rex.op as Rex.Op.Select, coercion))
+                true -> rex(StaticType.ANY, rexOpSubquery(rex.op, coercion))
                 else -> rex
             }
         }
@@ -439,44 +441,21 @@ internal object RexConverter {
             return rex(type, call)
         }
 
-        // coalesce(expr1, expr2, ... exprN) ->
-        //   CASE
-        //     WHEN expr1 IS NOT NULL THEN EXPR1
-        //     ...
-        //     WHEN exprn is NOT NULL THEN exprn
-        //     ELSE NULL END
-        override fun visitExprCoalesce(node: Expr.Coalesce, ctx: Env): Rex = plan {
+        override fun visitExprCoalesce(node: Expr.Coalesce, ctx: Env): Rex {
             val type = StaticType.ANY
-            val createBranch: (Rex) -> Rex.Op.Case.Branch = { expr: Rex ->
-                val updatedCondition = rex(type, negate(call("is_null", expr)))
-                rexOpCaseBranch(updatedCondition, expr)
+            val args = node.args.map { arg ->
+                visitExprCoerce(arg, ctx)
             }
-
-            val branches = node.args.map {
-                createBranch(visitExpr(it, ctx))
-            }.toMutableList()
-
-            val defaultRex = rex(type = StaticType.NULL, op = rexOpLit(value = nullValue()))
-            val op = rexOpCase(branches, defaultRex)
-            rex(type, op)
+            val op = rexOpCoalesce(args)
+            return rex(type, op)
         }
 
-        // nullIf(expr1, expr2) ->
-        //   CASE
-        //     WHEN expr1 = expr2 THEN NULL
-        //     ELSE expr1 END
-        override fun visitExprNullIf(node: Expr.NullIf, ctx: Env): Rex = plan {
+        override fun visitExprNullIf(node: Expr.NullIf, ctx: Env): Rex {
             val type = StaticType.ANY
-            val expr1 = visitExpr(node.value, ctx)
-            val expr2 = visitExpr(node.nullifier, ctx)
-            val id = identifierSymbol(Expr.Binary.Op.EQ.name.lowercase(), Identifier.CaseSensitivity.SENSITIVE)
-            val fn = fnUnresolved(id, true)
-            val call = rexOpCallStatic(fn, listOf(expr1, expr2))
-            val branches = listOf(
-                rexOpCaseBranch(rex(type, call), rex(type = StaticType.NULL, op = rexOpLit(value = nullValue()))),
-            )
-            val op = rexOpCase(branches.toMutableList(), expr1)
-            rex(type, op)
+            val expr1 = visitExprCoerce(node.value, ctx)
+            val expr2 = visitExprCoerce(node.nullifier, ctx)
+            val op = rexOpNullif(expr1, expr2)
+            return rex(type, op)
         }
 
         /**

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
@@ -452,9 +452,9 @@ internal object RexConverter {
 
         override fun visitExprNullIf(node: Expr.NullIf, ctx: Env): Rex {
             val type = StaticType.ANY
-            val expr1 = visitExprCoerce(node.value, ctx)
-            val expr2 = visitExprCoerce(node.nullifier, ctx)
-            val op = rexOpNullif(expr1, expr2)
+            val value = visitExprCoerce(node.value, ctx)
+            val nullifier = visitExprCoerce(node.nullifier, ctx)
+            val op = rexOpNullif(value, nullifier)
             return rex(type, op)
         }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -55,9 +55,11 @@ import org.partiql.planner.internal.ir.rexOpCallDynamic
 import org.partiql.planner.internal.ir.rexOpCallDynamicCandidate
 import org.partiql.planner.internal.ir.rexOpCallStatic
 import org.partiql.planner.internal.ir.rexOpCaseBranch
+import org.partiql.planner.internal.ir.rexOpCoalesce
 import org.partiql.planner.internal.ir.rexOpCollection
 import org.partiql.planner.internal.ir.rexOpErr
 import org.partiql.planner.internal.ir.rexOpLit
+import org.partiql.planner.internal.ir.rexOpNullif
 import org.partiql.planner.internal.ir.rexOpPathIndex
 import org.partiql.planner.internal.ir.rexOpPathKey
 import org.partiql.planner.internal.ir.rexOpPathSymbol
@@ -757,6 +759,54 @@ internal class PlanTyper(
             }
 
             val op = Rex.Op.Case(newBranches, newDefault)
+            return rex(type, op)
+        }
+
+        // COALESCE(v1, v2,..., vN)
+        // ==
+        // CASE
+        //     WHEN v1 IS NOT NULL THEN v1  -- WHEN branch always a boolean
+        //     WHEN v2 IS NOT NULL THEN v2  -- WHEN branch always a boolean
+        //     ... -- similarly for v3..vN-1
+        //     ELSE vN
+        // END
+        // --> minimal common supertype of(<type v1>, <type v2>, ..., <type v3>)
+        override fun visitRexOpCoalesce(node: Rex.Op.Coalesce, ctx: StaticType?): Rex {
+            val args = node.args.map { visitRex(it, it.type) }.toMutableList()
+            val typer = DynamicTyper()
+            args.forEach { v ->
+                typer.accumulate(v.type)
+            }
+            val (type, mapping) = typer.mapping()
+            if (mapping != null) {
+                assert(mapping.size == args.size) { "Coercion mappings `len ${mapping.size}` did not match the number of COALESCE arguments `len ${args.size}`" }
+                for (i in args.indices) {
+                    val (operand, target) = mapping[i]
+                    if (operand == target) continue // skip; no coercion needed
+                    val cast = env.fnResolver.cast(operand, target)
+                    val rex = rex(type, rexOpCallStatic(fnResolved(cast), listOf(args[i])))
+                    args[i] = rex
+                }
+            }
+            val op = rexOpCoalesce(args)
+            return rex(type, op)
+        }
+
+        // NULLIF(v1, v2)
+        // ==
+        // CASE
+        //     WHEN v1 = v2 THEN NULL -- WHEN branch always a boolean
+        //     ELSE v1
+        // END
+        // --> minimal common supertype of (NULL, <type v1>)
+        override fun visitRexOpNullif(node: Rex.Op.Nullif, ctx: StaticType?): Rex {
+            val v1 = visitRex(node.v1, node.v1.type)
+            val v2 = visitRex(node.v2, node.v2.type)
+            val typer = DynamicTyper()
+            typer.accumulate(NULL)
+            typer.accumulate(v1.type)
+            val (type, _) = typer.mapping()
+            val op = rexOpNullif(v1, v2)
             return rex(type, op)
         }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -800,13 +800,13 @@ internal class PlanTyper(
         // END
         // --> minimal common supertype of (NULL, <type v1>)
         override fun visitRexOpNullif(node: Rex.Op.Nullif, ctx: StaticType?): Rex {
-            val v1 = visitRex(node.v1, node.v1.type)
-            val v2 = visitRex(node.v2, node.v2.type)
+            val value = visitRex(node.value, node.value.type)
+            val nullifier = visitRex(node.nullifier, node.nullifier.type)
             val typer = DynamicTyper()
             typer.accumulate(NULL)
-            typer.accumulate(v1.type)
+            typer.accumulate(value.type)
             val (type, _) = typer.mapping()
-            val op = rexOpNullif(v1, v2)
+            val op = rexOpNullif(value, nullifier)
             return rex(type, op)
         }
 

--- a/partiql-planner/src/main/resources/partiql_plan_internal.ion
+++ b/partiql-planner/src/main/resources/partiql_plan_internal.ion
@@ -159,8 +159,8 @@ rex::{
     },
 
     nullif::{
-      v1: rex,
-      v2: rex
+      value: rex,
+      nullifier: rex
     },
 
     coalesce::{

--- a/partiql-planner/src/main/resources/partiql_plan_internal.ion
+++ b/partiql-planner/src/main/resources/partiql_plan_internal.ion
@@ -158,6 +158,15 @@ rex::{
       ],
     },
 
+    nullif::{
+      v1: rex,
+      v2: rex
+    },
+
+    coalesce::{
+      args: list::[rex]
+    },
+
     collection::{
       values: list::[rex],
     },

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -2461,7 +2461,7 @@ class PlanTyperTestsPorted {
             SuccessTestCase(
                 key = PartiQLTest.Key("basics", "case-when-11"),
                 catalog = "pql",
-                expected = unionOf(StaticType.INT, StaticType.NULL, StaticType.MISSING),
+                expected = unionOf(StaticType.INT, StaticType.MISSING),
             ),
             SuccessTestCase(
                 key = PartiQLTest.Key("basics", "case-when-12"),
@@ -2571,6 +2571,199 @@ class PlanTyperTestsPorted {
                 key = PartiQLTest.Key("basics", "case-when-30"),
                 catalog = "pql",
                 expected = MISSING
+            ),
+        )
+
+        @JvmStatic
+        fun nullIf() = listOf(
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-00"),
+                catalog = "pql",
+                expected = StaticType.INT4.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-01"),
+                catalog = "pql",
+                expected = StaticType.INT4.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-02"),
+                catalog = "pql",
+                expected = StaticType.INT4.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-03"),
+                catalog = "pql",
+                expected = StaticType.INT4.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-04"),
+                catalog = "pql",
+                expected = StaticType.INT8.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-05"),
+                catalog = "pql",
+                expected = StaticType.INT4.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-06"),
+                catalog = "pql",
+                expected = StaticType.NULL
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-07"),
+                catalog = "pql",
+                expected = StaticType.INT4.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-08"),
+                catalog = "pql",
+                expected = StaticType.NULL_OR_MISSING
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-09"),
+                catalog = "pql",
+                expected = StaticType.INT4.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-10"),
+                catalog = "pql",
+                expected = StaticType.INT4.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-11"),
+                catalog = "pql",
+                expected = StaticType.INT4.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-12"),
+                catalog = "pql",
+                expected = StaticType.INT8.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-13"),
+                catalog = "pql",
+                expected = StaticType.INT4.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-14"),
+                catalog = "pql",
+                expected = StaticType.STRING.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-15"),
+                catalog = "pql",
+                expected = StaticType.INT4.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-16"),
+                catalog = "pql",
+                expected = unionOf(StaticType.INT2, StaticType.INT4, StaticType.INT8, StaticType.INT, StaticType.DECIMAL, StaticType.NULL)
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-17"),
+                catalog = "pql",
+                expected = StaticType.INT4.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "nullif-18"),
+                catalog = "pql",
+                expected = unionOf(StaticType.ANY.allTypes.toSet())
+            ),
+        )
+
+        @JvmStatic
+        fun coalesce() = listOf(
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-00"),
+                catalog = "pql",
+                expected = StaticType.INT4
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-01"),
+                catalog = "pql",
+                expected = StaticType.INT4
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-02"),
+                catalog = "pql",
+                expected = StaticType.DECIMAL
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-03"),
+                catalog = "pql",
+                expected = unionOf(StaticType.NULL, StaticType.DECIMAL)
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-04"),
+                catalog = "pql",
+                expected = unionOf(StaticType.NULL, StaticType.MISSING, StaticType.DECIMAL)
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-05"),
+                catalog = "pql",
+                expected = unionOf(StaticType.NULL, StaticType.MISSING, StaticType.DECIMAL)
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-06"),
+                catalog = "pql",
+                expected = StaticType.INT4
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-07"),
+                catalog = "pql",
+                expected = StaticType.INT4
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-08"),
+                catalog = "pql",
+                expected = StaticType.INT8
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-09"),
+                catalog = "pql",
+                expected = StaticType.INT8.asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-10"),
+                catalog = "pql",
+                expected = unionOf(StaticType.INT8, StaticType.NULL, StaticType.MISSING)
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-11"),
+                catalog = "pql",
+                expected = unionOf(StaticType.INT8, StaticType.STRING)
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-12"),
+                catalog = "pql",
+                expected = unionOf(StaticType.INT8, StaticType.NULL, StaticType.STRING)
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-13"),
+                catalog = "pql",
+                expected = unionOf(StaticType.INT2, StaticType.INT4, StaticType.INT8, StaticType.INT, StaticType.DECIMAL)
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-14"),
+                catalog = "pql",
+                expected = unionOf(StaticType.INT2, StaticType.INT4, StaticType.INT8, StaticType.INT, StaticType.DECIMAL, StaticType.STRING)
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-15"),
+                catalog = "pql",
+                expected = unionOf(StaticType.INT2, StaticType.INT4, StaticType.INT8, StaticType.INT, StaticType.DECIMAL, StaticType.STRING, StaticType.NULL)
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-16"),
+                catalog = "pql",
+                expected = unionOf(StaticType.ANY.allTypes.toSet())
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "coalesce-17"),
+                catalog = "pql",
+                expected = unionOf(StaticType.ANY.allTypes.toSet())
             ),
         )
 
@@ -3226,6 +3419,16 @@ class PlanTyperTestsPorted {
     @MethodSource("caseWhens")
     @Execution(ExecutionMode.CONCURRENT)
     fun testCaseWhens(tc: TestCase) = runTest(tc)
+
+    @ParameterizedTest
+    @MethodSource("nullIf")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun testNullIf(tc: TestCase) = runTest(tc)
+
+    @ParameterizedTest
+    @MethodSource("coalesce")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun testCoalesce(tc: TestCase) = runTest(tc)
 
     @ParameterizedTest
     @MethodSource("subqueryCases")

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -2572,6 +2572,26 @@ class PlanTyperTestsPorted {
                 catalog = "pql",
                 expected = MISSING
             ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-31"),
+                catalog = "pql",
+                expected = StaticType.ANY
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-32"),
+                catalog = "pql",
+                expected = StaticType.ANY
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-33"),
+                catalog = "pql",
+                expected = StaticType.ANY
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-34"),
+                catalog = "pql",
+                expected = StaticType.ANY
+            ),
         )
 
         @JvmStatic
@@ -2669,7 +2689,7 @@ class PlanTyperTestsPorted {
             SuccessTestCase(
                 key = PartiQLTest.Key("basics", "nullif-18"),
                 catalog = "pql",
-                expected = unionOf(StaticType.ANY.allTypes.toSet())
+                expected = StaticType.ANY
             ),
         )
 
@@ -2758,12 +2778,12 @@ class PlanTyperTestsPorted {
             SuccessTestCase(
                 key = PartiQLTest.Key("basics", "coalesce-16"),
                 catalog = "pql",
-                expected = unionOf(StaticType.ANY.allTypes.toSet())
+                expected = StaticType.ANY
             ),
             SuccessTestCase(
                 key = PartiQLTest.Key("basics", "coalesce-17"),
                 catalog = "pql",
-                expected = unionOf(StaticType.ANY.allTypes.toSet())
+                expected = StaticType.ANY
             ),
         )
 

--- a/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
@@ -257,6 +257,42 @@ CASE t_item.t_string
 END;
 
 -- -----------------------------
+--  Any Branches
+-- -----------------------------
+
+--#[case-when-31]
+-- type: (any)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_any
+    WHEN 'b' THEN t_item.t_int32
+    ELSE NULL
+END;
+
+--#[case-when-32]
+-- type: (any)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_int32
+    WHEN 'b' THEN t_item.t_any
+    ELSE NULL
+END;
+
+--#[case-when-33]
+-- type: (any)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_int32
+    WHEN 'b' THEN NULL
+    ELSE t_item.t_any
+END;
+
+--#[case-when-34]
+-- type: (any)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_int32_null
+    WHEN 'b' THEN t_item.t_any
+    ELSE t_item.t_any
+END;
+
+-- -----------------------------
 --  (Unused) old tests
 -- -----------------------------
 

--- a/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
@@ -85,8 +85,7 @@ CASE t_item.t_string
 END;
 
 --#[case-when-11]
--- type: (int|null|missing)
--- TODO should really be (int|missing) but our translation of coalesce doesn't consider types.
+-- type: (int|missing)
 COALESCE(CAST(t_item.t_string AS INT), 1);
 
 -- -----------------------------

--- a/partiql-planner/src/testFixtures/resources/inputs/basics/coalesce.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/basics/coalesce.sql
@@ -1,0 +1,71 @@
+--#[coalesce-00]
+-- type: (int32)
+COALESCE(1);
+
+--#[coalesce-01]
+-- type: (int32)
+COALESCE(1, 2);
+
+--#[coalesce-02]
+-- type: (decimal)
+COALESCE(1, 1.23);
+
+--#[coalesce-03]
+-- type: (null | decimal)
+COALESCE(NULL, 1, 1.23);
+
+--#[coalesce-04]
+-- type: (null | missing | decimal)
+COALESCE(NULL, MISSING, 1, 1.23);
+
+--#[coalesce-05]
+-- type: (null | missing | decimal); same as above
+COALESCE(1, 1.23, NULL, MISSING);
+
+--#[coalesce-06]
+-- type: (int32)
+COALESCE(t_item.t_int32);
+
+--#[coalesce-07]
+-- type: (int32)
+COALESCE(t_item.t_int32, t_item.t_int32);
+
+--#[coalesce-08]
+-- type: (int64)
+COALESCE(t_item.t_int64, t_item.t_int32);
+
+--#[coalesce-09]
+-- type: (int64 | null)
+COALESCE(t_item.t_int64_null, t_item.t_int32, t_item.t_int32_null);
+
+--#[coalesce-10]
+-- type: (int64 | null | missing)
+COALESCE(t_item.t_int64_null, t_item.t_int32, t_item.t_int32_null, MISSING);
+
+--#[coalesce-11]
+-- type: (int64 | string)
+COALESCE(t_item.t_int64, t_item.t_string);
+
+--#[coalesce-12]
+-- type: (int64 | null | string)
+COALESCE(t_item.t_int64_null, t_item.t_string);
+
+--#[coalesce-13]
+-- type: (int16 | int32 | int64 | int | decimal)
+COALESCE(t_item.t_num_exact, t_item.t_int32);
+
+--#[coalesce-14]
+-- type: (int16 | int32 | int64 | int | decimal, string)
+COALESCE(t_item.t_num_exact, t_item.t_string);
+
+--#[coalesce-15]
+-- type: (int16 | int32 | int64 | int | decimal, string, null)
+COALESCE(t_item.t_num_exact, t_item.t_string, NULL);
+
+--#[coalesce-16]
+-- type: (any)
+COALESCE(t_item.t_any, t_item.t_int32);
+
+--#[coalesce-17]
+-- type: (any)
+COALESCE(t_item.t_int32, t_item.t_any);

--- a/partiql-planner/src/testFixtures/resources/inputs/basics/nullif.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/basics/nullif.sql
@@ -1,0 +1,77 @@
+--#[nullif-00]
+-- Currently, no constant-folding. If there was, return type could be int32.
+-- type: (int32 | null)
+NULLIF(1, 2);
+
+--#[nullif-01]
+-- Currently, no constant-folding. If there was, return type could be null.
+-- type: (int32 | null)
+NULLIF(1, 1);
+
+--#[nullif-02]
+-- type: (int32 | null)
+NULLIF(t_item.t_int32, t_item.t_int32);
+
+--#[nullif-03]
+-- type: (int32 | null)
+NULLIF(t_item.t_int32, t_item.t_int64);
+
+--#[nullif-04]
+-- type: (int64 | null)
+NULLIF(t_item.t_int64, t_item.t_int32);
+
+--#[nullif-05]
+-- type: (int32 | null)
+NULLIF(t_item.t_int32, t_item.t_null);
+
+--#[nullif-06]
+-- type: (null)
+NULLIF(t_item.t_null, t_item.t_int32);
+
+--#[nullif-07]
+-- type: (int32 | null)
+NULLIF(t_item.t_int32, MISSING);
+
+--#[nullif-08]
+-- type: (missing | null)
+NULLIF(MISSING, t_item.t_int32);
+
+--#[nullif-09]
+-- type: (int32 | null)
+NULLIF(t_item.t_int32, t_item.t_int32_null);
+
+--#[nullif-10]
+-- type: (int32 | null)
+NULLIF(t_item.t_int32_null, t_item.t_int32);
+
+--#[nullif-11]
+-- type: (int32 | null)
+NULLIF(t_item.t_int32, t_item.t_int64_null);
+
+--#[nullif-12]
+-- type: (int64 | null)
+NULLIF(t_item.t_int64_null, t_item.t_int32);
+
+--#[nullif-13]
+-- type: (int32 | null)
+NULLIF(t_item.t_int32, t_item.t_string);
+
+--#[nullif-14]
+-- type: (string | null)
+NULLIF(t_item.t_string, t_item.t_int32);
+
+--#[nullif-15]
+-- type: (int32 | null)
+NULLIF(t_item.t_int32, t_item.t_num_exact);
+
+--#[nullif-16]
+-- type: (int16 | int32 | int64 | int | decimal | null)
+NULLIF(t_item.t_num_exact, t_item.t_int32);
+
+--#[nullif-17]
+-- type: (int32 | null)
+NULLIF(t_item.t_int32, t_item.t_any);
+
+--#[nullif-18]
+-- type: (any)
+NULLIF(t_item.t_any, t_item.t_int32);


### PR DESCRIPTION
## Relevant Issues
Related to https://github.com/partiql/partiql-scribe/issues/26.

## Description
Previous rewrite according to SQL-99 spec was creating large logical plans with nested `COALESCE` and `NULLIF` expressions. This change makes dedicated `COALESCE` and `NULLIF` nodes within the logical plan.

Other than that,
- fixes a prior typing issue related to `COALESCE` (context in https://github.com/partiql/partiql-lang-kotlin/pull/1404#discussion_r1543461964)
- fixes a slight bug in dynamic typer w/ `StaticType.ANY`, where it was previously getting expanded to all of its types

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**

- Any backward-incompatible changes? **[YES]**

Adding new nodes to the plan is technically a breaking change for the `PlanVisitor` interface. Tracking the sprout generation to add a warning on the interface as a separate issue -- https://github.com/partiql/partiql-lang-kotlin/issues/1405.

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.