### PR TITLE
Upgrade JMH plugin dependency to 0.7.2

### DIFF
--- a/buildSrc/src/main/kotlin/partiql.versions.kt
+++ b/buildSrc/src/main/kotlin/partiql.versions.kt
@@ -36,7 +36,7 @@ object Versions {
     const val jansi = "2.4.0"
     const val jgenhtml = "1.6"
     const val jline = "3.21.0"
-    const val jmhGradlePlugin = "0.5.3"
+    const val jmhGradlePlugin = "0.7.2"
     const val jmhCore = "1.37"
     const val jmhGeneratorAnnprocess = "1.37"
     const val jmhGeneratorBytecode = "1.37"
@@ -108,11 +108,6 @@ object Deps {
     const val mockk = "io.mockk:mockk:${Versions.mockk}"
     const val kotlinxCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinxCoroutinesTest}"
     const val ktlintTest = "com.pinterest.ktlint:ktlint-test:${Versions.ktlint}"
-
-    // JMH Benchmarking
-    const val jmhCore = "org.openjdk.jmh:jmh-core:${Versions.jmhCore}"
-    const val jmhGeneratorAnnprocess = "org.openjdk.jmh:jmh-core:${Versions.jmhGeneratorAnnprocess}"
-    const val jmhGeneratorBytecode = "org.openjdk.jmh:jmh-core:${Versions.jmhGeneratorBytecode}"
 }
 
 object Plugins {
@@ -126,7 +121,7 @@ object Plugins {
     const val application = "org.gradle.application"
     const val detekt = "io.gitlab.arturbosch.detekt"
     const val dokka = "org.jetbrains.dokka"
-    const val jmh = "me.champeau.gradle.jmh"
+    const val jmh = "me.champeau.jmh"
     const val library = "org.gradle.java-library"
     const val testFixtures = "org.gradle.java-test-fixtures"
 }

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -50,18 +50,6 @@ dependencies {
     testImplementation(Deps.junitVintage) // Enables JUnit4
     testImplementation(Deps.mockk)
     testImplementation(Deps.kotlinxCoroutinesTest)
-
-    // The JMH gradle plugin that we currently use is 0.5.3, which uses JMH version 1.25. The JMH gradle plugin has a
-    // newer version (see https://github.com/melix/jmh-gradle-plugin/releases) which upgrades the JMH version. We can't
-    // use that newer plugin version until we upgrade our gradle version to 8.0+. JMH version 1.25 does not support
-    // creating CPU flamegraphs using the JMH benchmarks, hence why the newer version dependency is specified here.
-    //
-    // When we upgrade gradle to 8.0+, we can upgrade the gradle plugin to the latest and remove this dependency block
-    dependencies {
-        jmh(Deps.jmhCore)
-        jmh(Deps.jmhGeneratorAnnprocess)
-        jmh(Deps.jmhGeneratorBytecode)
-    }
 }
 
 val relocations = mapOf(
@@ -91,7 +79,7 @@ publish {
 jmh {
     resultFormat = properties["resultFormat"] as String? ?: "json"
     resultsFile = project.file(properties["resultsFile"] as String? ?: "$buildDir/reports/jmh/results.json")
-    include = listOfNotNull(properties["include"] as String?)
+    includes = listOfNotNull(properties["include"] as String?)
     properties["warmupIterations"]?.let { it -> warmupIterations = Integer.parseInt(it as String) }
     properties["iterations"]?.let { it -> iterations = Integer.parseInt(it as String) }
     properties["fork"]?.let { it -> fork = Integer.parseInt(it as String) }


### PR DESCRIPTION
## Description
#1439 had upgraded the gradle version to 8+, which is incompatible with the previous JMH plugin version, 0.5.3. This PR upgrades the JMH plugin version to the latest, 0.7.2, which is compatible w/ gradle 8+.

The older version caused a build failure for the GH actions JMH steps -- https://github.com/partiql/partiql-lang-kotlin/actions/runs/9086996607/job/24974662217.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - No public API changes.

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[YES]**
  - Upgrade jmh plugin version from 0.5.3 to 0.7.2 (also involved using the updated plugin name).

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.