### PR TITLE
Makes a planner missing node into a compile-time error for strict mode

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprMissing.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprMissing.kt
@@ -1,0 +1,17 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.errors.TypeCheckException
+import org.partiql.eval.internal.Environment
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.value.PartiQLValue
+import org.partiql.value.PartiQLValueExperimental
+
+internal class ExprMissing(
+    private val message: String,
+) : Operator.Expr {
+
+    @OptIn(PartiQLValueExperimental::class)
+    override fun eval(env: Environment): PartiQLValue {
+        throw TypeCheckException(message)
+    }
+}


### PR DESCRIPTION
Possible replacement for https://github.com/partiql/partiql-lang-kotlin/pull/1416/

## Description

Makes a planner missing node into a compile-time error for strict mode.Locally went from 780 failing to 591 failing.

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**

Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.