### PR TITLE
Increases conformance by fixing small JOIN bug

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinNestedLoop.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelJoinNestedLoop.kt
@@ -63,7 +63,10 @@ internal abstract class RelJoinNestedLoop : RelPeeking() {
                 toReturn = join(result.isTrue(), lhsRecord!!, rhsRecord)
             }
             // Move the pointer to the next row for the RHS
-            if (toReturn == null) rhsRecord = rhs.next()
+            if (toReturn == null) rhsRecord = when (rhs.hasNext()) {
+                true -> rhs.next()
+                false -> null
+            }
         }
         while (toReturn == null)
         return toReturn


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Increases conformance by fixing small JOIN bug
- Quantitative impact:
  - "Number passing in legacy engine but fail in eval engine:" **760 --> 711**
  - Old evaluator stays the same for passing failing tests.
  - Conformance gap decreased from **10.11% --> 9.26%**

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.