### PR TITLE
struct type field meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Thank you to all who have contributed!
 ## [Unreleased]
 
 ### Added
-
+- Ability to append Meta in Field of Struct Type. 
 ### Changed
 - **Behavioral change**: The planner now does NOT support the NullType and MissingType variants of StaticType. The logic
 is that the null and missing values are part of *all* data types. Therefore, one must assume that the types returned by

--- a/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
@@ -671,7 +671,29 @@ public data class StructType(
     public data class Field(
         val key: String,
         val value: StaticType
-    )
+    ) {
+        // for backward compatible reason, we do not put metas into the data class constructor
+        val metas: MutableMap<String, Any> = mutableMapOf()
+
+        public constructor(key: String, value: StaticType, metas: Map<String, Any>) : this(key, value) {
+            this.metas.putAll(metas)
+        }
+
+        override fun hashCode(): Int {
+            var hc = key.hashCode()
+            hc = 31 * hc + value.hashCode()
+            hc = 31 * hc + metas.hashCode()
+            return hc
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (other !is Field) return false
+            return key == other.key && value == other.value && metas == other.metas
+        }
+
+        public fun copyWithMetas(key: String = this.key, value: StaticType = this.value, metas: Map<String, Any> = this.metas.toMap()) : Field =
+            Field(key, value, metas)
+    }
 
     override fun flatten(): StaticType = this
 

--- a/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
+++ b/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt
@@ -691,7 +691,7 @@ public data class StructType(
             return key == other.key && value == other.value && metas == other.metas
         }
 
-        public fun copyWithMetas(key: String = this.key, value: StaticType = this.value, metas: Map<String, Any> = this.metas.toMap()) : Field =
+        public fun copyWithMetas(key: String = this.key, value: StaticType = this.value, metas: Map<String, Any> = this.metas.toMap()): Field =
             Field(key, value, metas)
     }
 


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue N/A

## Description
- Ability to add meta in Field of StructType. 
- The purpose was to store information on field (attribute) directly, instead of push the metadata into type of field, which is not ergonomic and carries different semantic meaning. 
- To make the change backward compatible: instead of adding a parameter in the data class construct, we come up with a secondary constructor and override the equals and hash code function. We also introduced a function called copyWithMeta() to mimic the data class copy behavior.  

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - Yes.

- Any backward-incompatible changes? **[YES/NO]**
  -  No
 
- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >
- No

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.