### PR TITLE
Fix bag constructor parsing

### DIFF
--- a/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigParser.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigParser.kt
@@ -95,7 +95,7 @@ internal class PartiQLPigParser(val customTypes: List<CustomType> = listOf()) : 
         val tokenStream = createTokenStream(queryStream)
         val parser = parserInit(tokenStream)
         val tree = parser.root()
-        val visitor = PartiQLPigVisitor(customTypes, tokenStream.parameterIndexes)
+        val visitor = PartiQLPigVisitor(tokenStream, customTypes, tokenStream.parameterIndexes)
         return visitor.visit(tree) as PartiqlAst.Statement
     }
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -5019,4 +5019,38 @@ class PartiQLParserTest : PartiQLParserTestBase() {
             lit(ionInt(1))
         )
     }
+
+    // regression tests for bag constructor angle bracket
+    @Test
+    fun testBagConstructor() = assertExpression("<<<<1>>>>") {
+        bag(
+            bag(
+                lit(ionInt(1))
+            )
+        )
+    }
+
+    @Test
+    fun testSpacesInBagConstructor() = checkInputThrowingParserException(
+        "< < < < 1 > > > >",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        expectErrorContextValues = mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 1L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.ANGLE_LEFT.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ION.newSymbol("<")
+        )
+    )
+
+    @Test
+    fun testCommentsInBagConstructor() = checkInputThrowingParserException(
+        "</* some comment */<<<1>>>>",
+        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        expectErrorContextValues = mapOf(
+            Property.LINE_NUMBER to 1L,
+            Property.COLUMN_NUMBER to 1L,
+            Property.TOKEN_DESCRIPTION to PartiQLParser.ANGLE_LEFT.getAntlrDisplayString(),
+            Property.TOKEN_VALUE to ION.newSymbol("<")
+        )
+    )
 }

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTest.kt
@@ -5033,7 +5033,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun testSpacesInBagConstructor() = checkInputThrowingParserException(
         "< < < < 1 > > > >",
-        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        ErrorCode.PARSE_UNEXPECTED_TOKEN, // partiql-ast parser ErrorCode
         expectErrorContextValues = mapOf(
             Property.LINE_NUMBER to 1L,
             Property.COLUMN_NUMBER to 1L,
@@ -5045,7 +5045,7 @@ class PartiQLParserTest : PartiQLParserTestBase() {
     @Test
     fun testCommentsInBagConstructor() = checkInputThrowingParserException(
         "</* some comment */<<<1>>>>",
-        ErrorCode.PARSE_UNEXPECTED_TOKEN,
+        ErrorCode.PARSE_UNEXPECTED_TOKEN, // partiql-ast parser ErrorCode
         expectErrorContextValues = mapOf(
             Property.LINE_NUMBER to 1L,
             Property.COLUMN_NUMBER to 1L,

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTestBase.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/PartiQLParserTestBase.kt
@@ -152,7 +152,6 @@ abstract class PartiQLParserTestBase : TestBase() {
         input: String,
         errorCode: ErrorCode,
         expectErrorContextValues: Map<Property, Any>,
-        targets: Array<ParserTarget> = arrayOf(ParserTarget.DEFAULT),
         assertContext: Boolean = true,
     ): Unit = forEachTarget {
         softAssert {
@@ -160,7 +159,8 @@ abstract class PartiQLParserTestBase : TestBase() {
                 parser.parseAstStatement(input)
                 fail("Expected ParserException but there was no Exception")
             } catch (ex: ParserException) {
-                // split parser target does not use ErrorCode
+                // NOTE: only perform error code and error context checks for `ParserTarget.EXPERIMENTAL` (partiql-ast
+                // parser).
                 if (assertContext && (this@forEachTarget == ParserTarget.EXPERIMENTAL)) {
                     checkErrorAndErrorContext(errorCode, ex, expectErrorContextValues)
                 }


### PR DESCRIPTION
## Relevant Issues
- Fixes #1498 

## Description
- Previous behavior on `v1` allowed for inserting whitespace and comments between the angle brackets of a bag constructor. This PR corrects the behavior and gives an error for these scenarios.
- This PR follows what the Definitive ANTLR 4 Reference describes in Chapter 12 regarding double right angle brackets:
>  To address this, either we can add semantic predicates to the grammar or
we can check the parse tree afterward using a listener or visitor to ensure that
the > token column numbers are adjacent for shift operators. It’d be inefficient
to use predicates during the parse, so it’s better to check the right shift operators
after the parse. Most language applications need to walk the parse tree anyway.

I looked at some other alternatives such as
- pushing the typing to a separate `mode` in the lexer (similar to what Ion lexer rules we currently have)
  - this had some drawbacks in some duplicated lexer rules
  - we could always revisit this approach in the future
- semantic predicates
  - potential slowdown in the lexer step

but decided to keep the recommendation of the ANTLR reference book.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - No, on `v1` branch

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.