### PR TITLE
Add warning to not implement sprout-generated visitor interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Thank you to all who have contributed!
 ## [Unreleased]
 
 ### Added
+- partiql-ast: adds warning not to implement `AstVisitor` interface directly. Please extend `AstBaseVisitor` instead.
+- partiql-plan: adds warning not to implement `PlanVisitor` interface directly. Please extend `PlanBaseVisitor` instead.
 
 ### Changed
 - Change `StaticType.AnyOfType`'s `.toString` to not perform `.flatten()`

--- a/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/poems/KotlinVisitorPoem.kt
+++ b/lib/sprout/src/main/kotlin/org/partiql/sprout/generator/target/kotlin/poems/KotlinVisitorPoem.kt
@@ -183,6 +183,7 @@ class KotlinVisitorPoem(symbols: KotlinSymbols) : KotlinPoem(symbols) {
                     addFunction(visit)
                 }
             }
+            .addKdoc("WARNING: This interface should not be implemented or extended by code outside of this library. Please extend [$baseVisitorName].")
             .build()
         return FileSpec.builder(visitorPackageName, visitorName).addType(visitor).build()
     }


### PR DESCRIPTION
## Relevant Issues
- Closes #1405.
- Copies over the kdoc warning from #1406.

## Description
Similar to #1406 but just adds the warning to not implement the sprout-generated visitor interfaces. This will currently be applied for the `AstVisitor` and `PlanVisitor`.

```Kotlin
// AstVisitor.kt
/**
 * WARNING: This interface should not be implemented or extended by code outside of this library.
 * Please extend [AstBaseVisitor].
 */
public interface AstVisitor<R, C> {
	// rest of code
}
```

```Kotlin
// PlanVisitor.kt
/**
 * WARNING: This interface should not be implemented or extended by code outside of this library.
 * Please extend [PlanBaseVisitor].
 */
public interface PlanVisitor<R, C> {
	// rest of code
}
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.