### PR TITLE
Handles null calls in dynamic dispatch

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -239,7 +239,7 @@ internal class Compiler(
             val coercions = candidate.coercions.toTypedArray()
             // Check this candidate
             val fnArity = fn.signature.parameters.size
-            val fnName = fn.signature.name
+            val fnName = fn.signature.name.uppercase()
             if (arity == -1) {
                 arity = fnArity
                 name = fnName

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCast.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCast.kt
@@ -318,7 +318,7 @@ internal class ExprCast(val arg: Operator.Expr, val cast: Ref.Cast) : Operator.E
             PartiQLValueType.INTERVAL,
             PartiQLValueType.BAG, PartiQLValueType.LIST,
             PartiQLValueType.SEXP,
-            PartiQLValueType.STRUCT -> error("can not perform cast from INT8 to $t")
+            PartiQLValueType.STRUCT -> error("can not perform cast from struct to $t")
             PartiQLValueType.NULL -> error("cast to null not supported")
             PartiQLValueType.MISSING -> error("cast to missing not supported")
         }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSelect.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprSelect.kt
@@ -51,10 +51,6 @@ internal class ExprSelect(
         }
     }
 
-    /**
-     * @param record
-     * @return
-     */
     @PartiQLValueExperimental
     override fun eval(env: Environment): PartiQLValue {
         val elements = Elements(input, constructor, env)

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.partiql.eval.PartiQLEngine
 import org.partiql.eval.PartiQLResult
+import org.partiql.eval.internal.PartiQLEngineDefaultTest.SuccessTestCase.Global
 import org.partiql.parser.PartiQLParser
 import org.partiql.plan.PartiQLPlan
 import org.partiql.plan.debug.PlanPrinter
@@ -1171,7 +1172,7 @@ class PartiQLEngineDefaultTest {
         val input: String,
         val expected: PartiQLValue,
         val mode: PartiQLEngine.Mode = PartiQLEngine.Mode.PERMISSIVE,
-        val globals: List<Global> = emptyList()
+        val globals: List<Global> = emptyList(),
     ) {
 
         private val engine = PartiQLEngine.builder().build()
@@ -1243,7 +1244,7 @@ class PartiQLEngineDefaultTest {
     public class TypingTestCase @OptIn(PartiQLValueExperimental::class) constructor(
         val name: String,
         val input: String,
-        val expectedPermissive: PartiQLValue
+        val expectedPermissive: PartiQLValue,
     ) {
 
         private val engine = PartiQLEngine.builder().build()

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamicTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamicTest.kt
@@ -36,7 +36,11 @@ class ExprCallDynamicTest {
 
         @OptIn(PartiQLValueExperimental::class)
         fun assert() {
-            val expr = ExprCallDynamic(candidates, args = arrayOf(ExprLiteral(lhs), ExprLiteral(rhs)))
+            val expr = ExprCallDynamic(
+                name = "example_function",
+                candidates = candidates,
+                args = arrayOf(ExprLiteral(lhs), ExprLiteral(rhs)),
+            )
             val result = expr.eval(Environment.empty).check<Int32Value>()
             assertEquals(expectedIndex, result.value)
         }
@@ -72,6 +76,7 @@ class ExprCallDynamicTest {
                                 FnParameter("second", type = it.second),
                             )
                         )
+
                         override fun invoke(args: Array<PartiQLValue>): PartiQLValue = int32Value(index)
                     },
                     coercions = arrayOf(null, null)


### PR DESCRIPTION
## Description

Handles null calls in dynamic dispatch

## Tests Addressed

```


    OVERLAY mismatched type, compileOption: LEGACY

    null value on any of the 3 inputs returns false{likeExpr:" d.sid LIKE null ESCAPE null "}, compileOption: PERMISSIVE

    null value on any of the 3 inputs returns false{likeExpr:" d.sid LIKE null ESCAPE null "}, compileOption: LEGACY

    null value on any of the 3 inputs returns false{likeExpr:" d.sid LIKE null ESCAPE '[' "}, compileOption: PERMISSIVE

    null value on any of the 3 inputs returns false{likeExpr:" d.sid LIKE null ESCAPE '[' "}, compileOption: LEGACY

    null value on any of the 3 inputs returns false{likeExpr:" d.sid LIKE 'S1' ESCAPE null "}, compileOption: PERMISSIVE

    null value on any of the 3 inputs returns false{likeExpr:" d.sid LIKE 'S1' ESCAPE null "}, compileOption: LEGACY

    null value on any of the 3 inputs returns false{likeExpr:" d.sid LIKE null "}, compileOption: PERMISSIVE

    null value on any of the 3 inputs returns false{likeExpr:" d.sid LIKE null "}, compileOption: LEGACY

```

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.