### PR TITLE
Update Maven publishing to use nexus publish plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,28 @@
+import io.github.gradlenexus.publishplugin.NexusPublishExtension
+import java.time.Duration
+
+plugins {
+    id("io.github.gradle-nexus.publish-plugin")
+}
+
+// We use gradle-nexus's publish-plugin to publish all of our published artifacts to Maven using OSSRH.
+// Documentation for this plugin, see https://github.com/gradle-nexus/publish-plugin/blob/v2.0.0/README.md
+// This plugin must be applied at the root project, so we include the following block around the nexus publish
+// extension.
+rootProject.run {
+    plugins.apply("io.github.gradle-nexus.publish-plugin")
+    extensions.getByType(NexusPublishExtension::class.java).run {
+        this.repositories {
+            sonatype {
+                nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
+                username.set(properties["ossrhUsername"].toString())
+                password.set(properties["ossrhPassword"].toString())
+            }
+        }
+
+        // these are not strictly required. The default timeouts are set to 1 minute. But Sonatype can be really slow.
+        // If you get the error "java.net.SocketTimeoutException: timeout", these lines will help.
+        connectTimeout.set(Duration.ofMinutes(3))
+        clientTimeout.set(Duration.ofMinutes(3))
+    }
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -27,6 +27,7 @@ object Versions {
     const val dokka = "1.6.10"
     const val kotlin = "1.6.20"
     const val ktlintGradle = "10.2.1"
+    const val nexusPublish = "2.0.0"
     const val pig = "0.6.1"
     const val shadow = "8.1.1"
 }
@@ -36,6 +37,7 @@ object Plugins {
     const val dokka = "org.jetbrains.dokka:dokka-gradle-plugin:${Versions.dokka}"
     const val kotlinGradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
     const val ktlintGradle = "org.jlleitschuh.gradle:ktlint-gradle:${Versions.ktlintGradle}"
+    const val nexusPublish = "io.github.gradle-nexus:publish-plugin:${Versions.nexusPublish}"
     const val pig = "org.partiql:pig-gradle-plugin:${Versions.pig}"
     const val shadow = "com.github.johnrengelman:shadow:${Versions.shadow}"
 }
@@ -45,6 +47,7 @@ dependencies {
     implementation(Plugins.dokka)
     implementation(Plugins.kotlinGradle)
     implementation(Plugins.ktlintGradle)
+    implementation(Plugins.nexusPublish)
     implementation(Plugins.pig)
     implementation(Plugins.shadow)
 }

--- a/buildSrc/src/main/kotlin/org/partiql/gradle/plugin/publish/PublishPlugin.kt
+++ b/buildSrc/src/main/kotlin/org/partiql/gradle/plugin/publish/PublishPlugin.kt
@@ -29,7 +29,6 @@ import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getByName
-import org.gradle.kotlin.dsl.provideDelegate
 import org.gradle.plugins.signing.SigningExtension
 import org.gradle.plugins.signing.SigningPlugin
 import org.jetbrains.dokka.gradle.DokkaPlugin
@@ -122,7 +121,7 @@ abstract class PublishPlugin : Plugin<Project> {
                             licenses {
                                 license {
                                     name.set("The Apache License, Version 2.0")
-                                    url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                                    url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
                                 }
                             }
                             developers {
@@ -157,17 +156,6 @@ abstract class PublishPlugin : Plugin<Project> {
                                     dependencyNode.appendNode("scope", "runtime")
                                 }
                             }
-                        }
-                    }
-                }
-                repositories {
-                    maven {
-                        url = uri("https://aws.oss.sonatype.org/service/local/staging/deploy/maven2")
-                        credentials {
-                            val ossrhUsername: String by rootProject
-                            val ossrhPassword: String by rootProject
-                            username = ossrhUsername
-                            password = ossrhPassword
                         }
                     }
                 }


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- The sonatype host that we publish to now requires a token to publish (more on [tokens](https://central.sonatype.org/publish/generate-token/#create-an-account))
- Our previous plugin for publishing, gradle maven publish [plugin](https://docs.gradle.org/current/userguide/publishing_maven.html) would not work for this new auth requirement
- Migrated to use https://github.com/gradle-nexus/publish-plugin, which worked for publishing to our sonatype host.
- Testing -- ran `./gradlew publish` and the artifacts appeared in the sonatype server for release

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No, no changes to source code.
- Any backward-incompatible changes? **[NO]**
  - No, no changes to source code.
- Any new external dependencies? **[YES]**
  - Yes, for publishing, using https://github.com/gradle-nexus/publish-plugin.
  - Alternatives considered
    - Existing gradle maven publish [plugin](https://docs.gradle.org/current/userguide/publishing_maven.html) -- was not able to publish with the new OSSRH token auth
    - [jreleaser](https://jreleaser.org/) -- a lot different set up in the publish plugin; had difficulty in changing the configuration
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.