### PR TITLE
[EXPERIMENTAL] Example of how we can source the dynamic dispatch logic to the planner

### DIFF
--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
@@ -1,5 +1,6 @@
 package org.partiql.eval.internal.operator.rex
 
+import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Environment
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.eval.value.Datum
@@ -34,7 +35,7 @@ internal class ExprCallDynamic(
             actualArgs[it].toPartiQLValue()
         }
         val actualTypes = actualArgs.map { it.type }
-        val match = FunctionResolver.resolve(candidates, actualTypes) as FunctionResolver.FnMatch.Static
+        val match = FunctionResolver.resolve(candidates, actualTypes) as? FunctionResolver.FnMatch.Static ?: throw TypeCheckException()
         return candidateImpls[match.index].eval(transformedArgs, env)
     }
 

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
@@ -1,16 +1,14 @@
 package org.partiql.eval.internal.operator.rex
 
-import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Environment
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.eval.value.Datum
 import org.partiql.plan.Ref
+import org.partiql.planner.FunctionResolver
 import org.partiql.spi.fn.Fn
 import org.partiql.spi.fn.FnExperimental
-import org.partiql.types.PType
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
-import org.partiql.value.PartiQLValueType
 
 /**
  * This represents Dynamic Dispatch.
@@ -23,26 +21,21 @@ import org.partiql.value.PartiQLValueType
 @OptIn(PartiQLValueExperimental::class, FnExperimental::class)
 internal class ExprCallDynamic(
     private val name: String,
-    private val candidates: Array<Candidate>,
+    candidates: Array<Candidate>,
     private val args: Array<Operator.Expr>
 ) : Operator.Expr {
 
-    private val candidateIndex = CandidateIndex.All(candidates)
+    private val candidateImpls = candidates.map { it }
+    private val candidates = candidates.map { it.fn.signature }
 
     override fun eval(env: Environment): Datum {
         val actualArgs = args.map { it.eval(env) }.toTypedArray()
+        val transformedArgs = Array(actualArgs.size) {
+            actualArgs[it].toPartiQLValue()
+        }
         val actualTypes = actualArgs.map { it.type }
-        candidateIndex.get(actualTypes)?.let {
-            val transformedArgs = Array(actualArgs.size) {
-                actualArgs[it].toPartiQLValue()
-            }
-            return it.eval(transformedArgs, env)
-        }
-        val errorString = buildString {
-            val argString = actualArgs.joinToString(", ")
-            append("Could not dynamically find function ($name) for arguments $argString.")
-        }
-        throw TypeCheckException(errorString)
+        val match = FunctionResolver.resolve(candidates, actualTypes) as FunctionResolver.FnMatch.Static
+        return candidateImpls[match.index].eval(transformedArgs, env)
     }
 
     /**
@@ -74,154 +67,6 @@ internal class ExprCallDynamic(
                 }
             }.toTypedArray()
             return Datum.of(fn.invoke(args))
-        }
-    }
-
-    private sealed interface CandidateIndex {
-
-        public fun get(args: List<PType>): Candidate?
-
-        /**
-         * Preserves the original ordering of the passed-in candidates while making it faster to lookup matching
-         * functions. Utilizes both [Direct] and [Indirect].
-         *
-         * Say a user passes in the following ordered candidates:
-         * [
-         *      foo(int16, int16) -> int16,
-         *      foo(int32, int32) -> int32,
-         *      foo(int64, int64) -> int64,
-         *      foo(string, string) -> string,
-         *      foo(struct, struct) -> struct,
-         *      foo(numeric, numeric) -> numeric,
-         *      foo(int64, dynamic) -> dynamic,
-         *      foo(struct, dynamic) -> dynamic,
-         *      foo(bool, bool) -> bool
-         * ]
-         *
-         * With the above candidates, the [CandidateIndex.All] will maintain the original ordering by utilizing:
-         * - [CandidateIndex.Direct] to match hashable runtime types
-         * - [CandidateIndex.Indirect] to match the dynamic type
-         *
-         * For the above example, the internal representation of [CandidateIndex.All] is a list of
-         * [CandidateIndex.Direct] and [CandidateIndex.Indirect] that looks like:
-         * ALL listOf(
-         *      DIRECT hashMap(
-         *          [int16, int16] --> foo(int16, int16) -> int16,
-         *          [int32, int32] --> foo(int32, int32) -> int32,
-         *          [int64, int64] --> foo(int64, int64) -> int64
-         *          [string, string] --> foo(string, string) -> string,
-         *          [struct, struct] --> foo(struct, struct) -> struct,
-         *          [numeric, numeric] --> foo(numeric, numeric) -> numeric
-         *      ),
-         *      INDIRECT listOf(
-         *          foo(int64, dynamic) -> dynamic,
-         *          foo(struct, dynamic) -> dynamic
-         *      ),
-         *      DIRECT hashMap(
-         *          [bool, bool] --> foo(bool, bool) -> bool
-         *      )
-         * )
-         *
-         * @param candidates
-         */
-        class All(private val candidates: Array<Candidate>) : CandidateIndex {
-
-            private val lookups: List<CandidateIndex>
-
-            init {
-                val lookupsMutable = mutableListOf<CandidateIndex>()
-                val accumulator = mutableListOf<Pair<List<PType>, Candidate>>()
-
-                // Indicates that we are currently processing dynamic candidates that accept ANY.
-                var activelyProcessingAny = true
-
-                candidates.forEach { candidate ->
-                    // Gather the input types to the dynamic invocation
-                    val lookupTypes = candidate.coercions.mapIndexed { index, cast ->
-                        when (cast) {
-                            null -> candidate.fn.signature.parameters[index].type
-                            else -> cast.input
-                        }
-                    }
-                    val parametersIncludeAny = lookupTypes.any { it.kind == PType.Kind.DYNAMIC }
-                    // A way to simplify logic further below. If it's empty, add something and set the processing type.
-                    if (accumulator.isEmpty()) {
-                        activelyProcessingAny = parametersIncludeAny
-                        accumulator.add(lookupTypes to candidate)
-                        return@forEach
-                    }
-                    when (parametersIncludeAny) {
-                        true -> when (activelyProcessingAny) {
-                            true -> accumulator.add(lookupTypes to candidate)
-                            false -> {
-                                activelyProcessingAny = true
-                                lookupsMutable.add(Direct.of(accumulator.toList()))
-                                accumulator.clear()
-                                accumulator.add(lookupTypes to candidate)
-                            }
-                        }
-                        false -> when (activelyProcessingAny) {
-                            false -> accumulator.add(lookupTypes to candidate)
-                            true -> {
-                                activelyProcessingAny = false
-                                lookupsMutable.add(Indirect(accumulator.toList()))
-                                accumulator.clear()
-                                accumulator.add(lookupTypes to candidate)
-                            }
-                        }
-                    }
-                }
-                // Add any remaining candidates (that we didn't submit due to not ending while switching)
-                when (accumulator.isEmpty()) {
-                    true -> { /* Do nothing! */ }
-                    false -> when (activelyProcessingAny) {
-                        true -> lookupsMutable.add(Indirect(accumulator.toList()))
-                        false -> lookupsMutable.add(Direct.of(accumulator.toList()))
-                    }
-                }
-                this.lookups = lookupsMutable
-            }
-
-            override fun get(args: List<PType>): Candidate? {
-                return this.lookups.firstNotNullOfOrNull { it.get(args) }
-            }
-        }
-
-        /**
-         * An O(1) structure to quickly find directly matching dynamic candidates. This is specifically used for runtime
-         * types that can be matched directly. AKA int32, int64, etc. This does NOT include [PartiQLValueType.ANY].
-         */
-        data class Direct private constructor(val directCandidates: HashMap<List<PType>, Candidate>) : CandidateIndex {
-
-            companion object {
-                internal fun of(candidates: List<Pair<List<PType>, Candidate>>): Direct {
-                    val candidateMap = java.util.HashMap<List<PType>, Candidate>()
-                    candidateMap.putAll(candidates)
-                    return Direct(candidateMap)
-                }
-            }
-
-            override fun get(args: List<PType>): Candidate? {
-                return directCandidates[args]
-            }
-        }
-
-        /**
-         * Holds all candidates that expect a [PartiQLValueType.ANY] on input. This maintains the original
-         * precedence order.
-         */
-        data class Indirect(private val candidates: List<Pair<List<PType>, Candidate>>) : CandidateIndex {
-            override fun get(args: List<PType>): Candidate? {
-                candidates.forEach { (types, candidate) ->
-                    for (i in args.indices) {
-                        if (args[i] != types[i] && types[i].kind != PType.Kind.DYNAMIC) {
-                            return@forEach
-                        }
-                    }
-                    return candidate
-                }
-                return null
-            }
         }
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCast.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCast.kt
@@ -96,7 +96,7 @@ internal class ExprCast(val arg: Operator.Expr, val cast: Ref.Cast) : Operator.E
             }
             return Datum.of(partiqlValue)
         } catch (e: DataException) {
-            throw TypeCheckException()
+            throw TypeCheckException(cause = e)
         }
     }
 

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCast.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCast.kt
@@ -96,7 +96,7 @@ internal class ExprCast(val arg: Operator.Expr, val cast: Ref.Cast) : Operator.E
             }
             return Datum.of(partiqlValue)
         } catch (e: DataException) {
-            throw TypeCheckException(cause = e)
+            throw TypeCheckException()
         }
     }
 

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -1387,16 +1387,8 @@ class PartiQLEngineDefaultTest {
     fun developmentTest() {
         val tc = SuccessTestCase(
             input = """
-                SELECT VALUE
-                    CASE x + 1
-                        WHEN NULL THEN 'shouldnt be null'
-                        WHEN MISSING THEN 'shouldnt be missing'
-                        WHEN i THEN 'ONE'
-                        WHEN f THEN 'TWO'
-                        WHEN d THEN 'THREE'
-                        ELSE '?'
-                    END
-                FROM << i, f, d, null, missing >> AS x
+                (1 + 3.1 - 2.764 + d) > d
+                -- select fld1 from t2 where fld1=250501 or fld1=250502 or fld1 >= 250505 and fld1 <= 250601 or fld1 between 250501 and 250502
             """,
             expected = boolValue(true),
             globals = listOf(

--- a/partiql-planner/api/partiql-planner.api
+++ b/partiql-planner/api/partiql-planner.api
@@ -1,3 +1,36 @@
+public final class org/partiql/planner/FunctionResolver {
+	public static final field INSTANCE Lorg/partiql/planner/FunctionResolver;
+	public final fun resolve (Ljava/util/List;Ljava/util/List;)Lorg/partiql/planner/FunctionResolver$FnMatch;
+}
+
+public abstract class org/partiql/planner/FunctionResolver$FnMatch {
+}
+
+public final class org/partiql/planner/FunctionResolver$FnMatch$Dynamic : org/partiql/planner/FunctionResolver$FnMatch {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lorg/partiql/planner/FunctionResolver$FnMatch$Dynamic;
+	public static synthetic fun copy$default (Lorg/partiql/planner/FunctionResolver$FnMatch$Dynamic;Ljava/util/List;ILjava/lang/Object;)Lorg/partiql/planner/FunctionResolver$FnMatch$Dynamic;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCandidates ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/planner/FunctionResolver$FnMatch$Static : org/partiql/planner/FunctionResolver$FnMatch {
+	public fun <init> (I[Lorg/partiql/plan/Ref$Cast;)V
+	public final fun component1 ()I
+	public final fun component2 ()[Lorg/partiql/plan/Ref$Cast;
+	public final fun copy (I[Lorg/partiql/plan/Ref$Cast;)Lorg/partiql/planner/FunctionResolver$FnMatch$Static;
+	public static synthetic fun copy$default (Lorg/partiql/planner/FunctionResolver$FnMatch$Static;I[Lorg/partiql/plan/Ref$Cast;ILjava/lang/Object;)Lorg/partiql/planner/FunctionResolver$FnMatch$Static;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExact ()I
+	public final fun getIndex ()I
+	public final fun getMapping ()[Lorg/partiql/plan/Ref$Cast;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class org/partiql/planner/PartiQLPlanner {
 	public static final field Companion Lorg/partiql/planner/PartiQLPlanner$Companion;
 	public static fun builder ()Lorg/partiql/planner/PartiQLPlannerBuilder;

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/FunctionResolver.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/FunctionResolver.kt
@@ -1,11 +1,12 @@
-package org.partiql.planner.internal
+package org.partiql.planner
 
+import org.partiql.plan.Ref
+import org.partiql.planner.internal.FnComparator
 import org.partiql.planner.internal.casts.Coercions
-import org.partiql.planner.internal.ir.Ref
-import org.partiql.planner.internal.typer.CompilerType
 import org.partiql.planner.internal.typer.PlanTyper.Companion.toCType
 import org.partiql.spi.fn.FnExperimental
 import org.partiql.spi.fn.FnSignature
+import org.partiql.types.PType
 import org.partiql.types.PType.Kind
 
 /**
@@ -24,7 +25,7 @@ import org.partiql.types.PType.Kind
  * Reference https://www.postgresql.org/docs/current/typeconv-func.html
  */
 @OptIn(FnExperimental::class)
-internal object FnResolver {
+public object FunctionResolver {
 
     /**
      * Resolution of either a static or dynamic function.
@@ -35,15 +36,16 @@ internal object FnResolver {
      * @param args
      * @return
      */
-    fun resolve(variants: List<FnSignature>, args: List<CompilerType>): FnMatch? {
+    public fun resolve(variants: List<FnSignature>, args: List<PType>): FnMatch? {
         val candidates = variants
-            .filter { it.parameters.size == args.size }
+            .mapIndexed { index, fnSignature -> Candidate(index, fnSignature) }
+            .filter { it.signature.parameters.size == args.size }
             .ifEmpty { return null }
 
         // 1. Look for exact match
         for (candidate in candidates) {
-            if (candidate.matchesExactly(args)) {
-                return FnMatch.Static(candidate, arrayOfNulls(args.size))
+            if (candidate.signature.matchesExactly(args)) {
+                return FnMatch.Static(candidate.index, arrayOfNulls(args.size))
             }
         }
 
@@ -74,6 +76,11 @@ internal object FnResolver {
         return matches.sortedWith(MatchResultComparator).first().match
     }
 
+    private class Candidate(
+        val index: Int,
+        val signature: FnSignature
+    )
+
     /**
      * Resolution of a static function.
      *
@@ -81,7 +88,7 @@ internal object FnResolver {
      * @param args
      * @return
      */
-    private fun match(candidates: List<FnSignature>, args: List<CompilerType>): List<MatchResult> {
+    private fun match(candidates: List<Candidate>, args: List<PType>): List<MatchResult> {
         val matches = mutableSetOf<MatchResult>()
         for (candidate in candidates) {
             val m = candidate.match(args) ?: continue
@@ -111,7 +118,7 @@ internal object FnResolver {
     /**
      * Check if this function accepts the exact input argument types. Assume same arity.
      */
-    private fun FnSignature.matchesExactly(args: List<CompilerType>): Boolean {
+    private fun FnSignature.matchesExactly(args: List<PType>): Boolean {
         for (i in args.indices) {
             val a = args[i]
             val p = parameters[i]
@@ -126,12 +133,12 @@ internal object FnResolver {
      * @param args
      * @return
      */
-    private fun FnSignature.match(args: List<CompilerType>): MatchResult? {
+    private fun Candidate.match(args: List<PType>): MatchResult? {
         val mapping = arrayOfNulls<Ref.Cast?>(args.size)
         var exactInputTypes: Int = 0
         for (i in args.indices) {
             val arg = args[i]
-            val p = parameters[i]
+            val p = this.signature.parameters[i]
             when {
                 // 1. Exact match
                 arg == p.type -> {
@@ -143,29 +150,69 @@ internal object FnResolver {
                 arg.kind == Kind.UNKNOWN -> continue
                 // 3. Allow for ANY arguments
                 arg.kind == Kind.DYNAMIC -> {
-                    mapping[i] = Ref.Cast(arg, p.type.toCType(), Ref.Cast.Safety.UNSAFE, true)
+                    mapping[i] = Ref.Cast(arg, p.type.toCType(), true)
                 }
                 // 4. Check for a coercion
                 else -> when (val coercion = Coercions.get(arg, p.type)) {
                     null -> return null // short-circuit
-                    else -> mapping[i] = coercion
+                    else -> mapping[i] = coercion.toPublic()
                 }
             }
         }
         return MatchResult(
-            FnMatch.Static(this, mapping),
+            FnMatch.Static(this.index, mapping),
+            this.signature,
             exactInputTypes,
         )
     }
 
     private class MatchResult(
         val match: FnMatch.Static,
+        val signature: FnSignature,
         val numberOfExactInputTypes: Int,
     )
 
     private object MatchResultComparator : Comparator<MatchResult> {
         override fun compare(o1: MatchResult, o2: MatchResult): Int {
-            return FnComparator.reversed().compare(o1.match.signature, o2.match.signature)
+            return FnComparator.reversed().compare(o1.signature, o2.signature)
         }
+    }
+
+    private fun org.partiql.planner.internal.ir.Ref.Cast.toPublic() = Ref.Cast(
+        input = input,
+        target = target,
+        isNullable = isNullable
+    )
+
+    /**
+     * Result of matching an unresolved function.
+     */
+    public sealed class FnMatch {
+
+        /**
+         * Successful match of a static function call.
+         *
+         * @property signature
+         * @property mapping
+         */
+        public data class Static(
+            val index: Int,
+            val mapping: Array<Ref.Cast?>,
+        ) : FnMatch() {
+
+            /**
+             * The number of exact matches. Useful when ranking function matches.
+             */
+            val exact: Int = mapping.count { it != null }
+        }
+
+        /**
+         * This represents dynamic dispatch.
+         *
+         * @property candidates     Ordered list of potentially applicable functions to dispatch dynamically.
+         */
+        public data class Dynamic(
+            val candidates: List<Static>,
+        ) : FnMatch()
     }
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/FnMatch.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/FnMatch.kt
@@ -16,7 +16,7 @@ internal sealed class FnMatch {
      * @property signature
      * @property mapping
      */
-    data class Static(
+    public data class Static(
         val signature: FnSignature,
         val mapping: Array<Ref.Cast?>,
     ) : FnMatch() {
@@ -52,7 +52,7 @@ internal sealed class FnMatch {
      *
      * @property candidates     Ordered list of potentially applicable functions to dispatch dynamically.
      */
-    data class Dynamic(
+    public data class Dynamic(
         val candidates: List<Static>,
     ) : FnMatch()
 }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/PlannerErrorReportingTests.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/PlannerErrorReportingTests.kt
@@ -279,13 +279,13 @@ internal class PlannerErrorReportingTests {
                 "1 + not_a_function(1)",
                 false,
                 assertOnProblemCount(0, 1),
-                StaticType.INT4,
+                StaticType.ANY,
             ),
             TestCase(
                 "1 + not_a_function(1)",
                 true,
                 assertOnProblemCount(0, 1),
-                StaticType.INT4,
+                StaticType.ANY,
             ),
 
             TestCase(


### PR DESCRIPTION
## Description
- DRAFT / EXPERIMENTAL. Not meant to merge.
- Example of how we can source the dynamic dispatch logic to the planner by exposing a FunctionResolver in the planner package (to reduce duplicated logic).

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**

- Any backward-incompatible changes? **[YES/NO]**

- Any new external dependencies? **[YES/NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.