### PR TITLE
Add opt-in for sprout-generated interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Thank you to all who have contributed!
 ### Changed
 - Change `StaticType.AnyOfType`'s `.toString` to not perform `.flatten()`
 - Change modeling of `COALESCE` and `NULLIF` to dedicated nodes in logical plan
+- partiql-plan: Adds an `OptIn` annotation `DoNotImplementInterface` for the `PlanVisitor` interface
+  - `PlanVisitor` should not be implemented directly in favor of extending `PlanBaseVisitor`
 
 ### Deprecated
 - The current SqlBlock, SqlDialect, and SqlLayout are marked as deprecated and will be slightly changed in the next release. 

--- a/lib/sprout/README.md
+++ b/lib/sprout/README.md
@@ -15,19 +15,22 @@ Sprout is a graphical IR generator. It is inspired by PIG, ANTLR, and Protobuf.
 ```shell
 $ ./lib/sprout/build/install/sprout/bin/sprout generate kotlin --help
 
-Usage: sprout generate kotlin [-hV] [-m=<modifier>] [-o=<out>]
-                              [-p=<packageRoot>] [-u=<id>] [--poems=<poems>]...
-                              <file>
+Usage: sprout generate kotlin [-hV] [--restrict-interface-impl] [-o=<out>]
+                              [-p=<packageRoot>] [-u=<id>]
+                              [--opt-in=<optIns>]... [--poems=<poems>]... <file>
 Generates Kotlin sources from type universe definitions
-      <file>            Type definition file
-  -h, --help            Show this help message and exit.
-  -m, --modifier=<modifier>
-                        Generated node class modifier. Options FINAL, DATA, OPEN
-  -o, --out=<out>       Generated source output directory
+      <file>              Type definition file
+  -h, --help              Show this help message and exit.
+  -o, --out=<out>         Generated source output directory
+      --opt-in=<optIns>   Opt-in annotations to add to generated sources
   -p, --package=<packageRoot>
-                        Package root
-      --poems=<poems>   Poem templates to apply
-  -u, --universe=<id>   Universe identifier
+                          Package root
+      --poems=<poems>     Poem templates to apply
+      --restrict-interface-impl
+                          Restrict interface implementations with an opt-in
+                            annotation
+  -u, --universe=<id>     Universe identifier
+  -V, --version           Print version information and exit.
 ```
 
 **Example**

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/KotlinGenerator.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/KotlinGenerator.kt
@@ -9,6 +9,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import net.pearx.kasechange.toCamelCase
 import org.partiql.sprout.generator.Generator
 import org.partiql.sprout.generator.target.kotlin.poems.KotlinBuilderPoem
+import org.partiql.sprout.generator.target.kotlin.poems.KotlinDoNotImplementInterfacePoem
 import org.partiql.sprout.generator.target.kotlin.poems.KotlinFactoryPoem
 import org.partiql.sprout.generator.target.kotlin.poems.KotlinJacksonPoem
 import org.partiql.sprout.generator.target.kotlin.poems.KotlinListenerPoem
@@ -17,6 +18,7 @@ import org.partiql.sprout.generator.target.kotlin.poems.KotlinVisitorPoem
 import org.partiql.sprout.generator.target.kotlin.spec.KotlinFileSpec
 import org.partiql.sprout.generator.target.kotlin.spec.KotlinNodeSpec
 import org.partiql.sprout.generator.target.kotlin.spec.KotlinUniverseSpec
+import org.partiql.sprout.generator.target.kotlin.types.Annotations.DO_NOT_IMPLEMENT_INTERFACE
 import org.partiql.sprout.model.TypeDef
 import org.partiql.sprout.model.TypeProp
 import org.partiql.sprout.model.Universe
@@ -44,6 +46,7 @@ class KotlinGenerator(private val options: KotlinOptions) : Generator<KotlinResu
                 "listener" -> KotlinListenerPoem(symbols)
                 "jackson" -> KotlinJacksonPoem(symbols)
                 "util" -> KotlinUtilsPoem(symbols)
