### PR TITLE
Add operator node to AST and parser

### DIFF
--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -14,9 +14,9 @@ public final class org/partiql/ast/Ast {
 	public static final fun excludeStepCollWildcard ()Lorg/partiql/ast/Exclude$Step$CollWildcard;
 	public static final fun excludeStepStructField (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Exclude$Step$StructField;
 	public static final fun excludeStepStructWildcard ()Lorg/partiql/ast/Exclude$Step$StructWildcard;
+	public static final fun exprAnd (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$And;
 	public static final fun exprBagOp (Lorg/partiql/ast/SetOp;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Ljava/lang/Boolean;)Lorg/partiql/ast/Expr$BagOp;
 	public static final fun exprBetween (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Ljava/lang/Boolean;)Lorg/partiql/ast/Expr$Between;
-	public static final fun exprBinary (Lorg/partiql/ast/Expr$Binary$Op;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Binary;
 	public static final fun exprCall (Lorg/partiql/ast/Identifier;Ljava/util/List;Lorg/partiql/ast/SetQuantifier;)Lorg/partiql/ast/Expr$Call;
 	public static final fun exprCanCast (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Type;)Lorg/partiql/ast/Expr$CanCast;
 	public static final fun exprCanLosslessCast (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Type;)Lorg/partiql/ast/Expr$CanLosslessCast;
@@ -34,7 +34,10 @@ public final class org/partiql/ast/Ast {
 	public static final fun exprLike (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Ljava/lang/Boolean;)Lorg/partiql/ast/Expr$Like;
 	public static final fun exprLit (Lorg/partiql/value/PartiQLValue;)Lorg/partiql/ast/Expr$Lit;
 	public static final fun exprMatch (Lorg/partiql/ast/Expr;Lorg/partiql/ast/GraphMatch;)Lorg/partiql/ast/Expr$Match;
+	public static final fun exprNot (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Not;
 	public static final fun exprNullIf (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$NullIf;
+	public static final fun exprOperator (Ljava/lang/String;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Operator;
+	public static final fun exprOr (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Or;
 	public static final fun exprOverlay (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Overlay;
 	public static final fun exprParameter (I)Lorg/partiql/ast/Expr$Parameter;
 	public static final fun exprPath (Lorg/partiql/ast/Expr;Ljava/util/List;)Lorg/partiql/ast/Expr$Path;
@@ -50,7 +53,6 @@ public final class org/partiql/ast/Ast {
 	public static final fun exprStructField (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Struct$Field;
 	public static final fun exprSubstring (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Substring;
 	public static final fun exprTrim (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr$Trim$Spec;)Lorg/partiql/ast/Expr$Trim;
-	public static final fun exprUnary (Lorg/partiql/ast/Expr$Unary$Op;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Unary;
 	public static final fun exprValues (Ljava/util/List;)Lorg/partiql/ast/Expr$Values;
 	public static final fun exprValuesRow (Ljava/util/List;)Lorg/partiql/ast/Expr$Values$Row;
 	public static final fun exprVar (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr$Var$Scope;)Lorg/partiql/ast/Expr$Var;
@@ -515,6 +517,27 @@ public abstract class org/partiql/ast/Expr : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class org/partiql/ast/Expr$And : org/partiql/ast/Expr {
+	public static final field Companion Lorg/partiql/ast/Expr$And$Companion;
+	public final field lhs Lorg/partiql/ast/Expr;
+	public final field rhs Lorg/partiql/ast/Expr;
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)V
+	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun builder ()Lorg/partiql/ast/builder/ExprAndBuilder;
+	public final fun component1 ()Lorg/partiql/ast/Expr;
+	public final fun component2 ()Lorg/partiql/ast/Expr;
+	public final fun copy (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$And;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Expr$And;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;ILjava/lang/Object;)Lorg/partiql/ast/Expr$And;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/ast/Expr$And$Companion {
+	public final fun builder ()Lorg/partiql/ast/builder/ExprAndBuilder;
+}
+
 public final class org/partiql/ast/Expr$BagOp : org/partiql/ast/Expr {
 	public static final field Companion Lorg/partiql/ast/Expr$BagOp$Companion;
 	public final field lhs Lorg/partiql/ast/Expr;
@@ -563,49 +586,6 @@ public final class org/partiql/ast/Expr$Between : org/partiql/ast/Expr {
 
 public final class org/partiql/ast/Expr$Between$Companion {
 	public final fun builder ()Lorg/partiql/ast/builder/ExprBetweenBuilder;
-}
-
-public final class org/partiql/ast/Expr$Binary : org/partiql/ast/Expr {
-	public static final field Companion Lorg/partiql/ast/Expr$Binary$Companion;
-	public final field lhs Lorg/partiql/ast/Expr;
-	public final field op Lorg/partiql/ast/Expr$Binary$Op;
-	public final field rhs Lorg/partiql/ast/Expr;
-	public fun <init> (Lorg/partiql/ast/Expr$Binary$Op;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)V
-	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	public static final fun builder ()Lorg/partiql/ast/builder/ExprBinaryBuilder;
-	public final fun component1 ()Lorg/partiql/ast/Expr$Binary$Op;
-	public final fun component2 ()Lorg/partiql/ast/Expr;
-	public final fun component3 ()Lorg/partiql/ast/Expr;
-	public final fun copy (Lorg/partiql/ast/Expr$Binary$Op;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Binary;
-	public static synthetic fun copy$default (Lorg/partiql/ast/Expr$Binary;Lorg/partiql/ast/Expr$Binary$Op;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Binary;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getChildren ()Ljava/util/List;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class org/partiql/ast/Expr$Binary$Companion {
-	public final fun builder ()Lorg/partiql/ast/builder/ExprBinaryBuilder;
-}
-
-public final class org/partiql/ast/Expr$Binary$Op : java/lang/Enum {
-	public static final field AND Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field BITWISE_AND Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field CONCAT Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field DIVIDE Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field EQ Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field GT Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field GTE Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field LT Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field LTE Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field MINUS Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field MODULO Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field NE Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field OR Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field PLUS Lorg/partiql/ast/Expr$Binary$Op;
-	public static final field TIMES Lorg/partiql/ast/Expr$Binary$Op;
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/Expr$Binary$Op;
-	public static fun values ()[Lorg/partiql/ast/Expr$Binary$Op;
 }
 
 public final class org/partiql/ast/Expr$Call : org/partiql/ast/Expr {
@@ -985,6 +965,25 @@ public final class org/partiql/ast/Expr$Match$Companion {
 	public final fun builder ()Lorg/partiql/ast/builder/ExprMatchBuilder;
 }
 
+public final class org/partiql/ast/Expr$Not : org/partiql/ast/Expr {
+	public static final field Companion Lorg/partiql/ast/Expr$Not$Companion;
+	public final field value Lorg/partiql/ast/Expr;
+	public fun <init> (Lorg/partiql/ast/Expr;)V
+	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun builder ()Lorg/partiql/ast/builder/ExprNotBuilder;
+	public final fun component1 ()Lorg/partiql/ast/Expr;
+	public final fun copy (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Not;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Expr$Not;Lorg/partiql/ast/Expr;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Not;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/ast/Expr$Not$Companion {
+	public final fun builder ()Lorg/partiql/ast/builder/ExprNotBuilder;
+}
+
 public final class org/partiql/ast/Expr$NullIf : org/partiql/ast/Expr {
 	public static final field Companion Lorg/partiql/ast/Expr$NullIf$Companion;
 	public final field nullifier Lorg/partiql/ast/Expr;
@@ -1004,6 +1003,50 @@ public final class org/partiql/ast/Expr$NullIf : org/partiql/ast/Expr {
 
 public final class org/partiql/ast/Expr$NullIf$Companion {
 	public final fun builder ()Lorg/partiql/ast/builder/ExprNullIfBuilder;
+}
+
+public final class org/partiql/ast/Expr$Operator : org/partiql/ast/Expr {
+	public static final field Companion Lorg/partiql/ast/Expr$Operator$Companion;
+	public final field lhs Lorg/partiql/ast/Expr;
+	public final field rhs Lorg/partiql/ast/Expr;
+	public final field symbol Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)V
+	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun builder ()Lorg/partiql/ast/builder/ExprOperatorBuilder;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/partiql/ast/Expr;
+	public final fun component3 ()Lorg/partiql/ast/Expr;
+	public final fun copy (Ljava/lang/String;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Operator;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Expr$Operator;Ljava/lang/String;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Operator;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/ast/Expr$Operator$Companion {
+	public final fun builder ()Lorg/partiql/ast/builder/ExprOperatorBuilder;
+}
+
+public final class org/partiql/ast/Expr$Or : org/partiql/ast/Expr {
+	public static final field Companion Lorg/partiql/ast/Expr$Or$Companion;
+	public final field lhs Lorg/partiql/ast/Expr;
+	public final field rhs Lorg/partiql/ast/Expr;
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)V
+	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun builder ()Lorg/partiql/ast/builder/ExprOrBuilder;
+	public final fun component1 ()Lorg/partiql/ast/Expr;
+	public final fun component2 ()Lorg/partiql/ast/Expr;
+	public final fun copy (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Or;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Expr$Or;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Or;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/ast/Expr$Or$Companion {
+	public final fun builder ()Lorg/partiql/ast/builder/ExprOrBuilder;
 }
 
 public final class org/partiql/ast/Expr$Overlay : org/partiql/ast/Expr {
@@ -1354,35 +1397,6 @@ public final class org/partiql/ast/Expr$Trim$Spec : java/lang/Enum {
 	public static final field TRAILING Lorg/partiql/ast/Expr$Trim$Spec;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/Expr$Trim$Spec;
 	public static fun values ()[Lorg/partiql/ast/Expr$Trim$Spec;
-}
-
-public final class org/partiql/ast/Expr$Unary : org/partiql/ast/Expr {
-	public static final field Companion Lorg/partiql/ast/Expr$Unary$Companion;
-	public final field expr Lorg/partiql/ast/Expr;
-	public final field op Lorg/partiql/ast/Expr$Unary$Op;
-	public fun <init> (Lorg/partiql/ast/Expr$Unary$Op;Lorg/partiql/ast/Expr;)V
-	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	public static final fun builder ()Lorg/partiql/ast/builder/ExprUnaryBuilder;
-	public final fun component1 ()Lorg/partiql/ast/Expr$Unary$Op;
-	public final fun component2 ()Lorg/partiql/ast/Expr;
-	public final fun copy (Lorg/partiql/ast/Expr$Unary$Op;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Expr$Unary;
-	public static synthetic fun copy$default (Lorg/partiql/ast/Expr$Unary;Lorg/partiql/ast/Expr$Unary$Op;Lorg/partiql/ast/Expr;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Unary;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getChildren ()Ljava/util/List;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class org/partiql/ast/Expr$Unary$Companion {
-	public final fun builder ()Lorg/partiql/ast/builder/ExprUnaryBuilder;
-}
-
-public final class org/partiql/ast/Expr$Unary$Op : java/lang/Enum {
-	public static final field NEG Lorg/partiql/ast/Expr$Unary$Op;
-	public static final field NOT Lorg/partiql/ast/Expr$Unary$Op;
-	public static final field POS Lorg/partiql/ast/Expr$Unary$Op;
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/Expr$Unary$Op;
-	public static fun values ()[Lorg/partiql/ast/Expr$Unary$Op;
 }
 
 public final class org/partiql/ast/Expr$Values : org/partiql/ast/Expr {
@@ -4006,12 +4020,12 @@ public final class org/partiql/ast/builder/AstBuilder {
 	public static synthetic fun excludeStepStructField$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Exclude$Step$StructField;
 	public final fun excludeStepStructWildcard (Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Exclude$Step$StructWildcard;
 	public static synthetic fun excludeStepStructWildcard$default (Lorg/partiql/ast/builder/AstBuilder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Exclude$Step$StructWildcard;
+	public final fun exprAnd (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$And;
+	public static synthetic fun exprAnd$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$And;
 	public final fun exprBagOp (Lorg/partiql/ast/SetOp;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$BagOp;
 	public static synthetic fun exprBagOp$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/SetOp;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$BagOp;
 	public final fun exprBetween (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Between;
 	public static synthetic fun exprBetween$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Between;
-	public final fun exprBinary (Lorg/partiql/ast/Expr$Binary$Op;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Binary;
-	public static synthetic fun exprBinary$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr$Binary$Op;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Binary;
 	public final fun exprCall (Lorg/partiql/ast/Identifier;Ljava/util/List;Lorg/partiql/ast/SetQuantifier;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Call;
 	public static synthetic fun exprCall$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier;Ljava/util/List;Lorg/partiql/ast/SetQuantifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Call;
 	public final fun exprCanCast (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Type;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$CanCast;
@@ -4046,8 +4060,14 @@ public final class org/partiql/ast/builder/AstBuilder {
 	public static synthetic fun exprLit$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/value/PartiQLValue;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Lit;
 	public final fun exprMatch (Lorg/partiql/ast/Expr;Lorg/partiql/ast/GraphMatch;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Match;
 	public static synthetic fun exprMatch$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/GraphMatch;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Match;
+	public final fun exprNot (Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Not;
+	public static synthetic fun exprNot$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Not;
 	public final fun exprNullIf (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$NullIf;
 	public static synthetic fun exprNullIf$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$NullIf;
+	public final fun exprOperator (Ljava/lang/String;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Operator;
+	public static synthetic fun exprOperator$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/lang/String;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Operator;
+	public final fun exprOr (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Or;
+	public static synthetic fun exprOr$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Or;
 	public final fun exprOverlay (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Overlay;
 	public static synthetic fun exprOverlay$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Overlay;
 	public final fun exprParameter (Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Parameter;
@@ -4078,8 +4098,6 @@ public final class org/partiql/ast/builder/AstBuilder {
 	public static synthetic fun exprSubstring$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Substring;
 	public final fun exprTrim (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr$Trim$Spec;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Trim;
 	public static synthetic fun exprTrim$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr$Trim$Spec;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Trim;
-	public final fun exprUnary (Lorg/partiql/ast/Expr$Unary$Op;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Unary;
-	public static synthetic fun exprUnary$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr$Unary$Op;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Unary;
 	public final fun exprValues (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Values;
 	public static synthetic fun exprValues$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Values;
 	public final fun exprValuesRow (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Expr$Values$Row;
@@ -4473,6 +4491,19 @@ public final class org/partiql/ast/builder/ExcludeStepStructWildcardBuilder {
 	public final fun build ()Lorg/partiql/ast/Exclude$Step$StructWildcard;
 }
 
+public final class org/partiql/ast/builder/ExprAndBuilder {
+	public fun <init> ()V
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun build ()Lorg/partiql/ast/Expr$And;
+	public final fun getLhs ()Lorg/partiql/ast/Expr;
+	public final fun getRhs ()Lorg/partiql/ast/Expr;
+	public final fun lhs (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprAndBuilder;
+	public final fun rhs (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprAndBuilder;
+	public final fun setLhs (Lorg/partiql/ast/Expr;)V
+	public final fun setRhs (Lorg/partiql/ast/Expr;)V
+}
+
 public final class org/partiql/ast/builder/ExprBagOpBuilder {
 	public fun <init> ()V
 	public fun <init> (Lorg/partiql/ast/SetOp;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Ljava/lang/Boolean;)V
@@ -4509,22 +4540,6 @@ public final class org/partiql/ast/builder/ExprBetweenBuilder {
 	public final fun setValue (Lorg/partiql/ast/Expr;)V
 	public final fun to (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprBetweenBuilder;
 	public final fun value (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprBetweenBuilder;
-}
-
-public final class org/partiql/ast/builder/ExprBinaryBuilder {
-	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Expr$Binary$Op;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Expr$Binary$Op;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun build ()Lorg/partiql/ast/Expr$Binary;
-	public final fun getLhs ()Lorg/partiql/ast/Expr;
-	public final fun getOp ()Lorg/partiql/ast/Expr$Binary$Op;
-	public final fun getRhs ()Lorg/partiql/ast/Expr;
-	public final fun lhs (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprBinaryBuilder;
-	public final fun op (Lorg/partiql/ast/Expr$Binary$Op;)Lorg/partiql/ast/builder/ExprBinaryBuilder;
-	public final fun rhs (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprBinaryBuilder;
-	public final fun setLhs (Lorg/partiql/ast/Expr;)V
-	public final fun setOp (Lorg/partiql/ast/Expr$Binary$Op;)V
-	public final fun setRhs (Lorg/partiql/ast/Expr;)V
 }
 
 public final class org/partiql/ast/builder/ExprCallBuilder {
@@ -4763,6 +4778,16 @@ public final class org/partiql/ast/builder/ExprMatchBuilder {
 	public final fun setPattern (Lorg/partiql/ast/GraphMatch;)V
 }
 
+public final class org/partiql/ast/builder/ExprNotBuilder {
+	public fun <init> ()V
+	public fun <init> (Lorg/partiql/ast/Expr;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Expr;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun build ()Lorg/partiql/ast/Expr$Not;
+	public final fun getValue ()Lorg/partiql/ast/Expr;
+	public final fun setValue (Lorg/partiql/ast/Expr;)V
+	public final fun value (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprNotBuilder;
+}
+
 public final class org/partiql/ast/builder/ExprNullIfBuilder {
 	public fun <init> ()V
 	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)V
@@ -4774,6 +4799,35 @@ public final class org/partiql/ast/builder/ExprNullIfBuilder {
 	public final fun setNullifier (Lorg/partiql/ast/Expr;)V
 	public final fun setValue (Lorg/partiql/ast/Expr;)V
 	public final fun value (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprNullIfBuilder;
+}
+
+public final class org/partiql/ast/builder/ExprOperatorBuilder {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun build ()Lorg/partiql/ast/Expr$Operator;
+	public final fun getLhs ()Lorg/partiql/ast/Expr;
+	public final fun getRhs ()Lorg/partiql/ast/Expr;
+	public final fun getSymbol ()Ljava/lang/String;
+	public final fun lhs (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprOperatorBuilder;
+	public final fun rhs (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprOperatorBuilder;
+	public final fun setLhs (Lorg/partiql/ast/Expr;)V
+	public final fun setRhs (Lorg/partiql/ast/Expr;)V
+	public final fun setSymbol (Ljava/lang/String;)V
+	public final fun symbol (Ljava/lang/String;)Lorg/partiql/ast/builder/ExprOperatorBuilder;
+}
+
+public final class org/partiql/ast/builder/ExprOrBuilder {
+	public fun <init> ()V
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun build ()Lorg/partiql/ast/Expr$Or;
+	public final fun getLhs ()Lorg/partiql/ast/Expr;
+	public final fun getRhs ()Lorg/partiql/ast/Expr;
+	public final fun lhs (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprOrBuilder;
+	public final fun rhs (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprOrBuilder;
+	public final fun setLhs (Lorg/partiql/ast/Expr;)V
+	public final fun setRhs (Lorg/partiql/ast/Expr;)V
 }
 
 public final class org/partiql/ast/builder/ExprOverlayBuilder {
@@ -4977,19 +5031,6 @@ public final class org/partiql/ast/builder/ExprTrimBuilder {
 	public final fun setValue (Lorg/partiql/ast/Expr;)V
 	public final fun spec (Lorg/partiql/ast/Expr$Trim$Spec;)Lorg/partiql/ast/builder/ExprTrimBuilder;
 	public final fun value (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprTrimBuilder;
-}
-
-public final class org/partiql/ast/builder/ExprUnaryBuilder {
-	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Expr$Unary$Op;Lorg/partiql/ast/Expr;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Expr$Unary$Op;Lorg/partiql/ast/Expr;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun build ()Lorg/partiql/ast/Expr$Unary;
-	public final fun expr (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/ExprUnaryBuilder;
-	public final fun getExpr ()Lorg/partiql/ast/Expr;
-	public final fun getOp ()Lorg/partiql/ast/Expr$Unary$Op;
-	public final fun op (Lorg/partiql/ast/Expr$Unary$Op;)Lorg/partiql/ast/builder/ExprUnaryBuilder;
-	public final fun setExpr (Lorg/partiql/ast/Expr;)V
-	public final fun setOp (Lorg/partiql/ast/Expr$Unary$Op;)V
 }
 
 public final class org/partiql/ast/builder/ExprValuesBuilder {
@@ -6369,12 +6410,12 @@ public abstract class org/partiql/ast/sql/SqlDialect : org/partiql/ast/visitor/A
 	public fun visitExcludeStepStructField (Lorg/partiql/ast/Exclude$Step$StructField;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExcludeStepStructWildcard (Lorg/partiql/ast/Exclude$Step$StructWildcard;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExcludeStepStructWildcard (Lorg/partiql/ast/Exclude$Step$StructWildcard;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitExprAnd (Lorg/partiql/ast/Expr$And;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprAnd (Lorg/partiql/ast/Expr$And;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprBagOp (Lorg/partiql/ast/Expr$BagOp;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprBagOp (Lorg/partiql/ast/Expr$BagOp;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprBetween (Lorg/partiql/ast/Expr$Between;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprBetween (Lorg/partiql/ast/Expr$Between;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
-	public synthetic fun visitExprBinary (Lorg/partiql/ast/Expr$Binary;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun visitExprBinary (Lorg/partiql/ast/Expr$Binary;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprCall (Lorg/partiql/ast/Expr$Call;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprCall (Lorg/partiql/ast/Expr$Call;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprCanCast (Lorg/partiql/ast/Expr$CanCast;Ljava/lang/Object;)Ljava/lang/Object;
@@ -6407,8 +6448,14 @@ public abstract class org/partiql/ast/sql/SqlDialect : org/partiql/ast/visitor/A
 	public fun visitExprLike (Lorg/partiql/ast/Expr$Like;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprLit (Lorg/partiql/ast/Expr$Lit;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprLit (Lorg/partiql/ast/Expr$Lit;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitExprNot (Lorg/partiql/ast/Expr$Not;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprNot (Lorg/partiql/ast/Expr$Not;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprNullIf (Lorg/partiql/ast/Expr$NullIf;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprNullIf (Lorg/partiql/ast/Expr$NullIf;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitExprOperator (Lorg/partiql/ast/Expr$Operator;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprOperator (Lorg/partiql/ast/Expr$Operator;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitExprOr (Lorg/partiql/ast/Expr$Or;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprOr (Lorg/partiql/ast/Expr$Or;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprOverlay (Lorg/partiql/ast/Expr$Overlay;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprOverlay (Lorg/partiql/ast/Expr$Overlay;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprParameter (Lorg/partiql/ast/Expr$Parameter;Ljava/lang/Object;)Ljava/lang/Object;
@@ -6439,8 +6486,6 @@ public abstract class org/partiql/ast/sql/SqlDialect : org/partiql/ast/visitor/A
 	public fun visitExprSubstring (Lorg/partiql/ast/Expr$Substring;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprTrim (Lorg/partiql/ast/Expr$Trim;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprTrim (Lorg/partiql/ast/Expr$Trim;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
-	public synthetic fun visitExprUnary (Lorg/partiql/ast/Expr$Unary;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun visitExprUnary (Lorg/partiql/ast/Expr$Unary;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprValues (Lorg/partiql/ast/Expr$Values;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprValues (Lorg/partiql/ast/Expr$Values;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprValuesRow (Lorg/partiql/ast/Expr$Values$Row;Ljava/lang/Object;)Ljava/lang/Object;
@@ -6642,12 +6687,12 @@ public abstract class org/partiql/ast/util/AstRewriter : org/partiql/ast/visitor
 	public fun visitExcludeStepStructField (Lorg/partiql/ast/Exclude$Step$StructField;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitExcludeStepStructWildcard (Lorg/partiql/ast/Exclude$Step$StructWildcard;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExcludeStepStructWildcard (Lorg/partiql/ast/Exclude$Step$StructWildcard;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
+	public synthetic fun visitExprAnd (Lorg/partiql/ast/Expr$And;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprAnd (Lorg/partiql/ast/Expr$And;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitExprBagOp (Lorg/partiql/ast/Expr$BagOp;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprBagOp (Lorg/partiql/ast/Expr$BagOp;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitExprBetween (Lorg/partiql/ast/Expr$Between;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprBetween (Lorg/partiql/ast/Expr$Between;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
-	public synthetic fun visitExprBinary (Lorg/partiql/ast/Expr$Binary;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun visitExprBinary (Lorg/partiql/ast/Expr$Binary;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitExprCall (Lorg/partiql/ast/Expr$Call;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprCall (Lorg/partiql/ast/Expr$Call;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitExprCanCast (Lorg/partiql/ast/Expr$CanCast;Ljava/lang/Object;)Ljava/lang/Object;
@@ -6682,8 +6727,14 @@ public abstract class org/partiql/ast/util/AstRewriter : org/partiql/ast/visitor
 	public fun visitExprLit (Lorg/partiql/ast/Expr$Lit;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitExprMatch (Lorg/partiql/ast/Expr$Match;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprMatch (Lorg/partiql/ast/Expr$Match;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
+	public synthetic fun visitExprNot (Lorg/partiql/ast/Expr$Not;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprNot (Lorg/partiql/ast/Expr$Not;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitExprNullIf (Lorg/partiql/ast/Expr$NullIf;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprNullIf (Lorg/partiql/ast/Expr$NullIf;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
+	public synthetic fun visitExprOperator (Lorg/partiql/ast/Expr$Operator;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprOperator (Lorg/partiql/ast/Expr$Operator;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
+	public synthetic fun visitExprOr (Lorg/partiql/ast/Expr$Or;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprOr (Lorg/partiql/ast/Expr$Or;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitExprOverlay (Lorg/partiql/ast/Expr$Overlay;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprOverlay (Lorg/partiql/ast/Expr$Overlay;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitExprParameter (Lorg/partiql/ast/Expr$Parameter;Ljava/lang/Object;)Ljava/lang/Object;
@@ -6714,8 +6765,6 @@ public abstract class org/partiql/ast/util/AstRewriter : org/partiql/ast/visitor
 	public fun visitExprSubstring (Lorg/partiql/ast/Expr$Substring;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitExprTrim (Lorg/partiql/ast/Expr$Trim;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprTrim (Lorg/partiql/ast/Expr$Trim;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
-	public synthetic fun visitExprUnary (Lorg/partiql/ast/Expr$Unary;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun visitExprUnary (Lorg/partiql/ast/Expr$Unary;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitExprValues (Lorg/partiql/ast/Expr$Values;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprValues (Lorg/partiql/ast/Expr$Values;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitExprValuesRow (Lorg/partiql/ast/Expr$Values$Row;Ljava/lang/Object;)Ljava/lang/Object;
@@ -6972,9 +7021,9 @@ public abstract class org/partiql/ast/visitor/AstBaseVisitor : org/partiql/ast/v
 	public fun visitExcludeStepStructField (Lorg/partiql/ast/Exclude$Step$StructField;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExcludeStepStructWildcard (Lorg/partiql/ast/Exclude$Step$StructWildcard;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExpr (Lorg/partiql/ast/Expr;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprAnd (Lorg/partiql/ast/Expr$And;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprBagOp (Lorg/partiql/ast/Expr$BagOp;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprBetween (Lorg/partiql/ast/Expr$Between;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun visitExprBinary (Lorg/partiql/ast/Expr$Binary;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprCall (Lorg/partiql/ast/Expr$Call;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprCanCast (Lorg/partiql/ast/Expr$CanCast;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprCanLosslessCast (Lorg/partiql/ast/Expr$CanLosslessCast;Ljava/lang/Object;)Ljava/lang/Object;
@@ -6992,7 +7041,10 @@ public abstract class org/partiql/ast/visitor/AstBaseVisitor : org/partiql/ast/v
 	public fun visitExprLike (Lorg/partiql/ast/Expr$Like;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprLit (Lorg/partiql/ast/Expr$Lit;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprMatch (Lorg/partiql/ast/Expr$Match;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprNot (Lorg/partiql/ast/Expr$Not;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprNullIf (Lorg/partiql/ast/Expr$NullIf;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprOperator (Lorg/partiql/ast/Expr$Operator;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprOr (Lorg/partiql/ast/Expr$Or;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprOverlay (Lorg/partiql/ast/Expr$Overlay;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprParameter (Lorg/partiql/ast/Expr$Parameter;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprPath (Lorg/partiql/ast/Expr$Path;Ljava/lang/Object;)Ljava/lang/Object;
@@ -7009,7 +7061,6 @@ public abstract class org/partiql/ast/visitor/AstBaseVisitor : org/partiql/ast/v
 	public fun visitExprStructField (Lorg/partiql/ast/Expr$Struct$Field;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprSubstring (Lorg/partiql/ast/Expr$Substring;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprTrim (Lorg/partiql/ast/Expr$Trim;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun visitExprUnary (Lorg/partiql/ast/Expr$Unary;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprValues (Lorg/partiql/ast/Expr$Values;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprValuesRow (Lorg/partiql/ast/Expr$Values$Row;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprVar (Lorg/partiql/ast/Expr$Var;Ljava/lang/Object;)Ljava/lang/Object;
@@ -7165,9 +7216,9 @@ public abstract interface class org/partiql/ast/visitor/AstVisitor {
 	public abstract fun visitExcludeStepStructField (Lorg/partiql/ast/Exclude$Step$StructField;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExcludeStepStructWildcard (Lorg/partiql/ast/Exclude$Step$StructWildcard;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExpr (Lorg/partiql/ast/Expr;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitExprAnd (Lorg/partiql/ast/Expr$And;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprBagOp (Lorg/partiql/ast/Expr$BagOp;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprBetween (Lorg/partiql/ast/Expr$Between;Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun visitExprBinary (Lorg/partiql/ast/Expr$Binary;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprCall (Lorg/partiql/ast/Expr$Call;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprCanCast (Lorg/partiql/ast/Expr$CanCast;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprCanLosslessCast (Lorg/partiql/ast/Expr$CanLosslessCast;Ljava/lang/Object;)Ljava/lang/Object;
@@ -7185,7 +7236,10 @@ public abstract interface class org/partiql/ast/visitor/AstVisitor {
 	public abstract fun visitExprLike (Lorg/partiql/ast/Expr$Like;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprLit (Lorg/partiql/ast/Expr$Lit;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprMatch (Lorg/partiql/ast/Expr$Match;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitExprNot (Lorg/partiql/ast/Expr$Not;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprNullIf (Lorg/partiql/ast/Expr$NullIf;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitExprOperator (Lorg/partiql/ast/Expr$Operator;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitExprOr (Lorg/partiql/ast/Expr$Or;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprOverlay (Lorg/partiql/ast/Expr$Overlay;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprParameter (Lorg/partiql/ast/Expr$Parameter;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprPath (Lorg/partiql/ast/Expr$Path;Ljava/lang/Object;)Ljava/lang/Object;
@@ -7202,7 +7256,6 @@ public abstract interface class org/partiql/ast/visitor/AstVisitor {
 	public abstract fun visitExprStructField (Lorg/partiql/ast/Expr$Struct$Field;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprSubstring (Lorg/partiql/ast/Expr$Substring;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprTrim (Lorg/partiql/ast/Expr$Trim;Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun visitExprUnary (Lorg/partiql/ast/Expr$Unary;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprValues (Lorg/partiql/ast/Expr$Values;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprValuesRow (Lorg/partiql/ast/Expr$Values$Row;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitExprVar (Lorg/partiql/ast/Expr$Var;Ljava/lang/Object;)Ljava/lang/Object;

--- a/partiql-ast/src/main/resources/partiql_ast.ion
+++ b/partiql-ast/src/main/resources/partiql_ast.ion
@@ -354,19 +354,26 @@ expr::[
     index: int,
   },
 
-  // Unary Operators
-  unary::{
-    op:   [ NOT, POS, NEG ],
-    expr: expr,
+  // Operator expr node
+  operator::{
+    symbol: string,
+    lhs: optional::expr,
+    rhs: expr
   },
 
-  // Binary Operators
-  binary::{
-    op: [
-      PLUS, MINUS, TIMES, DIVIDE, MODULO, CONCAT, BITWISE_AND,
-      AND, OR,
-      EQ, NE, GT, GTE, LT, LTE,
-    ],
+  // SQL special form `NOT`
+  not::{
+    value: expr,
+  },
+
+  // SQL special form `AND`
+  and::{
+    lhs: expr,
+    rhs: expr,
+  },
+
+  // SQL special form `OR`
+  or::{
     lhs: expr,
     rhs: expr,
   },

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
@@ -286,27 +286,26 @@ class ToLegacyAstTest {
         @JvmStatic
         fun operators() = listOf(
             expect("(not (lit null))") {
-                exprUnary {
-                    op = Expr.Unary.Op.NOT
-                    expr = NULL
+                exprNot {
+                    value = NULL
                 }
             },
             expect("(pos (lit null))") {
-                exprUnary {
-                    op = Expr.Unary.Op.POS
-                    expr = NULL
+                exprOperator {
+                    symbol = "+"
+                    rhs = NULL
                 }
             },
             expect("(neg (lit null))") {
-                exprUnary {
-                    op = Expr.Unary.Op.NEG
-                    expr = NULL
+                exprOperator {
+                    symbol = "-"
+                    rhs = NULL
                 }
             },
             // we don't really need to test _all_ binary operators
             expect("(plus (lit null) (lit null))") {
-                exprBinary {
-                    op = Expr.Binary.Op.PLUS
+                exprOperator {
+                    symbol = "+"
                     lhs = NULL
                     rhs = NULL
                 }

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
@@ -228,65 +228,62 @@ class SqlDialectTest {
         @JvmStatic
         fun exprOperators() = listOf(
             expect("NOT (NULL)") {
-                exprUnary {
-                    op = Expr.Unary.Op.NOT
-                    expr = NULL
+                exprNot {
+                    value = NULL
                 }
             },
             expect("+(NULL)") {
-                exprUnary {
-                    op = Expr.Unary.Op.POS
-                    expr = NULL
+                exprOperator {
+                    symbol = "+"
+                    rhs = NULL
                 }
             },
             expect("-(NULL)") {
-                exprUnary {
-                    op = Expr.Unary.Op.NEG
-                    expr = NULL
+                exprOperator {
+                    symbol = "-"
+                    rhs = NULL
                 }
             },
             expect("NOT (NOT (NULL))") {
-                exprUnary {
-                    op = Expr.Unary.Op.NOT
-                    expr = exprUnary {
-                        op = Expr.Unary.Op.NOT
-                        expr = NULL
+                exprNot {
+                    value = exprNot {
+                        value = NULL
                     }
                 }
             },
             expect("+(+(NULL))") {
-                exprUnary {
-                    op = Expr.Unary.Op.POS
-                    expr = exprUnary {
-                        op = Expr.Unary.Op.POS
-                        expr = NULL
+                exprOperator {
+                    symbol = "+"
+                    rhs = exprOperator {
+                        symbol = "+"
+                        rhs = NULL
                     }
                 }
             },
             expect("-(-(NULL))") {
-                exprUnary {
-                    op = Expr.Unary.Op.NEG
-                    expr = exprUnary {
-                        op = Expr.Unary.Op.NEG
-                        expr = NULL
+                exprOperator {
+                    symbol = "-"
+                    rhs = exprOperator {
+                        symbol = "-"
+                        rhs = NULL
                     }
                 }
             },
             expect("+(-(+(NULL)))") {
-                exprUnary {
-                    op = Expr.Unary.Op.POS
-                    expr = exprUnary {
-                        op = Expr.Unary.Op.NEG
-                        expr = exprUnary {
-                            op = Expr.Unary.Op.POS
-                            expr = NULL
+                exprOperator {
+                    symbol = "+"
+                    rhs = exprOperator {
+                        symbol = "-"
+                        rhs = exprOperator {
+                            symbol = "+"
+                            rhs = NULL
                         }
                     }
                 }
             },
             expect("NULL + NULL") {
-                exprBinary {
-                    op = Expr.Binary.Op.PLUS
+                exprOperator {
+                    symbol = "+"
                     lhs = NULL
                     rhs = NULL
                 }
@@ -538,8 +535,8 @@ class SqlDialectTest {
                         scope = Expr.Var.Scope.DEFAULT
                     }
                     steps += exprPathStepIndex(
-                        exprBinary {
-                            op = Expr.Binary.Op.PLUS
+                        exprOperator {
+                            symbol = "+"
                             lhs = exprLit(int32Value(1))
                             rhs = exprVar {
                                 identifier = id("a")
@@ -1738,8 +1735,8 @@ class SqlDialectTest {
         @JvmStatic
         private fun subqueryCases() = listOf(
             expect("1 = (SELECT a FROM T)") {
-                exprBinary {
-                    op = Expr.Binary.Op.EQ
+                exprOperator {
+                    symbol = "="
                     lhs = exprLit(int32Value(1))
                     rhs = exprSFW {
                         select = select("a")
@@ -1748,8 +1745,8 @@ class SqlDialectTest {
                 }
             },
             expect("(1, 2) = (SELECT a FROM T)") {
-                exprBinary {
-                    op = Expr.Binary.Op.EQ
+                exprOperator {
+                    symbol = "="
                     lhs = exprCollection {
                         type = Expr.Collection.Type.LIST
                         values += exprLit(int32Value(1))

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -5053,4 +5053,69 @@ class PartiQLParserTest : PartiQLParserTestBase() {
             Property.TOKEN_VALUE to ION.newSymbol("<")
         )
     )
+
+    // regression tests for neq operator
+    @Test
+    fun testNeqOp() = assertExpression("1 <> 2") {
+        ne(
+            lit(ionInt(1)),
+            lit(ionInt(2))
+        )
+    }
+
+    @Test
+    fun testNeqOpAlt() = assertExpression("1 != 2") {
+        ne(
+            lit(ionInt(1)),
+            lit(ionInt(2))
+        )
+    }
+
+    @Test
+    fun testSpacesInNeq() = checkInputThrowingParserException(
+        "1 < > 2",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN, // partiql-ast parser ErrorCode
+        expectErrorContextValues = mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 3L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.ANGLE_LEFT.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ION.newSymbol("<")
+        )
+    )
+
+    @Test
+    fun testSpacesInNeqAlt() = checkInputThrowingParserException(
+        "1 ! = 2",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN, // partiql-ast parser ErrorCode
+        expectErrorContextValues = mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 3L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.BANG.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ION.newSymbol("!")
+        )
+    )
+
+    @Test
+    fun testCommentsInNeq() = checkInputThrowingParserException(
+        "1 </* some comment*/> 2",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN, // partiql-ast parser ErrorCode
+        expectErrorContextValues = mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 3L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.ANGLE_LEFT.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ION.newSymbol("<")
+        )
+    )
+
+    @Test
+    fun testCommentsInNeqAlt() = checkInputThrowingParserException(
+        "1 !/* some comment*/= 2",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN, // partiql-ast parser ErrorCode
+        expectErrorContextValues = mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 3L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.BANG.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ION.newSymbol("!")
+        )
+    )
 }

--- a/partiql-parser/src/main/antlr/PartiQLParser.g4
+++ b/partiql-parser/src/main/antlr/PartiQLParser.g4
@@ -622,6 +622,8 @@ comparisonOp
 otherOp
     : OPERATOR
     | AMPERSAND
+    // TODO introduce a separate lexical mode for GPML MATCH expressions (https://github.com/partiql/partiql-lang-kotlin/issues/1512)
+    //  This will eliminiate the need for this `AMPERSAND` parse branch.
     ;
 
 // TODO : Opreator precedence of `otherOp` may change in the future.

--- a/partiql-parser/src/main/antlr/PartiQLParser.g4
+++ b/partiql-parser/src/main/antlr/PartiQLParser.g4
@@ -619,20 +619,30 @@ comparisonOp
     | BANG EQ
     ;
 
-// TODO : Opreator precedence of BITWISE_AND (&) may change in the future.
+otherOp
+    : OPERATOR
+    | AMPERSAND
+    ;
+
+// TODO : Opreator precedence of `otherOp` may change in the future.
 //  SEE: https://github.com/partiql/partiql-docs/issues/50
 mathOp00
-    : lhs=mathOp00 op=(AMPERSAND|CONCAT) rhs=mathOp01
+    : lhs=mathOp00 op=otherOp rhs=mathOp01
     | parent=mathOp01
     ;
 
 mathOp01
-    : lhs=mathOp01 op=(PLUS|MINUS) rhs=mathOp02
+    : op=otherOp rhs=mathOp02
     | parent=mathOp02
     ;
 
 mathOp02
-    : lhs=mathOp02 op=(PERCENT|ASTERISK|SLASH_FORWARD) rhs=valueExpr
+    : lhs=mathOp02 op=(PLUS|MINUS) rhs=mathOp03
+    | parent=mathOp03
+    ;
+
+mathOp03
+    : lhs=mathOp03 op=(PERCENT|ASTERISK|SLASH_FORWARD) rhs=valueExpr
     | parent=valueExpr
     ;
 

--- a/partiql-parser/src/main/antlr/PartiQLTokens.g4
+++ b/partiql-parser/src/main/antlr/PartiQLTokens.g4
@@ -337,7 +337,6 @@ BANG: '!';
 LT_EQ: '<=';
 GT_EQ: '>=';
 EQ: '=';
-CONCAT: '||';
 ANGLE_LEFT: '<';
 ANGLE_RIGHT: '>';
 BRACKET_LEFT: '[';
@@ -351,6 +350,34 @@ COLON: ':';
 COLON_SEMI: ';';
 QUESTION_MARK: '?';
 PERIOD: '.';
+HASH: '#';
+
+// Operators w/ special characters
+// Similar to postgresql's supported operator creation -- https://www.postgresql.org/docs/16/sql-createoperator.html
+OPERATOR
+    // may not end with + or -
+    : OpBasic+ OpBasicEnd
+    // must include at least one of OpSpecial to end w/ anything
+    | (OpBasic | OpSpecial)* OpSpecial (OpBasic | OpSpecial)*
+    ;
+
+fragment OpBasic
+    : [+*=] // TODO support `<` and `>`?
+    // comments are not matched
+    | '-' {_input.LA(1) != '-'}?
+    | '/' {_input.LA(1) != '*'}?
+    ;
+
+fragment OpBasicEnd
+    : [*/=] // TODO support `<` and `>`?
+    ;
+fragment OpSpecial
+    : [~@#%^?]  // TODO support backtick (`)?
+    // graph patterns are not matched
+    | '|' {_input.LA(1) != '!'}?
+    | '!' {_input.LA(1) != '%'}?
+    | '&' {_input.LA(1) != '%'}?
+    ;
 
 /**
  *

--- a/partiql-parser/src/main/antlr/PartiQLTokens.g4
+++ b/partiql-parser/src/main/antlr/PartiQLTokens.g4
@@ -374,6 +374,8 @@ fragment OpBasicEnd
 fragment OpSpecial
     : [~@#%^?]  // TODO support backtick (`)?
     // graph patterns are not matched
+    // TODO make GPML MATCH patterns a separate lexical mode (https://github.com/partiql/partiql-lang-kotlin/issues/1512)
+    //  Creating a separate lexical mode will allow us to get rid of the following semantic predicates.
     | '|' {_input.LA(1) != '!'}?
     | '!' {_input.LA(1) != '%'}?
     | '&' {_input.LA(1) != '%'}?

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserDDLTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserDDLTests.kt
@@ -18,8 +18,8 @@ import org.partiql.ast.constraintDefinitionNotNull
 import org.partiql.ast.constraintDefinitionUnique
 import org.partiql.ast.ddlOpCreateTable
 import org.partiql.ast.ddlOpDropTable
-import org.partiql.ast.exprBinary
 import org.partiql.ast.exprLit
+import org.partiql.ast.exprOperator
 import org.partiql.ast.exprVar
 import org.partiql.ast.identifierQualified
 import org.partiql.ast.identifierSymbol
@@ -219,8 +219,8 @@ class PartiQLParserDDLTests {
                                     constraint(
                                         null,
                                         constraintDefinitionCheck(
-                                            exprBinary(
-                                                Expr.Binary.Op.GT,
+                                            exprOperator(
+                                                ">",
                                                 exprVar(identifierSymbol("a", Identifier.CaseSensitivity.INSENSITIVE), Expr.Var.Scope.DEFAULT),
                                                 exprLit(int32Value(0))
                                             )
@@ -311,8 +311,8 @@ class PartiQLParserDDLTests {
                             constraint(
                                 null,
                                 constraintDefinitionCheck(
-                                    exprBinary(
-                                        Expr.Binary.Op.GT,
+                                    exprOperator(
+                                        ">",
                                         exprVar(identifierSymbol("a", Identifier.CaseSensitivity.INSENSITIVE), Expr.Var.Scope.DEFAULT),
                                         exprLit(int32Value(0))
                                     )

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserOperatorTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserOperatorTests.kt
@@ -1,0 +1,73 @@
+package org.partiql.parser.internal
+
+import org.junit.jupiter.api.Test
+import org.partiql.ast.AstNode
+import org.partiql.ast.Expr
+import org.partiql.ast.exprLit
+import org.partiql.ast.exprOperator
+import org.partiql.ast.statementQuery
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.int32Value
+import kotlin.test.assertEquals
+
+@OptIn(PartiQLValueExperimental::class)
+class PartiQLParserOperatorTests {
+
+    private val parser = PartiQLParserDefault()
+
+    private inline fun query(body: () -> Expr) = statementQuery(body())
+
+    @Test
+    fun builtinUnaryOperator() = assertExpression(
+        "-2",
+        query {
+            exprOperator(
+                symbol = "-",
+                lhs = null,
+                rhs = exprLit(int32Value(2))
+            )
+        }
+    )
+
+    @Test
+    fun builtinBinaryOperator() = assertExpression(
+        "1 <= 2",
+        query {
+            exprOperator(
+                symbol = "<=",
+                lhs = exprLit(int32Value(1)),
+                rhs = exprLit(int32Value(2))
+            )
+        }
+    )
+
+    @Test
+    fun customUnaryOperator() = assertExpression(
+        "==!2",
+        query {
+            exprOperator(
+                symbol = "==!",
+                lhs = null,
+                rhs = exprLit(int32Value(2))
+            )
+        }
+    )
+
+    @Test
+    fun customBinaryOperator() = assertExpression(
+        "1 ==! 2",
+        query {
+            exprOperator(
+                symbol = "==!",
+                lhs = exprLit(int32Value(1)),
+                rhs = exprLit(int32Value(2))
+            )
+        }
+    )
+
+    private fun assertExpression(input: String, expected: AstNode) {
+        val result = parser.parse(input)
+        val actual = result.root
+        assertEquals(expected, actual)
+    }
+}

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserSessionAttributeTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserSessionAttributeTests.kt
@@ -3,8 +3,8 @@ package org.partiql.parser.internal
 import org.junit.jupiter.api.Test
 import org.partiql.ast.AstNode
 import org.partiql.ast.Expr
-import org.partiql.ast.exprBinary
 import org.partiql.ast.exprLit
+import org.partiql.ast.exprOperator
 import org.partiql.ast.exprSessionAttribute
 import org.partiql.ast.statementQuery
 import org.partiql.value.PartiQLValueExperimental
@@ -46,8 +46,8 @@ class PartiQLParserSessionAttributeTests {
     fun currentUserEquals() = assertExpression(
         "1 = current_user",
         query {
-            exprBinary(
-                op = Expr.Binary.Op.EQ,
+            exprOperator(
+                symbol = "=",
                 lhs = exprLit(int32Value(1)),
                 rhs = exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_USER)
             )


### PR DESCRIPTION
## Relevant Issues
- Closes out https://github.com/partiql/partiql-lang-kotlin/issues/1478

## Description
- Adds an operator node to AST
- Adds additional parsing rules for special character sequences that can become operators

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - `v1` branch

- Any backward-incompatible changes? **[YES]**
  - Yes but on `v1` branch

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.