### PR TITLE
Add to non-reserved keywords; rework `functionName` and `symbolPrimitive` parse rules

### DIFF
--- a/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
@@ -1326,7 +1326,7 @@ internal class PartiQLPigVisitor(
     }
 
     override fun visitFunctionCall(ctx: PartiQLParser.FunctionCallContext) = PartiqlAst.build {
-        val nameCtx = ctx.functionName()
+        val nameCtx = ctx.qualifiedName()
         val name = if (nameCtx.qualifier.isNotEmpty()) {
             error("Legacy AST does not support qualified function names")
         } else {

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/errors/ParserErrorsTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/errors/ParserErrorsTest.kt
@@ -15,6 +15,7 @@
 package org.partiql.lang.errors
 
 import com.amazon.ion.Timestamp
+import org.junit.Ignore
 import org.junit.Test
 import org.partiql.errors.ErrorCode
 import org.partiql.errors.Property
@@ -655,6 +656,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
     }
 
     @Test
+    @Ignore("No longer a parser error; evaluation error")
     fun callTrimNoArgs() {
         checkInputThrowingParserException(
             "trim()",
@@ -683,6 +685,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
     }
 
     @Test
+    @Ignore("No longer a parser error; evaluation error")
     fun callTrimZeroArguments() {
         checkInputThrowingParserException(
             "trim()",
@@ -795,6 +798,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
     }
 
     @Test
+    @Ignore("No longer a parser error; evaluation error")
     fun aggregateWithNoArgs() {
         checkInputThrowingParserException(
             "SUM()",
@@ -809,6 +813,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
     }
 
     @Test
+    @Ignore("No longer a parser error; evaluation error")
     fun aggregateWithTooManyArgs() {
         checkInputThrowingParserException(
             "SUM(a, b)",
@@ -1672,6 +1677,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
     }
 
     @Test
+    @Ignore("No longer a parser error; evaluation error")
     fun callExtractMissingFromWithComma() {
         checkInputThrowingParserException(
             "extract(year, b)",
@@ -1717,6 +1723,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
     }
 
     @Test
+    @Ignore("No longer a parser error; evaluation error")
     fun callExtractOnlySecondArgument() {
         checkInputThrowingParserException(
             "extract(b)",
@@ -1746,6 +1753,7 @@ class ParserErrorsTest : PartiQLParserTestBase() {
     }
 
     @Test
+    @Ignore("No longer a parser error; evaluation error")
     fun callExtractOnlyDateTimePart() {
         checkInputThrowingParserException(
             "extract(year)",

--- a/partiql-parser/src/main/antlr/PartiQL.g4
+++ b/partiql-parser/src/main/antlr/PartiQL.g4
@@ -763,12 +763,7 @@ dateFunction
 
 // SQL-99 10.4 — <routine invocation> ::= <routine name> <SQL argument list>
 functionCall
-    : functionName PAREN_LEFT ( expr ( COMMA expr )* )? PAREN_RIGHT
-    ;
-
-// SQL-99 10.4 — <routine name> ::= [ <schema name> <period> ] <qualified identifier>
-functionName
-    : (qualifier+=symbolPrimitive PERIOD)* name=symbolPrimitive
+    : qualifiedName PAREN_LEFT ( expr ( COMMA expr )* )? PAREN_RIGHT
     ;
 
 pathStep

--- a/partiql-parser/src/main/antlr/PartiQL.g4
+++ b/partiql-parser/src/main/antlr/PartiQL.g4
@@ -40,9 +40,9 @@ byIdent
     : BY symbolPrimitive;
 
 symbolPrimitive
-    : IDENTIFIER            # UnquotedIdentifier
-    | IDENTIFIER_QUOTED     # QuotedIdentifier
-    | nonReserved           # UnquotedIdentifier
+    : IDENTIFIER            # IdentifierUnquoted
+    | IDENTIFIER_QUOTED     # IdentifierQuoted
+    | nonReserved           # IdentifierUnquoted
     ;
 
 /**

--- a/partiql-parser/src/main/antlr/PartiQL.g4
+++ b/partiql-parser/src/main/antlr/PartiQL.g4
@@ -40,7 +40,9 @@ byIdent
     : BY symbolPrimitive;
 
 symbolPrimitive
-    : ident=( IDENTIFIER | IDENTIFIER_QUOTED )
+    : IDENTIFIER            # UnquotedIdentifier
+    | IDENTIFIER_QUOTED     # QuotedIdentifier
+    | nonReserved           # UnquotedIdentifier
     ;
 
 /**
@@ -653,8 +655,8 @@ exprPrimary
     | dateFunction               # ExprPrimaryBase
     | aggregate                  # ExprPrimaryBase
     | trimFunction               # ExprPrimaryBase
-    | functionCall               # ExprPrimaryBase
     | nullIf                     # ExprPrimaryBase
+    | functionCall               # ExprPrimaryBase
     | exprPrimary pathStep+      # ExprPrimaryPath
     | exprGraphMatchMany         # ExprPrimaryBase
     | caseExpr                   # ExprPrimaryBase
@@ -766,8 +768,7 @@ functionCall
 
 // SQL-99 10.4 — <routine name> ::= [ <schema name> <period> ] <qualified identifier>
 functionName
-    : (qualifier+=symbolPrimitive PERIOD)* name=( CHAR_LENGTH | CHARACTER_LENGTH | OCTET_LENGTH | BIT_LENGTH | UPPER | LOWER | SIZE | EXISTS | COUNT | MOD )  # FunctionNameReserved
-    | (qualifier+=symbolPrimitive PERIOD)* name=symbolPrimitive                                                                                         # FunctionNameSymbol
+    : (qualifier+=symbolPrimitive PERIOD)* name=symbolPrimitive
     ;
 
 pathStep
@@ -789,11 +790,52 @@ parameter
 
 varRefExpr
     : qualifier=AT_SIGN? ident=(IDENTIFIER|IDENTIFIER_QUOTED)   # VariableIdentifier
-    | qualifier=AT_SIGN? key=nonReservedKeywords                # VariableKeyword
+    | qualifier=AT_SIGN? key=nonReserved                # VariableKeyword
     ;
 
-nonReservedKeywords
-    : EXCLUDED
+nonReserved
+    : /* From SQL99 <non-reserved word> https://ronsavage.github.io/SQL/sql-99.bnf.html#non-reserved%20word */
+    ABS | ADA | ADMIN | ASENSITIVE | ASSIGNMENT | ASYMMETRIC | ATOMIC
+    | ATTRIBUTE | AVG
+    | BIT_LENGTH
+    | C | CALLED | CARDINALITY | CATALOG_NAME | CHAIN | CHAR_LENGTH
+    | CHARACTERISTICS | CHARACTER_LENGTH | CHARACTER_SET_CATALOG
+    | CHARACTER_SET_NAME | CHARACTER_SET_SCHEMA | CHECKED | CLASS_ORIGIN
+    | COALESCE | COBOL | COLLATION_CATALOG | COLLATION_NAME | COLLATION_SCHEMA
+    | COLUMN_NAME | COMMAND_FUNCTION | COMMAND_FUNCTION_CODE | COMMITTED
+    | CONDITION_IDENTIFIER | CONDITION_NUMBER | CONNECTION_NAME
+    | CONSTRAINT_CATALOG | CONSTRAINT_NAME | CONSTRAINT_SCHEMA | CONTAINS
+    | CONVERT | COUNT | CURSOR_NAME
+    | DATETIME_INTERVAL_CODE | DATETIME_INTERVAL_PRECISION | DEFINED
+    | DEFINER | DEGREE | DERIVED | DISPATCH
+    | EVERY | EXTRACT
+    | FINAL | FORTRAN
+    | G | GENERATED | GRANTED
+    | HIERARCHY
+    | IMPLEMENTATION | INSENSITIVE | INSTANCE | INSTANTIABLE | INVOKER
+    | K | KEY_MEMBER | KEY_TYPE
+    | LENGTH | LOWER
+    | M | MAX | MIN | MESSAGE_LENGTH | MESSAGE_OCTET_LENGTH | MESSAGE_TEXT
+    | MOD | MORE | MUMPS
+    | NAME | NULLABLE | NUMBER | NULLIF
+    | OCTET_LENGTH | ORDERING | OPTIONS | OVERLAY | OVERRIDING
+    | PASCAL | PARAMETER_MODE | PARAMETER_NAME
+    | PARAMETER_ORDINAL_POSITION | PARAMETER_SPECIFIC_CATALOG
+    | PARAMETER_SPECIFIC_NAME | PARAMETER_SPECIFIC_SCHEMA | PLI | POSITION
+    | REPEATABLE | RETURNED_CARDINALITY | RETURNED_LENGTH
+    | RETURNED_OCTET_LENGTH | RETURNED_SQLSTATE | ROUTINE_CATALOG
+    | ROUTINE_NAME | ROUTINE_SCHEMA | ROW_COUNT
+    | SCALE | SCHEMA_NAME | SCOPE | SECURITY | SELF | SENSITIVE | SERIALIZABLE
+    | SERVER_NAME | SIMPLE | SOURCE | SPECIFIC_NAME | STATEMENT | STRUCTURE
+    | STYLE | SUBCLASS_ORIGIN | SUBSTRING | SUM | SYMMETRIC | SYSTEM
+    | TABLE_NAME | TOP_LEVEL_COUNT | TRANSACTIONS_COMMITTED
+    | TRANSACTIONS_ROLLED_BACK | TRANSACTION_ACTIVE | TRANSFORM
+    | TRANSFORMS | TRANSLATE | TRIGGER_CATALOG | TRIGGER_SCHEMA
+    | TRIGGER_NAME | TRIM | TYPE
+    | UNCOMMITTED | UNNAMED | UPPER
+    /* PartiQL */
+    | EXCLUDED | EXISTS
+    | SIZE
     ;
 
 /**

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -557,29 +557,29 @@ internal class PartiQLParserDefault : PartiQLParser {
          *
          */
 
-        override fun visitAsIdent(ctx: GeneratedParser.AsIdentContext) = visitSymbolPrimitive(ctx.symbolPrimitive())
+        override fun visitAsIdent(ctx: GeneratedParser.AsIdentContext) = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
 
-        override fun visitAtIdent(ctx: GeneratedParser.AtIdentContext) = visitSymbolPrimitive(ctx.symbolPrimitive())
+        override fun visitAtIdent(ctx: GeneratedParser.AtIdentContext) = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
 
-        override fun visitByIdent(ctx: GeneratedParser.ByIdentContext) = visitSymbolPrimitive(ctx.symbolPrimitive())
+        override fun visitByIdent(ctx: GeneratedParser.ByIdentContext) = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
 
-        override fun visitSymbolPrimitive(ctx: GeneratedParser.SymbolPrimitiveContext) = translate(ctx) {
-            when (ctx.ident.type) {
-                GeneratedParser.IDENTIFIER_QUOTED -> identifierSymbol(
-                    ctx.IDENTIFIER_QUOTED().getStringValue(),
-                    Identifier.CaseSensitivity.SENSITIVE,
-                )
-                GeneratedParser.IDENTIFIER -> identifierSymbol(
-                    ctx.IDENTIFIER().getStringValue(),
-                    Identifier.CaseSensitivity.INSENSITIVE,
-                )
-                else -> throw error(ctx, "Invalid symbol reference.")
-            }
+        override fun visitQuotedIdentifier(ctx: org.partiql.parser.internal.antlr.PartiQLParser.QuotedIdentifierContext): Identifier.Symbol = translate(ctx) {
+            identifierSymbol(
+                ctx.IDENTIFIER_QUOTED().getStringValue(),
+                Identifier.CaseSensitivity.SENSITIVE
+            )
+        }
+
+        override fun visitUnquotedIdentifier(ctx: org.partiql.parser.internal.antlr.PartiQLParser.UnquotedIdentifierContext): Identifier.Symbol = translate(ctx) {
+            identifierSymbol(
+                ctx.text,
+                Identifier.CaseSensitivity.INSENSITIVE
+            )
         }
 
         override fun visitQualifiedName(ctx: GeneratedParser.QualifiedNameContext) = translate(ctx) {
-            val qualifier = ctx.qualifier.map { visitSymbolPrimitive(it) }
-            val name = visitSymbolPrimitive(ctx.name)
+            val qualifier = ctx.qualifier.map { visitAs<Identifier.Symbol> (it) }
+            val name = visitAs<Identifier.Symbol> (ctx.name)
             if (qualifier.isEmpty()) {
                 name
             } else {
@@ -605,8 +605,8 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitDropIndex(ctx: GeneratedParser.DropIndexContext) = translate(ctx) {
-            val table = visitSymbolPrimitive(ctx.on)
-            val index = visitSymbolPrimitive(ctx.target)
+            val table = visitAs<Identifier.Symbol> (ctx.on)
+            val index = visitAs<Identifier.Symbol> (ctx.target)
             ddlOpDropIndex(index, table)
         }
 
@@ -638,7 +638,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitCreateIndex(ctx: GeneratedParser.CreateIndexContext) = translate(ctx) {
             // TODO add index name to ANTLR grammar
             val name: Identifier? = null
-            val table = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val table = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             val fields = ctx.pathSimple().map { path -> visitPathSimple(path) }
             ddlOpCreateIndex(name, table, fields)
         }
@@ -867,7 +867,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitInsertStatement(ctx: GeneratedParser.InsertStatementContext) = translate(ctx) {
-            val target = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val target = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             val values = visitExpr(ctx.value)
             val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
             val onConflict = ctx.onConflict()?.let { visitOnConflictClause(it) }
@@ -875,14 +875,14 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitReplaceCommand(ctx: GeneratedParser.ReplaceCommandContext) = translate(ctx) {
-            val target = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val target = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             val values = visitExpr(ctx.value)
             val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
             statementDMLReplace(target, values, asAlias)
         }
 
         override fun visitUpsertCommand(ctx: GeneratedParser.UpsertCommandContext) = translate(ctx) {
-            val target = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val target = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             val values = visitExpr(ctx.value)
             val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
             statementDMLUpsert(target, values, asAlias)
@@ -928,9 +928,9 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitConflictTarget(ctx: GeneratedParser.ConflictTargetContext) = translate(ctx) {
             if (ctx.constraintName() != null) {
-                onConflictTargetConstraint(visitSymbolPrimitive(ctx.constraintName().symbolPrimitive()))
+                onConflictTargetConstraint(visitAs<Identifier.Symbol> (ctx.constraintName().symbolPrimitive()))
             } else {
-                val symbols = ctx.symbolPrimitive().map { visitSymbolPrimitive(it) }
+                val symbols = ctx.symbolPrimitive().map { visitAs<Identifier.Symbol> (it) }
                 onConflictTargetSymbols(symbols)
             }
         }
@@ -953,7 +953,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitPathSimple(ctx: GeneratedParser.PathSimpleContext) = translate(ctx) {
-            val root = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val root = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             val steps = visitOrEmpty<Path.Step>(ctx.pathSimpleSteps())
             path(root, steps)
         }
@@ -975,12 +975,12 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitPathSimpleSymbol(ctx: GeneratedParser.PathSimpleSymbolContext) = translate(ctx) {
-            val identifier = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val identifier = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             pathStepSymbol(identifier)
         }
 
         override fun visitPathSimpleDotSymbol(ctx: GeneratedParser.PathSimpleDotSymbolContext) = translate(ctx) {
-            val identifier = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val identifier = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             pathStepSymbol(identifier)
         }
 
@@ -1063,7 +1063,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitProjectionItem(ctx: GeneratedParser.ProjectionItemContext) = translate(ctx) {
             val expr = visitExpr(ctx.expr())
-            val alias = ctx.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
+            val alias = ctx.symbolPrimitive()?.let { visitAs<Identifier.Symbol> (it) }
             if (expr is Expr.Path) {
                 convertPathToProjectionItem(ctx, expr, alias)
             } else {
@@ -1107,7 +1107,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitLetBinding(ctx: GeneratedParser.LetBindingContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.expr())
-            val alias = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val alias = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             letBinding(expr, alias)
         }
 
@@ -1148,13 +1148,13 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitGroupClause(ctx: GeneratedParser.GroupClauseContext) = translate(ctx) {
             val strategy = if (ctx.PARTIAL() != null) GroupBy.Strategy.PARTIAL else GroupBy.Strategy.FULL
             val keys = visitOrEmpty<GroupBy.Key>(ctx.groupKey())
-            val alias = ctx.groupAlias()?.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
+            val alias = ctx.groupAlias()?.symbolPrimitive()?.let { visitAs<Identifier.Symbol> (it) }
             groupBy(strategy, keys, alias)
         }
 
         override fun visitGroupKey(ctx: GeneratedParser.GroupKeyContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.key)
-            val alias = ctx.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
+            val alias = ctx.symbolPrimitive()?.let { visitAs<Identifier.Symbol> (it) }
             groupByKey(expr, alias)
         }
 
@@ -1169,14 +1169,14 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitExcludeExpr(ctx: GeneratedParser.ExcludeExprContext) = translate(ctx) {
-            val rootId = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val rootId = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             val root = exprVar(rootId, Expr.Var.Scope.DEFAULT)
             val steps = visitOrEmpty<Exclude.Step>(ctx.excludeExprSteps())
             excludeItem(root, steps)
         }
 
         override fun visitExcludeExprTupleAttr(ctx: GeneratedParser.ExcludeExprTupleAttrContext) = translate(ctx) {
-            val identifier = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val identifier = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             excludeStepStructField(identifier)
         }
 
@@ -1284,7 +1284,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitPatternPathVariable(ctx: GeneratedParser.PatternPathVariableContext) =
-            visitSymbolPrimitive(ctx.symbolPrimitive())
+            visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
 
         override fun visitSelectorBasic(ctx: GeneratedParser.SelectorBasicContext) = translate(ctx) {
             when (ctx.mod.type) {
@@ -1327,7 +1327,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitLabelPrimaryName(ctx: GeneratedParser.LabelPrimaryNameContext) = translate(ctx) {
-            val x = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val x = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             graphMatchLabelName(x.symbol)
         }
 
@@ -1457,17 +1457,17 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitTableBaseRefClauses(ctx: GeneratedParser.TableBaseRefClausesContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val asAlias = ctx.asIdent()?.let { visitAs<Identifier.Symbol> (it.symbolPrimitive()) }
+            val atAlias = ctx.atIdent()?.let { visitAs<Identifier.Symbol> (it.symbolPrimitive()) }
+            val byAlias = ctx.byIdent()?.let { visitAs<Identifier.Symbol> (it.symbolPrimitive()) }
             fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
 
         override fun visitTableBaseRefMatch(ctx: GeneratedParser.TableBaseRefMatchContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val asAlias = ctx.asIdent()?.let { visitAs<Identifier.Symbol> (it.symbolPrimitive()) }
+            val atAlias = ctx.atIdent()?.let { visitAs<Identifier.Symbol> (it.symbolPrimitive()) }
+            val byAlias = ctx.byIdent()?.let { visitAs<Identifier.Symbol> (it.symbolPrimitive()) }
             fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
 
@@ -1489,15 +1489,15 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitFromClauseSimpleImplicit(ctx: GeneratedParser.FromClauseSimpleImplicitContext) =
             translate(ctx) {
                 val path = visitPathSimple(ctx.pathSimple())
-                val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive())
+                val asAlias = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
                 statementDMLDeleteTarget(path, asAlias, null, null)
             }
 
         override fun visitTableUnpivot(ctx: GeneratedParser.TableUnpivotContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.expr())
-            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val asAlias = ctx.asIdent()?.let { visitAs<Identifier.Symbol> (it.symbolPrimitive()) }
+            val atAlias = ctx.atIdent()?.let { visitAs<Identifier.Symbol> (it.symbolPrimitive()) }
+            val byAlias = ctx.byIdent()?.let { visitAs<Identifier.Symbol> (it.symbolPrimitive()) }
             fromValue(expr, From.Value.Type.UNPIVOT, asAlias, atAlias, byAlias)
         }
 
@@ -1543,7 +1543,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitTableBaseRefSymbol(ctx: GeneratedParser.TableBaseRefSymbolContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val asAlias = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             fromValue(expr, From.Value.Type.SCAN, asAlias, null, null)
         }
 
@@ -1753,7 +1753,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitPathStepDotExpr(ctx: GeneratedParser.PathStepDotExprContext) = translate(ctx) {
-            val symbol = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val symbol = visitAs<Identifier.Symbol> (ctx.symbolPrimitive())
             exprPathStepSymbol(symbol)
         }
 
@@ -1851,8 +1851,8 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitFunctionCall(ctx: GeneratedParser.FunctionCallContext) = translate(ctx) {
             val args = visitOrEmpty<Expr>(ctx.expr())
             when (val funcName = ctx.functionName()) {
-                is GeneratedParser.FunctionNameReservedContext -> {
-                    when (funcName.name.type) {
+                is GeneratedParser.FunctionNameContext -> {
+                    when (funcName.name.start.type) {
                         GeneratedParser.MOD -> exprBinary(Expr.Binary.Op.MODULO, args[0], args[1])
                         else -> visitNonReservedFunctionCall(ctx, args)
                     }
@@ -1865,26 +1865,13 @@ internal class PartiQLParserDefault : PartiQLParser {
             return exprCall(function, args)
         }
 
-        override fun visitFunctionNameReserved(ctx: GeneratedParser.FunctionNameReservedContext): Identifier {
-            val path = ctx.qualifier.map { visitSymbolPrimitive(it) }
-            val name = when (ctx.name.type) {
+        override fun visitFunctionName(ctx: GeneratedParser.FunctionNameContext): Identifier {
+            val path = ctx.qualifier.map { visitAs<Identifier.Symbol> (it) }
+            val name = when (ctx.name.start.type) {
                 GeneratedParser.CHARACTER_LENGTH, GeneratedParser.CHAR_LENGTH ->
                     identifierSymbol("char_length", Identifier.CaseSensitivity.INSENSITIVE)
-                else ->
-                    identifierSymbol(ctx.name.text, Identifier.CaseSensitivity.INSENSITIVE)
+                else -> visitAs<Identifier.Symbol> (ctx.name)
             }
-            return if (path.isEmpty()) {
-                name
-            } else {
-                val root = path.first()
-                val steps = path.drop(1) + listOf(name)
-                identifierQualified(root, steps)
-            }
-        }
-
-        override fun visitFunctionNameSymbol(ctx: GeneratedParser.FunctionNameSymbolContext): Identifier {
-            val path = ctx.qualifier.map { visitSymbolPrimitive(it) }
-            val name = visitSymbolPrimitive(ctx.name)
             return if (path.isEmpty()) {
                 name
             } else {
@@ -2313,9 +2300,9 @@ internal class PartiQLParserDefault : PartiQLParser {
         /**
          * Visiting a symbol to get a string, skip the wrapping, unwrapping, and location tracking.
          */
-        private fun symbolToString(ctx: GeneratedParser.SymbolPrimitiveContext) = when (ctx.ident.type) {
-            GeneratedParser.IDENTIFIER_QUOTED -> ctx.IDENTIFIER_QUOTED().getStringValue()
-            GeneratedParser.IDENTIFIER -> ctx.IDENTIFIER().getStringValue()
+        private fun symbolToString(ctx: GeneratedParser.SymbolPrimitiveContext) = when (ctx) {
+            is GeneratedParser.QuotedIdentifierContext -> ctx.IDENTIFIER_QUOTED().getStringValue()
+            is GeneratedParser.UnquotedIdentifierContext -> ctx.text
             else -> throw error(ctx, "Invalid symbol reference.")
         }
 


### PR DESCRIPTION
## Description
- Adds non-reserved keywords from SQL-99 (https://ronsavage.github.io/SQL/sql-99.bnf.html#non-reserved%20word)
- Reworks the following ANTLR rules
  - `functionName` -- gets rid of hard-coded reserved keywords as function names block
  - `symbolPrimitive` -- adds `nonReserved` keywords to this rule

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - No, v1 branch

- Any backward-incompatible changes? **[NO?]**
  - Will have some behavioral changes related to some invalid queries not resulting in a parse error (will still be an evaluation error)

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.