### PR TITLE
Remove unnecessary conversion steps in PartiQLValueIonReaderBuilder

### DIFF
--- a/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
@@ -3,7 +3,6 @@ package org.partiql.value.io
 import com.amazon.ion.IonReader
 import com.amazon.ion.IonType
 import com.amazon.ion.system.IonReaderBuilder
-import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ion.system.IonTextWriterBuilder
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.toIonValue

--- a/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
@@ -5,7 +5,6 @@ import com.amazon.ion.IonType
 import com.amazon.ion.system.IonReaderBuilder
 import com.amazon.ion.system.IonTextWriterBuilder
 import com.amazon.ionelement.api.IonElement
-import com.amazon.ionelement.api.toIonValue
 import org.partiql.value.DecimalValue
 import org.partiql.value.IntValue
 import org.partiql.value.PartiQLValue

--- a/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/value/io/PartiQLValueIonReader.kt
@@ -626,9 +626,8 @@ public class PartiQLValueIonReaderBuilder private constructor(
 
     public fun build(ionElement: IonElement): PartiQLValueReader {
         val out = ByteArrayOutputStream()
-        val reader = IonReaderBuilder.standard().build(ionElement.toIonValue(IonSystemBuilder.standard().build()))
         val writer = IonTextWriterBuilder.standard().build(out)
-        writer.writeValues(reader)
+        ionElement.writeTo(writer)
         val input = ByteArrayInputStream(out.toByteArray())
         return build(input)
     }


### PR DESCRIPTION
## Relevant Issues

N/A

## Description

There is a lot of unnecessary computation in `PartiQLValueIonReaderBuilder.build(ionElement: IonElement)` as it converts from `IonElement -> IonValue -> text Ion -> PartiQLValue`. This PR eliminates the hop to `IonValue`, resulting in `IonElement -> text Ion -> PartiQLValue`.

```
// Current implementation
val reader = IonReaderBuilder.standard().build(ionElement.toIonValue(IonSystemBuilder.standard().build()))
val writer = IonTextWriterBuilder.standard().build(out)
writer.writeValues(reader) 
```
The IonReader in the current implementation is completely unnecessary. We can eliminate the construction and overhead of passing data through an IonReader by writing the `IonValue`s directly to the writer.
```
val writer = IonTextWriterBuilder.standard().build(out)
ionElement.toIonValue(IonSystemBuilder.standard().build()).writeTo(writer)
```

The conversion to `IonValue` also adds a non-trivial amount of computation. The implementation of `IonElement.toIonValue()` constructs an `IonWriter` that will write directly to `IonValue`. We can take things one step further, and skip `IonValue` completely, which is what this PR does. I.e.:
```
val writer = IonTextWriterBuilder.standard().build(out)
ionElement.writeTo(writer)
```


## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**

CHANGELOG says:
> All notable changes to this project will be documented in this file.

Is this PR "notable"? I'll let you be the judge.

- Any backward-incompatible changes? **NO**

- Any new external dependencies? **NO**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md) and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.