+                DO_NOT_IMPLEMENT_INTERFACE -> KotlinDoNotImplementInterfacePoem(symbols)
                 else -> error("unknown poem $it, expected: visitor, builder, listener, jackson, util")
             }
         }

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/KotlinOptions.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/KotlinOptions.kt
@@ -9,4 +9,5 @@ class KotlinOptions(
     val packageRoot: String,
     val poems: List<String>,
     val optIns: List<String> = emptyList(),
+    val restrictInterfaceImpl: Boolean = false,
 )

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/KotlinSymbols.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/KotlinSymbols.kt
@@ -52,6 +52,11 @@ class KotlinSymbols private constructor(
     val base: ClassName = ClassName(rootPackage, "${rootId}Node")
 
     /**
+     * Whether generated interfaces will restrict implementation using an opt-in annotation
+     */
+    val restrictInterfaceImpl = options.restrictInterfaceImpl
+
+    /**
      * Memoize converting a TypeRef.Path to a camel case identifier to be used as method/function names
      */
     private val camels: MutableMap<TypeRef.Path, String> = mutableMapOf()

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/poems/KotlinDoNotImplementInterfacePoem.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/poems/KotlinDoNotImplementInterfacePoem.kt
@@ -1,0 +1,51 @@
+package org.partiql.sprout.generator.target.kotlin.poems
+
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.TypeSpec
+import org.partiql.sprout.generator.target.kotlin.KotlinPoem
+import org.partiql.sprout.generator.target.kotlin.KotlinSymbols
+import org.partiql.sprout.generator.target.kotlin.spec.KotlinPackageSpec
+import org.partiql.sprout.generator.target.kotlin.spec.KotlinUniverseSpec
+import org.partiql.sprout.generator.target.kotlin.types.Annotations.DO_NOT_IMPLEMENT_INTERFACE
+
+/**
+ * Poem which creates the [DO_NOT_IMPLEMENT_INTERFACE] annotation. This annotation require [OptIn] for the interface to
+ * be implemented or extended.
+ */
+class KotlinDoNotImplementInterfacePoem(symbols: KotlinSymbols) : KotlinPoem(symbols) {
+
+    override val id = DO_NOT_IMPLEMENT_INTERFACE
+
+    private val annotationPackageName = "${symbols.rootPackage}.annotation"
+
+    private val annotationFileName = "${DO_NOT_IMPLEMENT_INTERFACE}Annotation"
+
+    override fun apply(universe: KotlinUniverseSpec) {
+        universe.packages.add(
+            KotlinPackageSpec(
+                name = annotationPackageName,
+                files = mutableListOf(universe.annotation()),
+            )
+        )
+        super.apply(universe)
+    }
+
+    // --- Internal ----------------------------------------------------
+    private fun KotlinUniverseSpec.annotation(): FileSpec {
+        val annotation = TypeSpec.classBuilder(DO_NOT_IMPLEMENT_INTERFACE)
+            .addModifiers(KModifier.PUBLIC, KModifier.ANNOTATION)
+            .addAnnotation(
+                AnnotationSpec.builder(ClassName(annotationPackageName, listOf("RequiresOptIn")))
+                    .addMember("message = %S", "$DO_NOT_IMPLEMENT_INTERFACE requires explicit opt-in")
+                    .addMember("level = RequiresOptIn.Level.ERROR")
+                    .build()
+            )
+            .build()
+        return FileSpec.builder(annotationPackageName, annotationFileName)
+            .addType(annotation)
+            .build()
+    }
+}

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/poems/KotlinVisitorPoem.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/poems/KotlinVisitorPoem.kt
@@ -15,6 +15,8 @@ import org.partiql.sprout.generator.target.kotlin.KotlinSymbols
 import org.partiql.sprout.generator.target.kotlin.spec.KotlinNodeSpec
 import org.partiql.sprout.generator.target.kotlin.spec.KotlinPackageSpec
 import org.partiql.sprout.generator.target.kotlin.spec.KotlinUniverseSpec
+import org.partiql.sprout.generator.target.kotlin.types.Annotations.DO_NOT_IMPLEMENT_INTERFACE
+import org.partiql.sprout.generator.target.kotlin.types.Annotations.DO_NOT_IMPLEMENT_INTERFACE_WARNING
 import org.partiql.sprout.generator.target.kotlin.types.Parameters
 import org.partiql.sprout.model.TypeDef
 import org.partiql.sprout.model.TypeRef
@@ -183,8 +185,21 @@ class KotlinVisitorPoem(symbols: KotlinSymbols) : KotlinPoem(symbols) {
                     addFunction(visit)
                 }
             }
