### PR TITLE
Fixes to UNPIVOT normalization and empty struct typing

### DIFF
--- a/partiql-ast/src/main/kotlin/org/partiql/ast/normalize/NormalizeFromSource.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/normalize/NormalizeFromSource.kt
@@ -53,8 +53,10 @@ internal object NormalizeFromSource : AstPass {
         override fun visitFromValue(node: From.Value, ctx: Int): From {
             val expr = visitExpr(node.expr, ctx) as Expr
             val asAlias = node.asAlias ?: expr.toBinder(ctx)
-            return if (expr !== node.expr || asAlias !== node.asAlias) {
-                node.copy(expr = expr, asAlias = asAlias)
+            val atAlias = node.atAlias ?: expr.toBinder(ctx + 1)
+            val byAlias = node.byAlias ?: expr.toBinder(ctx + 2)
+            return if (expr !== node.expr || asAlias !== node.asAlias || atAlias !== node.atAlias || byAlias !== node.byAlias) {
+                node.copy(expr = expr, asAlias = asAlias, atAlias = atAlias, byAlias = byAlias)
             } else {
                 node
             }

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/normalize/NormalizeFromSource.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/normalize/NormalizeFromSource.kt
@@ -52,11 +52,19 @@ internal object NormalizeFromSource : AstPass {
 
         override fun visitFromValue(node: From.Value, ctx: Int): From {
             val expr = visitExpr(node.expr, ctx) as Expr
-            val asAlias = node.asAlias ?: expr.toBinder(ctx)
-            val atAlias = node.atAlias ?: expr.toBinder(ctx + 1)
-            val byAlias = node.byAlias ?: expr.toBinder(ctx + 2)
-            return if (expr !== node.expr || asAlias !== node.asAlias || atAlias !== node.atAlias || byAlias !== node.byAlias) {
-                node.copy(expr = expr, asAlias = asAlias, atAlias = atAlias, byAlias = byAlias)
+            var i = ctx
+            var asAlias = node.asAlias
+            var atAlias = node.atAlias
+            // derive AS alias
+            if (asAlias == null) {
+                asAlias = expr.toBinder(i++)
+            }
+            // derive AT binder
+            if (atAlias == null && node.type == From.Value.Type.UNPIVOT) {
+                atAlias = expr.toBinder(i++)
+            }
+            return if (expr !== node.expr || asAlias !== node.asAlias || atAlias !== node.atAlias) {
+                node.copy(expr = expr, asAlias = asAlias, atAlias = atAlias)
             } else {
                 node
             }

--- a/test/partiql-tests-runner/build.gradle.kts
+++ b/test/partiql-tests-runner/build.gradle.kts
@@ -64,8 +64,8 @@ val generateTestReport by tasks.registering(Test::class) {
     environment(Env.PARTIQL_EQUIV, file("$tests/eval-equiv/").absolutePath)
     environment("conformanceReportDir", reportDir)
     include("org/partiql/runner/ConformanceTestEval.class", "org/partiql/runner/ConformanceTestLegacy.class")
-    if (project.hasProperty("Engine")) {
-        val engine = property("Engine")!! as String
+    if (project.hasProperty("engine")) {
+        val engine = project.property("engine")!! as String
         if (engine.toLowerCase() == "legacy") {
             exclude("org/partiql/runner/ConformanceTestEval.class")
         } else if (engine.toLowerCase() == "eval") {


### PR DESCRIPTION
## Relevant Tests

* Unpivot AT Alias Normalization
    * equiv wildcard steps struct
        * PERMISSIVE
        * LEGACY
    * equiv path expression with wildcard steps
        * PERMISSIVE
        * LEGACY
    * unpivotMissing
        * PERMISSIVE
        * LEGACY
    * unpivotEmptyStruct
        * PERMISSIVE
        * LEGACY
    * unpivotStructWithMissingField
    * selectFromScalarAndAtUnpivotWildCardOverScalar
* UNPIVOT Empty
    * pathUnpivotEmptyStruct1
    * pathUnpivotEmptyStruct2
    * pathUnpivotEmptyStruct3
* Unable to resolve IS_STRUCT
    * equiv attribute value pair unpivot missing




- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.