### PR TITLE
Eradicates premature failures when visiting error nodes

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -53,7 +53,6 @@ import org.partiql.plan.Ref
 import org.partiql.plan.Rel
 import org.partiql.plan.Rex
 import org.partiql.plan.Statement
-import org.partiql.plan.debug.PlanPrinter
 import org.partiql.plan.rexOpErr
 import org.partiql.plan.visitor.PlanBaseVisitor
 import org.partiql.spi.fn.Agg
@@ -77,12 +76,24 @@ internal class Compiler(
         TODO("Not yet implemented")
     }
 
+    /**
+     * Currently, this returns MISSING as the conformance tests work under the assumption that all permissive mode
+     * tests shall not fail during compilation and should still return MISSING in this scenarios. That being said, this
+     * is likely WRONG.
+     *
+     * In the PartiQL Specification:
+     * > For example, in the presence of schema validation, an PartiQL query processor can throw a compile-time error
+     * > when given the path expression {a:1, b:2}.c. In a more important and common case, an PartiQL implementation can
+     * > utilize the input data schema to prove that a path expression always returns MISSING and thus throw a
+     * > compile-time error.
+     *
+     * TODO: The usage of "can throw a compile-time error" is NOT reflected in the PartiQL Conformance Tests. The
+     *  existing conformance tests do not fail during compilation. We likely want to fail at compilation, however,
+     *  it is not against the specification to fail during evaluation. As such, while the current implementation isn't
+     *  wrong conformance-wise, it is not ideal.
+     */
     override fun visitRexOpErr(node: Rex.Op.Err, ctx: StaticType?): Operator {
-        val message = buildString {
-            this.appendLine(node.message)
-            PlanPrinter.append(this, plan)
-        }
-        throw IllegalStateException(message)
+        return ExprMissing(node.message)
     }
 
     override fun visitRelOpErr(node: Rel.Op.Err, ctx: StaticType?): Operator {


### PR DESCRIPTION
## Relevant Issues
- None

## Description

According to the PartiQL Specification:
> For example, in the presence of schema validation, an PartiQL query processor can throw a compile-time error
> when given the path expression {a:1, b:2}.c. In a more important and common case, an PartiQL implementation can
> utilize the input data schema to prove that a path expression always returns MISSING and thus throw a
> compile-time error.

So, this translates to deferring failure until evaluation. While it is sub-optimal, it complies with the specification. We can always change the testing mechanism in the future.

Beyond that, I found that we had some bugs due to throwing errors when we saw unresolved nodes in the PlanTransform. The root cause is that we were appending unresolved nodes to the "causes" list of Rex.Op.Err. Therefore, with the introduction of Rex.Op.Err, yes -- we would temporarily handle errors, however, when we'd visit those errors, we would prematurely fail compilation.

This PR fixes both of the above situations.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.