### PR TITLE
Adds support for nullable casts and missable/missingCall functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 ### Fixed
+- Fixes [#1398](https://github.com/partiql/partiql-lang-kotlin/issues/1398) by handling "missable" arguments to
+functions. This fix also adds support for conversion of NULL to typed nulls. **Behavior change**: Function return
+types may now return nullable types when one of their arguments is NULL. For example: `5 + NULL` (INT4 + NULL) is
+now inferred to return a nullable INT4 (union of INT4 and NULL).
 
 ### Removed
 
@@ -21,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Contributors
 Thank you to all who have contributed!
+- @johnedquinn
 -->
 
 ## [Unreleased]

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PartiQLHeader.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PartiQLHeader.kt
@@ -164,6 +164,7 @@ internal object PartiQLHeader : Header() {
             isNullCall = true,
             isNullable = false,
             parameters = listOf(FunctionParameter("value", BOOL)),
+            isMissingCall = false
         ),
         FunctionSignature.Scalar(
             name = "not",
@@ -171,6 +172,7 @@ internal object PartiQLHeader : Header() {
             isNullCall = true,
             isNullable = false,
             parameters = listOf(FunctionParameter("value", MISSING)),
+            isMissingCall = false
         ),
     )
 
@@ -182,7 +184,7 @@ internal object PartiQLHeader : Header() {
         unary("neg", t, t)
     }
 
-    private fun eq(): List<FunctionSignature.Scalar> = types.all.map { t ->
+    private fun eq(): List<FunctionSignature.Scalar> = types.all.filterNot { it == ANY || it == MISSING }.map { t ->
         FunctionSignature.Scalar(
             name = "eq",
             returns = BOOL,
@@ -190,7 +192,16 @@ internal object PartiQLHeader : Header() {
             isNullable = false,
             isNullCall = true,
         )
-    }
+    } + listOf(
+        FunctionSignature.Scalar(
+            name = "eq",
+            returns = BOOL,
+            parameters = listOf(FunctionParameter("lhs", ANY), FunctionParameter("rhs", ANY)),
+            isNullable = false,
+            isNullCall = true,
+            isMissingCall = false
+        )
+    )
 
     private fun and(): List<FunctionSignature.Scalar> = listOf(
         FunctionSignature.Scalar(
@@ -199,6 +210,7 @@ internal object PartiQLHeader : Header() {
             isNullCall = false,
             isNullable = true,
             parameters = listOf(FunctionParameter("lhs", BOOL), FunctionParameter("rhs", BOOL)),
+            isMissingCall = false,
         ),
         FunctionSignature.Scalar(
             name = "and",
@@ -206,6 +218,7 @@ internal object PartiQLHeader : Header() {
             isNullCall = false,
             isNullable = true,
             parameters = listOf(FunctionParameter("lhs", MISSING), FunctionParameter("rhs", BOOL)),
+            isMissingCall = false,
         ),
         FunctionSignature.Scalar(
             name = "and",
@@ -213,6 +226,7 @@ internal object PartiQLHeader : Header() {
             isNullCall = false,
             isNullable = true,
             parameters = listOf(FunctionParameter("lhs", BOOL), FunctionParameter("rhs", MISSING)),
+            isMissingCall = false,
         ),
         FunctionSignature.Scalar(
             name = "and",
@@ -220,6 +234,7 @@ internal object PartiQLHeader : Header() {
             isNullCall = false,
             isNullable = true,
             parameters = listOf(FunctionParameter("lhs", MISSING), FunctionParameter("rhs", MISSING)),
+            isMissingCall = false,
         ),
     )
 
@@ -230,6 +245,7 @@ internal object PartiQLHeader : Header() {
             isNullCall = false,
             isNullable = true,
             parameters = listOf(FunctionParameter("lhs", BOOL), FunctionParameter("rhs", BOOL)),
+            isMissingCall = false,
         ),
         FunctionSignature.Scalar(
             name = "or",
@@ -237,6 +253,7 @@ internal object PartiQLHeader : Header() {
             isNullCall = false,
             isNullable = true,
             parameters = listOf(FunctionParameter("lhs", MISSING), FunctionParameter("rhs", BOOL)),
+            isMissingCall = false,
         ),
         FunctionSignature.Scalar(
             name = "or",
@@ -244,6 +261,7 @@ internal object PartiQLHeader : Header() {
             isNullCall = false,
             isNullable = true,
             parameters = listOf(FunctionParameter("lhs", BOOL), FunctionParameter("rhs", MISSING)),
+            isMissingCall = false,
         ),
         FunctionSignature.Scalar(
             name = "or",
@@ -251,6 +269,7 @@ internal object PartiQLHeader : Header() {
             isNullCall = false,
             isNullable = true,
             parameters = listOf(FunctionParameter("lhs", MISSING), FunctionParameter("rhs", MISSING)),
+            isMissingCall = false,
         ),
     )
 
@@ -384,7 +403,8 @@ internal object PartiQLHeader : Header() {
                 FunctionParameter("value", ANY) // TODO: Decide if we need to further segment this
             ),
             isNullCall = false,
-            isNullable = false
+            isNullable = false,
+            isMissingCall = false
         )
     )
 
@@ -396,7 +416,8 @@ internal object PartiQLHeader : Header() {
                 FunctionParameter("value", ANY) // TODO: Decide if we need to further segment this
             ),
             isNullCall = false,
-            isNullable = false
+            isNullable = false,
+            isMissingCall = false
         )
     )
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/FnComparator.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/FnComparator.kt
@@ -1,0 +1,104 @@
+package org.partiql.planner.internal.typer
+
+import org.partiql.types.function.FunctionParameter
+import org.partiql.types.function.FunctionSignature
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.PartiQLValueType
+import org.partiql.value.PartiQLValueType.ANY
+import org.partiql.value.PartiQLValueType.BAG
+import org.partiql.value.PartiQLValueType.BINARY
+import org.partiql.value.PartiQLValueType.BLOB
+import org.partiql.value.PartiQLValueType.BOOL
+import org.partiql.value.PartiQLValueType.BYTE
+import org.partiql.value.PartiQLValueType.CHAR
+import org.partiql.value.PartiQLValueType.CLOB
+import org.partiql.value.PartiQLValueType.DATE
+import org.partiql.value.PartiQLValueType.DECIMAL
+import org.partiql.value.PartiQLValueType.DECIMAL_ARBITRARY
+import org.partiql.value.PartiQLValueType.FLOAT32
+import org.partiql.value.PartiQLValueType.FLOAT64
+import org.partiql.value.PartiQLValueType.INT
+import org.partiql.value.PartiQLValueType.INT16
+import org.partiql.value.PartiQLValueType.INT32
+import org.partiql.value.PartiQLValueType.INT64
+import org.partiql.value.PartiQLValueType.INT8
+import org.partiql.value.PartiQLValueType.INTERVAL
+import org.partiql.value.PartiQLValueType.LIST
+import org.partiql.value.PartiQLValueType.MISSING
+import org.partiql.value.PartiQLValueType.NULL
+import org.partiql.value.PartiQLValueType.SEXP
+import org.partiql.value.PartiQLValueType.STRING
+import org.partiql.value.PartiQLValueType.STRUCT
+import org.partiql.value.PartiQLValueType.SYMBOL
+import org.partiql.value.PartiQLValueType.TIME
+import org.partiql.value.PartiQLValueType.TIMESTAMP
+
+/**
+ * Function precedence comparator; this is not formally specified.
+ *
+ *  1. Fewest args first
+ *  2. Parameters are compared left-to-right
+ */
+@OptIn(PartiQLValueExperimental::class)
+internal object FnComparator : Comparator<FunctionSignature.Scalar> {
+
+    override fun compare(fn1: FunctionSignature.Scalar, fn2: FunctionSignature.Scalar): Int {
+        // Compare number of arguments
+        if (fn1.parameters.size != fn2.parameters.size) {
+            return fn1.parameters.size - fn2.parameters.size
+        }
+        // Compare operand type precedence
+        for (i in fn1.parameters.indices) {
+            val p1 = fn1.parameters[i]
+            val p2 = fn2.parameters[i]
+            val comparison = p1.compareTo(p2)
+            if (comparison != 0) return comparison
+        }
+        // unreachable?
+        return 0
+    }
+
+    private fun FunctionParameter.compareTo(other: FunctionParameter): Int =
+        comparePrecedence(this.type, other.type)
+
+    private fun comparePrecedence(t1: PartiQLValueType, t2: PartiQLValueType): Int {
+        if (t1 == t2) return 0
+        val p1 = precedence[t1]!!
+        val p2 = precedence[t2]!!
+        return p1 - p2
+    }
+
+    // This simply describes some precedence for ordering functions.
+    // This is not explicitly defined in the PartiQL Specification!!
+    // This does not imply the ability to CAST; this defines function resolution behavior.
+    private val precedence: Map<PartiQLValueType, Int> = listOf(
+        NULL,
+        MISSING,
+        BOOL,
+        INT8,
+        INT16,
+        INT32,
+        INT64,
+        INT,
+        DECIMAL,
+        FLOAT32,
+        FLOAT64,
+        DECIMAL_ARBITRARY, // Arbitrary precision decimal has a higher precedence than FLOAT
+        CHAR,
+        STRING,
+        CLOB,
+        SYMBOL,
+        BINARY,
+        BYTE,
+        BLOB,
+        DATE,
+        TIME,
+        TIMESTAMP,
+        INTERVAL,
+        LIST,
+        SEXP,
+        BAG,
+        STRUCT,
+        ANY,
+    ).mapIndexed { precedence, type -> type to precedence }.toMap()
+}

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeLattice.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeLattice.kt
@@ -176,7 +176,7 @@ internal class TypeLattice private constructor(
                 ANY to coercion()
             )
             graph[NULL] = relationships(
-                NULL to coercion()
+                *types.map { it to coercion() }.toTypedArray()
             )
             graph[MISSING] = relationships(
                 MISSING to coercion()

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/FunctionResolverTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/FunctionResolverTest.kt
@@ -2,7 +2,15 @@ package org.partiql.planner.internal.typer
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.partiql.planner.internal.Header
+import org.partiql.planner.internal.ir.Fn
+import org.partiql.planner.internal.ir.Identifier
+import org.partiql.planner.internal.ir.Rex
+import org.partiql.types.StaticType
 import org.partiql.types.function.FunctionParameter
 import org.partiql.types.function.FunctionSignature
 import org.partiql.value.PartiQLValueExperimental
@@ -14,7 +22,30 @@ import org.partiql.value.PartiQLValueType
  * Only the "types" of expressions matter, we ignore the underlying ops.
  */
 @OptIn(PartiQLValueExperimental::class)
-class FunctionResolverTest {
+internal class FunctionResolverTest {
+
+    @ParameterizedTest
+    @MethodSource("allCases")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun cases(tc: Case) {
+        tc.assert()
+    }
+
+    @Test
+    fun singleTest() {
+        val tc =
+            Case.ResolveScalarFn(
+                name = "Higher Precedence PLUS",
+                identifier = "plus",
+                args = listOf(StaticType.INT2, StaticType.INT2),
+                expected = FnMatch.Ok(
+                    signature = plus2,
+                    mapping = listOf(null, null),
+                    isMissable = false
+                )
+            )
+        tc.assert()
+    }
 
     @Test
     fun sanity() {
@@ -47,14 +78,32 @@ class FunctionResolverTest {
 
     companion object {
 
-        val split = FunctionSignature.Scalar(
-            name = "split",
-            returns = PartiQLValueType.LIST,
-            parameters = listOf(
-                FunctionParameter("value", PartiQLValueType.STRING),
-                FunctionParameter("delimiter", PartiQLValueType.STRING),
-            ),
-            isNullable = false,
+        val split =
+            fn("split", PartiQLValueType.LIST, PartiQLValueType.STRING, PartiQLValueType.STRING, isNullable = false)
+
+        val plus1 = fn("plus", PartiQLValueType.INT, PartiQLValueType.INT, PartiQLValueType.INT, isNullable = false)
+        val plus2 = fn("plus", PartiQLValueType.INT8, PartiQLValueType.INT16, PartiQLValueType.INT16, isNullable = false)
+
+        // Handles MISSING
+        val eq1 = fn("eq", PartiQLValueType.BOOL, PartiQLValueType.INT16, PartiQLValueType.INT16, isNullable = false, isMissingCall = false)
+        val eq2 = fn("eq", PartiQLValueType.BOOL, PartiQLValueType.ANY, PartiQLValueType.ANY, isNullable = false, isMissingCall = false)
+
+        private fun fn(
+            name: String,
+            returns: PartiQLValueType,
+            vararg args: PartiQLValueType,
+            isNullable: Boolean = true,
+            isNullCall: Boolean = false,
+            isMissable: Boolean = false,
+            isMissingCall: Boolean = true
+        ) = FunctionSignature.Scalar(
+            name = name,
+            returns = returns,
+            parameters = args.mapIndexed { index, paramType -> FunctionParameter("p$index", paramType) },
+            isNullable = isNullable,
+            isNullCall = isNullCall,
+            isMissable = isMissable,
+            isMissingCall = isMissingCall
         )
 
         private val myHeader = object : Header() {
@@ -62,16 +111,139 @@ class FunctionResolverTest {
             override val namespace: String = "my_header"
 
             override val functions: List<FunctionSignature.Scalar> = listOf(
-                split
+                split,
+                plus1,
+                plus2,
+                eq1,
+                eq2
             )
         }
 
         private val resolver = FnResolver(myHeader)
+
+        @JvmStatic
+        fun allCases() = listOf(
+            Case.ResolveScalarFn(
+                name = "Implicit Coercion PLUS",
+                identifier = "plus",
+                args = listOf(StaticType.INT, StaticType.INT4),
+                expected = FnMatch.Ok(
+                    signature = plus1,
+                    mapping = listOf(null, null),
+                    isMissable = false
+                )
+            ),
+            Case.ResolveScalarFn(
+                name = "Higher Precedence PLUS",
+                identifier = "plus",
+                args = listOf(StaticType.INT2, StaticType.INT2),
+                expected = FnMatch.Ok(
+                    signature = plus2,
+                    mapping = listOf(null, null),
+                    isMissable = false
+                )
+            ),
+            Case.ResolveScalarFn(
+                name = "UNION PLUS",
+                identifier = "plus",
+                args = listOf(StaticType.unionOf(StaticType.INT2, StaticType.MISSING), StaticType.INT2),
+                expected = FnMatch.Ok(
+                    signature = plus2,
+                    mapping = listOf(null, null),
+                    isMissable = false
+                )
+            ),
+            Case.ResolveScalarFn(
+                name = "Straightforward EQ",
+                identifier = "eq",
+                args = listOf(StaticType.INT2, StaticType.INT2),
+                expected = FnMatch.Ok(
+                    signature = eq1,
+                    mapping = listOf(null, null),
+                    isMissable = false
+                )
+            ),
+            Case.ResolveScalarFn(
+                name = "ANY EQ",
+                identifier = "eq",
+                args = listOf(StaticType.DECIMAL, StaticType.INT8),
+                expected = FnMatch.Ok(
+                    signature = eq2,
+                    mapping = listOf(null, null),
+                    isMissable = false
+                )
+            ),
+            Case.ResolveScalarFn(
+                name = "UNION EQ",
+                identifier = "eq",
+                args = listOf(StaticType.unionOf(StaticType.DECIMAL, StaticType.INT), StaticType.INT8),
+                expected = FnMatch.Ok(
+                    signature = eq2,
+                    mapping = listOf(null, null),
+                    isMissable = false
+                )
+            ),
+        )
     }
 
-    private sealed class Case {
+    sealed class Case {
 
         abstract fun assert()
+
+        class ResolveScalarFn(
+            private val name: String,
+            private val identifier: String,
+            private val isHidden: Boolean = false,
+            private val args: List<StaticType>,
+            private val expected: FnMatch<FunctionSignature.Scalar>
+        ) : Case() {
+
+            override fun assert() {
+                val identifier = Identifier.Symbol(identifier, Identifier.CaseSensitivity.INSENSITIVE)
+                val rexArgs = args.map { Rex(it, Rex.Op.Var.Resolved(0)) }
+                val match = resolver.resolveFnScalar(Fn.Unresolved(identifier, isHidden), rexArgs)
+                assert(matches(expected, match)) {
+                    errorMessage(expected, match)
+                }
+            }
+
+            private fun matches(expected: FnMatch<FunctionSignature.Scalar>, actual: FnMatch<FunctionSignature.Scalar>): Boolean {
+                return when {
+                    expected is FnMatch.Ok && actual is FnMatch.Ok -> matches(expected, actual)
+                    expected is FnMatch.Dynamic && actual is FnMatch.Dynamic -> matches(expected, actual)
+                    expected is FnMatch.Error && actual is FnMatch.Error -> expected == actual
+                    else -> false
+                }
+            }
+
+            /**
+             * Ignores the casts for testing.
+             */
+            private fun matches(expected: FnMatch.Ok<FunctionSignature.Scalar>, actual: FnMatch.Ok<FunctionSignature.Scalar>): Boolean {
+                return (expected.signature == actual.signature) && (expected.isMissable == actual.isMissable)
+            }
+
+            private fun matches(expected: FnMatch.Dynamic<FunctionSignature.Scalar>, actual: FnMatch.Dynamic<FunctionSignature.Scalar>): Boolean {
+                if (expected.candidates.size != actual.candidates.size) {
+                    return false
+                }
+                expected.candidates.forEachIndexed { index, ok ->
+                    if (!matches(ok, actual.candidates[index])) {
+                        return false
+                    }
+                }
+                return expected.isMissable == actual.isMissable
+            }
+
+            private fun errorMessage(expected: FnMatch<FunctionSignature.Scalar>, actual: FnMatch<FunctionSignature.Scalar>): String {
+                return buildString {
+                    appendLine("Expected  : $expected")
+                    appendLine("Actual    : $actual")
+                }
+            }
+
+            override fun toString(): String = this.name
+        }
 
         class Success(
             private val signature: FunctionSignature,

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -36,8 +36,9 @@ import org.partiql.types.BagType
 import org.partiql.types.ListType
 import org.partiql.types.SexpType
 import org.partiql.types.StaticType
-import org.partiql.types.StaticType.Companion.ANY
+import org.partiql.types.StaticType.Companion.INT4
 import org.partiql.types.StaticType.Companion.MISSING
+import org.partiql.types.StaticType.Companion.NULL
 import org.partiql.types.StaticType.Companion.unionOf
 import org.partiql.types.StructType
 import org.partiql.types.TupleConstraint
@@ -636,7 +637,7 @@ class PlanTyperTestsPorted {
             SuccessTestCase(
                 name = "BITWISE_AND_NULL_OPERAND",
                 query = "1 & NULL",
-                expected = StaticType.NULL,
+                expected = unionOf(StaticType.NULL, INT4),
             ),
             ErrorTestCase(
                 name = "BITWISE_AND_MISSING_OPERAND",
@@ -3636,19 +3637,6 @@ class PlanTyperTestsPorted {
     @Execution(ExecutionMode.CONCURRENT)
     fun testCasts(tc: TestCase) = runTest(tc)
 
-    @Test
-    fun singleTest() {
-        val query = """
-            SELECT v + 1
-            FROM <<
-                1,
-                MISSING
-            >> v
-        """.trimIndent()
-        val tc = SuccessTestCase(query = query, expected = ANY)
-        runTest(tc)
-    }
-
     // --------- Finish Parameterized Tests ------
 
     //
@@ -4140,7 +4128,7 @@ class PlanTyperTestsPorted {
                 catalog = CATALOG_DB,
                 catalogPath = DB_SCHEMA_MARKETS,
                 query = "order_info.\"CUSTOMER_ID\" = 1",
-                expected = StaticType.NULL
+                expected = unionOf(StaticType.NULL, StaticType.BOOL)
             ),
             SuccessTestCase(
                 name = "Case Sensitive success",

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -36,6 +36,7 @@ import org.partiql.types.BagType
 import org.partiql.types.ListType
 import org.partiql.types.SexpType
 import org.partiql.types.StaticType
+import org.partiql.types.StaticType.Companion.ANY
 import org.partiql.types.StaticType.Companion.MISSING
 import org.partiql.types.StaticType.Companion.unionOf
 import org.partiql.types.StructType
@@ -3634,6 +3635,19 @@ class PlanTyperTestsPorted {
     @MethodSource("castCases")
     @Execution(ExecutionMode.CONCURRENT)
     fun testCasts(tc: TestCase) = runTest(tc)
+
+    @Test
+    fun singleTest() {
+        val query = """
+            SELECT v + 1
+            FROM <<
+                1,
+                MISSING
+            >> v
+        """.trimIndent()
+        val tc = SuccessTestCase(query = query, expected = ANY)
+        runTest(tc)
+    }
 
     // --------- Finish Parameterized Tests ------
 

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/logical/OpLogicalTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/logical/OpLogicalTest.kt
@@ -34,8 +34,8 @@ class OpLogicalTest : PartiQLTyperTestBase() {
             successArgs.forEach { args: List<StaticType> ->
                 val arg = args.first()
                 if (arg.isUnknown()) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
+                    (this[TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL))] ?: setOf(args)).let {
+                        put(TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL)), it + setOf(args))
                     }
                 } else {
                     (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpArithmeticTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpArithmeticTest.kt
@@ -8,6 +8,7 @@ import org.partiql.planner.util.allNumberType
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.cartesianProduct
 import org.partiql.planner.util.castTable
+import org.partiql.types.NullType
 import org.partiql.types.StaticType
 import java.util.stream.Stream
 
@@ -35,9 +36,14 @@ class OpArithmeticTest : PartiQLTyperTestBase() {
             successArgs.forEach { args: List<StaticType> ->
                 val arg0 = args.first()
                 val arg1 = args[1]
-                if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
+                if (args.all { it is NullType }) {
+                    val nullableHighestPrecedenceType = StaticType.unionOf(StaticType.INT2, StaticType.NULL)
+                    (this[TestResult.Success(nullableHighestPrecedenceType)] ?: setOf(args)).let {
+                        put(TestResult.Success(nullableHighestPrecedenceType), it + setOf(args))
+                    }
+                } else if (args.contains(StaticType.NULL)) {
+                    (this[TestResult.Success(StaticType.unionOf(args.toSet()))] ?: setOf(args)).let {
+                        put(TestResult.Success(StaticType.unionOf(args.toSet())), it + setOf(args))
                     }
                 } else if (arg0 == arg1) {
                     (this[TestResult.Success(arg1)] ?: setOf(args)).let {

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpBitwiseAndTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/operator/OpBitwiseAndTest.kt
@@ -8,6 +8,7 @@ import org.partiql.planner.util.allIntType
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.cartesianProduct
 import org.partiql.planner.util.castTable
+import org.partiql.types.NullType
 import org.partiql.types.StaticType
 import java.util.stream.Stream
 
@@ -31,9 +32,14 @@ class OpBitwiseAndTest : PartiQLTyperTestBase() {
             successArgs.forEach { args: List<StaticType> ->
                 val arg0 = args.first()
                 val arg1 = args[1]
-                if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
+                if (args.all { it is NullType }) {
+                    val nullableHighestPrecedenceType = StaticType.unionOf(StaticType.INT2, StaticType.NULL)
+                    (this[TestResult.Success(nullableHighestPrecedenceType)] ?: setOf(args)).let {
+                        put(TestResult.Success(nullableHighestPrecedenceType), it + setOf(args))
+                    }
+                } else if (args.contains(StaticType.NULL)) {
+                    (this[TestResult.Success(StaticType.unionOf(args.toSet()))] ?: setOf(args)).let {
+                        put(TestResult.Success(StaticType.unionOf(args.toSet())), it + setOf(args))
                     }
                 } else if (arg0 == arg1) {
                     (this[TestResult.Success(arg1)] ?: setOf(args)).let {

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpBetweenTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpBetweenTest.kt
@@ -51,12 +51,9 @@ class OpBetweenTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                val arg0 = args.first()
-                val arg1 = args[1]
-                val arg2 = args[2]
                 if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
+                    (this[TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL))] ?: setOf(args)).let {
+                        put(TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL)), it + setOf(args))
                     }
                 } else {
                     (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpComparisonTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpComparisonTest.kt
@@ -22,13 +22,14 @@ class OpComparisonTest : PartiQLTyperTestBase() {
             val successArgs = cartesianProduct(allSupportedType, allSupportedType)
 
             successArgs.forEach { args: List<StaticType> ->
+
                 if (args.contains(StaticType.MISSING)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
+                    (this[TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL))] ?: setOf(args)).let {
+                        put(TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL)), it + setOf(args))
                     }
                 } else if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
+                    (this[TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL))] ?: setOf(args)).let {
+                        put(TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL)), it + setOf(args))
                     }
                 } else {
                     (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {
@@ -83,8 +84,8 @@ class OpComparisonTest : PartiQLTyperTestBase() {
 
             successArgs.forEach { args: List<StaticType> ->
                 if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
+                    (this[TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL))] ?: setOf(args)).let {
+                        put(TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL)), it + setOf(args))
                     }
                 } else {
                     (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpInTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpInTest.kt
@@ -7,6 +7,7 @@ import org.partiql.planner.util.allCollectionType
 import org.partiql.planner.util.allSupportedType
 import org.partiql.planner.util.cartesianProduct
 import org.partiql.types.MissingType
+import org.partiql.types.NullType
 import org.partiql.types.StaticType
 import java.util.stream.Stream
 
@@ -26,9 +27,14 @@ class OpInTest : PartiQLTyperTestBase() {
                     .toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
+                if (args.all { it is NullType }) {
+                    val nullableHighestPrecedenceType = StaticType.unionOf(StaticType.BOOL, StaticType.NULL)
+                    (this[TestResult.Success(nullableHighestPrecedenceType)] ?: setOf(args)).let {
+                        put(TestResult.Success(nullableHighestPrecedenceType), it + setOf(args))
+                    }
+                } else if (args.contains(StaticType.NULL)) {
+                    (this[TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL))] ?: setOf(args)).let {
+                        put(TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL)), it + setOf(args))
                     }
                 } else {
                     (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {
@@ -62,9 +68,14 @@ class OpInTest : PartiQLTyperTestBase() {
             }.toSet()
 
             successArgs.forEach { args: List<StaticType> ->
-                if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
+                if (args.all { it is NullType }) {
+                    val nullableHighestPrecedenceType = StaticType.unionOf(StaticType.BOOL, StaticType.NULL)
+                    (this[TestResult.Success(nullableHighestPrecedenceType)] ?: setOf(args)).let {
+                        put(TestResult.Success(nullableHighestPrecedenceType), it + setOf(args))
+                    }
+                } else if (args.contains(StaticType.NULL)) {
+                    (this[TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL))] ?: setOf(args)).let {
+                        put(TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL)), it + setOf(args))
                     }
                 } else {
                     (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpLikeTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpLikeTest.kt
@@ -28,8 +28,8 @@ class OpLikeTest : PartiQLTyperTestBase() {
 
             successArgs.forEach { args: List<StaticType> ->
                 if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
+                    (this[TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL))] ?: setOf(args)).let {
+                        put(TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL)), it + setOf(args))
                     }
                 } else {
                     (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {
@@ -63,8 +63,8 @@ class OpLikeTest : PartiQLTyperTestBase() {
 
             successArgs.forEach { args: List<StaticType> ->
                 if (args.contains(StaticType.NULL)) {
-                    (this[TestResult.Success(StaticType.NULL)] ?: setOf(args)).let {
-                        put(TestResult.Success(StaticType.NULL), it + setOf(args))
+                    (this[TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL))] ?: setOf(args)).let {
+                        put(TestResult.Success(StaticType.unionOf(StaticType.NULL, StaticType.BOOL)), it + setOf(args))
                     }
                 } else {
                     (this[TestResult.Success(StaticType.BOOL)] ?: setOf(args)).let {

--- a/partiql-types/src/main/kotlin/org/partiql/types/function/FunctionSignature.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/function/FunctionSignature.kt
@@ -47,6 +47,9 @@ public sealed class FunctionSignature(
      *
      * @property isDeterministic    Flag indicating this function always produces the same output given the same input.
      * @property isNullCall         Flag indicating if any of the call arguments is NULL, then return NULL.
+     * @property isMissable         Indicates whether the function's operator may return MISSING.
+     * @property isMissingCall      Indicates behavior when any of the arguments are MISSING. If set to true, the function
+     * will return MISSING. If false, the operator itself will handle the MISSING.
      * @constructor
      */
     public class Scalar(
@@ -57,6 +60,8 @@ public sealed class FunctionSignature(
         isNullable: Boolean = true,
         @JvmField public val isDeterministic: Boolean = true,
         @JvmField public val isNullCall: Boolean = false,
+        @JvmField public val isMissable: Boolean = false,
+        @JvmField public val isMissingCall: Boolean = true,
     ) : FunctionSignature(name, returns, parameters, description, isNullable) {
 
         override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
## Relevant Issues
- Closes #1398 

## Description
- Adds support for nullable casts and missable/missingCall functions. Since branch `v1` largely has these changes already, this is a port of its functionality.
- Adds a dedicated test file to test static vs dynamic invocation of functions. Included within this test file are tests pertaining to #1398 as well as other edge-cases.

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.