+            .apply {
+                if (symbols.restrictInterfaceImpl) {
+                    addKdoc("$DO_NOT_IMPLEMENT_INTERFACE_WARNING. Please extend [$baseVisitorName].")
+                    addAnnotation(ClassName(visitorPackageName, listOf(DO_NOT_IMPLEMENT_INTERFACE)))
+                }
+            }
             .build()
-        return FileSpec.builder(visitorPackageName, visitorName).addType(visitor).build()
+        return FileSpec.builder(visitorPackageName, visitorName)
+            .apply {
+                if (symbols.restrictInterfaceImpl) {
+                    addImport(ClassName(symbols.rootPackage, listOf("annotation")), listOf(DO_NOT_IMPLEMENT_INTERFACE))
+                }
+            }
+            .addType(visitor)
+            .build()
     }
 
     /**

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/types/Annotations.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/types/Annotations.kt
@@ -21,5 +21,9 @@ object Annotations {
 
     val jvmStatic = AnnotationSpec.builder(JvmStatic::class).build()
 
+    internal const val DO_NOT_IMPLEMENT_INTERFACE = "DoNotImplementInterface"
+
+    internal const val DO_NOT_IMPLEMENT_INTERFACE_WARNING = "WARNING: This interface should not be implemented or extended by code outside of this library"
+
     fun suppress(what: String) = AnnotationSpec.builder(Suppress::class).addMember("\"$what\"").build()
 }

--- a/partiql-plan/build.gradle.kts
+++ b/partiql-plan/build.gradle.kts
@@ -52,6 +52,7 @@ val generate = tasks.register<Exec>("generate") {
         "--poems", "builder",
         "--poems", "util",
         "--opt-in", "org.partiql.value.PartiQLValueExperimental",
+        "--restrict-interface-impl",
         "./src/main/resources/partiql_plan.ion"
     )
 }

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/debug/PlanPrinter.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/debug/PlanPrinter.kt
@@ -1,7 +1,10 @@
+@file:OptIn(DoNotImplementInterface::class)
+
 package org.partiql.plan.debug
 
 import org.partiql.plan.PlanNode
 import org.partiql.plan.Rel
+import org.partiql.plan.annotation.DoNotImplementInterface
 import org.partiql.plan.visitor.PlanBaseVisitor
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.isSubclassOf

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/util/PlanNodeEquivalentVisitor.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/util/PlanNodeEquivalentVisitor.kt
@@ -1,3 +1,5 @@
+@file:OptIn(DoNotImplementInterface::class)
+
 package org.partiql.planner.util
 
 import org.partiql.plan.Agg
@@ -7,6 +9,7 @@ import org.partiql.plan.Identifier
 import org.partiql.plan.PlanNode
 import org.partiql.plan.Rel
 import org.partiql.plan.Rex
+import org.partiql.plan.annotation.DoNotImplementInterface
 import org.partiql.plan.visitor.PlanBaseVisitor
 import org.partiql.value.PartiQLValueExperimental
 


### PR DESCRIPTION
## Relevant Issues
- Closes https://github.com/partiql/partiql-lang-kotlin/issues/1405

## Description
- Add sprout opt-in annotation `DoNotImplementInterface` option for sprout-generated interfaces
- Currently annotation added for just the public plan's `PlanVisitor`

```
// Snippet from `PlanVisitor.kt`
/**
 * WARNING: This interface should not be implemented or extended by code outside of this library.
 * Please extend [PlanBaseVisitor].
 */
@DoNotImplementInterface
public interface PlanVisitor<R, C> {
  public fun visit(node: PlanNode, ctx: C): R

  public fun visitPartiQLPlan(node: PartiQLPlan, ctx: C): R
  ...
```



## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**

- Any backward-incompatible changes? **[YES/NO]**

Still TBD. Adding the opt-in annotation could be a breaking change.

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.