### PR TITLE
Changes INT/INTEGER to be an alias for INT4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ Thank you to all who have contributed!
 is that the null and missing values are part of *all* data types. Therefore, one must assume that the types returned by
 the planner allow for NULL and MISSING values. Similarly, the testFixtures Ion-encoded test resources
 representing the catalog do not use "null" or "missing".
+- **Behavioral change**: The `INTEGER/INT` type is now an alias to the `INT4` type. Previously the INTEGER type was
+unconstrained which is not SQL-conformant and is causing issues in integrating with other systems. This release makes
+INTEGER an alias for INT4 which is the internal type name. In a later release, we will make INTEGER the default 32-bit
+integer with INT/INT4/INTEGER4 being aliases per other systems. This change only applies to
+org.partiql.parser.PartiQLParser, not the org.partiql.lang.syntax.PartiQLParser.
 
 ### Deprecated
 - We have deprecated `org.partiql.type.NullType` and `org.partiql.type.MissingType`. Please see the corresponding

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -3998,6 +3998,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     )
 
     @Test
+    @Ignore("This test is disabled while the new parser uses INT as an INT4 alias whereas the older parser does not.")
     fun createTableWithConstraints() = assertExpression(
         """
             CREATE TABLE Customer (

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -183,7 +183,6 @@ import org.partiql.ast.typeDate
 import org.partiql.ast.typeDecimal
 import org.partiql.ast.typeFloat32
 import org.partiql.ast.typeFloat64
-import org.partiql.ast.typeInt
 import org.partiql.ast.typeInt2
 import org.partiql.ast.typeInt4
 import org.partiql.ast.typeInt8
@@ -2051,9 +2050,10 @@ internal class PartiQLParserDefault : PartiQLParser {
                 GeneratedParser.NULL -> typeNullType()
                 GeneratedParser.BOOL, GeneratedParser.BOOLEAN -> typeBool()
                 GeneratedParser.SMALLINT, GeneratedParser.INT2, GeneratedParser.INTEGER2 -> typeInt2()
+                // TODO, we have INT aliased to INT4 when it should be visa-versa.
                 GeneratedParser.INT4, GeneratedParser.INTEGER4 -> typeInt4()
+                GeneratedParser.INT, GeneratedParser.INTEGER -> typeInt4()
                 GeneratedParser.BIGINT, GeneratedParser.INT8, GeneratedParser.INTEGER8 -> typeInt8()
-                GeneratedParser.INT, GeneratedParser.INTEGER -> typeInt()
                 GeneratedParser.FLOAT -> typeFloat32()
                 GeneratedParser.DOUBLE -> typeFloat64()
                 GeneratedParser.REAL -> typeReal()

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -496,7 +496,7 @@ class PlanTyperTestsPorted {
                 name = "DECIMAL AS INT",
                 key = key("cast-03"),
                 catalog = "pql",
-                expected = StaticType.INT,
+                expected = StaticType.INT4,
             ),
             SuccessTestCase(
                 name = "DECIMAL AS BIGINT",
@@ -2459,7 +2459,7 @@ class PlanTyperTestsPorted {
             SuccessTestCase(
                 key = PartiQLTest.Key("basics", "case-when-11"),
                 catalog = "pql",
-                expected = StaticType.INT,
+                expected = StaticType.INT4,
             ),
             SuccessTestCase(
                 key = PartiQLTest.Key("basics", "case-when-12"),
@@ -4190,7 +4190,7 @@ class PlanTyperTestsPorted {
                 query = "SELECT CAST(breed AS INT) AS cast_breed FROM pets",
                 expected = BagType(
                     StructType(
-                        fields = mapOf("cast_breed" to StaticType.INT),
+                        fields = mapOf("cast_breed" to StaticType.INT4),
                         contentClosed = true,
                         constraints = setOf(
                             TupleConstraint.Open(false),

--- a/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
@@ -80,7 +80,7 @@ CASE t_item.t_string
 END;
 
 --#[case-when-11]
--- type: (int|missing)
+-- type: (int4|missing)
 COALESCE(CAST(t_item.t_string AS INT), 1);
 
 -- -----------------------------


### PR DESCRIPTION
## Relevant Issues

#1471 

## Description

Details are in the linked issue. Effectively this PR makes INT an alias for INT4. Today, the typing and handling of the 32-bit integer is covered by INT4, but we have (for historical reasons) had INT as the Ion unbounded integer. This has created a situation in which INT != INT4 and INT has no precision whereas BIGINT does; therefore BIGINT < INT.

The other systems we integrate with all have INT = INT4 because SQL dictates you must have a bound precision for the INTEGER type and pretty much every implementation uses 32-bit precision.

**Update**
```
SMALLINT    -> 16-bit
INT         -> 32-bit
BIGINT      -> 64-bit
```

Now, this PR is a somewhat sly half-measure by making INT an _alias_ to INT4 so that I don't have to change any planning/typing logic. John is working on updates to typing logic now, so I've simply made a tiny parser change. For version 1.0 we will flip this and make INT4 an alias for INT.

For the unbounded integer in other systems, we use `DECIMAL(38,0)` as this is typically the maximum size (e.g. Presto, Snowflake, SQL Server, Impala) but some allow higher precision (postgres).

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
Yes

- Any backward-incompatible changes? **[YES/NO]**
Yes, behavioral change. Detailed note in changelog.

- Any new external dependencies? **[YES/NO]**
No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
YEs

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.