### PR TITLE
Identifier mode

### DIFF
--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -1,4 +1,5 @@
 public final class org/partiql/ast/Ast {
+	public static final fun binder (Ljava/lang/String;Lorg/partiql/ast/Binder$CaseSensitivity;)Lorg/partiql/ast/Binder;
 	public static final fun constraint (Ljava/lang/String;Lorg/partiql/ast/Constraint$Definition;)Lorg/partiql/ast/Constraint;
 	public static final fun constraintDefinitionCheck (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Constraint$Definition$Check;
 	public static final fun constraintDefinitionNotNull ()Lorg/partiql/ast/Constraint$Definition$NotNull;
@@ -57,7 +58,7 @@ public final class org/partiql/ast/Ast {
 	public static final fun exprWindow (Lorg/partiql/ast/Expr$Window$Function;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr$Window$Over;)Lorg/partiql/ast/Expr$Window;
 	public static final fun exprWindowOver (Ljava/util/List;Ljava/util/List;)Lorg/partiql/ast/Expr$Window$Over;
 	public static final fun fromJoin (Lorg/partiql/ast/From;Lorg/partiql/ast/From;Lorg/partiql/ast/From$Join$Type;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/From$Join;
-	public static final fun fromValue (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/From$Value;
+	public static final fun fromValue (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/From$Value;
 	public static final fun graphMatch (Ljava/util/List;Lorg/partiql/ast/GraphMatch$Selector;)Lorg/partiql/ast/GraphMatch;
 	public static final fun graphMatchLabelConj (Lorg/partiql/ast/GraphMatch$Label;Lorg/partiql/ast/GraphMatch$Label;)Lorg/partiql/ast/GraphMatch$Label$Conj;
 	public static final fun graphMatchLabelDisj (Lorg/partiql/ast/GraphMatch$Label;Lorg/partiql/ast/GraphMatch$Label;)Lorg/partiql/ast/GraphMatch$Label$Disj;
@@ -75,12 +76,12 @@ public final class org/partiql/ast/Ast {
 	public static final fun graphMatchSelectorAnyShortest ()Lorg/partiql/ast/GraphMatch$Selector$AnyShortest;
 	public static final fun graphMatchSelectorShortestK (J)Lorg/partiql/ast/GraphMatch$Selector$ShortestK;
 	public static final fun graphMatchSelectorShortestKGroup (J)Lorg/partiql/ast/GraphMatch$Selector$ShortestKGroup;
-	public static final fun groupBy (Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/GroupBy;
-	public static final fun groupByKey (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/GroupBy$Key;
+	public static final fun groupBy (Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/GroupBy;
+	public static final fun groupByKey (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/GroupBy$Key;
 	public static final fun identifierQualified (Lorg/partiql/ast/Identifier$Symbol;Ljava/util/List;)Lorg/partiql/ast/Identifier$Qualified;
 	public static final fun identifierSymbol (Ljava/lang/String;Lorg/partiql/ast/Identifier$CaseSensitivity;)Lorg/partiql/ast/Identifier$Symbol;
 	public static final fun let (Ljava/util/List;)Lorg/partiql/ast/Let;
-	public static final fun letBinding (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Let$Binding;
+	public static final fun letBinding (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/Let$Binding;
 	public static final fun onConflict (Lorg/partiql/ast/OnConflict$Target;Lorg/partiql/ast/OnConflict$Action;)Lorg/partiql/ast/OnConflict;
 	public static final fun onConflictActionDoNothing ()Lorg/partiql/ast/OnConflict$Action$DoNothing;
 	public static final fun onConflictActionDoReplace (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/OnConflict$Action$DoReplace;
@@ -99,7 +100,7 @@ public final class org/partiql/ast/Ast {
 	public static final fun selectPivot (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Select$Pivot;
 	public static final fun selectProject (Ljava/util/List;Lorg/partiql/ast/SetQuantifier;)Lorg/partiql/ast/Select$Project;
 	public static final fun selectProjectItemAll (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Select$Project$Item$All;
-	public static final fun selectProjectItemExpression (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Select$Project$Item$Expression;
+	public static final fun selectProjectItemExpression (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/Select$Project$Item$Expression;
 	public static final fun selectStar (Lorg/partiql/ast/SetQuantifier;)Lorg/partiql/ast/Select$Star;
 	public static final fun selectValue (Lorg/partiql/ast/Expr;Lorg/partiql/ast/SetQuantifier;)Lorg/partiql/ast/Select$Value;
 	public static final fun setOp (Lorg/partiql/ast/SetOp$Type;Lorg/partiql/ast/SetQuantifier;)Lorg/partiql/ast/SetOp;
@@ -107,19 +108,19 @@ public final class org/partiql/ast/Ast {
 	public static final fun statementDDL (Lorg/partiql/ast/DdlOp;)Lorg/partiql/ast/Statement$DDL;
 	public static final fun statementDMLBatchLegacy (Ljava/util/List;Lorg/partiql/ast/From;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Returning;)Lorg/partiql/ast/Statement$DML$BatchLegacy;
 	public static final fun statementDMLBatchLegacyOpDelete ()Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Delete;
-	public static final fun statementDMLBatchLegacyOpInsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;
+	public static final fun statementDMLBatchLegacyOpInsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;
 	public static final fun statementDMLBatchLegacyOpInsertLegacy (Lorg/partiql/ast/Path;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$InsertLegacy;
 	public static final fun statementDMLBatchLegacyOpRemove (Lorg/partiql/ast/Path;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Remove;
 	public static final fun statementDMLBatchLegacyOpSet (Ljava/util/List;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Set;
 	public static final fun statementDMLDelete (Lorg/partiql/ast/Statement$DML$Delete$Target;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Returning;)Lorg/partiql/ast/Statement$DML$Delete;
-	public static final fun statementDMLDeleteTarget (Lorg/partiql/ast/Path;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Statement$DML$Delete$Target;
-	public static final fun statementDMLInsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;)Lorg/partiql/ast/Statement$DML$Insert;
+	public static final fun statementDMLDeleteTarget (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Statement$DML$Delete$Target;
+	public static final fun statementDMLInsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;)Lorg/partiql/ast/Statement$DML$Insert;
 	public static final fun statementDMLInsertLegacy (Lorg/partiql/ast/Path;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Statement$DML$InsertLegacy;
 	public static final fun statementDMLRemove (Lorg/partiql/ast/Path;)Lorg/partiql/ast/Statement$DML$Remove;
-	public static final fun statementDMLReplace (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Statement$DML$Replace;
+	public static final fun statementDMLReplace (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/Statement$DML$Replace;
 	public static final fun statementDMLUpdate (Lorg/partiql/ast/Path;Ljava/util/List;)Lorg/partiql/ast/Statement$DML$Update;
 	public static final fun statementDMLUpdateAssignment (Lorg/partiql/ast/Path;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Statement$DML$Update$Assignment;
-	public static final fun statementDMLUpsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Statement$DML$Upsert;
+	public static final fun statementDMLUpsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/Statement$DML$Upsert;
 	public static final fun statementExec (Ljava/lang/String;Ljava/util/List;)Lorg/partiql/ast/Statement$Exec;
 	public static final fun statementExplain (Lorg/partiql/ast/Statement$Explain$Target;)Lorg/partiql/ast/Statement$Explain;
 	public static final fun statementExplainTargetDomain (Lorg/partiql/ast/Statement;Ljava/lang/String;Ljava/lang/String;)Lorg/partiql/ast/Statement$Explain$Target$Domain;
@@ -157,7 +158,7 @@ public final class org/partiql/ast/Ast {
 	public static final fun typeSmallint ()Lorg/partiql/ast/Type$Smallint;
 	public static final fun typeString (Ljava/lang/Integer;)Lorg/partiql/ast/Type$String;
 	public static final fun typeStruct (Ljava/util/List;)Lorg/partiql/ast/Type$Struct;
-	public static final fun typeStructField (Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Type;Ljava/util/List;ZLjava/lang/String;)Lorg/partiql/ast/Type$Struct$Field;
+	public static final fun typeStructField (Lorg/partiql/ast/Binder;Lorg/partiql/ast/Type;Ljava/util/List;ZLjava/lang/String;)Lorg/partiql/ast/Type$Struct$Field;
 	public static final fun typeSymbol ()Lorg/partiql/ast/Type$Symbol;
 	public static final fun typeTime (Ljava/lang/Integer;)Lorg/partiql/ast/Type$Time;
 	public static final fun typeTimeWithTz (Ljava/lang/Integer;)Lorg/partiql/ast/Type$TimeWithTz;
@@ -173,6 +174,34 @@ public abstract class org/partiql/ast/AstNode {
 	public fun <init> ()V
 	public abstract fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getChildren ()Ljava/util/List;
+}
+
+public final class org/partiql/ast/Binder : org/partiql/ast/AstNode {
+	public static final field Companion Lorg/partiql/ast/Binder$Companion;
+	public final field caseSensitivity Lorg/partiql/ast/Binder$CaseSensitivity;
+	public final field symbol Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;Lorg/partiql/ast/Binder$CaseSensitivity;)V
+	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun builder ()Lorg/partiql/ast/builder/BinderBuilder;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/partiql/ast/Binder$CaseSensitivity;
+	public final fun copy (Ljava/lang/String;Lorg/partiql/ast/Binder$CaseSensitivity;)Lorg/partiql/ast/Binder;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Binder;Ljava/lang/String;Lorg/partiql/ast/Binder$CaseSensitivity;ILjava/lang/Object;)Lorg/partiql/ast/Binder;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/ast/Binder$CaseSensitivity : java/lang/Enum {
+	public static final field INSENSITIVE Lorg/partiql/ast/Binder$CaseSensitivity;
+	public static final field SENSITIVE Lorg/partiql/ast/Binder$CaseSensitivity;
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/Binder$CaseSensitivity;
+	public static fun values ()[Lorg/partiql/ast/Binder$CaseSensitivity;
+}
+
+public final class org/partiql/ast/Binder$Companion {
+	public final fun builder ()Lorg/partiql/ast/builder/BinderBuilder;
 }
 
 public final class org/partiql/ast/Constraint : org/partiql/ast/AstNode {
@@ -1551,21 +1580,21 @@ public final class org/partiql/ast/From$Join$Type : java/lang/Enum {
 
 public final class org/partiql/ast/From$Value : org/partiql/ast/From {
 	public static final field Companion Lorg/partiql/ast/From$Value$Companion;
-	public final field asAlias Lorg/partiql/ast/Identifier$Symbol;
-	public final field atAlias Lorg/partiql/ast/Identifier$Symbol;
+	public final field asAlias Lorg/partiql/ast/Binder;
+	public final field atAlias Lorg/partiql/ast/Binder;
 	public final field byAlias Lorg/partiql/ast/Identifier$Symbol;
 	public final field expr Lorg/partiql/ast/Expr;
 	public final field type Lorg/partiql/ast/From$Value$Type;
-	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;)V
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/FromValueBuilder;
 	public final fun component1 ()Lorg/partiql/ast/Expr;
 	public final fun component2 ()Lorg/partiql/ast/From$Value$Type;
-	public final fun component3 ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun component4 ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun component3 ()Lorg/partiql/ast/Binder;
+	public final fun component4 ()Lorg/partiql/ast/Binder;
 	public final fun component5 ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun copy (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/From$Value;
-	public static synthetic fun copy$default (Lorg/partiql/ast/From$Value;Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;ILjava/lang/Object;)Lorg/partiql/ast/From$Value;
+	public final fun copy (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/From$Value;
+	public static synthetic fun copy$default (Lorg/partiql/ast/From$Value;Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;ILjava/lang/Object;)Lorg/partiql/ast/From$Value;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -1976,17 +2005,17 @@ public final class org/partiql/ast/GraphMatch$Selector$ShortestKGroup$Companion 
 
 public final class org/partiql/ast/GroupBy : org/partiql/ast/AstNode {
 	public static final field Companion Lorg/partiql/ast/GroupBy$Companion;
-	public final field asAlias Lorg/partiql/ast/Identifier$Symbol;
+	public final field asAlias Lorg/partiql/ast/Binder;
 	public final field keys Ljava/util/List;
 	public final field strategy Lorg/partiql/ast/GroupBy$Strategy;
-	public fun <init> (Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Identifier$Symbol;)V
+	public fun <init> (Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Binder;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/GroupByBuilder;
 	public final fun component1 ()Lorg/partiql/ast/GroupBy$Strategy;
 	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun copy (Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/GroupBy;
-	public static synthetic fun copy$default (Lorg/partiql/ast/GroupBy;Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Identifier$Symbol;ILjava/lang/Object;)Lorg/partiql/ast/GroupBy;
+	public final fun component3 ()Lorg/partiql/ast/Binder;
+	public final fun copy (Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/GroupBy;
+	public static synthetic fun copy$default (Lorg/partiql/ast/GroupBy;Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Binder;ILjava/lang/Object;)Lorg/partiql/ast/GroupBy;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -1999,15 +2028,15 @@ public final class org/partiql/ast/GroupBy$Companion {
 
 public final class org/partiql/ast/GroupBy$Key : org/partiql/ast/AstNode {
 	public static final field Companion Lorg/partiql/ast/GroupBy$Key$Companion;
-	public final field asAlias Lorg/partiql/ast/Identifier$Symbol;
+	public final field asAlias Lorg/partiql/ast/Binder;
 	public final field expr Lorg/partiql/ast/Expr;
-	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)V
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/GroupByKeyBuilder;
 	public final fun component1 ()Lorg/partiql/ast/Expr;
-	public final fun component2 ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun copy (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/GroupBy$Key;
-	public static synthetic fun copy$default (Lorg/partiql/ast/GroupBy$Key;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;ILjava/lang/Object;)Lorg/partiql/ast/GroupBy$Key;
+	public final fun component2 ()Lorg/partiql/ast/Binder;
+	public final fun copy (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/GroupBy$Key;
+	public static synthetic fun copy$default (Lorg/partiql/ast/GroupBy$Key;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;ILjava/lang/Object;)Lorg/partiql/ast/GroupBy$Key;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -2095,15 +2124,15 @@ public final class org/partiql/ast/Let : org/partiql/ast/AstNode {
 
 public final class org/partiql/ast/Let$Binding : org/partiql/ast/AstNode {
 	public static final field Companion Lorg/partiql/ast/Let$Binding$Companion;
-	public final field asAlias Lorg/partiql/ast/Identifier$Symbol;
+	public final field asAlias Lorg/partiql/ast/Binder;
 	public final field expr Lorg/partiql/ast/Expr;
-	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)V
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/LetBindingBuilder;
 	public final fun component1 ()Lorg/partiql/ast/Expr;
-	public final fun component2 ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun copy (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Let$Binding;
-	public static synthetic fun copy$default (Lorg/partiql/ast/Let$Binding;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;ILjava/lang/Object;)Lorg/partiql/ast/Let$Binding;
+	public final fun component2 ()Lorg/partiql/ast/Binder;
+	public final fun copy (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/Let$Binding;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Let$Binding;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;ILjava/lang/Object;)Lorg/partiql/ast/Let$Binding;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -2520,15 +2549,15 @@ public final class org/partiql/ast/Select$Project$Item$All$Companion {
 
 public final class org/partiql/ast/Select$Project$Item$Expression : org/partiql/ast/Select$Project$Item {
 	public static final field Companion Lorg/partiql/ast/Select$Project$Item$Expression$Companion;
-	public final field asAlias Lorg/partiql/ast/Identifier$Symbol;
+	public final field asAlias Lorg/partiql/ast/Binder;
 	public final field expr Lorg/partiql/ast/Expr;
-	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)V
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/SelectProjectItemExpressionBuilder;
 	public final fun component1 ()Lorg/partiql/ast/Expr;
-	public final fun component2 ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun copy (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Select$Project$Item$Expression;
-	public static synthetic fun copy$default (Lorg/partiql/ast/Select$Project$Item$Expression;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;ILjava/lang/Object;)Lorg/partiql/ast/Select$Project$Item$Expression;
+	public final fun component2 ()Lorg/partiql/ast/Binder;
+	public final fun copy (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/Select$Project$Item$Expression;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Select$Project$Item$Expression;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;ILjava/lang/Object;)Lorg/partiql/ast/Select$Project$Item$Expression;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -2731,19 +2760,19 @@ public final class org/partiql/ast/Statement$DML$BatchLegacy$Op$Delete$Companion
 
 public final class org/partiql/ast/Statement$DML$BatchLegacy$Op$Insert : org/partiql/ast/Statement$DML$BatchLegacy$Op {
 	public static final field Companion Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert$Companion;
-	public final field asAlias Lorg/partiql/ast/Identifier$Symbol;
+	public final field asAlias Lorg/partiql/ast/Binder;
 	public final field onConflict Lorg/partiql/ast/OnConflict;
 	public final field target Lorg/partiql/ast/Identifier;
 	public final field values Lorg/partiql/ast/Expr;
-	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;)V
+	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/StatementDmlBatchLegacyOpInsertBuilder;
 	public final fun component1 ()Lorg/partiql/ast/Identifier;
 	public final fun component2 ()Lorg/partiql/ast/Expr;
-	public final fun component3 ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun component3 ()Lorg/partiql/ast/Binder;
 	public final fun component4 ()Lorg/partiql/ast/OnConflict;
-	public final fun copy (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;
-	public static synthetic fun copy$default (Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;
+	public final fun copy (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -2842,19 +2871,19 @@ public final class org/partiql/ast/Statement$DML$Delete$Companion {
 
 public final class org/partiql/ast/Statement$DML$Delete$Target : org/partiql/ast/AstNode {
 	public static final field Companion Lorg/partiql/ast/Statement$DML$Delete$Target$Companion;
-	public final field asAlias Lorg/partiql/ast/Identifier$Symbol;
-	public final field atAlias Lorg/partiql/ast/Identifier$Symbol;
+	public final field asAlias Lorg/partiql/ast/Binder;
+	public final field atAlias Lorg/partiql/ast/Binder;
 	public final field byAlias Lorg/partiql/ast/Identifier$Symbol;
 	public final field path Lorg/partiql/ast/Path;
-	public fun <init> (Lorg/partiql/ast/Path;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;)V
+	public fun <init> (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
 	public final fun component1 ()Lorg/partiql/ast/Path;
-	public final fun component2 ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun component3 ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun component2 ()Lorg/partiql/ast/Binder;
+	public final fun component3 ()Lorg/partiql/ast/Binder;
 	public final fun component4 ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun copy (Lorg/partiql/ast/Path;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Statement$DML$Delete$Target;
-	public static synthetic fun copy$default (Lorg/partiql/ast/Statement$DML$Delete$Target;Lorg/partiql/ast/Path;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Delete$Target;
+	public final fun copy (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Statement$DML$Delete$Target;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Statement$DML$Delete$Target;Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Delete$Target;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -2867,19 +2896,19 @@ public final class org/partiql/ast/Statement$DML$Delete$Target$Companion {
 
 public final class org/partiql/ast/Statement$DML$Insert : org/partiql/ast/Statement$DML {
 	public static final field Companion Lorg/partiql/ast/Statement$DML$Insert$Companion;
-	public final field asAlias Lorg/partiql/ast/Identifier$Symbol;
+	public final field asAlias Lorg/partiql/ast/Binder;
 	public final field onConflict Lorg/partiql/ast/OnConflict;
 	public final field target Lorg/partiql/ast/Identifier;
 	public final field values Lorg/partiql/ast/Expr;
-	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;)V
+	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/StatementDmlInsertBuilder;
 	public final fun component1 ()Lorg/partiql/ast/Identifier;
 	public final fun component2 ()Lorg/partiql/ast/Expr;
-	public final fun component3 ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun component3 ()Lorg/partiql/ast/Binder;
 	public final fun component4 ()Lorg/partiql/ast/OnConflict;
-	public final fun copy (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;)Lorg/partiql/ast/Statement$DML$Insert;
-	public static synthetic fun copy$default (Lorg/partiql/ast/Statement$DML$Insert;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Insert;
+	public final fun copy (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;)Lorg/partiql/ast/Statement$DML$Insert;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Statement$DML$Insert;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Insert;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -2936,17 +2965,17 @@ public final class org/partiql/ast/Statement$DML$Remove$Companion {
 
 public final class org/partiql/ast/Statement$DML$Replace : org/partiql/ast/Statement$DML {
 	public static final field Companion Lorg/partiql/ast/Statement$DML$Replace$Companion;
-	public final field asAlias Lorg/partiql/ast/Identifier$Symbol;
+	public final field asAlias Lorg/partiql/ast/Binder;
 	public final field target Lorg/partiql/ast/Identifier;
 	public final field values Lorg/partiql/ast/Expr;
-	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)V
+	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/StatementDmlReplaceBuilder;
 	public final fun component1 ()Lorg/partiql/ast/Identifier;
 	public final fun component2 ()Lorg/partiql/ast/Expr;
-	public final fun component3 ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun copy (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Statement$DML$Replace;
-	public static synthetic fun copy$default (Lorg/partiql/ast/Statement$DML$Replace;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Replace;
+	public final fun component3 ()Lorg/partiql/ast/Binder;
+	public final fun copy (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/Statement$DML$Replace;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Statement$DML$Replace;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Replace;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -3001,17 +3030,17 @@ public final class org/partiql/ast/Statement$DML$Update$Companion {
 
 public final class org/partiql/ast/Statement$DML$Upsert : org/partiql/ast/Statement$DML {
 	public static final field Companion Lorg/partiql/ast/Statement$DML$Upsert$Companion;
-	public final field asAlias Lorg/partiql/ast/Identifier$Symbol;
+	public final field asAlias Lorg/partiql/ast/Binder;
 	public final field target Lorg/partiql/ast/Identifier;
 	public final field values Lorg/partiql/ast/Expr;
-	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)V
+	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/StatementDmlUpsertBuilder;
 	public final fun component1 ()Lorg/partiql/ast/Identifier;
 	public final fun component2 ()Lorg/partiql/ast/Expr;
-	public final fun component3 ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun copy (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Statement$DML$Upsert;
-	public static synthetic fun copy$default (Lorg/partiql/ast/Statement$DML$Upsert;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Upsert;
+	public final fun component3 ()Lorg/partiql/ast/Binder;
+	public final fun copy (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/Statement$DML$Upsert;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Statement$DML$Upsert;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Upsert;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -3794,18 +3823,18 @@ public final class org/partiql/ast/Type$Struct$Field : org/partiql/ast/AstNode {
 	public final field comment Ljava/lang/String;
 	public final field constraints Ljava/util/List;
 	public final field isOptional Z
-	public final field name Lorg/partiql/ast/Identifier$Symbol;
+	public final field name Lorg/partiql/ast/Binder;
 	public final field type Lorg/partiql/ast/Type;
-	public fun <init> (Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Type;Ljava/util/List;ZLjava/lang/String;)V
+	public fun <init> (Lorg/partiql/ast/Binder;Lorg/partiql/ast/Type;Ljava/util/List;ZLjava/lang/String;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/TypeStructFieldBuilder;
-	public final fun component1 ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun component1 ()Lorg/partiql/ast/Binder;
 	public final fun component2 ()Lorg/partiql/ast/Type;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Z
 	public final fun component5 ()Ljava/lang/String;
-	public final fun copy (Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Type;Ljava/util/List;ZLjava/lang/String;)Lorg/partiql/ast/Type$Struct$Field;
-	public static synthetic fun copy$default (Lorg/partiql/ast/Type$Struct$Field;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Type;Ljava/util/List;ZLjava/lang/String;ILjava/lang/Object;)Lorg/partiql/ast/Type$Struct$Field;
+	public final fun copy (Lorg/partiql/ast/Binder;Lorg/partiql/ast/Type;Ljava/util/List;ZLjava/lang/String;)Lorg/partiql/ast/Type$Struct$Field;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Type$Struct$Field;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Type;Ljava/util/List;ZLjava/lang/String;ILjava/lang/Object;)Lorg/partiql/ast/Type$Struct$Field;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -3976,6 +4005,8 @@ public final class org/partiql/ast/Type$Varchar$Companion {
 
 public final class org/partiql/ast/builder/AstBuilder {
 	public fun <init> ()V
+	public final fun binder (Ljava/lang/String;Lorg/partiql/ast/Binder$CaseSensitivity;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Binder;
+	public static synthetic fun binder$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/lang/String;Lorg/partiql/ast/Binder$CaseSensitivity;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Binder;
 	public final fun constraint (Ljava/lang/String;Lorg/partiql/ast/Constraint$Definition;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Constraint;
 	public static synthetic fun constraint$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/lang/String;Lorg/partiql/ast/Constraint$Definition;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Constraint;
 	public final fun constraintDefinitionCheck (Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Constraint$Definition$Check;
@@ -4092,8 +4123,8 @@ public final class org/partiql/ast/builder/AstBuilder {
 	public static synthetic fun exprWindowOver$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Window$Over;
 	public final fun fromJoin (Lorg/partiql/ast/From;Lorg/partiql/ast/From;Lorg/partiql/ast/From$Join$Type;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/From$Join;
 	public static synthetic fun fromJoin$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/From;Lorg/partiql/ast/From;Lorg/partiql/ast/From$Join$Type;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/From$Join;
-	public final fun fromValue (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/From$Value;
-	public static synthetic fun fromValue$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/From$Value;
+	public final fun fromValue (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/From$Value;
+	public static synthetic fun fromValue$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/From$Value;
 	public final fun graphMatch (Ljava/util/List;Lorg/partiql/ast/GraphMatch$Selector;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/GraphMatch;
 	public static synthetic fun graphMatch$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/util/List;Lorg/partiql/ast/GraphMatch$Selector;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/GraphMatch;
 	public final fun graphMatchLabelConj (Lorg/partiql/ast/GraphMatch$Label;Lorg/partiql/ast/GraphMatch$Label;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/GraphMatch$Label$Conj;
@@ -4128,18 +4159,18 @@ public final class org/partiql/ast/builder/AstBuilder {
 	public static synthetic fun graphMatchSelectorShortestK$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/GraphMatch$Selector$ShortestK;
 	public final fun graphMatchSelectorShortestKGroup (Ljava/lang/Long;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/GraphMatch$Selector$ShortestKGroup;
 	public static synthetic fun graphMatchSelectorShortestKGroup$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/lang/Long;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/GraphMatch$Selector$ShortestKGroup;
-	public final fun groupBy (Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/GroupBy;
-	public static synthetic fun groupBy$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/GroupBy;
-	public final fun groupByKey (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/GroupBy$Key;
-	public static synthetic fun groupByKey$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/GroupBy$Key;
+	public final fun groupBy (Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/GroupBy;
+	public static synthetic fun groupBy$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/GroupBy;
+	public final fun groupByKey (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/GroupBy$Key;
+	public static synthetic fun groupByKey$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/GroupBy$Key;
 	public final fun identifierQualified (Lorg/partiql/ast/Identifier$Symbol;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Identifier$Qualified;
 	public static synthetic fun identifierQualified$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier$Symbol;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Identifier$Qualified;
 	public final fun identifierSymbol (Ljava/lang/String;Lorg/partiql/ast/Identifier$CaseSensitivity;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Identifier$Symbol;
 	public static synthetic fun identifierSymbol$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/lang/String;Lorg/partiql/ast/Identifier$CaseSensitivity;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Identifier$Symbol;
 	public final fun let (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Let;
 	public static synthetic fun let$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Let;
-	public final fun letBinding (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Let$Binding;
-	public static synthetic fun letBinding$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Let$Binding;
+	public final fun letBinding (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Let$Binding;
+	public static synthetic fun letBinding$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Let$Binding;
 	public final fun onConflict (Lorg/partiql/ast/OnConflict$Target;Lorg/partiql/ast/OnConflict$Action;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/OnConflict;
 	public static synthetic fun onConflict$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/OnConflict$Target;Lorg/partiql/ast/OnConflict$Action;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/OnConflict;
 	public final fun onConflictActionDoNothing (Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/OnConflict$Action$DoNothing;
@@ -4176,8 +4207,8 @@ public final class org/partiql/ast/builder/AstBuilder {
 	public static synthetic fun selectProject$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/util/List;Lorg/partiql/ast/SetQuantifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Select$Project;
 	public final fun selectProjectItemAll (Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Select$Project$Item$All;
 	public static synthetic fun selectProjectItemAll$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Select$Project$Item$All;
-	public final fun selectProjectItemExpression (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Select$Project$Item$Expression;
-	public static synthetic fun selectProjectItemExpression$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Select$Project$Item$Expression;
+	public final fun selectProjectItemExpression (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Select$Project$Item$Expression;
+	public static synthetic fun selectProjectItemExpression$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Select$Project$Item$Expression;
 	public final fun selectStar (Lorg/partiql/ast/SetQuantifier;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Select$Star;
 	public static synthetic fun selectStar$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/SetQuantifier;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Select$Star;
 	public final fun selectValue (Lorg/partiql/ast/Expr;Lorg/partiql/ast/SetQuantifier;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Select$Value;
@@ -4192,8 +4223,8 @@ public final class org/partiql/ast/builder/AstBuilder {
 	public static synthetic fun statementDMLBatchLegacy$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/util/List;Lorg/partiql/ast/From;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Returning;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$BatchLegacy;
 	public final fun statementDMLBatchLegacyOpDelete (Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Delete;
 	public static synthetic fun statementDMLBatchLegacyOpDelete$default (Lorg/partiql/ast/builder/AstBuilder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Delete;
-	public final fun statementDMLBatchLegacyOpInsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;
-	public static synthetic fun statementDMLBatchLegacyOpInsert$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;
+	public final fun statementDMLBatchLegacyOpInsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;
+	public static synthetic fun statementDMLBatchLegacyOpInsert$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;
 	public final fun statementDMLBatchLegacyOpInsertLegacy (Lorg/partiql/ast/Path;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$InsertLegacy;
 	public static synthetic fun statementDMLBatchLegacyOpInsertLegacy$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Path;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$InsertLegacy;
 	public final fun statementDMLBatchLegacyOpRemove (Lorg/partiql/ast/Path;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Remove;
@@ -4202,22 +4233,22 @@ public final class org/partiql/ast/builder/AstBuilder {
 	public static synthetic fun statementDMLBatchLegacyOpSet$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Set;
 	public final fun statementDMLDelete (Lorg/partiql/ast/Statement$DML$Delete$Target;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Returning;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Delete;
 	public static synthetic fun statementDMLDelete$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Statement$DML$Delete$Target;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Returning;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Delete;
-	public final fun statementDMLDeleteTarget (Lorg/partiql/ast/Path;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Delete$Target;
-	public static synthetic fun statementDMLDeleteTarget$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Path;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Delete$Target;
-	public final fun statementDMLInsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Insert;
-	public static synthetic fun statementDMLInsert$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Insert;
+	public final fun statementDMLDeleteTarget (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Delete$Target;
+	public static synthetic fun statementDMLDeleteTarget$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Delete$Target;
+	public final fun statementDMLInsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Insert;
+	public static synthetic fun statementDMLInsert$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Insert;
 	public final fun statementDMLInsertLegacy (Lorg/partiql/ast/Path;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$InsertLegacy;
 	public static synthetic fun statementDMLInsertLegacy$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Path;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$InsertLegacy;
 	public final fun statementDMLRemove (Lorg/partiql/ast/Path;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Remove;
 	public static synthetic fun statementDMLRemove$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Path;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Remove;
-	public final fun statementDMLReplace (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Replace;
-	public static synthetic fun statementDMLReplace$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Replace;
+	public final fun statementDMLReplace (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Replace;
+	public static synthetic fun statementDMLReplace$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Replace;
 	public final fun statementDMLUpdate (Lorg/partiql/ast/Path;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Update;
 	public static synthetic fun statementDMLUpdate$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Path;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Update;
 	public final fun statementDMLUpdateAssignment (Lorg/partiql/ast/Path;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Update$Assignment;
 	public static synthetic fun statementDMLUpdateAssignment$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Path;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Update$Assignment;
-	public final fun statementDMLUpsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Upsert;
-	public static synthetic fun statementDMLUpsert$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Upsert;
+	public final fun statementDMLUpsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Upsert;
+	public static synthetic fun statementDMLUpsert$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Upsert;
 	public final fun statementExec (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$Exec;
 	public static synthetic fun statementExec$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$Exec;
 	public final fun statementExplain (Lorg/partiql/ast/Statement$Explain$Target;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$Explain;
@@ -4292,8 +4323,8 @@ public final class org/partiql/ast/builder/AstBuilder {
 	public static synthetic fun typeString$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Type$String;
 	public final fun typeStruct (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Type$Struct;
 	public static synthetic fun typeStruct$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Type$Struct;
-	public final fun typeStructField (Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Type;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Type$Struct$Field;
-	public static synthetic fun typeStructField$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Type;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Type$Struct$Field;
+	public final fun typeStructField (Lorg/partiql/ast/Binder;Lorg/partiql/ast/Type;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Type$Struct$Field;
+	public static synthetic fun typeStructField$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Type;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Type$Struct$Field;
 	public final fun typeSymbol (Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Type$Symbol;
 	public static synthetic fun typeSymbol$default (Lorg/partiql/ast/builder/AstBuilder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Type$Symbol;
 	public final fun typeTime (Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Type$Time;
@@ -4314,6 +4345,19 @@ public final class org/partiql/ast/builder/AstBuilder {
 
 public final class org/partiql/ast/builder/AstBuilderKt {
 	public static final fun ast (Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/AstNode;
+}
+
+public final class org/partiql/ast/builder/BinderBuilder {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lorg/partiql/ast/Binder$CaseSensitivity;)V
+	public synthetic fun <init> (Ljava/lang/String;Lorg/partiql/ast/Binder$CaseSensitivity;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun build ()Lorg/partiql/ast/Binder;
+	public final fun caseSensitivity (Lorg/partiql/ast/Binder$CaseSensitivity;)Lorg/partiql/ast/builder/BinderBuilder;
+	public final fun getCaseSensitivity ()Lorg/partiql/ast/Binder$CaseSensitivity;
+	public final fun getSymbol ()Ljava/lang/String;
+	public final fun setCaseSensitivity (Lorg/partiql/ast/Binder$CaseSensitivity;)V
+	public final fun setSymbol (Ljava/lang/String;)V
+	public final fun symbol (Ljava/lang/String;)Lorg/partiql/ast/builder/BinderBuilder;
 }
 
 public final class org/partiql/ast/builder/ConstraintBuilder {
@@ -5081,20 +5125,20 @@ public final class org/partiql/ast/builder/FromJoinBuilder {
 
 public final class org/partiql/ast/builder/FromValueBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun asAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/FromValueBuilder;
-	public final fun atAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/FromValueBuilder;
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun asAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/FromValueBuilder;
+	public final fun atAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/FromValueBuilder;
 	public final fun build ()Lorg/partiql/ast/From$Value;
 	public final fun byAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/FromValueBuilder;
 	public final fun expr (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/FromValueBuilder;
-	public final fun getAsAlias ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun getAtAlias ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getAsAlias ()Lorg/partiql/ast/Binder;
+	public final fun getAtAlias ()Lorg/partiql/ast/Binder;
 	public final fun getByAlias ()Lorg/partiql/ast/Identifier$Symbol;
 	public final fun getExpr ()Lorg/partiql/ast/Expr;
 	public final fun getType ()Lorg/partiql/ast/From$Value$Type;
-	public final fun setAsAlias (Lorg/partiql/ast/Identifier$Symbol;)V
-	public final fun setAtAlias (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setAsAlias (Lorg/partiql/ast/Binder;)V
+	public final fun setAtAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setByAlias (Lorg/partiql/ast/Identifier$Symbol;)V
 	public final fun setExpr (Lorg/partiql/ast/Expr;)V
 	public final fun setType (Lorg/partiql/ast/From$Value$Type;)V
@@ -5295,15 +5339,15 @@ public final class org/partiql/ast/builder/GraphMatchSelectorShortestKGroupBuild
 
 public final class org/partiql/ast/builder/GroupByBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Identifier$Symbol;)V
-	public synthetic fun <init> (Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Identifier$Symbol;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun asAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/GroupByBuilder;
+	public fun <init> (Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Binder;)V
+	public synthetic fun <init> (Lorg/partiql/ast/GroupBy$Strategy;Ljava/util/List;Lorg/partiql/ast/Binder;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun asAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/GroupByBuilder;
 	public final fun build ()Lorg/partiql/ast/GroupBy;
-	public final fun getAsAlias ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getAsAlias ()Lorg/partiql/ast/Binder;
 	public final fun getKeys ()Ljava/util/List;
 	public final fun getStrategy ()Lorg/partiql/ast/GroupBy$Strategy;
 	public final fun keys (Ljava/util/List;)Lorg/partiql/ast/builder/GroupByBuilder;
-	public final fun setAsAlias (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setAsAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setKeys (Ljava/util/List;)V
 	public final fun setStrategy (Lorg/partiql/ast/GroupBy$Strategy;)V
 	public final fun strategy (Lorg/partiql/ast/GroupBy$Strategy;)Lorg/partiql/ast/builder/GroupByBuilder;
@@ -5311,14 +5355,14 @@ public final class org/partiql/ast/builder/GroupByBuilder {
 
 public final class org/partiql/ast/builder/GroupByKeyBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun asAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/GroupByKeyBuilder;
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun asAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/GroupByKeyBuilder;
 	public final fun build ()Lorg/partiql/ast/GroupBy$Key;
 	public final fun expr (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/GroupByKeyBuilder;
-	public final fun getAsAlias ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getAsAlias ()Lorg/partiql/ast/Binder;
 	public final fun getExpr ()Lorg/partiql/ast/Expr;
-	public final fun setAsAlias (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setAsAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setExpr (Lorg/partiql/ast/Expr;)V
 }
 
@@ -5350,14 +5394,14 @@ public final class org/partiql/ast/builder/IdentifierSymbolBuilder {
 
 public final class org/partiql/ast/builder/LetBindingBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun asAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/LetBindingBuilder;
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun asAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/LetBindingBuilder;
 	public final fun build ()Lorg/partiql/ast/Let$Binding;
 	public final fun expr (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/LetBindingBuilder;
-	public final fun getAsAlias ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getAsAlias ()Lorg/partiql/ast/Binder;
 	public final fun getExpr ()Lorg/partiql/ast/Expr;
-	public final fun setAsAlias (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setAsAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setExpr (Lorg/partiql/ast/Expr;)V
 }
 
@@ -5561,14 +5605,14 @@ public final class org/partiql/ast/builder/SelectProjectItemAllBuilder {
 
 public final class org/partiql/ast/builder/SelectProjectItemExpressionBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun asAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/SelectProjectItemExpressionBuilder;
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun asAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/SelectProjectItemExpressionBuilder;
 	public final fun build ()Lorg/partiql/ast/Select$Project$Item$Expression;
 	public final fun expr (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/SelectProjectItemExpressionBuilder;
-	public final fun getAsAlias ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getAsAlias ()Lorg/partiql/ast/Binder;
 	public final fun getExpr ()Lorg/partiql/ast/Expr;
-	public final fun setAsAlias (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setAsAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setExpr (Lorg/partiql/ast/Expr;)V
 }
 
@@ -5660,16 +5704,16 @@ public final class org/partiql/ast/builder/StatementDmlBatchLegacyOpDeleteBuilde
 
 public final class org/partiql/ast/builder/StatementDmlBatchLegacyOpInsertBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun asAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/StatementDmlBatchLegacyOpInsertBuilder;
+	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun asAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/StatementDmlBatchLegacyOpInsertBuilder;
 	public final fun build ()Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Insert;
-	public final fun getAsAlias ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getAsAlias ()Lorg/partiql/ast/Binder;
 	public final fun getOnConflict ()Lorg/partiql/ast/OnConflict;
 	public final fun getTarget ()Lorg/partiql/ast/Identifier;
 	public final fun getValues ()Lorg/partiql/ast/Expr;
 	public final fun onConflict (Lorg/partiql/ast/OnConflict;)Lorg/partiql/ast/builder/StatementDmlBatchLegacyOpInsertBuilder;
-	public final fun setAsAlias (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setAsAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setOnConflict (Lorg/partiql/ast/OnConflict;)V
 	public final fun setTarget (Lorg/partiql/ast/Identifier;)V
 	public final fun setValues (Lorg/partiql/ast/Expr;)V
@@ -5734,35 +5778,35 @@ public final class org/partiql/ast/builder/StatementDmlDeleteBuilder {
 
 public final class org/partiql/ast/builder/StatementDmlDeleteTargetBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Path;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Path;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Identifier$Symbol;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun asAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
-	public final fun atAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
+	public fun <init> (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun asAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
+	public final fun atAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
 	public final fun build ()Lorg/partiql/ast/Statement$DML$Delete$Target;
 	public final fun byAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
-	public final fun getAsAlias ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun getAtAlias ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getAsAlias ()Lorg/partiql/ast/Binder;
+	public final fun getAtAlias ()Lorg/partiql/ast/Binder;
 	public final fun getByAlias ()Lorg/partiql/ast/Identifier$Symbol;
 	public final fun getPath ()Lorg/partiql/ast/Path;
 	public final fun path (Lorg/partiql/ast/Path;)Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
-	public final fun setAsAlias (Lorg/partiql/ast/Identifier$Symbol;)V
-	public final fun setAtAlias (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setAsAlias (Lorg/partiql/ast/Binder;)V
+	public final fun setAtAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setByAlias (Lorg/partiql/ast/Identifier$Symbol;)V
 	public final fun setPath (Lorg/partiql/ast/Path;)V
 }
 
 public final class org/partiql/ast/builder/StatementDmlInsertBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/OnConflict;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun asAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/StatementDmlInsertBuilder;
+	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun asAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/StatementDmlInsertBuilder;
 	public final fun build ()Lorg/partiql/ast/Statement$DML$Insert;
-	public final fun getAsAlias ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getAsAlias ()Lorg/partiql/ast/Binder;
 	public final fun getOnConflict ()Lorg/partiql/ast/OnConflict;
 	public final fun getTarget ()Lorg/partiql/ast/Identifier;
 	public final fun getValues ()Lorg/partiql/ast/Expr;
 	public final fun onConflict (Lorg/partiql/ast/OnConflict;)Lorg/partiql/ast/builder/StatementDmlInsertBuilder;
-	public final fun setAsAlias (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setAsAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setOnConflict (Lorg/partiql/ast/OnConflict;)V
 	public final fun setTarget (Lorg/partiql/ast/Identifier;)V
 	public final fun setValues (Lorg/partiql/ast/Expr;)V
@@ -5801,14 +5845,14 @@ public final class org/partiql/ast/builder/StatementDmlRemoveBuilder {
 
 public final class org/partiql/ast/builder/StatementDmlReplaceBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun asAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/StatementDmlReplaceBuilder;
+	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun asAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/StatementDmlReplaceBuilder;
 	public final fun build ()Lorg/partiql/ast/Statement$DML$Replace;
-	public final fun getAsAlias ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getAsAlias ()Lorg/partiql/ast/Binder;
 	public final fun getTarget ()Lorg/partiql/ast/Identifier;
 	public final fun getValues ()Lorg/partiql/ast/Expr;
-	public final fun setAsAlias (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setAsAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setTarget (Lorg/partiql/ast/Identifier;)V
 	public final fun setValues (Lorg/partiql/ast/Expr;)V
 	public final fun target (Lorg/partiql/ast/Identifier;)Lorg/partiql/ast/builder/StatementDmlReplaceBuilder;
@@ -5843,14 +5887,14 @@ public final class org/partiql/ast/builder/StatementDmlUpdateBuilder {
 
 public final class org/partiql/ast/builder/StatementDmlUpsertBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Identifier$Symbol;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun asAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/StatementDmlUpsertBuilder;
+	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun asAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/StatementDmlUpsertBuilder;
 	public final fun build ()Lorg/partiql/ast/Statement$DML$Upsert;
-	public final fun getAsAlias ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getAsAlias ()Lorg/partiql/ast/Binder;
 	public final fun getTarget ()Lorg/partiql/ast/Identifier;
 	public final fun getValues ()Lorg/partiql/ast/Expr;
-	public final fun setAsAlias (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setAsAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setTarget (Lorg/partiql/ast/Identifier;)V
 	public final fun setValues (Lorg/partiql/ast/Expr;)V
 	public final fun target (Lorg/partiql/ast/Identifier;)Lorg/partiql/ast/builder/StatementDmlUpsertBuilder;
@@ -6177,21 +6221,21 @@ public final class org/partiql/ast/builder/TypeStructBuilder {
 
 public final class org/partiql/ast/builder/TypeStructFieldBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Type;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Identifier$Symbol;Lorg/partiql/ast/Type;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/partiql/ast/Binder;Lorg/partiql/ast/Type;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Binder;Lorg/partiql/ast/Type;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun build ()Lorg/partiql/ast/Type$Struct$Field;
 	public final fun comment (Ljava/lang/String;)Lorg/partiql/ast/builder/TypeStructFieldBuilder;
 	public final fun constraints (Ljava/util/List;)Lorg/partiql/ast/builder/TypeStructFieldBuilder;
 	public final fun getComment ()Ljava/lang/String;
 	public final fun getConstraints ()Ljava/util/List;
-	public final fun getName ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getName ()Lorg/partiql/ast/Binder;
 	public final fun getType ()Lorg/partiql/ast/Type;
 	public final fun isOptional ()Ljava/lang/Boolean;
 	public final fun isOptional (Ljava/lang/Boolean;)Lorg/partiql/ast/builder/TypeStructFieldBuilder;
-	public final fun name (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/TypeStructFieldBuilder;
+	public final fun name (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/TypeStructFieldBuilder;
 	public final fun setComment (Ljava/lang/String;)V
 	public final fun setConstraints (Ljava/util/List;)V
-	public final fun setName (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setName (Lorg/partiql/ast/Binder;)V
 	public final fun setOptional (Ljava/lang/Boolean;)V
 	public final fun setType (Lorg/partiql/ast/Type;)V
 	public final fun type (Lorg/partiql/ast/Type;)Lorg/partiql/ast/builder/TypeStructFieldBuilder;
@@ -6262,11 +6306,6 @@ public final class org/partiql/ast/builder/TypeVarcharBuilder {
 	public final fun setLength (Ljava/lang/Integer;)V
 }
 
-public final class org/partiql/ast/helpers/ToBinderKt {
-	public static final fun toBinder (Lorg/partiql/ast/Expr;I)Lorg/partiql/ast/Identifier$Symbol;
-	public static final fun toBinder (Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function0;)Lorg/partiql/ast/Identifier$Symbol;
-}
-
 public final class org/partiql/ast/helpers/ToLegacyAstKt {
 	public static final fun toLegacyAst (Lorg/partiql/ast/AstNode;Ljava/util/Map;)Lorg/partiql/lang/domains/PartiqlAst$PartiqlAstNode;
 	public static synthetic fun toLegacyAst$default (Lorg/partiql/ast/AstNode;Ljava/util/Map;ILjava/lang/Object;)Lorg/partiql/lang/domains/PartiqlAst$PartiqlAstNode;
@@ -6274,15 +6313,6 @@ public final class org/partiql/ast/helpers/ToLegacyAstKt {
 
 public abstract interface class org/partiql/ast/normalize/AstPass {
 	public abstract fun apply (Lorg/partiql/ast/Statement;)Lorg/partiql/ast/Statement;
-}
-
-public final class org/partiql/ast/normalize/NormalizeGroupBy : org/partiql/ast/normalize/AstPass {
-	public static final field INSTANCE Lorg/partiql/ast/normalize/NormalizeGroupBy;
-	public fun apply (Lorg/partiql/ast/Statement;)Lorg/partiql/ast/Statement;
-}
-
-public final class org/partiql/ast/normalize/NormalizeKt {
-	public static final fun normalize (Lorg/partiql/ast/Statement;)Lorg/partiql/ast/Statement;
 }
 
 public abstract class org/partiql/ast/sql/BlockBaseVisitor : org/partiql/ast/sql/BlockVisitor {
@@ -6612,6 +6642,8 @@ public abstract class org/partiql/ast/util/AstRewriter : org/partiql/ast/visitor
 	public fun <init> ()V
 	public synthetic fun defaultReturn (Lorg/partiql/ast/AstNode;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun defaultReturn (Lorg/partiql/ast/AstNode;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
+	public synthetic fun visitBinder (Lorg/partiql/ast/Binder;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitBinder (Lorg/partiql/ast/Binder;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitConstraint (Lorg/partiql/ast/Constraint;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitConstraint (Lorg/partiql/ast/Constraint;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitConstraintDefinitionCheck (Lorg/partiql/ast/Constraint$Definition$Check;Ljava/lang/Object;)Ljava/lang/Object;
@@ -6953,6 +6985,7 @@ public abstract class org/partiql/ast/visitor/AstBaseVisitor : org/partiql/ast/v
 	public abstract fun defaultReturn (Lorg/partiql/ast/AstNode;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun defaultVisit (Lorg/partiql/ast/AstNode;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visit (Lorg/partiql/ast/AstNode;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitBinder (Lorg/partiql/ast/Binder;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitConstraint (Lorg/partiql/ast/Constraint;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitConstraintDefinition (Lorg/partiql/ast/Constraint$Definition;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitConstraintDefinitionCheck (Lorg/partiql/ast/Constraint$Definition$Check;Ljava/lang/Object;)Ljava/lang/Object;
@@ -7146,6 +7179,7 @@ public abstract class org/partiql/ast/visitor/AstBaseVisitor : org/partiql/ast/v
 
 public abstract interface class org/partiql/ast/visitor/AstVisitor {
 	public abstract fun visit (Lorg/partiql/ast/AstNode;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitBinder (Lorg/partiql/ast/Binder;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitConstraint (Lorg/partiql/ast/Constraint;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitConstraintDefinition (Lorg/partiql/ast/Constraint$Definition;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitConstraintDefinitionCheck (Lorg/partiql/ast/Constraint$Definition$Check;Ljava/lang/Object;)Ljava/lang/Object;

--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -58,7 +58,7 @@ public final class org/partiql/ast/Ast {
 	public static final fun exprWindow (Lorg/partiql/ast/Expr$Window$Function;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr$Window$Over;)Lorg/partiql/ast/Expr$Window;
 	public static final fun exprWindowOver (Ljava/util/List;Ljava/util/List;)Lorg/partiql/ast/Expr$Window$Over;
 	public static final fun fromJoin (Lorg/partiql/ast/From;Lorg/partiql/ast/From;Lorg/partiql/ast/From$Join$Type;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/From$Join;
-	public static final fun fromValue (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/From$Value;
+	public static final fun fromValue (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/From$Value;
 	public static final fun graphMatch (Ljava/util/List;Lorg/partiql/ast/GraphMatch$Selector;)Lorg/partiql/ast/GraphMatch;
 	public static final fun graphMatchLabelConj (Lorg/partiql/ast/GraphMatch$Label;Lorg/partiql/ast/GraphMatch$Label;)Lorg/partiql/ast/GraphMatch$Label$Conj;
 	public static final fun graphMatchLabelDisj (Lorg/partiql/ast/GraphMatch$Label;Lorg/partiql/ast/GraphMatch$Label;)Lorg/partiql/ast/GraphMatch$Label$Disj;
@@ -113,7 +113,7 @@ public final class org/partiql/ast/Ast {
 	public static final fun statementDMLBatchLegacyOpRemove (Lorg/partiql/ast/Path;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Remove;
 	public static final fun statementDMLBatchLegacyOpSet (Ljava/util/List;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Set;
 	public static final fun statementDMLDelete (Lorg/partiql/ast/Statement$DML$Delete$Target;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Returning;)Lorg/partiql/ast/Statement$DML$Delete;
-	public static final fun statementDMLDeleteTarget (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Statement$DML$Delete$Target;
+	public static final fun statementDMLDeleteTarget (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/Statement$DML$Delete$Target;
 	public static final fun statementDMLInsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;)Lorg/partiql/ast/Statement$DML$Insert;
 	public static final fun statementDMLInsertLegacy (Lorg/partiql/ast/Path;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;)Lorg/partiql/ast/Statement$DML$InsertLegacy;
 	public static final fun statementDMLRemove (Lorg/partiql/ast/Path;)Lorg/partiql/ast/Statement$DML$Remove;
@@ -1582,19 +1582,19 @@ public final class org/partiql/ast/From$Value : org/partiql/ast/From {
 	public static final field Companion Lorg/partiql/ast/From$Value$Companion;
 	public final field asAlias Lorg/partiql/ast/Binder;
 	public final field atAlias Lorg/partiql/ast/Binder;
-	public final field byAlias Lorg/partiql/ast/Identifier$Symbol;
+	public final field byAlias Lorg/partiql/ast/Binder;
 	public final field expr Lorg/partiql/ast/Expr;
 	public final field type Lorg/partiql/ast/From$Value$Type;
-	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)V
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/FromValueBuilder;
 	public final fun component1 ()Lorg/partiql/ast/Expr;
 	public final fun component2 ()Lorg/partiql/ast/From$Value$Type;
 	public final fun component3 ()Lorg/partiql/ast/Binder;
 	public final fun component4 ()Lorg/partiql/ast/Binder;
-	public final fun component5 ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun copy (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/From$Value;
-	public static synthetic fun copy$default (Lorg/partiql/ast/From$Value;Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;ILjava/lang/Object;)Lorg/partiql/ast/From$Value;
+	public final fun component5 ()Lorg/partiql/ast/Binder;
+	public final fun copy (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/From$Value;
+	public static synthetic fun copy$default (Lorg/partiql/ast/From$Value;Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;ILjava/lang/Object;)Lorg/partiql/ast/From$Value;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -2873,17 +2873,17 @@ public final class org/partiql/ast/Statement$DML$Delete$Target : org/partiql/ast
 	public static final field Companion Lorg/partiql/ast/Statement$DML$Delete$Target$Companion;
 	public final field asAlias Lorg/partiql/ast/Binder;
 	public final field atAlias Lorg/partiql/ast/Binder;
-	public final field byAlias Lorg/partiql/ast/Identifier$Symbol;
+	public final field byAlias Lorg/partiql/ast/Binder;
 	public final field path Lorg/partiql/ast/Path;
-	public fun <init> (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)V
+	public fun <init> (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;)V
 	public fun accept (Lorg/partiql/ast/visitor/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun builder ()Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
 	public final fun component1 ()Lorg/partiql/ast/Path;
 	public final fun component2 ()Lorg/partiql/ast/Binder;
 	public final fun component3 ()Lorg/partiql/ast/Binder;
-	public final fun component4 ()Lorg/partiql/ast/Identifier$Symbol;
-	public final fun copy (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/Statement$DML$Delete$Target;
-	public static synthetic fun copy$default (Lorg/partiql/ast/Statement$DML$Delete$Target;Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Delete$Target;
+	public final fun component4 ()Lorg/partiql/ast/Binder;
+	public final fun copy (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;)Lorg/partiql/ast/Statement$DML$Delete$Target;
+	public static synthetic fun copy$default (Lorg/partiql/ast/Statement$DML$Delete$Target;Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Delete$Target;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -4123,8 +4123,8 @@ public final class org/partiql/ast/builder/AstBuilder {
 	public static synthetic fun exprWindowOver$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Expr$Window$Over;
 	public final fun fromJoin (Lorg/partiql/ast/From;Lorg/partiql/ast/From;Lorg/partiql/ast/From$Join$Type;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/From$Join;
 	public static synthetic fun fromJoin$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/From;Lorg/partiql/ast/From;Lorg/partiql/ast/From$Join$Type;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/From$Join;
-	public final fun fromValue (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/From$Value;
-	public static synthetic fun fromValue$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/From$Value;
+	public final fun fromValue (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/From$Value;
+	public static synthetic fun fromValue$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/From$Value;
 	public final fun graphMatch (Ljava/util/List;Lorg/partiql/ast/GraphMatch$Selector;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/GraphMatch;
 	public static synthetic fun graphMatch$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/util/List;Lorg/partiql/ast/GraphMatch$Selector;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/GraphMatch;
 	public final fun graphMatchLabelConj (Lorg/partiql/ast/GraphMatch$Label;Lorg/partiql/ast/GraphMatch$Label;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/GraphMatch$Label$Conj;
@@ -4233,8 +4233,8 @@ public final class org/partiql/ast/builder/AstBuilder {
 	public static synthetic fun statementDMLBatchLegacyOpSet$default (Lorg/partiql/ast/builder/AstBuilder;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$BatchLegacy$Op$Set;
 	public final fun statementDMLDelete (Lorg/partiql/ast/Statement$DML$Delete$Target;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Returning;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Delete;
 	public static synthetic fun statementDMLDelete$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Statement$DML$Delete$Target;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Returning;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Delete;
-	public final fun statementDMLDeleteTarget (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Delete$Target;
-	public static synthetic fun statementDMLDeleteTarget$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Delete$Target;
+	public final fun statementDMLDeleteTarget (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Delete$Target;
+	public static synthetic fun statementDMLDeleteTarget$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Delete$Target;
 	public final fun statementDMLInsert (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$Insert;
 	public static synthetic fun statementDMLInsert$default (Lorg/partiql/ast/builder/AstBuilder;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Binder;Lorg/partiql/ast/OnConflict;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/ast/Statement$DML$Insert;
 	public final fun statementDMLInsertLegacy (Lorg/partiql/ast/Path;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function1;)Lorg/partiql/ast/Statement$DML$InsertLegacy;
@@ -5125,21 +5125,21 @@ public final class org/partiql/ast/builder/FromJoinBuilder {
 
 public final class org/partiql/ast/builder/FromValueBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Expr;Lorg/partiql/ast/From$Value$Type;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun asAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/FromValueBuilder;
 	public final fun atAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/FromValueBuilder;
 	public final fun build ()Lorg/partiql/ast/From$Value;
-	public final fun byAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/FromValueBuilder;
+	public final fun byAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/FromValueBuilder;
 	public final fun expr (Lorg/partiql/ast/Expr;)Lorg/partiql/ast/builder/FromValueBuilder;
 	public final fun getAsAlias ()Lorg/partiql/ast/Binder;
 	public final fun getAtAlias ()Lorg/partiql/ast/Binder;
-	public final fun getByAlias ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getByAlias ()Lorg/partiql/ast/Binder;
 	public final fun getExpr ()Lorg/partiql/ast/Expr;
 	public final fun getType ()Lorg/partiql/ast/From$Value$Type;
 	public final fun setAsAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setAtAlias (Lorg/partiql/ast/Binder;)V
-	public final fun setByAlias (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setByAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setExpr (Lorg/partiql/ast/Expr;)V
 	public final fun setType (Lorg/partiql/ast/From$Value$Type;)V
 	public final fun type (Lorg/partiql/ast/From$Value$Type;)Lorg/partiql/ast/builder/FromValueBuilder;
@@ -5778,20 +5778,20 @@ public final class org/partiql/ast/builder/StatementDmlDeleteBuilder {
 
 public final class org/partiql/ast/builder/StatementDmlDeleteTargetBuilder {
 	public fun <init> ()V
-	public fun <init> (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;)V
-	public synthetic fun <init> (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Identifier$Symbol;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;)V
+	public synthetic fun <init> (Lorg/partiql/ast/Path;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;Lorg/partiql/ast/Binder;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun asAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
 	public final fun atAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
 	public final fun build ()Lorg/partiql/ast/Statement$DML$Delete$Target;
-	public final fun byAlias (Lorg/partiql/ast/Identifier$Symbol;)Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
+	public final fun byAlias (Lorg/partiql/ast/Binder;)Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
 	public final fun getAsAlias ()Lorg/partiql/ast/Binder;
 	public final fun getAtAlias ()Lorg/partiql/ast/Binder;
-	public final fun getByAlias ()Lorg/partiql/ast/Identifier$Symbol;
+	public final fun getByAlias ()Lorg/partiql/ast/Binder;
 	public final fun getPath ()Lorg/partiql/ast/Path;
 	public final fun path (Lorg/partiql/ast/Path;)Lorg/partiql/ast/builder/StatementDmlDeleteTargetBuilder;
 	public final fun setAsAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setAtAlias (Lorg/partiql/ast/Binder;)V
-	public final fun setByAlias (Lorg/partiql/ast/Identifier$Symbol;)V
+	public final fun setByAlias (Lorg/partiql/ast/Binder;)V
 	public final fun setPath (Lorg/partiql/ast/Path;)V
 }
 

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/sql/internal/InternalSqlDialect.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/sql/internal/InternalSqlDialect.kt
@@ -15,6 +15,7 @@
 package org.partiql.ast.sql.internal
 
 import org.partiql.ast.AstNode
+import org.partiql.ast.Binder
 import org.partiql.ast.Exclude
 import org.partiql.ast.Expr
 import org.partiql.ast.From
@@ -29,6 +30,7 @@ import org.partiql.ast.SetQuantifier
 import org.partiql.ast.Sort
 import org.partiql.ast.Statement
 import org.partiql.ast.Type
+import org.partiql.ast.sql.sql
 import org.partiql.ast.visitor.AstBaseVisitor
 import org.partiql.value.MissingValue
 import org.partiql.value.NullValue
@@ -91,6 +93,8 @@ internal abstract class InternalSqlDialect : AstBaseVisitor<InternalSqlBlock, In
         val path = node.steps.fold(node.root.sql()) { p, step -> p + "." + step.sql() }
         return tail concat path
     }
+
+    override fun visitBinder(node: Binder, tail: InternalSqlBlock): InternalSqlBlock = tail concat node.sql()
 
     override fun visitPath(node: Path, tail: InternalSqlBlock): InternalSqlBlock {
         val path = node.steps.fold(node.root.sql()) { p, step ->
@@ -844,5 +848,10 @@ internal abstract class InternalSqlDialect : AstBaseVisitor<InternalSqlBlock, In
     private fun Identifier.Symbol.sql() = when (caseSensitivity) {
         Identifier.CaseSensitivity.SENSITIVE -> "\"$symbol\""
         Identifier.CaseSensitivity.INSENSITIVE -> symbol // verbatim ..
+    }
+
+    private fun Binder.sql() = when (caseSensitivity) {
+        Binder.CaseSensitivity.SENSITIVE -> "\"$symbol\""
+        Binder.CaseSensitivity.INSENSITIVE -> symbol
     }
 }

--- a/partiql-ast/src/main/resources/partiql_ast.ion
+++ b/partiql-ast/src/main/resources/partiql_ast.ion
@@ -18,7 +18,7 @@ statement::[
     insert::{
       target:       identifier,
       values:       expr,
-      as_alias:     optional::'.identifier.symbol',
+      as_alias:     optional::binder,
       on_conflict:  optional::on_conflict,
     },
 
@@ -34,14 +34,14 @@ statement::[
     upsert::{
       target:   identifier,
       values:   expr,
-      as_alias: optional::'.identifier.symbol',
+      as_alias: optional::binder,
     },
 
     // REPLACE INTO <target> [AS <alias>] <values>
     replace::{
       target:   identifier,
       values:   expr,
-      as_alias: optional::'.identifier.symbol',
+      as_alias: optional::binder,
     },
 
     // UPDATE <target> SET <set clause list> WHERE <expr>
@@ -65,8 +65,8 @@ statement::[
     delete::{
       target: {
         path:     path,
-        as_alias: optional::'.identifier.symbol',
-        at_alias: optional::'.identifier.symbol',
+        as_alias: optional::binder,
+        at_alias: optional::binder,
         by_alias: optional::'.identifier.symbol',
       },
       where:      optional::expr,
@@ -84,7 +84,7 @@ statement::[
           insert::{
             target:       identifier,
             values:       expr,
-            as_alias:     optional::'.identifier.symbol',
+            as_alias:     optional::binder,
             on_conflict:  optional::on_conflict,
           },
           insert_legacy::{
@@ -233,7 +233,7 @@ type::[
     fields: list::[field],
     _ : [
       field :: {
-        name: '.identifier.symbol',
+        name: binder,
         type: '.type',
         // This could be a boolean flag since we only support NOT NULL constraint
         // for struct subfield. But modeling this to be a list of constraints
@@ -273,6 +273,17 @@ identifier::[
     ],
   ],
 ]
+
+// identifier for lvalue
+// binder can not be qualified.
+// it exists for eaiser visitor implementation and maintainence
+binder::{
+  symbol: string,
+  case_sensitivity: [
+    SENSITIVE,
+    INSENSITIVE,
+  ],
+}
 
 // Path Literals
 //  - Much like qualified identifier but allowing bracket notation '[' <int> | <string> ']'
@@ -585,7 +596,7 @@ select::[
     _: [
       item::[
         all::{ expr: expr },                                                  // <expr>.*
-        expression::{ expr: expr, as_alias: optional::'.identifier.symbol' }  // <expr> [as <identifier>]
+        expression::{ expr: expr, as_alias: optional::binder }  // <expr> [as <identifier>]
       ],
     ],
   },
@@ -626,8 +637,8 @@ from::[
   value::{
     expr:     expr,
     type:     [ SCAN, UNPIVOT ],
-    as_alias: optional::'.identifier.symbol',
-    at_alias: optional::'.identifier.symbol',
+    as_alias: optional::binder,
+    at_alias: optional::binder,
     by_alias: optional::'.identifier.symbol',
   },
 
@@ -656,7 +667,7 @@ let::{
   _: [
     binding::{
       expr:     expr,
-      as_alias: '.identifier.symbol',
+      as_alias: binder,
     },
   ],
 }
@@ -665,11 +676,11 @@ let::{
 group_by::{
   strategy: [ FULL, PARTIAL ],
   keys:     list::[key],
-  as_alias: optional::'.identifier.symbol',
+  as_alias: optional::binder,
   _: [
     key::{
       expr:     expr,
-      as_alias: optional::'.identifier.symbol',
+      as_alias: optional::binder,
     },
   ],
 }

--- a/partiql-ast/src/main/resources/partiql_ast.ion
+++ b/partiql-ast/src/main/resources/partiql_ast.ion
@@ -67,7 +67,7 @@ statement::[
         path:     path,
         as_alias: optional::binder,
         at_alias: optional::binder,
-        by_alias: optional::'.identifier.symbol',
+        by_alias: optional::binder,
       },
       where:      optional::expr,
       returning:  optional::returning,
@@ -639,7 +639,7 @@ from::[
     type:     [ SCAN, UNPIVOT ],
     as_alias: optional::binder,
     at_alias: optional::binder,
-    by_alias: optional::'.identifier.symbol',
+    by_alias: optional::binder,
   },
 
   // TODO https://github.com/partiql/partiql-spec/issues/41

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
@@ -585,7 +585,7 @@ class ToLegacyAstTest {
                     type = From.Value.Type.SCAN
                     asAlias = bindName("a")
                     atAlias = bindName("b")
-                    byAlias = id("c")
+                    byAlias = bindName("c")
                 }
             },
             expect("(unpivot (lit null) null null null)") {
@@ -600,7 +600,7 @@ class ToLegacyAstTest {
                     type = From.Value.Type.UNPIVOT
                     asAlias = bindName("a")
                     atAlias = bindName("b")
-                    byAlias = id("c")
+                    byAlias = bindName("c")
                 }
             },
             expect(

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/helpers/ToLegacyAstTest.kt
@@ -18,12 +18,14 @@ import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.partiql.ast.AstNode
+import org.partiql.ast.Binder
 import org.partiql.ast.Expr
 import org.partiql.ast.From
 import org.partiql.ast.GroupBy
 import org.partiql.ast.Identifier
 import org.partiql.ast.SetQuantifier
 import org.partiql.ast.Sort
+import org.partiql.ast.binder
 import org.partiql.ast.builder.AstBuilder
 import org.partiql.ast.builder.ast
 import org.partiql.ast.exprLit
@@ -127,6 +129,8 @@ class ToLegacyAstTest {
 
         // Shortcut to construct a "legacy-compatible" simple identifier
         private fun id(name: String) = identifierSymbol(name, Identifier.CaseSensitivity.INSENSITIVE)
+
+        private fun bindName(name: String) = binder(name, org.partiql.ast.Binder.CaseSensitivity.INSENSITIVE)
 
         @JvmStatic
         fun literals() = listOf(
@@ -422,7 +426,7 @@ class ToLegacyAstTest {
             fail("The legacy AST does not support field declaration in struct type") {
                 typeStruct {
                     fields += org.partiql.ast.typeStructField(
-                        org.partiql.ast.identifierSymbol("a", Identifier.CaseSensitivity.INSENSITIVE),
+                        org.partiql.ast.binder("a", Binder.CaseSensitivity.INSENSITIVE),
                         typeInt2(),
                         emptyList(),
                         false,
@@ -549,7 +553,7 @@ class ToLegacyAstTest {
                     }
                     items += selectProjectItemExpression {
                         expr = exprLit(int32Value(1))
-                        asAlias = id("x")
+                        asAlias = bindName("x")
                     }
                 }
             },
@@ -579,8 +583,8 @@ class ToLegacyAstTest {
                 fromValue {
                     expr = NULL
                     type = From.Value.Type.SCAN
-                    asAlias = id("a")
-                    atAlias = id("b")
+                    asAlias = bindName("a")
+                    atAlias = bindName("b")
                     byAlias = id("c")
                 }
             },
@@ -594,8 +598,8 @@ class ToLegacyAstTest {
                 fromValue {
                     expr = NULL
                     type = From.Value.Type.UNPIVOT
-                    asAlias = id("a")
-                    atAlias = id("b")
+                    asAlias = bindName("a")
+                    atAlias = bindName("b")
                     byAlias = id("c")
                 }
             },
@@ -647,7 +651,7 @@ class ToLegacyAstTest {
                 let {
                     bindings += letBinding {
                         expr = NULL
-                        asAlias = id("x")
+                        asAlias = bindName("x")
                     }
                 }
             },
@@ -665,7 +669,7 @@ class ToLegacyAstTest {
                 groupBy {
                     strategy = GroupBy.Strategy.FULL
                     keys += groupByKey(exprLit(stringValue("a")), null)
-                    keys += groupByKey(exprLit(stringValue("b")), id("x"))
+                    keys += groupByKey(exprLit(stringValue("b")), bindName("x"))
                 }
             },
             expect(
@@ -682,8 +686,8 @@ class ToLegacyAstTest {
                 groupBy {
                     strategy = GroupBy.Strategy.PARTIAL
                     keys += groupByKey(exprLit(stringValue("a")), null)
-                    keys += groupByKey(exprLit(stringValue("b")), id("x"))
-                    asAlias = id("as")
+                    keys += groupByKey(exprLit(stringValue("b")), bindName("x"))
+                    asAlias = bindName("as")
                 }
             },
             expect(

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
@@ -1229,7 +1229,7 @@ class SqlDialectTest {
                         type = From.Value.Type.SCAN
                         asAlias = bindName("x")
                         atAlias = bindName("y")
-                        byAlias = id("z")
+                        byAlias = bindName("z")
                     }
                 }
             },
@@ -1271,7 +1271,7 @@ class SqlDialectTest {
                         type = From.Value.Type.UNPIVOT
                         asAlias = bindName("x")
                         atAlias = bindName("y")
-                        byAlias = id("z")
+                        byAlias = bindName("z")
                     }
                 }
             },

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.partiql.ast.AstNode
+import org.partiql.ast.Binder
 import org.partiql.ast.DatetimeField
 import org.partiql.ast.Expr
 import org.partiql.ast.From
@@ -1010,7 +1011,7 @@ class SqlDialectTest {
             expect("SELECT a AS x FROM T") {
                 exprSFW {
                     select = selectProject {
-                        items += selectProjectItemExpression(v("a"), id("x"))
+                        items += selectProjectItemExpression(v("a"), bindName("x"))
                     }
                     from = table("T")
                 }
@@ -1018,8 +1019,8 @@ class SqlDialectTest {
             expect("SELECT a AS x, b AS y FROM T") {
                 exprSFW {
                     select = selectProject {
-                        items += selectProjectItemExpression(v("a"), id("x"))
-                        items += selectProjectItemExpression(v("b"), id("y"))
+                        items += selectProjectItemExpression(v("a"), bindName("x"))
+                        items += selectProjectItemExpression(v("b"), bindName("y"))
                     }
                     from = table("T")
                 }
@@ -1205,7 +1206,7 @@ class SqlDialectTest {
                     from = fromValue {
                         expr = v("T")
                         type = From.Value.Type.SCAN
-                        asAlias = id("x")
+                        asAlias = bindName("x")
                     }
                 }
             },
@@ -1215,8 +1216,8 @@ class SqlDialectTest {
                     from = fromValue {
                         expr = v("T")
                         type = From.Value.Type.SCAN
-                        asAlias = id("x")
-                        atAlias = id("y")
+                        asAlias = bindName("x")
+                        atAlias = bindName("y")
                     }
                 }
             },
@@ -1226,8 +1227,8 @@ class SqlDialectTest {
                     from = fromValue {
                         expr = v("T")
                         type = From.Value.Type.SCAN
-                        asAlias = id("x")
-                        atAlias = id("y")
+                        asAlias = bindName("x")
+                        atAlias = bindName("y")
                         byAlias = id("z")
                     }
                 }
@@ -1247,7 +1248,7 @@ class SqlDialectTest {
                     from = fromValue {
                         expr = v("T")
                         type = From.Value.Type.UNPIVOT
-                        asAlias = id("x")
+                        asAlias = bindName("x")
                     }
                 }
             },
@@ -1257,8 +1258,8 @@ class SqlDialectTest {
                     from = fromValue {
                         expr = v("T")
                         type = From.Value.Type.UNPIVOT
-                        asAlias = id("x")
-                        atAlias = id("y")
+                        asAlias = bindName("x")
+                        atAlias = bindName("y")
                     }
                 }
             },
@@ -1268,8 +1269,8 @@ class SqlDialectTest {
                     from = fromValue {
                         expr = v("T")
                         type = From.Value.Type.UNPIVOT
-                        asAlias = id("x")
-                        atAlias = id("y")
+                        asAlias = bindName("x")
+                        atAlias = bindName("y")
                         byAlias = id("z")
                     }
                 }
@@ -1348,7 +1349,7 @@ class SqlDialectTest {
                     select = select("a")
                     from = table("T")
                     let = let(mutableListOf()) {
-                        bindings += letBinding(v("x"), id("i"))
+                        bindings += letBinding(v("x"), bindName("i"))
                     }
                 }
             },
@@ -1357,8 +1358,8 @@ class SqlDialectTest {
                     select = select("a")
                     from = table("T")
                     let = let(mutableListOf()) {
-                        bindings += letBinding(v("x"), id("i"))
-                        bindings += letBinding(v("y"), id("j"))
+                        bindings += letBinding(v("x"), bindName("i"))
+                        bindings += letBinding(v("y"), bindName("j"))
                     }
                 }
             },
@@ -1422,7 +1423,7 @@ class SqlDialectTest {
                     from = table("T")
                     groupBy = groupBy {
                         strategy = GroupBy.Strategy.FULL
-                        keys += groupByKey(v("x"), id("i"))
+                        keys += groupByKey(v("x"), bindName("i"))
                     }
                 }
             },
@@ -1443,8 +1444,8 @@ class SqlDialectTest {
                     from = table("T")
                     groupBy = groupBy {
                         strategy = GroupBy.Strategy.FULL
-                        keys += groupByKey(v("x"), id("i"))
-                        keys += groupByKey(v("y"), id("j"))
+                        keys += groupByKey(v("x"), bindName("i"))
+                        keys += groupByKey(v("y"), bindName("j"))
                     }
                 }
             },
@@ -1455,7 +1456,7 @@ class SqlDialectTest {
                     groupBy = groupBy {
                         strategy = GroupBy.Strategy.FULL
                         keys += groupByKey(v("x"))
-                        asAlias = id("g")
+                        asAlias = bindName("g")
                     }
                 }
             },
@@ -1465,8 +1466,8 @@ class SqlDialectTest {
                     from = table("T")
                     groupBy = groupBy {
                         strategy = GroupBy.Strategy.FULL
-                        keys += groupByKey(v("x"), id("i"))
-                        asAlias = id("g")
+                        keys += groupByKey(v("x"), bindName("i"))
+                        asAlias = bindName("g")
                     }
                 }
             },
@@ -1478,7 +1479,7 @@ class SqlDialectTest {
                         strategy = GroupBy.Strategy.FULL
                         keys += groupByKey(v("x"))
                         keys += groupByKey(v("y"))
-                        asAlias = id("g")
+                        asAlias = bindName("g")
                     }
                 }
             },
@@ -1488,9 +1489,9 @@ class SqlDialectTest {
                     from = table("T")
                     groupBy = groupBy {
                         strategy = GroupBy.Strategy.FULL
-                        keys += groupByKey(v("x"), id("i"))
-                        keys += groupByKey(v("y"), id("j"))
-                        asAlias = id("g")
+                        keys += groupByKey(v("x"), bindName("i"))
+                        keys += groupByKey(v("y"), bindName("j"))
+                        asAlias = bindName("g")
                     }
                 }
             },
@@ -1784,6 +1785,11 @@ class SqlDialectTest {
             symbol: String,
             case: Identifier.CaseSensitivity = Identifier.CaseSensitivity.INSENSITIVE,
         ) = this.identifierSymbol(symbol, case)
+
+        private fun AstBuilder.bindName(
+            symbol: String,
+            case: Binder.CaseSensitivity = Binder.CaseSensitivity.INSENSITIVE
+        ) = this.binder(symbol, case)
 
         private fun AstBuilder.select(vararg s: String) = selectProject {
             s.forEach {

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -1084,7 +1084,7 @@ class PartiQLEngineDefaultTest {
     ) {
 
         private val engine = PartiQLEngine.builder().build()
-        private val planner = PartiQLPlannerBuilder().build()
+        private val planner = PartiQLPlannerBuilder().casePreserve().lookUpBehavior("INSENSITIVE").build()
         private val parser = PartiQLParser.default()
         private val loader = createIonElementLoader()
 
@@ -1156,7 +1156,7 @@ class PartiQLEngineDefaultTest {
     ) {
 
         private val engine = PartiQLEngine.builder().build()
-        private val planner = PartiQLPlannerBuilder().build()
+        private val planner = PartiQLPlannerBuilder().casePreserve().lookUpBehavior("INSENSITIVE").build()
         private val parser = PartiQLParser.default()
 
         internal fun assert() {

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -1472,7 +1472,7 @@ internal class PartiQLParserDefault : PartiQLParser {
             val expr = visitAs<Expr>(ctx.source)
             val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
             val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
-            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
             fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
 
@@ -1480,7 +1480,7 @@ internal class PartiQLParserDefault : PartiQLParser {
             val expr = visitAs<Expr>(ctx.source)
             val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
             val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
-            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
             fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
 
@@ -1492,7 +1492,7 @@ internal class PartiQLParserDefault : PartiQLParser {
                 val path = visitPathSimple(ctx.pathSimple())
                 val asAlias = ctx.asIdent()?.let { visitAsIdent(it).asBinder() }
                 val atAlias = ctx.atIdent()?.let { visitAtIdent(it).asBinder() }
-                val byAlias = ctx.byIdent()?.let { visitByIdent(it) }
+                val byAlias = ctx.byIdent()?.let { visitByIdent(it).asBinder() }
                 statementDMLDeleteTarget(path, asAlias, atAlias, byAlias)
             }
 
@@ -1510,7 +1510,7 @@ internal class PartiQLParserDefault : PartiQLParser {
             val expr = visitAs<Expr>(ctx.expr())
             val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
             val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
-            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
             fromValue(expr, From.Value.Type.UNPIVOT, asAlias, atAlias, byAlias)
         }
 

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -33,6 +33,7 @@ import org.antlr.v4.runtime.atn.PredictionMode
 import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.antlr.v4.runtime.tree.TerminalNode
 import org.partiql.ast.AstNode
+import org.partiql.ast.Binder
 import org.partiql.ast.Constraint
 import org.partiql.ast.DatetimeField
 import org.partiql.ast.DdlOp
@@ -53,6 +54,7 @@ import org.partiql.ast.SetQuantifier
 import org.partiql.ast.Sort
 import org.partiql.ast.Statement
 import org.partiql.ast.Type
+import org.partiql.ast.binder
 import org.partiql.ast.constraint
 import org.partiql.ast.constraintDefinitionCheck
 import org.partiql.ast.constraintDefinitionNotNull
@@ -569,6 +571,11 @@ internal class PartiQLParserDefault : PartiQLParser {
                 else -> throw error(ctx, "Invalid symbol reference.")
             }
 
+        private fun Identifier.Symbol.asBinder() = when (this.caseSensitivity) {
+            Identifier.CaseSensitivity.SENSITIVE -> binder(this.symbol, Binder.CaseSensitivity.SENSITIVE)
+            Identifier.CaseSensitivity.INSENSITIVE -> binder(this.symbol, Binder.CaseSensitivity.INSENSITIVE)
+        }
+
         override fun visitIdentifierQuoted(ctx: GeneratedParser.IdentifierQuotedContext): Identifier.Symbol = translate(ctx) {
             identifierSymbol(
                 ctx.IDENTIFIER_QUOTED().getStringValue(),
@@ -875,7 +882,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitInsertStatement(ctx: GeneratedParser.InsertStatementContext) = translate(ctx) {
             val target = visitSymbolPrimitive(ctx.symbolPrimitive())
             val values = visitExpr(ctx.value)
-            val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
+            val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())?.asBinder()
             val onConflict = ctx.onConflict()?.let { visitOnConflictClause(it) }
             statementDMLInsert(target, values, asAlias, onConflict)
         }
@@ -883,14 +890,14 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitReplaceCommand(ctx: GeneratedParser.ReplaceCommandContext) = translate(ctx) {
             val target = visitSymbolPrimitive(ctx.symbolPrimitive())
             val values = visitExpr(ctx.value)
-            val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
+            val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())?.asBinder()
             statementDMLReplace(target, values, asAlias)
         }
 
         override fun visitUpsertCommand(ctx: GeneratedParser.UpsertCommandContext) = translate(ctx) {
             val target = visitSymbolPrimitive(ctx.symbolPrimitive())
             val values = visitExpr(ctx.value)
-            val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())
+            val asAlias = visitOrNull<Identifier.Symbol>(ctx.asIdent())?.asBinder()
             statementDMLUpsert(target, values, asAlias)
         }
 
@@ -1069,7 +1076,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitProjectionItem(ctx: GeneratedParser.ProjectionItemContext) = translate(ctx) {
             val expr = visitExpr(ctx.expr())
-            val alias = ctx.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
+            val alias = ctx.symbolPrimitive()?.let { visitSymbolPrimitive(it).asBinder() }
             if (expr is Expr.Path) {
                 convertPathToProjectionItem(ctx, expr, alias)
             } else {
@@ -1113,7 +1120,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitLetBinding(ctx: GeneratedParser.LetBindingContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.expr())
-            val alias = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val alias = visitSymbolPrimitive(ctx.symbolPrimitive()).asBinder()
             letBinding(expr, alias)
         }
 
@@ -1154,13 +1161,13 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitGroupClause(ctx: GeneratedParser.GroupClauseContext) = translate(ctx) {
             val strategy = if (ctx.PARTIAL() != null) GroupBy.Strategy.PARTIAL else GroupBy.Strategy.FULL
             val keys = visitOrEmpty<GroupBy.Key>(ctx.groupKey())
-            val alias = ctx.groupAlias()?.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
+            val alias = ctx.groupAlias()?.symbolPrimitive()?.let { visitSymbolPrimitive(it).asBinder() }
             groupBy(strategy, keys, alias)
         }
 
         override fun visitGroupKey(ctx: GeneratedParser.GroupKeyContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.key)
-            val alias = ctx.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
+            val alias = ctx.symbolPrimitive()?.let { visitSymbolPrimitive(it).asBinder() }
             groupByKey(expr, alias)
         }
 
@@ -1463,16 +1470,16 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitTableBaseRefClauses(ctx: GeneratedParser.TableBaseRefClausesContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
+            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
             val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
             fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
 
         override fun visitTableBaseRefMatch(ctx: GeneratedParser.TableBaseRefMatchContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
+            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
             val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
             fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
@@ -1483,8 +1490,8 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitFromClauseSimpleExplicit(ctx: GeneratedParser.FromClauseSimpleExplicitContext) =
             translate(ctx) {
                 val path = visitPathSimple(ctx.pathSimple())
-                val asAlias = ctx.asIdent()?.let { visitAsIdent(it) }
-                val atAlias = ctx.atIdent()?.let { visitAtIdent(it) }
+                val asAlias = ctx.asIdent()?.let { visitAsIdent(it).asBinder() }
+                val atAlias = ctx.atIdent()?.let { visitAtIdent(it).asBinder() }
                 val byAlias = ctx.byIdent()?.let { visitByIdent(it) }
                 statementDMLDeleteTarget(path, asAlias, atAlias, byAlias)
             }
@@ -1495,14 +1502,14 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitFromClauseSimpleImplicit(ctx: GeneratedParser.FromClauseSimpleImplicitContext) =
             translate(ctx) {
                 val path = visitPathSimple(ctx.pathSimple())
-                val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive())
+                val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive()).asBinder()
                 statementDMLDeleteTarget(path, asAlias, null, null)
             }
 
         override fun visitTableUnpivot(ctx: GeneratedParser.TableUnpivotContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.expr())
-            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
+            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()).asBinder() }
             val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
             fromValue(expr, From.Value.Type.UNPIVOT, asAlias, atAlias, byAlias)
         }
@@ -1549,7 +1556,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitTableBaseRefSymbol(ctx: GeneratedParser.TableBaseRefSymbolContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.source)
-            val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive())
+            val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive()).asBinder()
             fromValue(expr, From.Value.Type.SCAN, asAlias, null, null)
         }
 
@@ -2258,7 +2265,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitTypeStruct(ctx: GeneratedParser.TypeStructContext) = translate(ctx) {
             val fields = ctx.structField().map { structFieldCtx ->
-                val name = visitSymbolPrimitive(structFieldCtx.columnName().symbolPrimitive())
+                val name = visitSymbolPrimitive(structFieldCtx.columnName().symbolPrimitive()).asBinder()
                 val type = visitAs<Type>(structFieldCtx.type())
                     .also { isValidTypeDeclarationOrThrow(it, structFieldCtx.type()) }
 
@@ -2367,7 +2374,7 @@ internal class PartiQLParserDefault : PartiQLParser {
          *      SELECT foo.*.bar FROM foo
          * ```
          */
-        protected fun convertPathToProjectionItem(ctx: ParserRuleContext, path: Expr.Path, alias: Identifier.Symbol?) =
+        protected fun convertPathToProjectionItem(ctx: ParserRuleContext, path: Expr.Path, alias: Binder?) =
             translate(ctx) {
                 val steps = mutableListOf<Expr.Path.Step>()
                 var containsIndex = false

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserDDLTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserDDLTests.kt
@@ -6,12 +6,14 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
+import org.partiql.ast.Binder
 import org.partiql.ast.Constraint
 import org.partiql.ast.DdlOp
 import org.partiql.ast.Expr
 import org.partiql.ast.Identifier
 import org.partiql.ast.PartitionBy
 import org.partiql.ast.Type
+import org.partiql.ast.binder
 import org.partiql.ast.constraint
 import org.partiql.ast.constraintDefinitionCheck
 import org.partiql.ast.constraintDefinitionNotNull
@@ -370,14 +372,14 @@ class PartiQLParserDDLTests {
                                 Type.Struct(
                                     listOf(
                                         Type.Struct.Field(
-                                            identifierSymbol("b", Identifier.CaseSensitivity.INSENSITIVE),
+                                            binder("b", Binder.CaseSensitivity.INSENSITIVE),
                                             Type.Int2(),
                                             emptyList(),
                                             false,
                                             null
                                         ),
                                         Type.Struct.Field(
-                                            identifierSymbol("c", Identifier.CaseSensitivity.INSENSITIVE),
+                                            binder("c", Binder.CaseSensitivity.INSENSITIVE),
                                             Type.Int2(),
                                             listOf(Constraint(null, Constraint.Definition.NotNull())),
                                             false,
@@ -416,11 +418,11 @@ class PartiQLParserDDLTests {
                                 Type.Struct(
                                     listOf(
                                         Type.Struct.Field(
-                                            identifierSymbol("b", Identifier.CaseSensitivity.INSENSITIVE),
+                                            binder("b", Binder.CaseSensitivity.INSENSITIVE),
                                             Type.Struct(
                                                 listOf(
                                                     Type.Struct.Field(
-                                                        identifierSymbol("c", Identifier.CaseSensitivity.INSENSITIVE),
+                                                        binder("c", Binder.CaseSensitivity.INSENSITIVE),
                                                         Type.Int2(),
                                                         emptyList(),
                                                         false,
@@ -433,7 +435,7 @@ class PartiQLParserDDLTests {
                                             null
                                         ),
                                         Type.Struct.Field(
-                                            identifierSymbol("d", Identifier.CaseSensitivity.INSENSITIVE),
+                                            binder("d", Binder.CaseSensitivity.INSENSITIVE),
                                             Type.Array(Type.Int2()),
                                             emptyList(),
                                             false,
@@ -523,7 +525,7 @@ class PartiQLParserDDLTests {
                                     Type.Struct(
                                         listOf(
                                             Type.Struct.Field(
-                                                identifierSymbol("b", Identifier.CaseSensitivity.INSENSITIVE),
+                                                binder("b", Binder.CaseSensitivity.INSENSITIVE),
                                                 Type.Int2(),
                                                 emptyList(),
                                                 false,
@@ -560,7 +562,7 @@ class PartiQLParserDDLTests {
                                     Type.Struct(
                                         listOf(
                                             Type.Struct.Field(
-                                                identifierSymbol("b", Identifier.CaseSensitivity.INSENSITIVE),
+                                                binder("b", Binder.CaseSensitivity.INSENSITIVE),
                                                 Type.Int2(),
                                                 emptyList(),
                                                 false,
@@ -652,7 +654,7 @@ class PartiQLParserDDLTests {
                                 Type.Struct(
                                     listOf(
                                         Type.Struct.Field(
-                                            identifierSymbol("b", Identifier.CaseSensitivity.INSENSITIVE),
+                                            binder("b", Binder.CaseSensitivity.INSENSITIVE),
                                             Type.Int2(),
                                             emptyList(),
                                             true,
@@ -688,7 +690,7 @@ class PartiQLParserDDLTests {
                                 Type.Struct(
                                     listOf(
                                         Type.Struct.Field(
-                                            identifierSymbol("b", Identifier.CaseSensitivity.INSENSITIVE),
+                                            binder("b", Binder.CaseSensitivity.INSENSITIVE),
                                             Type.Int2(),
                                             emptyList(),
                                             true,
@@ -751,7 +753,7 @@ class PartiQLParserDDLTests {
                                 Type.Struct(
                                     listOf(
                                         Type.Struct.Field(
-                                            identifierSymbol("b", Identifier.CaseSensitivity.INSENSITIVE),
+                                            binder("b", Binder.CaseSensitivity.INSENSITIVE),
                                             Type.Int2(),
                                             emptyList(),
                                             false,
@@ -787,7 +789,7 @@ class PartiQLParserDDLTests {
                                 Type.Struct(
                                     listOf(
                                         Type.Struct.Field(
-                                            identifierSymbol("b", Identifier.CaseSensitivity.INSENSITIVE),
+                                            binder("b", Binder.CaseSensitivity.INSENSITIVE),
                                             Type.Int2(),
                                             emptyList(),
                                             false,

--- a/partiql-planner/api/partiql-planner.api
+++ b/partiql-planner/api/partiql-planner.api
@@ -46,3 +46,7 @@ public abstract interface class org/partiql/planner/PartiQLPlannerPass {
 	public abstract fun apply (Lorg/partiql/plan/PartiQLPlan;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/PartiQLPlan;
 }
 
+public final class org/partiql/planner/internal/utils/ToBinderKt {
+	public static final fun toBinder (Lorg/partiql/ast/Expr;Lkotlin/jvm/functions/Function0;)Lorg/partiql/ast/Binder;
+}
+

--- a/partiql-planner/api/partiql-planner.api
+++ b/partiql-planner/api/partiql-planner.api
@@ -37,7 +37,9 @@ public final class org/partiql/planner/PartiQLPlannerBuilder {
 	public final fun addPass (Lorg/partiql/planner/PartiQLPlannerPass;)Lorg/partiql/planner/PartiQLPlannerBuilder;
 	public final fun addPasses ([Lorg/partiql/planner/PartiQLPlannerPass;)Lorg/partiql/planner/PartiQLPlannerBuilder;
 	public final fun build ()Lorg/partiql/planner/PartiQLPlanner;
+	public final fun casePreserve ()Lorg/partiql/planner/PartiQLPlannerBuilder;
 	public final fun catalogs ([Lkotlin/Pair;)Lorg/partiql/planner/PartiQLPlannerBuilder;
+	public final fun lookUpBehavior (Ljava/lang/String;)Lorg/partiql/planner/PartiQLPlannerBuilder;
 	public final fun passes (Ljava/util/List;)Lorg/partiql/planner/PartiQLPlannerBuilder;
 	public final fun signalMode ()Lorg/partiql/planner/PartiQLPlannerBuilder;
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlanner.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlanner.kt
@@ -56,6 +56,10 @@ public interface PartiQLPlanner {
         public fun builder(): PartiQLPlannerBuilder = PartiQLPlannerBuilder()
 
         @JvmStatic
-        public fun default(): PartiQLPlanner = PartiQLPlannerBuilder().build()
+        public fun default(): PartiQLPlanner =
+            PartiQLPlannerBuilder()
+                .casePreserve()
+                .lookUpBehavior("INSENSITIVE")
+                .build()
     }
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlannerBuilder.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/PartiQLPlannerBuilder.kt
@@ -1,7 +1,9 @@
 package org.partiql.planner
 
+import org.partiql.planner.internal.BooleanFlag
 import org.partiql.planner.internal.PartiQLPlannerDefault
 import org.partiql.planner.internal.PlannerFlag
+import org.partiql.planner.internal.RValue
 import org.partiql.spi.connector.ConnectorMetadata
 
 /**
@@ -50,7 +52,24 @@ public class PartiQLPlannerBuilder {
      * Java style method for setting the planner to signal mode
      */
     public fun signalMode(): PartiQLPlannerBuilder = this.apply {
-        this.flags.add(PlannerFlag.SIGNAL_MODE)
+        this.flags.add(BooleanFlag.SIGNAL_MODE)
+    }
+
+    public fun casePreserve(): PartiQLPlannerBuilder = this.apply {
+        this.flags.add(BooleanFlag.CASE_PRESERVATION)
+    }
+
+    public fun lookUpBehavior(behavior: String): PartiQLPlannerBuilder = this.apply {
+        this.flags.removeAll(
+            this.flags.filterIsInstance<RValue>().toSet()
+        )
+        when (behavior.uppercase()) {
+            "FOLDING_UP" -> this.flags.add(RValue.FOLDING_UP)
+            "FOLDING_DOWN" -> this.flags.add(RValue.FOLDING_DOWN)
+            "SENSITIVE" -> this.flags.add(RValue.SENSITIVE)
+            "INSENSITIVE" -> this.flags.add(RValue.INSENSITIVE)
+            else -> error("Illegal flag, expect one of ${RValue.values()}")
+        }
     }
 
     /**

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/IdentifierManager.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/IdentifierManager.kt
@@ -1,0 +1,39 @@
+package org.partiql.planner.internal
+
+import org.partiql.ast.Binder
+import org.partiql.ast.Identifier
+import org.partiql.ast.binder
+import org.partiql.ast.identifierSymbol
+
+internal class IdentifierManager(
+    val casePreservation: Boolean,
+    val rValue: RValue
+) {
+    fun normalizeBinder(binder: Binder): Binder =
+        when (binder.caseSensitivity) {
+            Binder.CaseSensitivity.SENSITIVE -> binder
+            Binder.CaseSensitivity.INSENSITIVE -> {
+                if (casePreservation) {
+                    binder(binder.symbol, Binder.CaseSensitivity.SENSITIVE)
+                }
+                // This is a conscious decision
+                // Even though the case preservation is off, we still need a way to store the binder
+                // To make this compatible with the current implementation,
+                // the decision here is: we normalize by preserving case.
+                else {
+                    binder(binder.symbol, Binder.CaseSensitivity.SENSITIVE)
+                }
+            }
+        }
+
+    fun normalizeRvalue(id: Identifier.Symbol): Identifier.Symbol =
+        when (id.caseSensitivity) {
+            Identifier.CaseSensitivity.SENSITIVE -> id
+            Identifier.CaseSensitivity.INSENSITIVE -> when (rValue) {
+                RValue.FOLDING_UP -> identifierSymbol(id.symbol.uppercase(), Identifier.CaseSensitivity.SENSITIVE)
+                RValue.FOLDING_DOWN -> identifierSymbol(id.symbol.lowercase(), Identifier.CaseSensitivity.SENSITIVE)
+                RValue.SENSITIVE -> identifierSymbol(id.symbol, Identifier.CaseSensitivity.SENSITIVE)
+                RValue.INSENSITIVE -> identifierSymbol(id.symbol, Identifier.CaseSensitivity.INSENSITIVE)
+            }
+        }
+}

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PartiQLPlannerDefault.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PartiQLPlannerDefault.kt
@@ -1,10 +1,10 @@
 package org.partiql.planner.internal
 
 import org.partiql.ast.Statement
-import org.partiql.ast.normalize.normalize
 import org.partiql.errors.ProblemCallback
 import org.partiql.planner.PartiQLPlanner
 import org.partiql.planner.PartiQLPlannerPass
+import org.partiql.planner.internal.astPasses.normalize
 import org.partiql.planner.internal.transforms.AstToPlan
 import org.partiql.planner.internal.transforms.PlanTransform
 import org.partiql.planner.internal.typer.PlanTyper

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PartiQLPlannerDefault.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PartiQLPlannerDefault.kt
@@ -27,7 +27,7 @@ internal class PartiQLPlannerDefault(
         val env = Env(session)
 
         // 1. Normalize
-        val ast = statement.normalize()
+        val ast = statement.normalize(flags)
 
         // 2. AST to Rel/Rex
         val root = AstToPlan.apply(ast, env)

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PlannerFlag.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PlannerFlag.kt
@@ -1,6 +1,9 @@
 package org.partiql.planner.internal
 
-internal enum class PlannerFlag {
+// Marker interface
+internal interface PlannerFlag
+
+internal enum class BooleanFlag : PlannerFlag {
     /**
      * Determine the planner behavior upon encounter an operation that always returns MISSING.
      *
@@ -16,5 +19,38 @@ internal enum class PlannerFlag {
      *
      *    The result plan will turn the problematic operation into a missing node.
      */
-    SIGNAL_MODE
+    SIGNAL_MODE,
+
+    /**
+     * Determines lvalue behavior
+     *
+     * If this flag is included:
+     *    Lvalue (AS binding, DDL, etc) are case-sensitive
+     *
+     * If not included:
+     *   Lvalue are normalized using an implementation defined normalization rule
+     */
+    CASE_PRESERVATION
+}
+
+internal enum class RValue : PlannerFlag {
+    /**
+     * Using upper case text to look up
+     */
+    FOLDING_UP,
+
+    /**
+     * Using lower case text to look up
+     */
+    FOLDING_DOWN,
+
+    /**
+     * Using original text to look up
+     */
+    SENSITIVE,
+
+    /**
+     * Match behavior: text comparison with case ignored.
+     */
+    INSENSITIVE
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/astPasses/Normalize.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/astPasses/Normalize.kt
@@ -12,14 +12,14 @@
  *  language governing permissions and limitations under the License.
  */
 
-package org.partiql.ast.normalize
+package org.partiql.planner.internal.astPasses
 
 import org.partiql.ast.Statement
 
 /**
  * AST normalization
  */
-public fun Statement.normalize(): Statement {
+internal fun Statement.normalize(): Statement {
     // could be a fold, but this is nice for setting breakpoints
     var ast = this
     ast = NormalizeFromSource.apply(ast)

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/astPasses/Normalize.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/astPasses/Normalize.kt
@@ -15,14 +15,20 @@
 package org.partiql.planner.internal.astPasses
 
 import org.partiql.ast.Statement
+import org.partiql.planner.internal.BooleanFlag
+import org.partiql.planner.internal.PlannerFlag
+import org.partiql.planner.internal.RValue
 
 /**
  * AST normalization
  */
-internal fun Statement.normalize(): Statement {
+internal fun Statement.normalize(flags: Set<PlannerFlag>): Statement {
     // could be a fold, but this is nice for setting breakpoints
     var ast = this
     ast = NormalizeFromSource.apply(ast)
     ast = NormalizeGroupBy.apply(ast)
+    val casePreservation = flags.any { it == BooleanFlag.CASE_PRESERVATION }
+    val rValue = flags.first { it is RValue } as RValue
+    ast = NormalizeIdentifier(casePreservation, rValue).apply(ast)
     return ast
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/astPasses/NormalizeFromSource.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/astPasses/NormalizeFromSource.kt
@@ -12,15 +12,16 @@
  *  language governing permissions and limitations under the License.
  */
 
-package org.partiql.ast.normalize
+package org.partiql.planner.internal.astPasses
 
 import org.partiql.ast.AstNode
 import org.partiql.ast.Expr
 import org.partiql.ast.From
 import org.partiql.ast.Statement
 import org.partiql.ast.fromJoin
-import org.partiql.ast.helpers.toBinder
+import org.partiql.ast.normalize.AstPass
 import org.partiql.ast.util.AstRewriter
+import org.partiql.planner.internal.utils.toBinder
 
 /**
  * Assign aliases to any FROM source which does not have one.

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/astPasses/NormalizeGroupBy.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/astPasses/NormalizeGroupBy.kt
@@ -12,20 +12,21 @@
  *  language governing permissions and limitations under the License.
  */
 
-package org.partiql.ast.normalize
+package org.partiql.planner.internal.astPasses
 
 import org.partiql.ast.AstNode
 import org.partiql.ast.Expr
 import org.partiql.ast.GroupBy
 import org.partiql.ast.Statement
 import org.partiql.ast.groupByKey
-import org.partiql.ast.helpers.toBinder
+import org.partiql.ast.normalize.AstPass
 import org.partiql.ast.util.AstRewriter
+import org.partiql.planner.internal.utils.toBinder
 
 /**
  * Adds a unique binder to each group key.
  */
-object NormalizeGroupBy : AstPass {
+internal object NormalizeGroupBy : AstPass {
 
     override fun apply(statement: Statement) = Visitor.visitStatement(statement, 0) as Statement
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/astPasses/NormalizeIdentifier.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/astPasses/NormalizeIdentifier.kt
@@ -1,0 +1,41 @@
+package org.partiql.planner.internal.astPasses
+
+import org.partiql.ast.Binder
+import org.partiql.ast.Identifier
+import org.partiql.ast.Statement
+import org.partiql.ast.normalize.AstPass
+import org.partiql.ast.util.AstRewriter
+import org.partiql.planner.internal.IdentifierManager
+import org.partiql.planner.internal.RValue
+
+/**
+ * Case Preservation:
+ *   - If on, turn case-insensitive binder to case-sensitive binder, with symbol preserve the original case
+ *   - If off, normalize the binder.
+ *      - The normalization function in the spec perhaps will end up being implementation defined.
+ *      - Therefore, for now we normalize by preserving case.
+ *      - This is to stay consistent with the current behavior, and reduce one moving element during testing....
+ *
+ * Identifier Normalization:
+ *   - Determines the normalization for identifier (variable look up)
+ *   - Folding down: Using lower case text to look up
+ *   - Folding up: Using upper case text to look up.
+ *   - Case Sensitive: Using original text to look up
+ *   - Case Insensitive: Matching behavior, string comparison with case ignored.
+ */
+internal class NormalizeIdentifier(
+    casePreservation: Boolean,
+    rValue: RValue
+) : AstPass {
+
+    val identifierManager = IdentifierManager(casePreservation, rValue)
+    override fun apply(statement: Statement): Statement = Visitor(identifierManager).visitStatement(statement, Unit) as Statement
+
+    private class Visitor(val identifierManager: IdentifierManager) : AstRewriter<Unit>() {
+
+        override fun visitIdentifierSymbol(node: Identifier.Symbol, ctx: Unit) =
+            identifierManager.normalizeRvalue(node)
+
+        override fun visitBinder(node: Binder, ctx: Unit) = identifierManager.normalizeBinder(node)
+    }
+}

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/astPasses/NormalizeSelect.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/astPasses/NormalizeSelect.kt
@@ -12,13 +12,15 @@
  *  language governing permissions and limitations under the License.
  */
 
-package org.partiql.planner.internal.transforms
+package org.partiql.planner.internal.astPasses
 
+import org.partiql.ast.Binder
 import org.partiql.ast.Expr
 import org.partiql.ast.From
 import org.partiql.ast.GroupBy
 import org.partiql.ast.Identifier
 import org.partiql.ast.Select
+import org.partiql.ast.binder
 import org.partiql.ast.exprCall
 import org.partiql.ast.exprCase
 import org.partiql.ast.exprCaseBranch
@@ -27,13 +29,13 @@ import org.partiql.ast.exprLit
 import org.partiql.ast.exprStruct
 import org.partiql.ast.exprStructField
 import org.partiql.ast.exprVar
-import org.partiql.ast.helpers.toBinder
 import org.partiql.ast.identifierSymbol
 import org.partiql.ast.selectProject
 import org.partiql.ast.selectProjectItemExpression
 import org.partiql.ast.selectValue
 import org.partiql.ast.typeStruct
 import org.partiql.ast.util.AstRewriter
+import org.partiql.planner.internal.utils.toBinder
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.stringValue
 
@@ -333,10 +335,12 @@ internal object NormalizeSelect {
         // t -> t AS t
         private fun String.simple(): Select.Project.Item.Expression {
             val expr = exprVar(id(this), Expr.Var.Scope.DEFAULT)
-            val alias = id(this)
+            val alias = binder(this)
             return selectProjectItemExpression(expr, alias)
         }
 
         private fun id(symbol: String) = identifierSymbol(symbol, Identifier.CaseSensitivity.INSENSITIVE)
+
+        private fun binder(symbol: String) = binder(symbol, Binder.CaseSensitivity.INSENSITIVE)
     }
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -5,6 +5,7 @@ import org.partiql.plan.PlanNode
 import org.partiql.plan.partiQLPlan
 import org.partiql.plan.rexOpCast
 import org.partiql.plan.rexOpErr
+import org.partiql.planner.internal.BooleanFlag
 import org.partiql.planner.internal.PlannerFlag
 import org.partiql.planner.internal.ProblemGenerator
 import org.partiql.planner.internal.ir.Identifier
@@ -27,7 +28,7 @@ import org.partiql.value.PartiQLValueExperimental
 internal class PlanTransform(
     flags: Set<PlannerFlag>
 ) {
-    private val signalMode = flags.contains(PlannerFlag.SIGNAL_MODE)
+    private val signalMode = flags.contains(BooleanFlag.SIGNAL_MODE)
 
     fun transform(node: PartiQLPlan, onProblem: ProblemCallback): org.partiql.plan.PartiQLPlan {
         val symbols = Symbols.empty()

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
@@ -30,11 +30,11 @@ import org.partiql.ast.Sort
 import org.partiql.ast.builder.ast
 import org.partiql.ast.exprLit
 import org.partiql.ast.exprVar
-import org.partiql.ast.helpers.toBinder
 import org.partiql.ast.identifierSymbol
 import org.partiql.ast.util.AstRewriter
 import org.partiql.ast.visitor.AstBaseVisitor
 import org.partiql.planner.internal.Env
+import org.partiql.planner.internal.astPasses.NormalizeSelect
 import org.partiql.planner.internal.ir.Rel
 import org.partiql.planner.internal.ir.Rex
 import org.partiql.planner.internal.ir.rel
@@ -70,6 +70,7 @@ import org.partiql.planner.internal.ir.rexOpStruct
 import org.partiql.planner.internal.ir.rexOpStructField
 import org.partiql.planner.internal.ir.rexOpVarLocal
 import org.partiql.planner.internal.typer.CompilerType
+import org.partiql.planner.internal.utils.toBinder
 import org.partiql.types.PType
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.boolValue

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/utils/ToBinder.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/utils/ToBinder.kt
@@ -1,5 +1,6 @@
-package org.partiql.ast.helpers
+package org.partiql.planner.internal.utils
 
+import org.partiql.ast.Binder
 import org.partiql.ast.Expr
 import org.partiql.ast.Identifier
 import org.partiql.ast.builder.ast
@@ -18,7 +19,7 @@ private val col = { index: () -> Int -> "_${index()}" }
  *
  *  See https://github.com/partiql/partiql-lang-kotlin/issues/1122
  */
-public fun Expr.toBinder(index: () -> Int): Identifier.Symbol = when (this) {
+public fun Expr.toBinder(index: () -> Int): Binder = when (this) {
     is Expr.Var -> this.identifier.toBinder()
     is Expr.Path -> this.toBinder(index)
     is Expr.Cast -> this.value.toBinder(index)
@@ -32,14 +33,20 @@ public fun Expr.toBinder(index: () -> Int): Identifier.Symbol = when (this) {
  * @param index
  * @return
  */
-public fun Expr.toBinder(index: Int): Identifier.Symbol = toBinder { index }
+internal fun Expr.toBinder(index: Int): Binder = toBinder { index }
 
-private fun String.toBinder(): Identifier.Symbol = ast {
-    // Every binder preserves case
-    identifierSymbol(this@toBinder, Identifier.CaseSensitivity.SENSITIVE)
+// Conscious Decision, when generate binding during normalization pass
+// we produce case-insensitive bind, with original text as symbol.
+// a later pass will further normalize those binders based on CASE-PRESERVATION setting
+// This is :
+//  bAr -> bAr as bAr
+//  -> If case preservation on : bAr as bAr -> bAr as "bAr"
+//  -> If case preservation off : bAr as bAr -> bAr as normalize(bAr) where normalize is implementation defined.
+private fun String.toBinder(): Binder = ast {
+    binder(this@toBinder, Binder.CaseSensitivity.INSENSITIVE)
 }
 
-private fun Identifier.toBinder(): Identifier.Symbol = when (this@toBinder) {
+private fun Identifier.toBinder(): Binder = when (this@toBinder) {
     is Identifier.Qualified -> when (steps.isEmpty()) {
         true -> root.symbol.toBinder()
         else -> steps.last().symbol.toBinder()
@@ -48,14 +55,14 @@ private fun Identifier.toBinder(): Identifier.Symbol = when (this@toBinder) {
 }
 
 @OptIn(PartiQLValueExperimental::class)
-private fun Expr.Path.toBinder(index: () -> Int): Identifier.Symbol {
+private fun Expr.Path.toBinder(index: () -> Int): Binder {
     if (steps.isEmpty()) return root.toBinder(index)
     return when (val last = steps.last()) {
         is Expr.Path.Step.Symbol -> last.symbol.toBinder()
         is Expr.Path.Step.Index -> {
             val k = last.key
             if (k is Expr.Lit && k.value is StringValue) {
-                k.value.value!!.toBinder()
+                (k.value as StringValue).value!!.toBinder()
             } else {
                 col(index).toBinder()
             }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/PlanTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/PlanTest.kt
@@ -88,8 +88,8 @@ class PlanTest {
         val problemCollector = ProblemCollector()
         val ast = PartiQLParser.default().parse(test.statement).root
         val planner = when (isSignalMode) {
-            true -> PartiQLPlanner.builder().signalMode().build()
-            else -> PartiQLPlanner.builder().build()
+            true -> PartiQLPlanner.builder().signalMode().casePreserve().lookUpBehavior("INSENSITIVE").build()
+            else -> PartiQLPlanner.builder().casePreserve().lookUpBehavior("INSENSITIVE").build()
         }
         planner.plan(ast, session, problemCollector)
     }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/PlannerErrorReportingTests.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/PlannerErrorReportingTests.kt
@@ -398,8 +398,8 @@ internal class PlannerErrorReportingTests {
 
     private fun runTestCase(tc: TestCase) {
         val planner = when (tc.isSignal) {
-            true -> PartiQLPlanner.builder().signalMode().build()
-            else -> PartiQLPlanner.builder().build()
+            true -> PartiQLPlanner.builder().signalMode().casePreserve().lookUpBehavior("INSENSITIVE").build()
+            else -> PartiQLPlanner.builder().casePreserve().lookUpBehavior("INSENSITIVE").build()
         }
         val pc = ProblemCollector()
         val res = planner.plan(statement(tc.query), session, pc)

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/transforms/NormalizeSelectTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/transforms/NormalizeSelectTest.kt
@@ -1,15 +1,18 @@
 package org.partiql.planner.internal.transforms
 
 import org.junit.jupiter.api.Test
+import org.partiql.ast.Binder
 import org.partiql.ast.Expr
 import org.partiql.ast.From
 import org.partiql.ast.Identifier
 import org.partiql.ast.Select
+import org.partiql.ast.binder
 import org.partiql.ast.builder.ast
 import org.partiql.ast.exprLit
 import org.partiql.ast.exprVar
 import org.partiql.ast.identifierSymbol
 import org.partiql.ast.selectProjectItemExpression
+import org.partiql.planner.internal.astPasses.NormalizeSelect
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.int32Value
 import org.partiql.value.stringValue
@@ -167,12 +170,12 @@ class NormalizeSelectTest {
 
     private fun varItem(symbol: String, asAlias: String? = null) = selectProjectItemExpression(
         expr = variable(symbol),
-        asAlias = asAlias?.let { identifierSymbol(asAlias, Identifier.CaseSensitivity.INSENSITIVE) }
+        asAlias = asAlias?.let { binder(asAlias, Binder.CaseSensitivity.INSENSITIVE) }
     )
 
     private fun litItem(value: Int, asAlias: String? = null) = selectProjectItemExpression(
         expr = lit(value),
-        asAlias = asAlias?.let { identifierSymbol(asAlias, Identifier.CaseSensitivity.INSENSITIVE) }
+        asAlias = asAlias?.let { binder(asAlias, Binder.CaseSensitivity.INSENSITIVE) }
     )
 
     @OptIn(PartiQLValueExperimental::class)

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -130,7 +130,12 @@ internal class PlanTyperTestsPorted {
     companion object {
 
         private val parser = PartiQLParser.default()
-        private val planner = PartiQLPlanner.builder().signalMode().build()
+        private val planner = PartiQLPlanner
+            .builder()
+            .signalMode()
+            .casePreserve()
+            .lookUpBehavior("INSENSITIVE")
+            .build()
 
         private fun assertProblemExists(problem: Problem) = ProblemHandler { problems, ignoreSourceLocation ->
             val message = buildString {


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #1122 

## Note
- This is a draft PR that allows us to further experiment with the idea of adding modes for `lvalue` and `rvalue` behavior. 
- Some tests cases are still to-be-fixed, but the purpose of this PR is as a code reference point to further discuss the identifier behavior. 

## Semantics
- This draft PR enables adding planner modes to determine Case Preservation and Variable Look Up behavior. 
- Case Preservation: 
    -  A binary flag set on the planner: 
    -  This flag determines the lvalue behavior (As Binding, DDL, etc). 
    - If this flag is included: Lvalue (AS binding, DDL, etc) are case-sensitive and stored in the environment as-is. 
    - if this flag is not included: Lvalue are normalized using an implementation defined normalization rule.
         - In this PR we made a conscious decision to set this implementation defined normalization rule to be using the input string. 
         - This is: even without the case preservation flag, the lvalue will behave case sensitively. 
         - This allows us to reduce one moving element for the purpose of testing. 
         - While technically not breaking the semantics of "implementation-defined normalization rule", it does bug the question: do we also want to allow for different case preservation flag? If so, does it make sense to set case preservation to "FOLDING DOWN" and set Variable look up behavior to "FOLDING UP" ? 

- Variable Look Up (RValue): 
   - FOLDING UP: Using upper case text to look up
   - FOLDING DOWN: Using lower case text to look up
   - SENSITIVE: Using original text to look up
   - INSENSITIVE: "Match" behavior - text comparison with case ignored. This is the current behavior. 

## Modeling
- Behavior
   - Consider the follow expression `SELECT bAr .....` 
       - Folding UP -> the query should behave the same as `SELECT "BAR" ...` 
       - Folding DOWN -> the query should behave the same as `SELECT "bar" ...` 
       - SENSITIVE -> the query should behave the same as `SELECT "bAR" ...` 
   - Based on the above observation: we can keep the resolution logic as-is, with the only change to be normalize the identifier in "planning"
   - This PR does this during AST normalization steps, which is an internal process during planning. 

- AST Node: `Binder`
    - The Binder node differs from Identifier in two aspect: 
        - It is used for LValue. 
        - It is always present as unqualified.
        - i.e., `t.c.a AS A`, `t.c.a` is a qualified identifier and `t`, `c`, `a` are identifier symbol. `A` is a binder. 
    - The addition of binder node allow us to modifier the `lvalue` and `rvalue` on the AST level easily, without the need to go down each node and distinguish the type of identifier based on the node parameter. (check if the identifier symbol is an `as_alias`, etc). 

Removed to reduce noise in this PR.
~~- Decouple SelectNormalization with RelConverter.~~
~~- The previous invocation of SelectNormalization is invoked by RelConverter.~~
~~- This is due to the need of handling subquery coercion.~~
~~- I found this jumping between AST and Relational Operation introduces confusion, but to decouple the two, we are forced to add a boolean flag in the AST to indicate coercible. Not something I necessarily like either...~~
~~- We can revert this decouple per later discussion.~~
    
## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No. 

- Any backward-incompatible changes? **[YES/NO]**
  -  Yes. 

- Any new external dependencies? **[YES/NO]**
  - No.

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
 - Yes.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.