### PR TITLE
Cherry picks #1504 (Fix published jars for non-shadowed packages)

### DIFF
--- a/partiql-ast/build.gradle.kts
+++ b/partiql-ast/build.gradle.kts
@@ -25,6 +25,17 @@ dependencies {
     api(project(":partiql-types"))
 }
 
+tasks.shadowJar {
+    configurations = listOf(project.configurations.shadow.get())
+}
+
+// Workaround for https://github.com/johnrengelman/shadow/issues/651
+components.withType(AdhocComponentWithVariants::class.java).forEach { c ->
+    c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements.get()) {
+        skip()
+    }
+}
+
 publish {
     artifactId = "partiql-ast"
     name = "PartiQL AST"

--- a/partiql-coverage/build.gradle.kts
+++ b/partiql-coverage/build.gradle.kts
@@ -28,6 +28,17 @@ dependencies {
     implementation(Deps.jgenhtml)
 }
 
+tasks.shadowJar {
+    configurations = listOf(project.configurations.shadow.get())
+}
+
+// Workaround for https://github.com/johnrengelman/shadow/issues/651
+components.withType(AdhocComponentWithVariants::class.java).forEach { c ->
+    c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements.get()) {
+        skip()
+    }
+}
+
 // Need to add this as we have both Java and Kotlin sources. Dokka already handles multi-language projects. If
 // Javadoc is enabled, we end up overwriting index.html (causing compilation errors).
 tasks.withType<Javadoc>() {

--- a/partiql-eval/build.gradle.kts
+++ b/partiql-eval/build.gradle.kts
@@ -43,6 +43,17 @@ kotlin {
     explicitApi = null
 }
 
+tasks.shadowJar {
+    configurations = listOf(project.configurations.shadow.get())
+}
+
+// Workaround for https://github.com/johnrengelman/shadow/issues/651
+components.withType(AdhocComponentWithVariants::class.java).forEach { c ->
+    c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements.get()) {
+        skip()
+    }
+}
+
 // Need to add this as we have both Java and Kotlin sources. Dokka already handles multi-language projects. If
 // Javadoc is enabled, we end up overwriting index.html (causing compilation errors).
 tasks.withType<Javadoc>() {

--- a/partiql-plan/build.gradle.kts
+++ b/partiql-plan/build.gradle.kts
@@ -26,6 +26,17 @@ dependencies {
     implementation(Deps.kotlinReflect)
 }
 
+tasks.shadowJar {
+    configurations = listOf(project.configurations.shadow.get())
+}
+
+// Workaround for https://github.com/johnrengelman/shadow/issues/651
+components.withType(AdhocComponentWithVariants::class.java).forEach { c ->
+    c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements.get()) {
+        skip()
+    }
+}
+
 // Disabled for partiql-plan project.
 kotlin {
     explicitApi = null

--- a/partiql-planner/build.gradle.kts
+++ b/partiql-planner/build.gradle.kts
@@ -38,6 +38,17 @@ dependencies {
     testFixturesImplementation(project(":partiql-spi"))
 }
 
+tasks.shadowJar {
+    configurations = listOf(project.configurations.shadow.get())
+}
+
+// Workaround for https://github.com/johnrengelman/shadow/issues/651
+components.withType(AdhocComponentWithVariants::class.java).forEach { c ->
+    c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements.get()) {
+        skip()
+    }
+}
+
 tasks.register("generateResourcePath") {
     dependsOn("processTestFixturesResources")
     doLast {

--- a/partiql-spi/build.gradle.kts
+++ b/partiql-spi/build.gradle.kts
@@ -24,6 +24,17 @@ dependencies {
     testImplementation(Deps.kasechange)
 }
 
+tasks.shadowJar {
+    configurations = listOf(project.configurations.shadow.get())
+}
+
+// Workaround for https://github.com/johnrengelman/shadow/issues/651
+components.withType(AdhocComponentWithVariants::class.java).forEach { c ->
+    c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements.get()) {
+        skip()
+    }
+}
+
 publish {
     artifactId = "partiql-spi"
     name = "PartiQL SPI"

--- a/partiql-types/build.gradle.kts
+++ b/partiql-types/build.gradle.kts
@@ -23,6 +23,17 @@ dependencies {
     implementation(Deps.kotlinxCollections)
 }
 
+tasks.shadowJar {
+    configurations = listOf(project.configurations.shadow.get())
+}
+
+// Workaround for https://github.com/johnrengelman/shadow/issues/651
+components.withType(AdhocComponentWithVariants::class.java).forEach { c ->
+    c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements.get()) {
+        skip()
+    }
+}
+
 publish {
     artifactId = "partiql-types"
     name = "PartiQL Types"


### PR DESCRIPTION
(cherry picked from commit 6b49fc19f0e18fc5a80d1b8c07e9c0fac9b2f492)

Targets `v1` branch and copies patch to `partiql-eval` branch.

Below description copied from #1504.

## Relevant Issues
- None

## Description
- Fixes the publishing of jars for non-shadowed packages. Previously, all the packages that don't shadow any packages would fatjar all the dependencies (e.g. kotlin, ion-element). With this change, we now exclude those dependencies, so the jar contains what was there previously.
- Previous packages that shadowed certain dependencies (i.e. `partiql-parser` and `partiql-lang-kotlin`) did not have this issue
- Testing
  - Ran `publishToMavenLocal` and compared the jars between 0.14.5 and this version
  - Published jars for this version do not have the extra dependencies and retain the existing APIs

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]** No api changes.

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.