### PR TITLE
Adds arithmetic operators as separate nodes & fixes casts

### DIFF
--- a/partiql-eval/api/partiql-eval.api
+++ b/partiql-eval/api/partiql-eval.api
@@ -66,6 +66,9 @@ public abstract interface class org/partiql/eval/PartiQLStatement$Query : org/pa
 public abstract interface class org/partiql/eval/value/Datum : java/lang/Iterable {
 	public static fun bagValue (Ljava/lang/Iterable;)Lorg/partiql/eval/value/Datum;
 	public static fun boolValue (Z)Lorg/partiql/eval/value/Datum;
+	public static fun decimal (Ljava/math/BigDecimal;II)Lorg/partiql/eval/value/Datum;
+	public static fun decimalArbitrary (Ljava/math/BigDecimal;)Lorg/partiql/eval/value/Datum;
+	public static fun doublePrecision (D)Lorg/partiql/eval/value/Datum;
 	public fun get (Ljava/lang/String;)Lorg/partiql/eval/value/Datum;
 	public fun getBigDecimal ()Ljava/math/BigDecimal;
 	public fun getBigInteger ()Ljava/math/BigInteger;
@@ -87,6 +90,7 @@ public abstract interface class org/partiql/eval/value/Datum : java/lang/Iterabl
 	public abstract fun getType ()Lorg/partiql/types/PType;
 	public static fun int32Value (I)Lorg/partiql/eval/value/Datum;
 	public static fun int64Value (J)Lorg/partiql/eval/value/Datum;
+	public static fun intArbitrary (Ljava/math/BigInteger;)Lorg/partiql/eval/value/Datum;
 	public fun isMissing ()Z
 	public fun isNull ()Z
 	public fun iterator ()Ljava/util/Iterator;
@@ -96,9 +100,12 @@ public abstract interface class org/partiql/eval/value/Datum : java/lang/Iterabl
 	public static fun nullValue ()Lorg/partiql/eval/value/Datum;
 	public static fun nullValue (Lorg/partiql/types/PType;)Lorg/partiql/eval/value/Datum;
 	public static fun of (Lorg/partiql/value/PartiQLValue;)Lorg/partiql/eval/value/Datum;
+	public static fun real (F)Lorg/partiql/eval/value/Datum;
 	public static fun sexpValue (Ljava/lang/Iterable;)Lorg/partiql/eval/value/Datum;
+	public static fun smallInt (S)Lorg/partiql/eval/value/Datum;
 	public static fun stringValue (Ljava/lang/String;)Lorg/partiql/eval/value/Datum;
 	public static fun structValue (Ljava/lang/Iterable;)Lorg/partiql/eval/value/Datum;
+	public static fun tinyInt (B)Lorg/partiql/eval/value/Datum;
 	public fun toPartiQLValue ()Lorg/partiql/value/PartiQLValue;
 }
 

--- a/partiql-eval/src/main/java/org/partiql/eval/value/Datum.java
+++ b/partiql-eval/src/main/java/org/partiql/eval/value/Datum.java
@@ -345,6 +345,9 @@ public interface Datum extends Iterable<Datum> {
     @Deprecated
     default PartiQLValue toPartiQLValue() {
         PType type = this.getType();
+        if (this.isMissing()) {
+            return PartiQL.missingValue();
+        }
         switch (type.getKind()) {
             case BOOL:
                 return this.isNull() ? PartiQL.boolValue(null) : PartiQL.boolValue(this.getBoolean());
@@ -535,6 +538,16 @@ public interface Datum extends Iterable<Datum> {
     }
 
     @NotNull
+    static Datum tinyInt(byte value) {
+        return new DatumByte(value, PType.typeTinyInt());
+    }
+
+    @NotNull
+    static Datum smallInt(short value) {
+        return new DatumShort(value);
+    }
+
+    @NotNull
     static Datum int64Value(long value) {
         return new DatumLong(value);
     }
@@ -542,6 +555,33 @@ public interface Datum extends Iterable<Datum> {
     @NotNull
     static Datum int32Value(int value) {
         return new DatumInt(value);
+    }
+
+    @Deprecated
+    @NotNull
+    static Datum intArbitrary(@NotNull BigInteger value) {
+        return new DatumBigInteger(value);
+    }
+
+    @NotNull
+    static Datum real(float value) {
+        return new DatumFloat(value);
+    }
+
+    @NotNull
+    static Datum doublePrecision(double value) {
+        return new DatumDouble(value);
+    }
+
+    @Deprecated
+    @NotNull
+    static Datum decimalArbitrary(@NotNull BigDecimal value) {
+        return new DatumDecimal(value, PType.typeDecimalArbitrary());
+    }
+
+    @NotNull
+    static Datum decimal(@NotNull BigDecimal value, int precision, int scale) {
+        return new DatumDecimal(value, PType.typeDecimal(precision, scale));
     }
 
     @NotNull

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/ArithmeticTyper.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/ArithmeticTyper.kt
@@ -77,8 +77,8 @@ internal object ArithmeticTyper {
     private fun arithmeticUnary(arg: PType): PType? {
         val argMayBeNumber = arg.kind == Kind.DYNAMIC || TypeFamily.NUMBERS.contains(arg.kind)
         return when (argMayBeNumber) {
-            true -> null
-            false -> arg
+            true -> arg
+            false -> null
         }
     }
 

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/ArithmeticTyper.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/ArithmeticTyper.kt
@@ -1,0 +1,117 @@
+package org.partiql.eval.internal.helpers
+
+import org.partiql.types.PType
+import org.partiql.types.PType.Kind
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * This is a mirror copy to [org.partiql.planner.internal.typer.ArithmeticTyper].
+ */
+internal object ArithmeticTyper {
+
+    /**
+     * Follows SQL-Server for decimals:
+     * Result Precision = max(s1, s2) + max(p1 - s1, p2 - s2) + 1
+     * Result Scale = max(s1, s2)
+     * @return null if the operation is not allowed on the input types.
+     */
+    internal fun add(lhs: PType, rhs: PType): PType? = arithmeticBinary(lhs, rhs) { lDec, rDec ->
+        val precision = max(lDec.scale, rDec.scale) + max(lDec.precision - lDec.scale, rDec.precision - rDec.scale) + 1
+        val scale = max(lDec.scale, rDec.scale)
+        precision to scale
+    }
+
+    /**
+     * Follows SQL-Server for decimals:
+     * Result Precision = max(s1, s2) + max(p1 - s1, p2 - s2) + 1
+     * Result Scale = max(s1, s2)
+     * @return null if the operation is not allowed on the input types.
+     */
+    internal fun subtract(lhs: PType, rhs: PType): PType? = arithmeticBinary(lhs, rhs) { lDec, rDec ->
+        val precision = max(lhs.scale, rhs.scale) + max(lhs.precision - lhs.scale, rhs.precision - rhs.scale) + 1
+        val scale = max(lhs.scale, rhs.scale)
+        precision to scale
+    }
+
+    /**
+     * Follows SQL-Server for decimals:
+     * Result Precision = p1 - s1 + s2 + max(6, s1 + p2 + 1)
+     * Result Scale = max(6, s1 + p2 + 1)
+     * @return null if the operation is not allowed on the input types.
+     */
+    internal fun divide(lhs: PType, rhs: PType): PType? = arithmeticBinary(lhs, rhs) { lDec, rDec ->
+        val precision = lhs.precision - rhs.scale + lhs.scale + max(6, lhs.scale + rhs.precision + 1)
+        val scale = max(6, lhs.scale + rhs.precision + 1)
+        precision to scale
+    }
+
+    /**
+     * Follows SQL-Server for decimals:
+     * Result Precision = p1 + p2 + 1
+     * Result Scale = s1 + s2
+     * @return null if the operation is not allowed on the input types.
+     */
+    internal fun multiply(lhs: PType, rhs: PType): PType? = arithmeticBinary(lhs, rhs) { lDec, rDec ->
+        val precision = lhs.precision + rhs.precision + 1
+        val scale = lhs.scale + rhs.scale
+        precision to scale
+    }
+
+    /**
+     * Follows SQL-Server for decimals:
+     * Result Precision: min(p1 - s1, p2 - s2) + max(s1, s2)
+     * Result Scale: max(s1, s2)
+     * @return null if the operation is not allowed on the input types.
+     */
+    internal fun modulo(lhs: PType, rhs: PType): PType? = arithmeticBinary(lhs, rhs) { lDec, rDec ->
+        val precision = min(lhs.precision - lhs.scale, rhs.precision - rhs.scale) + max(lhs.scale, rhs.scale)
+        val scale = max(lhs.scale, rhs.scale)
+        precision to scale
+    }
+
+    internal fun negative(arg: PType): PType? = arithmeticUnary(arg)
+
+    internal fun positive(arg: PType): PType? = arithmeticUnary(arg)
+
+    private fun arithmeticUnary(arg: PType): PType? {
+        val argMayBeNumber = arg.kind == Kind.DYNAMIC || TypeFamily.NUMBERS.contains(arg.kind)
+        return when (argMayBeNumber) {
+            true -> null
+            false -> arg
+        }
+    }
+
+    private fun arithmeticBinary(
+        lhs: PType,
+        rhs: PType,
+        handleDecimal: (PType, PType) -> Pair<Int, Int>
+    ): PType? {
+        val lhsCannotBeNumber = lhs.kind != Kind.DYNAMIC && !TypeFamily.NUMBERS.contains(lhs.kind)
+        val rhsCannotBeNumber = rhs.kind != Kind.DYNAMIC && !TypeFamily.NUMBERS.contains(rhs.kind)
+        if (lhsCannotBeNumber || rhsCannotBeNumber) {
+            return null
+        }
+        if (lhs.kind == Kind.DYNAMIC || rhs.kind == Kind.DYNAMIC) {
+            return PType.typeDynamic()
+        }
+        val lhsPrecedence = TypePrecedence[lhs.kind]!!
+        val rhsPrecedence = TypePrecedence[rhs.kind]!!
+        val comp = lhsPrecedence.compareTo(rhsPrecedence)
+        when (comp) {
+            -1 -> return rhs
+            1 -> return lhs
+            0 -> if (lhs.kind != Kind.DECIMAL) {
+                return lhs
+            }
+
+            else -> error("This shouldn't have occurred.")
+        }
+        val (precision, scale) = handleDecimal(lhs, rhs)
+        // TODO: Check if this is what we want
+        return when (precision > 38 || scale > 38) {
+            true -> PType.typeDecimalArbitrary()
+            false -> PType.typeDecimal(precision, scale)
+        }
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/Coercions.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/Coercions.kt
@@ -1,0 +1,217 @@
+package org.partiql.eval.internal.helpers
+
+import org.partiql.plan.Ref
+import org.partiql.types.Field
+import org.partiql.types.PType
+import org.partiql.types.PType.Kind
+
+/**
+ * DEVELOPMENT NOTE: THIS IS ESSENTIALLY A COPY OF [org.partiql.planner.internal.casts.Coercions]. Please keep them updated.
+ *
+ * Important SQL Definitions:
+ * - assignable: The characteristic of a data type that permits a value of that data type to be
+ * assigned to a site of a specified data type.
+ */
+internal object Coercions {
+
+    fun get(input: PType, target: PType): Ref.Cast? {
+        return getCoercion(input, target)
+    }
+
+    /**
+     * Remaining coercions from SQL:1999:
+     * - Values corresponding to the binary data type are mutually assignable.
+     * - Values corresponding to the data types BIT and BIT VARYING are always mutually comparable and
+     * are mutually assignable.
+     * - Values of type interval are mutually assignable only if the source and target of the assignment are
+     * both year-month intervals or if they are both day-time intervals.
+     * - Values corresponding to user-defined types are discussed in Subclause 4.8.4, ‘‘User-defined type
+     * comparison and assignment’’.
+     */
+    private fun getCoercion(input: PType, target: PType): Ref.Cast? {
+        return when {
+            isAssignable(input, target) -> coercion(input, target)
+            else -> null
+        }
+    }
+
+    private val TYPES_NUMBER = setOf(
+        Kind.TINYINT,
+        Kind.SMALLINT,
+        Kind.INT,
+        Kind.BIGINT,
+        Kind.INT_ARBITRARY,
+        Kind.REAL,
+        Kind.DOUBLE_PRECISION,
+        Kind.DECIMAL,
+        Kind.DECIMAL_ARBITRARY
+    )
+
+    private val TYPES_TEXT = setOf(
+        Kind.CHAR,
+        Kind.VARCHAR,
+        Kind.STRING,
+        Kind.CLOB,
+        Kind.SYMBOL
+    )
+
+    private val TYPES_COLLECTION = setOf(
+        Kind.LIST,
+        Kind.SEXP,
+        Kind.BAG
+    )
+
+    private fun isAssignable(input: PType, target: PType): Boolean {
+        return areAssignableNumberTypes(input, target) ||
+            areAssignableTextTypes(input, target) ||
+            areAssignableBooleanTypes(input, target) ||
+            areAssignableDateTimeTypes(input, target) ||
+            areAssignableCollectionTypes(input, target) ||
+            areAssignableStructuralTypes(input, target) ||
+            areAssignableDynamicTypes(target)
+    }
+
+    /**
+     * NOT specified by SQL:1999. We assume that we can coerce a collection of one type to another if the subtype
+     * of each collection is assignable.
+     */
+    private fun areAssignableCollectionTypes(input: PType, target: PType): Boolean {
+        return input.kind in TYPES_COLLECTION && target.kind in TYPES_COLLECTION && isAssignable(input.typeParameter, target.typeParameter)
+    }
+
+    /**
+     * NOT specified by SQL:1999. We assume that we can statically coerce anything to DYNAMIC. However, note that
+     * CAST(<v> AS DYNAMIC) is NEVER inserted. We check for the use of DYNAMIC at function resolution. This is merely
+     * for the [PType.getTypeParameter] and [PType.getFields]
+     */
+    private fun areAssignableDynamicTypes(target: PType): Boolean {
+        return target.kind == Kind.DYNAMIC
+    }
+
+    /**
+     * NOT completely specified by SQL:1999.
+     *
+     * From SQL:1999:
+     * ```
+     * Values corresponding to row types are mutually assignable if and only if both have the same degree
+     * and every field in one row type is mutually assignable to the field in the same ordinal position of
+     * the other row type. Values corresponding to row types are mutually comparable if and only if both
+     * have the same degree and every field in one row type is mutually comparable to the field in the
+     * same ordinal position of the other row type.
+     * ```
+     */
+    private fun areAssignableStructuralTypes(input: PType, target: PType): Boolean {
+        return when {
+            input.kind == Kind.ROW && target.kind == Kind.ROW -> fieldsAreAssignable(input.fields!!.toList(), target.fields!!.toList())
+            input.kind == Kind.STRUCT && target.kind == Kind.ROW -> when (input.fields) {
+                null -> true
+                else -> namedFieldsAreAssignableUnordered(input.fields!!.toList(), target.fields!!.toList())
+            }
+            input.kind == Kind.ROW && target.kind == Kind.STRUCT -> when (target.fields) {
+                null -> true
+                else -> namedFieldsAreAssignableUnordered(input.fields!!.toList(), target.fields!!.toList())
+            }
+            input.kind == Kind.STRUCT && target.kind == Kind.STRUCT -> when {
+                input.fields == null || target.fields == null -> true
+                else -> fieldsAreAssignable(input.fields!!.toList(), target.fields!!.toList())
+            }
+            else -> false
+        }
+    }
+
+    private fun fieldsAreAssignable(input: List<Field>, target: List<Field>): Boolean {
+        if (input.size != target.size) { return false }
+        val iIter = input.iterator()
+        val tIter = target.iterator()
+        while (iIter.hasNext()) {
+            val iField = iIter.next()
+            val tField = tIter.next()
+            if (!isAssignable(iField.type, tField.type)) {
+                return false
+            }
+        }
+        return true
+    }
+
+    /**
+     * This is a PartiQL extension. We assume that structs/rows with the same field names may be assignable
+     * if all names match AND types are assignable.
+     */
+    private fun namedFieldsAreAssignableUnordered(input: List<Field>, target: List<Field>): Boolean {
+        if (input.size != target.size) { return false }
+        val inputSorted = input.sortedBy { it.name }
+        val targetSorted = target.sortedBy { it.name }
+        val iIter = inputSorted.iterator()
+        val tIter = targetSorted.iterator()
+        while (iIter.hasNext()) {
+            val iField = iIter.next()
+            val tField = tIter.next()
+            if (iField.name != tField.name) {
+                return false
+            }
+            if (!isAssignable(iField.type, tField.type)) {
+                return false
+            }
+        }
+        return true
+    }
+
+    /**
+     * From SQL:1999:
+     * ```
+     * Values of the data types NUMERIC, DECIMAL, INTEGER, SMALLINT, FLOAT, REAL, and
+     * DOUBLE PRECISION are numbers and are all mutually comparable and mutually assignable.
+     * ```
+     */
+    private fun areAssignableNumberTypes(input: PType, target: PType): Boolean {
+        return input.kind in TYPES_NUMBER && target.kind in TYPES_NUMBER
+    }
+
+    /**
+     * From SQL:1999:
+     * ```
+     * Values corresponding to the data type boolean are always mutually comparable and are mutually
+     * assignable.
+     * ```
+     */
+    private fun areAssignableBooleanTypes(input: PType, target: PType): Boolean {
+        return input.kind == Kind.BOOL && target.kind == Kind.BOOL
+    }
+
+    /**
+     * From SQL:1999:
+     * ```
+     * Values corresponding to the data types CHARACTER, CHARACTER VARYING, and CHARACTER
+     * LARGE OBJECT are mutually assignable if and only if they are taken from the same character
+     * repertoire. (For this implementation, we shall assume that all text types share the same
+     * character repertoire.)
+     * ```
+     */
+    private fun areAssignableTextTypes(input: PType, target: PType): Boolean {
+        return input.kind in TYPES_TEXT && target.kind in TYPES_TEXT
+    }
+
+    /**
+     * From SQL:1999:
+     * ```
+     * Values of type datetime are mutually assignable only if the source and target of the assignment are
+     * both of type DATE, or both of type TIME (regardless whether WITH TIME ZONE or WITHOUT
+     * TIME ZONE is specified or implicit), or both of type TIMESTAMP (regardless whether WITH TIME
+     * ZONE or WITHOUT TIME ZONE is specified or implicit)
+     * ```
+     */
+    private fun areAssignableDateTimeTypes(input: PType, target: PType): Boolean {
+        val i = input.kind
+        val t = target.kind
+        return when {
+            i == Kind.DATE && t == Kind.DATE -> true
+            (i == Kind.TIME_WITH_TZ || i == Kind.TIME_WITHOUT_TZ) && (t == Kind.TIME_WITH_TZ || t == Kind.TIME_WITHOUT_TZ) -> true
+            (i == Kind.TIMESTAMP_WITH_TZ || i == Kind.TIMESTAMP_WITHOUT_TZ) && (t == Kind.TIMESTAMP_WITH_TZ || t == Kind.TIMESTAMP_WITHOUT_TZ) -> true
+            else -> false
+        }
+    }
+
+    private fun coercion(input: PType, target: PType): Ref.Cast {
+        return Ref.Cast(input, target, isNullable = true)
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/FnComparator.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/FnComparator.kt
@@ -1,4 +1,4 @@
-package org.partiql.planner.internal
+package org.partiql.eval.internal.helpers
 
 import org.partiql.spi.fn.FnExperimental
 import org.partiql.spi.fn.FnParameter
@@ -7,6 +7,8 @@ import org.partiql.types.PType
 import org.partiql.types.PType.Kind
 
 /**
+ * DEVELOPMENT NOTE: THIS IS A COPY OF [org.partiql.planner.internal.FnComparator]. Keep them updated.
+ *
  * Function precedence comparator; this is not formally specified.
  *
  *  1. Fewest args first

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/TypeFamily.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/TypeFamily.kt
@@ -1,0 +1,20 @@
+package org.partiql.eval.internal.helpers
+
+import org.partiql.types.PType
+
+/**
+ * This is a utility class to help with planning.
+ */
+internal object TypeFamily {
+    val NUMBERS = setOf(
+        PType.Kind.TINYINT,
+        PType.Kind.SMALLINT,
+        PType.Kind.INT,
+        PType.Kind.BIGINT,
+        PType.Kind.INT_ARBITRARY,
+        PType.Kind.DECIMAL,
+        PType.Kind.DECIMAL_ARBITRARY,
+        PType.Kind.REAL,
+        PType.Kind.DOUBLE_PRECISION,
+    )
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/TypePrecedence.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/TypePrecedence.kt
@@ -1,0 +1,55 @@
+package org.partiql.eval.internal.helpers
+
+import org.partiql.types.PType.Kind
+
+/**
+ * Map of the type precedences.
+ */
+internal object TypePrecedence : Map<Kind, Int> {
+
+    private val _delegate: Map<Kind, Int> = listOf(
+        Kind.BOOL,
+        Kind.TINYINT,
+        Kind.SMALLINT,
+        Kind.INT,
+        Kind.BIGINT,
+        Kind.INT_ARBITRARY,
+        Kind.DECIMAL,
+        Kind.REAL,
+        Kind.DOUBLE_PRECISION,
+        Kind.DECIMAL_ARBITRARY, // Arbitrary precision decimal has a higher precedence than FLOAT
+        Kind.CHAR,
+        Kind.VARCHAR,
+        Kind.SYMBOL,
+        Kind.STRING,
+        Kind.CLOB,
+        Kind.BLOB,
+        Kind.DATE,
+        Kind.TIME_WITHOUT_TZ,
+        Kind.TIME_WITH_TZ,
+        Kind.TIMESTAMP_WITHOUT_TZ,
+        Kind.TIMESTAMP_WITH_TZ,
+        Kind.LIST,
+        Kind.SEXP,
+        Kind.BAG,
+        Kind.ROW,
+        Kind.STRUCT,
+        Kind.DYNAMIC,
+    ).mapIndexed { precedence, type -> type to precedence }.toMap()
+
+    override val entries: Set<Map.Entry<Kind, Int>> = _delegate.entries
+
+    override val keys: Set<Kind> = _delegate.keys
+
+    override val size: Int = _delegate.size
+
+    override val values: Collection<Int> = _delegate.values
+
+    override fun isEmpty(): Boolean = _delegate.isEmpty()
+
+    override fun get(key: Kind): Int? = _delegate.get(key)
+
+    override fun containsValue(value: Int): Boolean = _delegate.containsValue(value)
+
+    override fun containsKey(key: Kind): Boolean = _delegate.containsKey(key)
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprArithmeticBinary.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprArithmeticBinary.kt
@@ -1,0 +1,253 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.errors.TypeCheckException
+import org.partiql.eval.internal.Environment
+import org.partiql.eval.internal.helpers.ArithmeticTyper
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.eval.value.Datum
+import org.partiql.plan.Ref
+import org.partiql.types.PType
+import org.partiql.types.PType.Kind
+import java.math.BigDecimal
+import java.math.BigInteger
+
+internal class ExprArithmeticBinary<T>(
+    val lhs: Operator.Expr,
+    val rhs: Operator.Expr,
+    val extract: (Datum) -> T,
+    val toReturn: (T) -> Datum,
+    val op: (T, T) -> T,
+    val returnType: PType
+) : Operator.Expr {
+
+    override fun eval(env: Environment): Datum {
+        val lhsEval = lhs.eval(env)
+        val rhsEval = rhs.eval(env)
+        if (lhsEval.isNull || rhsEval.isNull) return Datum.nullValue(returnType)
+        if (lhsEval.isMissing || rhsEval.isMissing) throw TypeCheckException()
+        return toReturn(op(extract(lhsEval), extract(rhsEval)))
+    }
+
+    internal interface Factory {
+
+        fun add(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr
+
+        fun subtract(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr
+
+        fun modulo(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr
+
+        fun divide(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr
+
+        fun multiply(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr
+
+        abstract class Simple<T> : Factory {
+
+            abstract val extract: (Datum) -> T
+            abstract val toReturn: (T) -> Datum
+            abstract val add: (T, T) -> T
+            abstract val subtract: (T, T) -> T
+            abstract val divide: (T, T) -> T
+            abstract val multiply: (T, T) -> T
+            abstract val modulo: (T, T) -> T
+            abstract val returnType: PType
+
+            override fun add(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return ExprArithmeticBinary(lhs, rhs, extract, toReturn, add, returnType)
+            }
+
+            override fun subtract(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return ExprArithmeticBinary(lhs, rhs, extract, toReturn, subtract, returnType)
+            }
+
+            override fun divide(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return ExprArithmeticBinary(lhs, rhs, extract, toReturn, divide, returnType)
+            }
+
+            override fun multiply(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return ExprArithmeticBinary(lhs, rhs, extract, toReturn, multiply, returnType)
+            }
+
+            override fun modulo(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return ExprArithmeticBinary(lhs, rhs, extract, toReturn, modulo, returnType)
+            }
+        }
+
+        object Int : Simple<kotlin.Int>() {
+            override val extract: (Datum) -> kotlin.Int = Datum::getInt
+            override val toReturn: (kotlin.Int) -> Datum = Datum::int32Value
+            override val add: (kotlin.Int, kotlin.Int) -> kotlin.Int = kotlin.Int::plus
+            override val subtract: (kotlin.Int, kotlin.Int) -> kotlin.Int = kotlin.Int::minus
+            override val divide: (kotlin.Int, kotlin.Int) -> kotlin.Int = kotlin.Int::div
+            override val multiply: (kotlin.Int, kotlin.Int) -> kotlin.Int = kotlin.Int::times
+            override val modulo: (kotlin.Int, kotlin.Int) -> kotlin.Int = kotlin.Int::rem
+            override val returnType: PType = PType.typeInt()
+        }
+
+        object BigInt : Simple<kotlin.Long>() {
+            override val extract: (Datum) -> kotlin.Long = Datum::getLong
+            override val toReturn: (kotlin.Long) -> Datum = Datum::int64Value
+            override val add: (kotlin.Long, kotlin.Long) -> kotlin.Long = kotlin.Long::plus
+            override val subtract: (kotlin.Long, kotlin.Long) -> kotlin.Long = kotlin.Long::minus
+            override val divide: (kotlin.Long, kotlin.Long) -> kotlin.Long = kotlin.Long::div
+            override val multiply: (kotlin.Long, kotlin.Long) -> kotlin.Long = kotlin.Long::times
+            override val modulo: (kotlin.Long, kotlin.Long) -> kotlin.Long = kotlin.Long::rem
+            override val returnType: PType = PType.typeBigInt()
+        }
+
+        object Short : Simple<kotlin.Short>() {
+            override val extract: (Datum) -> kotlin.Short = Datum::getShort
+            override val toReturn: (kotlin.Short) -> Datum = Datum::smallInt
+            override val add: (kotlin.Short, kotlin.Short) -> kotlin.Short = { x, y -> (x + y).toShort() }
+            override val subtract: (kotlin.Short, kotlin.Short) -> kotlin.Short = { x, y -> (x - y).toShort() }
+            override val divide: (kotlin.Short, kotlin.Short) -> kotlin.Short = { x, y -> (x / y).toShort() }
+            override val multiply: (kotlin.Short, kotlin.Short) -> kotlin.Short = { x, y -> (x * y).toShort() }
+            override val modulo: (kotlin.Short, kotlin.Short) -> kotlin.Short = { x, y -> (x % y).toShort() }
+            override val returnType: PType = PType.typeSmallInt()
+        }
+
+        object Float : Simple<kotlin.Float>() {
+            override val extract: (Datum) -> kotlin.Float = Datum::getFloat
+            override val toReturn: (kotlin.Float) -> Datum = Datum::real
+            override val add: (kotlin.Float, kotlin.Float) -> kotlin.Float = kotlin.Float::plus
+            override val subtract: (kotlin.Float, kotlin.Float) -> kotlin.Float = kotlin.Float::minus
+            override val divide: (kotlin.Float, kotlin.Float) -> kotlin.Float = kotlin.Float::div
+            override val multiply: (kotlin.Float, kotlin.Float) -> kotlin.Float = kotlin.Float::times
+            override val modulo: (kotlin.Float, kotlin.Float) -> kotlin.Float = kotlin.Float::rem
+            override val returnType: PType = PType.typeReal()
+        }
+
+        object Double : Simple<kotlin.Double>() {
+            override val extract: (Datum) -> kotlin.Double = Datum::getDouble
+            override val toReturn: (kotlin.Double) -> Datum = Datum::doublePrecision
+            override val add: (kotlin.Double, kotlin.Double) -> kotlin.Double = kotlin.Double::plus
+            override val subtract: (kotlin.Double, kotlin.Double) -> kotlin.Double = kotlin.Double::minus
+            override val divide: (kotlin.Double, kotlin.Double) -> kotlin.Double = kotlin.Double::div
+            override val multiply: (kotlin.Double, kotlin.Double) -> kotlin.Double = kotlin.Double::times
+            override val modulo: (kotlin.Double, kotlin.Double) -> kotlin.Double = kotlin.Double::rem
+            override val returnType: PType = PType.typeDoublePrecision()
+        }
+
+        object IntArbitrary : Simple<BigInteger>() {
+            override val extract: (Datum) -> BigInteger = Datum::getBigInteger
+            override val toReturn: (BigInteger) -> Datum = Datum::intArbitrary
+            override val add: (BigInteger, BigInteger) -> BigInteger = BigInteger::plus
+            override val subtract: (BigInteger, BigInteger) -> BigInteger = BigInteger::minus
+            override val divide: (BigInteger, BigInteger) -> BigInteger = BigInteger::divide
+            override val multiply: (BigInteger, BigInteger) -> BigInteger = BigInteger::times
+            override val modulo: (BigInteger, BigInteger) -> BigInteger = BigInteger::rem
+            override val returnType: PType = PType.typeIntArbitrary()
+        }
+
+        object DecimalArbitrary : Simple<BigDecimal>() {
+            override val extract: (Datum) -> BigDecimal = Datum::getBigDecimal
+            override val toReturn: (BigDecimal) -> Datum = Datum::decimalArbitrary
+            override val add: (BigDecimal, BigDecimal) -> BigDecimal = BigDecimal::plus
+            override val subtract: (BigDecimal, BigDecimal) -> BigDecimal = BigDecimal::minus
+            override val divide: (BigDecimal, BigDecimal) -> BigDecimal = BigDecimal::divide
+            override val multiply: (BigDecimal, BigDecimal) -> BigDecimal = BigDecimal::times
+            override val modulo: (BigDecimal, BigDecimal) -> BigDecimal = BigDecimal::remainder
+            override val returnType: PType = PType.typeDecimalArbitrary()
+        }
+
+        object Byte : Simple<kotlin.Byte>() {
+            override val extract: (Datum) -> kotlin.Byte = Datum::getByte
+            override val toReturn: (kotlin.Byte) -> Datum = Datum::tinyInt
+            override val add: (kotlin.Byte, kotlin.Byte) -> kotlin.Byte = { x, y -> (x + y).toByte() }
+            override val subtract: (kotlin.Byte, kotlin.Byte) -> kotlin.Byte = { x, y -> (x - y).toByte() }
+            override val divide: (kotlin.Byte, kotlin.Byte) -> kotlin.Byte = { x, y -> (x / y).toByte() }
+            override val multiply: (kotlin.Byte, kotlin.Byte) -> kotlin.Byte = { x, y -> (x * y).toByte() }
+            override val modulo: (kotlin.Byte, kotlin.Byte) -> kotlin.Byte = { x, y -> (x % y).toByte() }
+            override val returnType: PType = PType.typeTinyInt()
+        }
+
+        class Decimal(private val returnType: PType) : Factory {
+            override fun add(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return Decimal(lhs, rhs, returnType, BigDecimal::plus)
+            }
+
+            override fun subtract(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return Decimal(lhs, rhs, returnType, BigDecimal::minus)
+            }
+
+            override fun multiply(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return Decimal(lhs, rhs, returnType, BigDecimal::times)
+            }
+
+            override fun divide(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return Decimal(lhs, rhs, returnType, BigDecimal::divide)
+            }
+            override fun modulo(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return Decimal(lhs, rhs, returnType, BigDecimal::remainder)
+            }
+        }
+
+        object Dynamic : Factory {
+            override fun add(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return Dynamic(lhs, rhs, Factory::add, ArithmeticTyper::add)
+            }
+
+            override fun subtract(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return Dynamic(lhs, rhs, Factory::subtract, ArithmeticTyper::subtract)
+            }
+
+            override fun divide(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return Dynamic(lhs, rhs, Factory::divide, ArithmeticTyper::divide)
+            }
+
+            override fun multiply(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return Dynamic(lhs, rhs, Factory::multiply, ArithmeticTyper::multiply)
+            }
+
+            override fun modulo(lhs: Operator.Expr, rhs: Operator.Expr): Operator.Expr {
+                return Dynamic(lhs, rhs, Factory::modulo, ArithmeticTyper::modulo)
+            }
+        }
+    }
+
+    internal class Decimal(
+        private val lhs: Operator.Expr,
+        private val rhs: Operator.Expr,
+        private val returnType: PType,
+        private val op: (BigDecimal, BigDecimal) -> BigDecimal
+    ) : Operator.Expr {
+
+        override fun eval(env: Environment): Datum {
+            val lhsEval = lhs.eval(env)
+            val rhsEval = rhs.eval(env)
+            if (lhsEval.isNull || rhsEval.isNull) return Datum.nullValue(returnType)
+            if (lhsEval.isMissing || rhsEval.isMissing) throw TypeCheckException()
+            return Datum.decimal(op(lhsEval.bigDecimal, rhsEval.bigDecimal), returnType.precision, returnType.scale)
+        }
+    }
+
+    internal class Dynamic(
+        val lhs: Operator.Expr,
+        val rhs: Operator.Expr,
+        val op: (Factory, Operator.Expr, Operator.Expr) -> Operator.Expr,
+        val type: (PType, PType) -> PType?
+    ) : Operator.Expr {
+        override fun eval(env: Environment): Datum {
+            val lhsEval = lhs.eval(env)
+            val rhsEval = rhs.eval(env)
+            val returns = type(lhsEval.type, rhsEval.type) ?: throw TypeCheckException()
+            val factory = when (returns.kind) {
+                PType.Kind.TINYINT -> Factory.Byte
+                PType.Kind.SMALLINT -> Factory.Short
+                PType.Kind.INT -> Factory.Int
+                PType.Kind.BIGINT -> Factory.BigInt
+                PType.Kind.INT_ARBITRARY -> Factory.IntArbitrary
+                PType.Kind.REAL -> Factory.Float
+                PType.Kind.DOUBLE_PRECISION -> Factory.Double
+                PType.Kind.DECIMAL -> Factory.Decimal(returns)
+                PType.Kind.DECIMAL_ARBITRARY -> Factory.DecimalArbitrary
+                else -> throw TypeCheckException()
+            }
+            return op(factory, lhsEval.coerce(lhsEval.type, returns), rhsEval.coerce(rhsEval.type, returns)).eval(env)
+        }
+
+        private fun Datum.coerce(input: PType, target: PType): Operator.Expr {
+            if (input == target) return ExprLiteral(this)
+            return ExprCast(ExprLiteral(this), Ref.Cast(input, target, isNullable = true))
+        }
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprArithmeticUnary.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprArithmeticUnary.kt
@@ -1,0 +1,178 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.errors.TypeCheckException
+import org.partiql.eval.internal.Environment
+import org.partiql.eval.internal.helpers.ArithmeticTyper
+import org.partiql.eval.internal.operator.Operator
+import org.partiql.eval.value.Datum
+import org.partiql.plan.Ref
+import org.partiql.types.PType
+import java.math.BigDecimal
+import java.math.BigInteger
+
+internal class ExprArithmeticUnary<T>(
+    val arg: Operator.Expr,
+    val extract: (Datum) -> T,
+    val toReturn: (T) -> Datum,
+    val op: (T) -> T,
+    val returnType: PType
+) : Operator.Expr {
+
+    override fun eval(env: Environment): Datum {
+        val argEval = arg.eval(env)
+        if (argEval.isNull) return Datum.nullValue(returnType)
+        if (argEval.isMissing) throw TypeCheckException()
+        return toReturn(op(extract(argEval)))
+    }
+
+    internal interface Factory {
+
+        fun positive(arg: Operator.Expr): Operator.Expr
+
+        fun negative(arg: Operator.Expr): Operator.Expr
+
+        abstract class Simple<T> : Factory {
+
+            abstract val extract: (Datum) -> T
+            abstract val toReturn: (T) -> Datum
+            abstract val positive: (T) -> T
+            abstract val negative: (T) -> T
+            abstract val returnType: PType
+
+            override fun positive(arg: Operator.Expr): Operator.Expr {
+                return ExprArithmeticUnary(arg, extract, toReturn, positive, returnType)
+            }
+
+            override fun negative(arg: Operator.Expr): Operator.Expr {
+                return ExprArithmeticUnary(arg, extract, toReturn, negative, returnType)
+            }
+        }
+
+        object Int : Simple<kotlin.Int>() {
+            override val extract: (Datum) -> kotlin.Int = Datum::getInt
+            override val toReturn: (kotlin.Int) -> Datum = Datum::int32Value
+            override val positive: (kotlin.Int) -> kotlin.Int = kotlin.Int::unaryPlus
+            override val negative: (kotlin.Int) -> kotlin.Int = kotlin.Int::unaryMinus
+            override val returnType: PType = PType.typeInt()
+        }
+
+        object BigInt : Simple<kotlin.Long>() {
+            override val extract: (Datum) -> kotlin.Long = Datum::getLong
+            override val toReturn: (kotlin.Long) -> Datum = Datum::int64Value
+            override val positive: (kotlin.Long) -> kotlin.Long = kotlin.Long::unaryPlus
+            override val negative: (kotlin.Long) -> kotlin.Long = kotlin.Long::unaryMinus
+            override val returnType: PType = PType.typeBigInt()
+        }
+
+        object Short : Simple<kotlin.Short>() {
+            override val extract: (Datum) -> kotlin.Short = Datum::getShort
+            override val toReturn: (kotlin.Short) -> Datum = Datum::smallInt
+            override val positive: (kotlin.Short) -> kotlin.Short = { x -> x }
+            override val negative: (kotlin.Short) -> kotlin.Short = { x -> (x * -1).toShort() }
+            override val returnType: PType = PType.typeSmallInt()
+        }
+
+        object Float : Simple<kotlin.Float>() {
+            override val extract: (Datum) -> kotlin.Float = Datum::getFloat
+            override val toReturn: (kotlin.Float) -> Datum = Datum::real
+            override val positive: (kotlin.Float) -> kotlin.Float = kotlin.Float::unaryPlus
+            override val negative: (kotlin.Float) -> kotlin.Float = kotlin.Float::unaryMinus
+            override val returnType: PType = PType.typeReal()
+        }
+
+        object Double : Simple<kotlin.Double>() {
+            override val extract: (Datum) -> kotlin.Double = Datum::getDouble
+            override val toReturn: (kotlin.Double) -> Datum = Datum::doublePrecision
+            override val positive: (kotlin.Double) -> kotlin.Double = kotlin.Double::unaryPlus
+            override val negative: (kotlin.Double) -> kotlin.Double = kotlin.Double::unaryMinus
+            override val returnType: PType = PType.typeDoublePrecision()
+        }
+
+        object IntArbitrary : Simple<BigInteger>() {
+            override val extract: (Datum) -> BigInteger = Datum::getBigInteger
+            override val toReturn: (BigInteger) -> Datum = Datum::intArbitrary
+            override val positive: (BigInteger) -> BigInteger = { x -> x }
+            override val negative: (BigInteger) -> BigInteger = BigInteger::unaryMinus
+            override val returnType: PType = PType.typeIntArbitrary()
+        }
+
+        object DecimalArbitrary : Simple<BigDecimal>() {
+            override val extract: (Datum) -> BigDecimal = Datum::getBigDecimal
+            override val toReturn: (BigDecimal) -> Datum = Datum::decimalArbitrary
+            override val positive: (BigDecimal) -> BigDecimal = { x -> x }
+            override val negative: (BigDecimal) -> BigDecimal = BigDecimal::unaryMinus
+            override val returnType: PType = PType.typeDecimalArbitrary()
+        }
+
+        object Byte : Simple<kotlin.Byte>() {
+            override val extract: (Datum) -> kotlin.Byte = Datum::getByte
+            override val toReturn: (kotlin.Byte) -> Datum = Datum::tinyInt
+            override val positive: (kotlin.Byte) -> kotlin.Byte = { x -> x }
+            override val negative: (kotlin.Byte) -> kotlin.Byte = { x -> (x * -1).toByte() }
+            override val returnType: PType = PType.typeTinyInt()
+        }
+
+        class Decimal(private val returnType: PType) : Factory {
+            override fun positive(arg: Operator.Expr): Operator.Expr {
+                return Decimal(arg, returnType) { x -> x }
+            }
+
+            override fun negative(arg: Operator.Expr): Operator.Expr {
+                return Decimal(arg, returnType, BigDecimal::unaryMinus)
+            }
+        }
+
+        object Dynamic : Factory {
+            override fun positive(arg: Operator.Expr): Operator.Expr {
+                return Dynamic(arg, Factory::positive, ArithmeticTyper::positive)
+            }
+
+            override fun negative(arg: Operator.Expr): Operator.Expr {
+                return Dynamic(arg, Factory::negative, ArithmeticTyper::negative)
+            }
+        }
+    }
+
+    internal class Decimal(
+        private val arg: Operator.Expr,
+        private val returnType: PType,
+        private val op: (BigDecimal) -> BigDecimal
+    ) : Operator.Expr {
+
+        override fun eval(env: Environment): Datum {
+            val lhsEval = arg.eval(env)
+            if (lhsEval.isNull) return Datum.nullValue(returnType)
+            if (lhsEval.isMissing) throw TypeCheckException()
+            return Datum.decimal(op(lhsEval.bigDecimal), returnType.precision, returnType.scale)
+        }
+    }
+
+    internal class Dynamic(
+        val arg: Operator.Expr,
+        val op: (Factory, Operator.Expr) -> Operator.Expr,
+        val type: (PType) -> PType?
+    ) : Operator.Expr {
+        override fun eval(env: Environment): Datum {
+            val lhsEval = arg.eval(env)
+            val returns = type(lhsEval.type) ?: throw TypeCheckException()
+            val factory = when (returns.kind) {
+                PType.Kind.TINYINT -> Factory.Byte
+                PType.Kind.SMALLINT -> Factory.Short
+                PType.Kind.INT -> Factory.Int
+                PType.Kind.BIGINT -> Factory.BigInt
+                PType.Kind.INT_ARBITRARY -> Factory.IntArbitrary
+                PType.Kind.REAL -> Factory.Float
+                PType.Kind.DOUBLE_PRECISION -> Factory.Double
+                PType.Kind.DECIMAL -> Factory.Decimal(returns)
+                PType.Kind.DECIMAL_ARBITRARY -> Factory.DecimalArbitrary
+                else -> throw TypeCheckException()
+            }
+            return op(factory, lhsEval.coerce(lhsEval.type, returns)).eval(env)
+        }
+
+        private fun Datum.coerce(input: PType, target: PType): Operator.Expr {
+            if (input == target) return ExprLiteral(this)
+            return ExprCast(ExprLiteral(this), Ref.Cast(input, target, isNullable = true))
+        }
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallDynamic.kt
@@ -2,15 +2,14 @@ package org.partiql.eval.internal.operator.rex
 
 import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Environment
+import org.partiql.eval.internal.helpers.FunctionResolver
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.eval.value.Datum
 import org.partiql.plan.Ref
 import org.partiql.spi.fn.Fn
 import org.partiql.spi.fn.FnExperimental
-import org.partiql.types.PType
 import org.partiql.value.PartiQLValue
 import org.partiql.value.PartiQLValueExperimental
-import org.partiql.value.PartiQLValueType
 
 /**
  * This represents Dynamic Dispatch.
@@ -23,26 +22,21 @@ import org.partiql.value.PartiQLValueType
 @OptIn(PartiQLValueExperimental::class, FnExperimental::class)
 internal class ExprCallDynamic(
     private val name: String,
-    private val candidates: Array<Candidate>,
+    candidates: Array<Candidate>,
     private val args: Array<Operator.Expr>
 ) : Operator.Expr {
 
-    private val candidateIndex = CandidateIndex.All(candidates)
+    private val candidateImpls = candidates.map { it }
+    private val candidates = candidates.map { it.fn.signature }
 
     override fun eval(env: Environment): Datum {
         val actualArgs = args.map { it.eval(env) }.toTypedArray()
+        val transformedArgs = Array(actualArgs.size) {
+            actualArgs[it].toPartiQLValue()
+        }
         val actualTypes = actualArgs.map { it.type }
-        candidateIndex.get(actualTypes)?.let {
-            val transformedArgs = Array(actualArgs.size) {
-                actualArgs[it].toPartiQLValue()
-            }
-            return it.eval(transformedArgs, env)
-        }
-        val errorString = buildString {
-            val argString = actualArgs.joinToString(", ")
-            append("Could not dynamically find function ($name) for arguments $argString.")
-        }
-        throw TypeCheckException(errorString)
+        val match = FunctionResolver.resolve(candidates, actualTypes) as? FunctionResolver.FnMatch.Static ?: throw TypeCheckException()
+        return candidateImpls[match.index].eval(transformedArgs, env)
     }
 
     /**
@@ -74,154 +68,6 @@ internal class ExprCallDynamic(
                 }
             }.toTypedArray()
             return Datum.of(fn.invoke(args))
-        }
-    }
-
-    private sealed interface CandidateIndex {
-
-        public fun get(args: List<PType>): Candidate?
-
-        /**
-         * Preserves the original ordering of the passed-in candidates while making it faster to lookup matching
-         * functions. Utilizes both [Direct] and [Indirect].
-         *
-         * Say a user passes in the following ordered candidates:
-         * [
-         *      foo(int16, int16) -> int16,
-         *      foo(int32, int32) -> int32,
-         *      foo(int64, int64) -> int64,
-         *      foo(string, string) -> string,
-         *      foo(struct, struct) -> struct,
-         *      foo(numeric, numeric) -> numeric,
-         *      foo(int64, dynamic) -> dynamic,
-         *      foo(struct, dynamic) -> dynamic,
-         *      foo(bool, bool) -> bool
-         * ]
-         *
-         * With the above candidates, the [CandidateIndex.All] will maintain the original ordering by utilizing:
-         * - [CandidateIndex.Direct] to match hashable runtime types
-         * - [CandidateIndex.Indirect] to match the dynamic type
-         *
-         * For the above example, the internal representation of [CandidateIndex.All] is a list of
-         * [CandidateIndex.Direct] and [CandidateIndex.Indirect] that looks like:
-         * ALL listOf(
-         *      DIRECT hashMap(
-         *          [int16, int16] --> foo(int16, int16) -> int16,
-         *          [int32, int32] --> foo(int32, int32) -> int32,
-         *          [int64, int64] --> foo(int64, int64) -> int64
-         *          [string, string] --> foo(string, string) -> string,
-         *          [struct, struct] --> foo(struct, struct) -> struct,
-         *          [numeric, numeric] --> foo(numeric, numeric) -> numeric
-         *      ),
-         *      INDIRECT listOf(
-         *          foo(int64, dynamic) -> dynamic,
-         *          foo(struct, dynamic) -> dynamic
-         *      ),
-         *      DIRECT hashMap(
-         *          [bool, bool] --> foo(bool, bool) -> bool
-         *      )
-         * )
-         *
-         * @param candidates
-         */
-        class All(private val candidates: Array<Candidate>) : CandidateIndex {
-
-            private val lookups: List<CandidateIndex>
-
-            init {
-                val lookupsMutable = mutableListOf<CandidateIndex>()
-                val accumulator = mutableListOf<Pair<List<PType>, Candidate>>()
-
-                // Indicates that we are currently processing dynamic candidates that accept ANY.
-                var activelyProcessingAny = true
-
-                candidates.forEach { candidate ->
-                    // Gather the input types to the dynamic invocation
-                    val lookupTypes = candidate.coercions.mapIndexed { index, cast ->
-                        when (cast) {
-                            null -> candidate.fn.signature.parameters[index].type
-                            else -> cast.input
-                        }
-                    }
-                    val parametersIncludeAny = lookupTypes.any { it.kind == PType.Kind.DYNAMIC }
-                    // A way to simplify logic further below. If it's empty, add something and set the processing type.
-                    if (accumulator.isEmpty()) {
-                        activelyProcessingAny = parametersIncludeAny
-                        accumulator.add(lookupTypes to candidate)
-                        return@forEach
-                    }
-                    when (parametersIncludeAny) {
-                        true -> when (activelyProcessingAny) {
-                            true -> accumulator.add(lookupTypes to candidate)
-                            false -> {
-                                activelyProcessingAny = true
-                                lookupsMutable.add(Direct.of(accumulator.toList()))
-                                accumulator.clear()
-                                accumulator.add(lookupTypes to candidate)
-                            }
-                        }
-                        false -> when (activelyProcessingAny) {
-                            false -> accumulator.add(lookupTypes to candidate)
-                            true -> {
-                                activelyProcessingAny = false
-                                lookupsMutable.add(Indirect(accumulator.toList()))
-                                accumulator.clear()
-                                accumulator.add(lookupTypes to candidate)
-                            }
-                        }
-                    }
-                }
-                // Add any remaining candidates (that we didn't submit due to not ending while switching)
-                when (accumulator.isEmpty()) {
-                    true -> { /* Do nothing! */ }
-                    false -> when (activelyProcessingAny) {
-                        true -> lookupsMutable.add(Indirect(accumulator.toList()))
-                        false -> lookupsMutable.add(Direct.of(accumulator.toList()))
-                    }
-                }
-                this.lookups = lookupsMutable
-            }
-
-            override fun get(args: List<PType>): Candidate? {
-                return this.lookups.firstNotNullOfOrNull { it.get(args) }
-            }
-        }
-
-        /**
-         * An O(1) structure to quickly find directly matching dynamic candidates. This is specifically used for runtime
-         * types that can be matched directly. AKA int32, int64, etc. This does NOT include [PartiQLValueType.ANY].
-         */
-        data class Direct private constructor(val directCandidates: HashMap<List<PType>, Candidate>) : CandidateIndex {
-
-            companion object {
-                internal fun of(candidates: List<Pair<List<PType>, Candidate>>): Direct {
-                    val candidateMap = java.util.HashMap<List<PType>, Candidate>()
-                    candidateMap.putAll(candidates)
-                    return Direct(candidateMap)
-                }
-            }
-
-            override fun get(args: List<PType>): Candidate? {
-                return directCandidates[args]
-            }
-        }
-
-        /**
-         * Holds all candidates that expect a [PartiQLValueType.ANY] on input. This maintains the original
-         * precedence order.
-         */
-        data class Indirect(private val candidates: List<Pair<List<PType>, Candidate>>) : CandidateIndex {
-            override fun get(args: List<PType>): Candidate? {
-                candidates.forEach { (types, candidate) ->
-                    for (i in args.indices) {
-                        if (args[i] != types[i] && types[i].kind != PType.Kind.DYNAMIC) {
-                            return@forEach
-                        }
-                    }
-                    return candidate
-                }
-                return null
-            }
         }
     }
 }

--- a/partiql-plan/api/partiql-plan.api
+++ b/partiql-plan/api/partiql-plan.api
@@ -199,6 +199,7 @@ public final class org/partiql/plan/Plan {
 	public static final fun relOpUnpivot (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rel$Op$Unpivot;
 	public static final fun relType (Ljava/util/List;Ljava/util/Set;)Lorg/partiql/plan/Rel$Type;
 	public static final fun rex (Lorg/partiql/types/PType;Lorg/partiql/plan/Rex$Op;)Lorg/partiql/plan/Rex;
+	public static final fun rexOpAdd (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Add;
 	public static final fun rexOpCallDynamic (Ljava/util/List;Ljava/util/List;)Lorg/partiql/plan/Rex$Op$Call$Dynamic;
 	public static final fun rexOpCallDynamicCandidate (Lorg/partiql/plan/Ref;Ljava/util/List;)Lorg/partiql/plan/Rex$Op$Call$Dynamic$Candidate;
 	public static final fun rexOpCallStatic (Lorg/partiql/plan/Ref;Ljava/util/List;)Lorg/partiql/plan/Rex$Op$Call$Static;
@@ -207,19 +208,25 @@ public final class org/partiql/plan/Plan {
 	public static final fun rexOpCast (Lorg/partiql/plan/Ref$Cast;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Cast;
 	public static final fun rexOpCoalesce (Ljava/util/List;)Lorg/partiql/plan/Rex$Op$Coalesce;
 	public static final fun rexOpCollection (Ljava/util/List;)Lorg/partiql/plan/Rex$Op$Collection;
+	public static final fun rexOpDivide (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Divide;
 	public static final fun rexOpErr (Ljava/lang/String;Ljava/util/List;)Lorg/partiql/plan/Rex$Op$Err;
 	public static final fun rexOpGlobal (Lorg/partiql/plan/Ref;)Lorg/partiql/plan/Rex$Op$Global;
 	public static final fun rexOpLit (Lorg/partiql/value/PartiQLValue;)Lorg/partiql/plan/Rex$Op$Lit;
 	public static final fun rexOpMissing (Ljava/lang/String;Ljava/util/List;)Lorg/partiql/plan/Rex$Op$Missing;
+	public static final fun rexOpModulo (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Modulo;
+	public static final fun rexOpMultiply (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Multiply;
+	public static final fun rexOpNegative (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Negative;
 	public static final fun rexOpNullif (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Nullif;
 	public static final fun rexOpPathIndex (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Path$Index;
 	public static final fun rexOpPathKey (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Path$Key;
 	public static final fun rexOpPathSymbol (Lorg/partiql/plan/Rex;Ljava/lang/String;)Lorg/partiql/plan/Rex$Op$Path$Symbol;
 	public static final fun rexOpPivot (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rel;)Lorg/partiql/plan/Rex$Op$Pivot;
+	public static final fun rexOpPositive (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Positive;
 	public static final fun rexOpSelect (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rel;)Lorg/partiql/plan/Rex$Op$Select;
 	public static final fun rexOpStruct (Ljava/util/List;)Lorg/partiql/plan/Rex$Op$Struct;
 	public static final fun rexOpStructField (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Struct$Field;
 	public static final fun rexOpSubquery (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rel;Lorg/partiql/plan/Rex$Op$Subquery$Coercion;)Lorg/partiql/plan/Rex$Op$Subquery;
+	public static final fun rexOpSubtract (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Subtract;
 	public static final fun rexOpTupleUnion (Ljava/util/List;)Lorg/partiql/plan/Rex$Op$TupleUnion;
 	public static final fun rexOpVar (II)Lorg/partiql/plan/Rex$Op$Var;
 	public static final fun statementQuery (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Statement$Query;
@@ -946,6 +953,27 @@ public abstract class org/partiql/plan/Rex$Op : org/partiql/plan/PlanNode {
 	public fun accept (Lorg/partiql/plan/visitor/PlanVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class org/partiql/plan/Rex$Op$Add : org/partiql/plan/Rex$Op {
+	public static final field Companion Lorg/partiql/plan/Rex$Op$Add$Companion;
+	public final field lhs Lorg/partiql/plan/Rex;
+	public final field rhs Lorg/partiql/plan/Rex;
+	public fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)V
+	public fun accept (Lorg/partiql/plan/visitor/PlanVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun builder ()Lorg/partiql/plan/builder/RexOpAddBuilder;
+	public final fun component1 ()Lorg/partiql/plan/Rex;
+	public final fun component2 ()Lorg/partiql/plan/Rex;
+	public final fun copy (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Add;
+	public static synthetic fun copy$default (Lorg/partiql/plan/Rex$Op$Add;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Add;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/plan/Rex$Op$Add$Companion {
+	public final fun builder ()Lorg/partiql/plan/builder/RexOpAddBuilder;
+}
+
 public abstract class org/partiql/plan/Rex$Op$Call : org/partiql/plan/Rex$Op {
 	public fun accept (Lorg/partiql/plan/visitor/PlanVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 }
@@ -1114,6 +1142,27 @@ public final class org/partiql/plan/Rex$Op$Collection$Companion {
 	public final fun builder ()Lorg/partiql/plan/builder/RexOpCollectionBuilder;
 }
 
+public final class org/partiql/plan/Rex$Op$Divide : org/partiql/plan/Rex$Op {
+	public static final field Companion Lorg/partiql/plan/Rex$Op$Divide$Companion;
+	public final field lhs Lorg/partiql/plan/Rex;
+	public final field rhs Lorg/partiql/plan/Rex;
+	public fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)V
+	public fun accept (Lorg/partiql/plan/visitor/PlanVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun builder ()Lorg/partiql/plan/builder/RexOpDivideBuilder;
+	public final fun component1 ()Lorg/partiql/plan/Rex;
+	public final fun component2 ()Lorg/partiql/plan/Rex;
+	public final fun copy (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Divide;
+	public static synthetic fun copy$default (Lorg/partiql/plan/Rex$Op$Divide;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Divide;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/plan/Rex$Op$Divide$Companion {
+	public final fun builder ()Lorg/partiql/plan/builder/RexOpDivideBuilder;
+}
+
 public final class org/partiql/plan/Rex$Op$Err : org/partiql/plan/Rex$Op {
 	public static final field Companion Lorg/partiql/plan/Rex$Op$Err$Companion;
 	public final field causes Ljava/util/List;
@@ -1192,6 +1241,67 @@ public final class org/partiql/plan/Rex$Op$Missing : org/partiql/plan/Rex$Op {
 
 public final class org/partiql/plan/Rex$Op$Missing$Companion {
 	public final fun builder ()Lorg/partiql/plan/builder/RexOpMissingBuilder;
+}
+
+public final class org/partiql/plan/Rex$Op$Modulo : org/partiql/plan/Rex$Op {
+	public static final field Companion Lorg/partiql/plan/Rex$Op$Modulo$Companion;
+	public final field lhs Lorg/partiql/plan/Rex;
+	public final field rhs Lorg/partiql/plan/Rex;
+	public fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)V
+	public fun accept (Lorg/partiql/plan/visitor/PlanVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun builder ()Lorg/partiql/plan/builder/RexOpModuloBuilder;
+	public final fun component1 ()Lorg/partiql/plan/Rex;
+	public final fun component2 ()Lorg/partiql/plan/Rex;
+	public final fun copy (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Modulo;
+	public static synthetic fun copy$default (Lorg/partiql/plan/Rex$Op$Modulo;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Modulo;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/plan/Rex$Op$Modulo$Companion {
+	public final fun builder ()Lorg/partiql/plan/builder/RexOpModuloBuilder;
+}
+
+public final class org/partiql/plan/Rex$Op$Multiply : org/partiql/plan/Rex$Op {
+	public static final field Companion Lorg/partiql/plan/Rex$Op$Multiply$Companion;
+	public final field lhs Lorg/partiql/plan/Rex;
+	public final field rhs Lorg/partiql/plan/Rex;
+	public fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)V
+	public fun accept (Lorg/partiql/plan/visitor/PlanVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun builder ()Lorg/partiql/plan/builder/RexOpMultiplyBuilder;
+	public final fun component1 ()Lorg/partiql/plan/Rex;
+	public final fun component2 ()Lorg/partiql/plan/Rex;
+	public final fun copy (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Multiply;
+	public static synthetic fun copy$default (Lorg/partiql/plan/Rex$Op$Multiply;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Multiply;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/plan/Rex$Op$Multiply$Companion {
+	public final fun builder ()Lorg/partiql/plan/builder/RexOpMultiplyBuilder;
+}
+
+public final class org/partiql/plan/Rex$Op$Negative : org/partiql/plan/Rex$Op {
+	public static final field Companion Lorg/partiql/plan/Rex$Op$Negative$Companion;
+	public final field arg Lorg/partiql/plan/Rex;
+	public fun <init> (Lorg/partiql/plan/Rex;)V
+	public fun accept (Lorg/partiql/plan/visitor/PlanVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun builder ()Lorg/partiql/plan/builder/RexOpNegativeBuilder;
+	public final fun component1 ()Lorg/partiql/plan/Rex;
+	public final fun copy (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Negative;
+	public static synthetic fun copy$default (Lorg/partiql/plan/Rex$Op$Negative;Lorg/partiql/plan/Rex;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Negative;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/plan/Rex$Op$Negative$Companion {
+	public final fun builder ()Lorg/partiql/plan/builder/RexOpNegativeBuilder;
 }
 
 public final class org/partiql/plan/Rex$Op$Nullif : org/partiql/plan/Rex$Op {
@@ -1305,6 +1415,25 @@ public final class org/partiql/plan/Rex$Op$Pivot$Companion {
 	public final fun builder ()Lorg/partiql/plan/builder/RexOpPivotBuilder;
 }
 
+public final class org/partiql/plan/Rex$Op$Positive : org/partiql/plan/Rex$Op {
+	public static final field Companion Lorg/partiql/plan/Rex$Op$Positive$Companion;
+	public final field arg Lorg/partiql/plan/Rex;
+	public fun <init> (Lorg/partiql/plan/Rex;)V
+	public fun accept (Lorg/partiql/plan/visitor/PlanVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun builder ()Lorg/partiql/plan/builder/RexOpPositiveBuilder;
+	public final fun component1 ()Lorg/partiql/plan/Rex;
+	public final fun copy (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Positive;
+	public static synthetic fun copy$default (Lorg/partiql/plan/Rex$Op$Positive;Lorg/partiql/plan/Rex;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Positive;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/plan/Rex$Op$Positive$Companion {
+	public final fun builder ()Lorg/partiql/plan/builder/RexOpPositiveBuilder;
+}
+
 public final class org/partiql/plan/Rex$Op$Select : org/partiql/plan/Rex$Op {
 	public static final field Companion Lorg/partiql/plan/Rex$Op$Select$Companion;
 	public final field constructor Lorg/partiql/plan/Rex;
@@ -1394,6 +1523,27 @@ public final class org/partiql/plan/Rex$Op$Subquery$Coercion : java/lang/Enum {
 
 public final class org/partiql/plan/Rex$Op$Subquery$Companion {
 	public final fun builder ()Lorg/partiql/plan/builder/RexOpSubqueryBuilder;
+}
+
+public final class org/partiql/plan/Rex$Op$Subtract : org/partiql/plan/Rex$Op {
+	public static final field Companion Lorg/partiql/plan/Rex$Op$Subtract$Companion;
+	public final field lhs Lorg/partiql/plan/Rex;
+	public final field rhs Lorg/partiql/plan/Rex;
+	public fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)V
+	public fun accept (Lorg/partiql/plan/visitor/PlanVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun builder ()Lorg/partiql/plan/builder/RexOpSubtractBuilder;
+	public final fun component1 ()Lorg/partiql/plan/Rex;
+	public final fun component2 ()Lorg/partiql/plan/Rex;
+	public final fun copy (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)Lorg/partiql/plan/Rex$Op$Subtract;
+	public static synthetic fun copy$default (Lorg/partiql/plan/Rex$Op$Subtract;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Subtract;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/plan/Rex$Op$Subtract$Companion {
+	public final fun builder ()Lorg/partiql/plan/builder/RexOpSubtractBuilder;
 }
 
 public final class org/partiql/plan/Rex$Op$TupleUnion : org/partiql/plan/Rex$Op {
@@ -1628,6 +1778,8 @@ public final class org/partiql/plan/builder/PlanBuilder {
 	public static synthetic fun relType$default (Lorg/partiql/plan/builder/PlanBuilder;Ljava/util/List;Ljava/util/Set;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rel$Type;
 	public final fun rex (Lorg/partiql/types/PType;Lorg/partiql/plan/Rex$Op;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex;
 	public static synthetic fun rex$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/types/PType;Lorg/partiql/plan/Rex$Op;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex;
+	public final fun rexOpAdd (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Add;
+	public static synthetic fun rexOpAdd$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Add;
 	public final fun rexOpCallDynamic (Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Call$Dynamic;
 	public static synthetic fun rexOpCallDynamic$default (Lorg/partiql/plan/builder/PlanBuilder;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Call$Dynamic;
 	public final fun rexOpCallDynamicCandidate (Lorg/partiql/plan/Ref;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Call$Dynamic$Candidate;
@@ -1644,6 +1796,8 @@ public final class org/partiql/plan/builder/PlanBuilder {
 	public static synthetic fun rexOpCoalesce$default (Lorg/partiql/plan/builder/PlanBuilder;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Coalesce;
 	public final fun rexOpCollection (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Collection;
 	public static synthetic fun rexOpCollection$default (Lorg/partiql/plan/builder/PlanBuilder;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Collection;
+	public final fun rexOpDivide (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Divide;
+	public static synthetic fun rexOpDivide$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Divide;
 	public final fun rexOpErr (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Err;
 	public static synthetic fun rexOpErr$default (Lorg/partiql/plan/builder/PlanBuilder;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Err;
 	public final fun rexOpGlobal (Lorg/partiql/plan/Ref;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Global;
@@ -1652,6 +1806,12 @@ public final class org/partiql/plan/builder/PlanBuilder {
 	public static synthetic fun rexOpLit$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/value/PartiQLValue;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Lit;
 	public final fun rexOpMissing (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Missing;
 	public static synthetic fun rexOpMissing$default (Lorg/partiql/plan/builder/PlanBuilder;Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Missing;
+	public final fun rexOpModulo (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Modulo;
+	public static synthetic fun rexOpModulo$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Modulo;
+	public final fun rexOpMultiply (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Multiply;
+	public static synthetic fun rexOpMultiply$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Multiply;
+	public final fun rexOpNegative (Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Negative;
+	public static synthetic fun rexOpNegative$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Negative;
 	public final fun rexOpNullif (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Nullif;
 	public static synthetic fun rexOpNullif$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Nullif;
 	public final fun rexOpPathIndex (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Path$Index;
@@ -1662,6 +1822,8 @@ public final class org/partiql/plan/builder/PlanBuilder {
 	public static synthetic fun rexOpPathSymbol$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Path$Symbol;
 	public final fun rexOpPivot (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rel;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Pivot;
 	public static synthetic fun rexOpPivot$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rel;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Pivot;
+	public final fun rexOpPositive (Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Positive;
+	public static synthetic fun rexOpPositive$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Positive;
 	public final fun rexOpSelect (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rel;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Select;
 	public static synthetic fun rexOpSelect$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rel;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Select;
 	public final fun rexOpStruct (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Struct;
@@ -1670,6 +1832,8 @@ public final class org/partiql/plan/builder/PlanBuilder {
 	public static synthetic fun rexOpStructField$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Struct$Field;
 	public final fun rexOpSubquery (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rel;Lorg/partiql/plan/Rex$Op$Subquery$Coercion;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Subquery;
 	public static synthetic fun rexOpSubquery$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rel;Lorg/partiql/plan/Rex$Op$Subquery$Coercion;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Subquery;
+	public final fun rexOpSubtract (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Subtract;
+	public static synthetic fun rexOpSubtract$default (Lorg/partiql/plan/builder/PlanBuilder;Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$Subtract;
 	public final fun rexOpTupleUnion (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$TupleUnion;
 	public static synthetic fun rexOpTupleUnion$default (Lorg/partiql/plan/builder/PlanBuilder;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/partiql/plan/Rex$Op$TupleUnion;
 	public final fun rexOpVar (Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/jvm/functions/Function1;)Lorg/partiql/plan/Rex$Op$Var;
@@ -2072,6 +2236,19 @@ public final class org/partiql/plan/builder/RexBuilder {
 	public final fun type (Lorg/partiql/types/PType;)Lorg/partiql/plan/builder/RexBuilder;
 }
 
+public final class org/partiql/plan/builder/RexOpAddBuilder {
+	public fun <init> ()V
+	public fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)V
+	public synthetic fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun build ()Lorg/partiql/plan/Rex$Op$Add;
+	public final fun getLhs ()Lorg/partiql/plan/Rex;
+	public final fun getRhs ()Lorg/partiql/plan/Rex;
+	public final fun lhs (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpAddBuilder;
+	public final fun rhs (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpAddBuilder;
+	public final fun setLhs (Lorg/partiql/plan/Rex;)V
+	public final fun setRhs (Lorg/partiql/plan/Rex;)V
+}
+
 public final class org/partiql/plan/builder/RexOpCallDynamicBuilder {
 	public fun <init> ()V
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
@@ -2170,6 +2347,19 @@ public final class org/partiql/plan/builder/RexOpCollectionBuilder {
 	public final fun values (Ljava/util/List;)Lorg/partiql/plan/builder/RexOpCollectionBuilder;
 }
 
+public final class org/partiql/plan/builder/RexOpDivideBuilder {
+	public fun <init> ()V
+	public fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)V
+	public synthetic fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun build ()Lorg/partiql/plan/Rex$Op$Divide;
+	public final fun getLhs ()Lorg/partiql/plan/Rex;
+	public final fun getRhs ()Lorg/partiql/plan/Rex;
+	public final fun lhs (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpDivideBuilder;
+	public final fun rhs (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpDivideBuilder;
+	public final fun setLhs (Lorg/partiql/plan/Rex;)V
+	public final fun setRhs (Lorg/partiql/plan/Rex;)V
+}
+
 public final class org/partiql/plan/builder/RexOpErrBuilder {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
@@ -2214,6 +2404,42 @@ public final class org/partiql/plan/builder/RexOpMissingBuilder {
 	public final fun message (Ljava/lang/String;)Lorg/partiql/plan/builder/RexOpMissingBuilder;
 	public final fun setCauses (Ljava/util/List;)V
 	public final fun setMessage (Ljava/lang/String;)V
+}
+
+public final class org/partiql/plan/builder/RexOpModuloBuilder {
+	public fun <init> ()V
+	public fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)V
+	public synthetic fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun build ()Lorg/partiql/plan/Rex$Op$Modulo;
+	public final fun getLhs ()Lorg/partiql/plan/Rex;
+	public final fun getRhs ()Lorg/partiql/plan/Rex;
+	public final fun lhs (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpModuloBuilder;
+	public final fun rhs (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpModuloBuilder;
+	public final fun setLhs (Lorg/partiql/plan/Rex;)V
+	public final fun setRhs (Lorg/partiql/plan/Rex;)V
+}
+
+public final class org/partiql/plan/builder/RexOpMultiplyBuilder {
+	public fun <init> ()V
+	public fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)V
+	public synthetic fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun build ()Lorg/partiql/plan/Rex$Op$Multiply;
+	public final fun getLhs ()Lorg/partiql/plan/Rex;
+	public final fun getRhs ()Lorg/partiql/plan/Rex;
+	public final fun lhs (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpMultiplyBuilder;
+	public final fun rhs (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpMultiplyBuilder;
+	public final fun setLhs (Lorg/partiql/plan/Rex;)V
+	public final fun setRhs (Lorg/partiql/plan/Rex;)V
+}
+
+public final class org/partiql/plan/builder/RexOpNegativeBuilder {
+	public fun <init> ()V
+	public fun <init> (Lorg/partiql/plan/Rex;)V
+	public synthetic fun <init> (Lorg/partiql/plan/Rex;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun arg (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpNegativeBuilder;
+	public final fun build ()Lorg/partiql/plan/Rex$Op$Negative;
+	public final fun getArg ()Lorg/partiql/plan/Rex;
+	public final fun setArg (Lorg/partiql/plan/Rex;)V
 }
 
 public final class org/partiql/plan/builder/RexOpNullifBuilder {
@@ -2284,6 +2510,16 @@ public final class org/partiql/plan/builder/RexOpPivotBuilder {
 	public final fun value (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpPivotBuilder;
 }
 
+public final class org/partiql/plan/builder/RexOpPositiveBuilder {
+	public fun <init> ()V
+	public fun <init> (Lorg/partiql/plan/Rex;)V
+	public synthetic fun <init> (Lorg/partiql/plan/Rex;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun arg (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpPositiveBuilder;
+	public final fun build ()Lorg/partiql/plan/Rex$Op$Positive;
+	public final fun getArg ()Lorg/partiql/plan/Rex;
+	public final fun setArg (Lorg/partiql/plan/Rex;)V
+}
+
 public final class org/partiql/plan/builder/RexOpSelectBuilder {
 	public fun <init> ()V
 	public fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rel;)V
@@ -2334,6 +2570,19 @@ public final class org/partiql/plan/builder/RexOpSubqueryBuilder {
 	public final fun setCoercion (Lorg/partiql/plan/Rex$Op$Subquery$Coercion;)V
 	public final fun setConstructor (Lorg/partiql/plan/Rex;)V
 	public final fun setRel (Lorg/partiql/plan/Rel;)V
+}
+
+public final class org/partiql/plan/builder/RexOpSubtractBuilder {
+	public fun <init> ()V
+	public fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;)V
+	public synthetic fun <init> (Lorg/partiql/plan/Rex;Lorg/partiql/plan/Rex;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun build ()Lorg/partiql/plan/Rex$Op$Subtract;
+	public final fun getLhs ()Lorg/partiql/plan/Rex;
+	public final fun getRhs ()Lorg/partiql/plan/Rex;
+	public final fun lhs (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpSubtractBuilder;
+	public final fun rhs (Lorg/partiql/plan/Rex;)Lorg/partiql/plan/builder/RexOpSubtractBuilder;
+	public final fun setLhs (Lorg/partiql/plan/Rex;)V
+	public final fun setRhs (Lorg/partiql/plan/Rex;)V
 }
 
 public final class org/partiql/plan/builder/RexOpTupleUnionBuilder {
@@ -2455,6 +2704,8 @@ public abstract class org/partiql/plan/util/PlanRewriter : org/partiql/plan/visi
 	public fun visitRelType (Lorg/partiql/plan/Rel$Type;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRex (Lorg/partiql/plan/Rex;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRex (Lorg/partiql/plan/Rex;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
+	public synthetic fun visitRexOpAdd (Lorg/partiql/plan/Rex$Op$Add;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpAdd (Lorg/partiql/plan/Rex$Op$Add;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpCallDynamic (Lorg/partiql/plan/Rex$Op$Call$Dynamic;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpCallDynamic (Lorg/partiql/plan/Rex$Op$Call$Dynamic;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpCallDynamicCandidate (Lorg/partiql/plan/Rex$Op$Call$Dynamic$Candidate;Ljava/lang/Object;)Ljava/lang/Object;
@@ -2471,6 +2722,8 @@ public abstract class org/partiql/plan/util/PlanRewriter : org/partiql/plan/visi
 	public fun visitRexOpCoalesce (Lorg/partiql/plan/Rex$Op$Coalesce;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpCollection (Lorg/partiql/plan/Rex$Op$Collection;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpCollection (Lorg/partiql/plan/Rex$Op$Collection;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
+	public synthetic fun visitRexOpDivide (Lorg/partiql/plan/Rex$Op$Divide;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpDivide (Lorg/partiql/plan/Rex$Op$Divide;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpErr (Lorg/partiql/plan/Rex$Op$Err;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpErr (Lorg/partiql/plan/Rex$Op$Err;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpGlobal (Lorg/partiql/plan/Rex$Op$Global;Ljava/lang/Object;)Ljava/lang/Object;
@@ -2479,6 +2732,12 @@ public abstract class org/partiql/plan/util/PlanRewriter : org/partiql/plan/visi
 	public fun visitRexOpLit (Lorg/partiql/plan/Rex$Op$Lit;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpMissing (Lorg/partiql/plan/Rex$Op$Missing;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpMissing (Lorg/partiql/plan/Rex$Op$Missing;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
+	public synthetic fun visitRexOpModulo (Lorg/partiql/plan/Rex$Op$Modulo;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpModulo (Lorg/partiql/plan/Rex$Op$Modulo;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
+	public synthetic fun visitRexOpMultiply (Lorg/partiql/plan/Rex$Op$Multiply;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpMultiply (Lorg/partiql/plan/Rex$Op$Multiply;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
+	public synthetic fun visitRexOpNegative (Lorg/partiql/plan/Rex$Op$Negative;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpNegative (Lorg/partiql/plan/Rex$Op$Negative;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpNullif (Lorg/partiql/plan/Rex$Op$Nullif;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpNullif (Lorg/partiql/plan/Rex$Op$Nullif;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpPathIndex (Lorg/partiql/plan/Rex$Op$Path$Index;Ljava/lang/Object;)Ljava/lang/Object;
@@ -2489,6 +2748,8 @@ public abstract class org/partiql/plan/util/PlanRewriter : org/partiql/plan/visi
 	public fun visitRexOpPathSymbol (Lorg/partiql/plan/Rex$Op$Path$Symbol;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpPivot (Lorg/partiql/plan/Rex$Op$Pivot;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpPivot (Lorg/partiql/plan/Rex$Op$Pivot;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
+	public synthetic fun visitRexOpPositive (Lorg/partiql/plan/Rex$Op$Positive;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpPositive (Lorg/partiql/plan/Rex$Op$Positive;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpSelect (Lorg/partiql/plan/Rex$Op$Select;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpSelect (Lorg/partiql/plan/Rex$Op$Select;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpStruct (Lorg/partiql/plan/Rex$Op$Struct;Ljava/lang/Object;)Ljava/lang/Object;
@@ -2497,6 +2758,8 @@ public abstract class org/partiql/plan/util/PlanRewriter : org/partiql/plan/visi
 	public fun visitRexOpStructField (Lorg/partiql/plan/Rex$Op$Struct$Field;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpSubquery (Lorg/partiql/plan/Rex$Op$Subquery;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpSubquery (Lorg/partiql/plan/Rex$Op$Subquery;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
+	public synthetic fun visitRexOpSubtract (Lorg/partiql/plan/Rex$Op$Subtract;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpSubtract (Lorg/partiql/plan/Rex$Op$Subtract;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpTupleUnion (Lorg/partiql/plan/Rex$Op$TupleUnion;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpTupleUnion (Lorg/partiql/plan/Rex$Op$TupleUnion;Ljava/lang/Object;)Lorg/partiql/plan/PlanNode;
 	public synthetic fun visitRexOpVar (Lorg/partiql/plan/Rex$Op$Var;Ljava/lang/Object;)Ljava/lang/Object;
@@ -2554,6 +2817,7 @@ public abstract class org/partiql/plan/visitor/PlanBaseVisitor : org/partiql/pla
 	public fun visitRelType (Lorg/partiql/plan/Rel$Type;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRex (Lorg/partiql/plan/Rex;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOp (Lorg/partiql/plan/Rex$Op;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpAdd (Lorg/partiql/plan/Rex$Op$Add;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpCall (Lorg/partiql/plan/Rex$Op$Call;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpCallDynamic (Lorg/partiql/plan/Rex$Op$Call$Dynamic;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpCallDynamicCandidate (Lorg/partiql/plan/Rex$Op$Call$Dynamic$Candidate;Ljava/lang/Object;)Ljava/lang/Object;
@@ -2563,20 +2827,26 @@ public abstract class org/partiql/plan/visitor/PlanBaseVisitor : org/partiql/pla
 	public fun visitRexOpCast (Lorg/partiql/plan/Rex$Op$Cast;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpCoalesce (Lorg/partiql/plan/Rex$Op$Coalesce;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpCollection (Lorg/partiql/plan/Rex$Op$Collection;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpDivide (Lorg/partiql/plan/Rex$Op$Divide;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpErr (Lorg/partiql/plan/Rex$Op$Err;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpGlobal (Lorg/partiql/plan/Rex$Op$Global;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpLit (Lorg/partiql/plan/Rex$Op$Lit;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpMissing (Lorg/partiql/plan/Rex$Op$Missing;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpModulo (Lorg/partiql/plan/Rex$Op$Modulo;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpMultiply (Lorg/partiql/plan/Rex$Op$Multiply;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpNegative (Lorg/partiql/plan/Rex$Op$Negative;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpNullif (Lorg/partiql/plan/Rex$Op$Nullif;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpPath (Lorg/partiql/plan/Rex$Op$Path;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpPathIndex (Lorg/partiql/plan/Rex$Op$Path$Index;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpPathKey (Lorg/partiql/plan/Rex$Op$Path$Key;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpPathSymbol (Lorg/partiql/plan/Rex$Op$Path$Symbol;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpPivot (Lorg/partiql/plan/Rex$Op$Pivot;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpPositive (Lorg/partiql/plan/Rex$Op$Positive;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpSelect (Lorg/partiql/plan/Rex$Op$Select;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpStruct (Lorg/partiql/plan/Rex$Op$Struct;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpStructField (Lorg/partiql/plan/Rex$Op$Struct$Field;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpSubquery (Lorg/partiql/plan/Rex$Op$Subquery;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitRexOpSubtract (Lorg/partiql/plan/Rex$Op$Subtract;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpTupleUnion (Lorg/partiql/plan/Rex$Op$TupleUnion;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitRexOpVar (Lorg/partiql/plan/Rex$Op$Var;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitStatement (Lorg/partiql/plan/Statement;Ljava/lang/Object;)Ljava/lang/Object;
@@ -2629,6 +2899,7 @@ public abstract interface class org/partiql/plan/visitor/PlanVisitor {
 	public abstract fun visitRelType (Lorg/partiql/plan/Rel$Type;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRex (Lorg/partiql/plan/Rex;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOp (Lorg/partiql/plan/Rex$Op;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitRexOpAdd (Lorg/partiql/plan/Rex$Op$Add;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpCall (Lorg/partiql/plan/Rex$Op$Call;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpCallDynamic (Lorg/partiql/plan/Rex$Op$Call$Dynamic;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpCallDynamicCandidate (Lorg/partiql/plan/Rex$Op$Call$Dynamic$Candidate;Ljava/lang/Object;)Ljava/lang/Object;
@@ -2638,20 +2909,26 @@ public abstract interface class org/partiql/plan/visitor/PlanVisitor {
 	public abstract fun visitRexOpCast (Lorg/partiql/plan/Rex$Op$Cast;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpCoalesce (Lorg/partiql/plan/Rex$Op$Coalesce;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpCollection (Lorg/partiql/plan/Rex$Op$Collection;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitRexOpDivide (Lorg/partiql/plan/Rex$Op$Divide;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpErr (Lorg/partiql/plan/Rex$Op$Err;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpGlobal (Lorg/partiql/plan/Rex$Op$Global;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpLit (Lorg/partiql/plan/Rex$Op$Lit;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpMissing (Lorg/partiql/plan/Rex$Op$Missing;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitRexOpModulo (Lorg/partiql/plan/Rex$Op$Modulo;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitRexOpMultiply (Lorg/partiql/plan/Rex$Op$Multiply;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitRexOpNegative (Lorg/partiql/plan/Rex$Op$Negative;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpNullif (Lorg/partiql/plan/Rex$Op$Nullif;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpPath (Lorg/partiql/plan/Rex$Op$Path;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpPathIndex (Lorg/partiql/plan/Rex$Op$Path$Index;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpPathKey (Lorg/partiql/plan/Rex$Op$Path$Key;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpPathSymbol (Lorg/partiql/plan/Rex$Op$Path$Symbol;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpPivot (Lorg/partiql/plan/Rex$Op$Pivot;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitRexOpPositive (Lorg/partiql/plan/Rex$Op$Positive;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpSelect (Lorg/partiql/plan/Rex$Op$Select;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpStruct (Lorg/partiql/plan/Rex$Op$Struct;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpStructField (Lorg/partiql/plan/Rex$Op$Struct$Field;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpSubquery (Lorg/partiql/plan/Rex$Op$Subquery;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitRexOpSubtract (Lorg/partiql/plan/Rex$Op$Subtract;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpTupleUnion (Lorg/partiql/plan/Rex$Op$TupleUnion;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitRexOpVar (Lorg/partiql/plan/Rex$Op$Var;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitStatement (Lorg/partiql/plan/Statement;Ljava/lang/Object;)Ljava/lang/Object;

--- a/partiql-plan/src/main/resources/partiql_plan.ion
+++ b/partiql-plan/src/main/resources/partiql_plan.ion
@@ -109,6 +109,41 @@ rex::{
       arg: rex,
     },
 
+    //
+    // START OF SPECIAL OPERATIONS
+    // The following expressions are SQL/PartiQL operations that cannot be directly represented by
+    // user-defined functions. Therefore, they are represented as distinct nodes.
+    //
+    negative::{
+      arg: rex
+    },
+    positive::{
+      arg: rex
+    },
+    add::{
+      lhs: rex,
+      rhs: rex
+    },
+    subtract::{
+      lhs: rex,
+      rhs: rex
+    },
+    multiply::{
+      lhs: rex,
+      rhs: rex
+    },
+    divide::{
+      lhs: rex,
+      rhs: rex
+    },
+    modulo::{
+      lhs: rex,
+      rhs: rex
+    },
+    //
+    // END OF SPECIAL OPERATIONS
+    //
+
     call::[
       static::{
         fn: ref,

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PlanningProblemDetails.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PlanningProblemDetails.kt
@@ -166,6 +166,13 @@ internal open class PlanningProblemDetails(
         "Unknown function `$identifier($types)"
     })
 
+    data class UnknownCast(
+        val source: PType,
+        val target: PType,
+    ) : PlanningProblemDetails(ProblemSeverity.ERROR, {
+        "Cast does not exist for $source to $target."
+    })
+
     public data class UnknownAggregateFunction(
         val identifier: Identifier,
         val args: List<StaticType>,

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ProblemGenerator.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ProblemGenerator.kt
@@ -77,6 +77,9 @@ internal object ProblemGenerator {
     fun undefinedFunction(args: List<PType>, identifier: String, location: ProblemLocation = UNKNOWN_PROBLEM_LOCATION): Problem =
         problem(location, PlanningProblemDetails.UnknownFunction(identifier, args))
 
+    fun undefinedCast(source: PType, target: PType, location: ProblemLocation = UNKNOWN_PROBLEM_LOCATION): Problem =
+        problem(location, PlanningProblemDetails.UnknownCast(source, target))
+
     fun undefinedVariable(id: Identifier, inScopeVariables: Set<String> = emptySet(), location: ProblemLocation = UNKNOWN_PROBLEM_LOCATION): Problem =
         problem(location, PlanningProblemDetails.UndefinedVariable(id, inScopeVariables))
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/TypeFamily.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/TypeFamily.kt
@@ -1,0 +1,20 @@
+package org.partiql.planner.internal
+
+import org.partiql.types.PType
+
+/**
+ * This is a utility class to help with planning.
+ */
+internal object TypeFamily {
+    val NUMBERS = setOf(
+        PType.Kind.TINYINT,
+        PType.Kind.SMALLINT,
+        PType.Kind.INT,
+        PType.Kind.BIGINT,
+        PType.Kind.INT_ARBITRARY,
+        PType.Kind.DECIMAL,
+        PType.Kind.DECIMAL_ARBITRARY,
+        PType.Kind.REAL,
+        PType.Kind.DOUBLE_PRECISION,
+    )
+}

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/TypePrecedence.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/TypePrecedence.kt
@@ -1,0 +1,55 @@
+package org.partiql.planner.internal
+
+import org.partiql.types.PType.Kind
+
+/**
+ * Map of the type precedences.
+ */
+internal object TypePrecedence : Map<Kind, Int> {
+
+    private val _delegate: Map<Kind, Int> = listOf(
+        Kind.BOOL,
+        Kind.TINYINT,
+        Kind.SMALLINT,
+        Kind.INT,
+        Kind.BIGINT,
+        Kind.INT_ARBITRARY,
+        Kind.DECIMAL,
+        Kind.REAL,
+        Kind.DOUBLE_PRECISION,
+        Kind.DECIMAL_ARBITRARY, // Arbitrary precision decimal has a higher precedence than FLOAT
+        Kind.CHAR,
+        Kind.VARCHAR,
+        Kind.SYMBOL,
+        Kind.STRING,
+        Kind.CLOB,
+        Kind.BLOB,
+        Kind.DATE,
+        Kind.TIME_WITHOUT_TZ,
+        Kind.TIME_WITH_TZ,
+        Kind.TIMESTAMP_WITHOUT_TZ,
+        Kind.TIMESTAMP_WITH_TZ,
+        Kind.LIST,
+        Kind.SEXP,
+        Kind.BAG,
+        Kind.ROW,
+        Kind.STRUCT,
+        Kind.DYNAMIC,
+    ).mapIndexed { precedence, type -> type to precedence }.toMap()
+
+    override val entries: Set<Map.Entry<Kind, Int>> = _delegate.entries
+
+    override val keys: Set<Kind> = _delegate.keys
+
+    override val size: Int = _delegate.size
+
+    override val values: Collection<Int> = _delegate.values
+
+    override fun isEmpty(): Boolean = _delegate.isEmpty()
+
+    override fun get(key: Kind): Int? = _delegate.get(key)
+
+    override fun containsValue(value: Int): Boolean = _delegate.containsValue(value)
+
+    override fun containsKey(key: Kind): Boolean = _delegate.containsKey(key)
+}

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
@@ -43,6 +43,7 @@ import org.partiql.planner.internal.ir.builder.RelOpSortSpecBuilder
 import org.partiql.planner.internal.ir.builder.RelOpUnpivotBuilder
 import org.partiql.planner.internal.ir.builder.RelTypeBuilder
 import org.partiql.planner.internal.ir.builder.RexBuilder
+import org.partiql.planner.internal.ir.builder.RexOpAddBuilder
 import org.partiql.planner.internal.ir.builder.RexOpCallDynamicBuilder
 import org.partiql.planner.internal.ir.builder.RexOpCallDynamicCandidateBuilder
 import org.partiql.planner.internal.ir.builder.RexOpCallStaticBuilder
@@ -53,17 +54,23 @@ import org.partiql.planner.internal.ir.builder.RexOpCastResolvedBuilder
 import org.partiql.planner.internal.ir.builder.RexOpCastUnresolvedBuilder
 import org.partiql.planner.internal.ir.builder.RexOpCoalesceBuilder
 import org.partiql.planner.internal.ir.builder.RexOpCollectionBuilder
+import org.partiql.planner.internal.ir.builder.RexOpDivideBuilder
 import org.partiql.planner.internal.ir.builder.RexOpErrBuilder
 import org.partiql.planner.internal.ir.builder.RexOpLitBuilder
+import org.partiql.planner.internal.ir.builder.RexOpModuloBuilder
+import org.partiql.planner.internal.ir.builder.RexOpMultiplyBuilder
+import org.partiql.planner.internal.ir.builder.RexOpNegativeBuilder
 import org.partiql.planner.internal.ir.builder.RexOpNullifBuilder
 import org.partiql.planner.internal.ir.builder.RexOpPathIndexBuilder
 import org.partiql.planner.internal.ir.builder.RexOpPathKeyBuilder
 import org.partiql.planner.internal.ir.builder.RexOpPathSymbolBuilder
 import org.partiql.planner.internal.ir.builder.RexOpPivotBuilder
+import org.partiql.planner.internal.ir.builder.RexOpPositiveBuilder
 import org.partiql.planner.internal.ir.builder.RexOpSelectBuilder
 import org.partiql.planner.internal.ir.builder.RexOpStructBuilder
 import org.partiql.planner.internal.ir.builder.RexOpStructFieldBuilder
 import org.partiql.planner.internal.ir.builder.RexOpSubqueryBuilder
+import org.partiql.planner.internal.ir.builder.RexOpSubtractBuilder
 import org.partiql.planner.internal.ir.builder.RexOpTupleUnionBuilder
 import org.partiql.planner.internal.ir.builder.RexOpVarGlobalBuilder
 import org.partiql.planner.internal.ir.builder.RexOpVarLocalBuilder
@@ -288,6 +295,13 @@ internal data class Rex(
             is TupleUnion -> visitor.visitRexOpTupleUnion(this, ctx)
             is Err -> visitor.visitRexOpErr(this, ctx)
             is Missing -> visitor.visitRexOpMissing(this, ctx)
+            is Add -> visitor.visitRexOpAdd(this, ctx)
+            is Subtract -> visitor.visitRexOpSubtract(this, ctx)
+            is Multiply -> visitor.visitRexOpMultiply(this, ctx)
+            is Divide -> visitor.visitRexOpDivide(this, ctx)
+            is Negative -> visitor.visitRexOpNegative(this, ctx)
+            is Positive -> visitor.visitRexOpPositive(this, ctx)
+            is Modulo -> visitor.visitRexOpModulo(this, ctx)
         }
 
         internal data class Lit(
@@ -477,6 +491,142 @@ internal data class Rex(
                     @JvmStatic
                     internal fun builder(): RexOpCastResolvedBuilder = RexOpCastResolvedBuilder()
                 }
+            }
+        }
+
+        internal data class Negative(
+            @JvmField internal val arg: Rex,
+        ) : Op() {
+            public override val children: List<PlanNode> by lazy {
+                val kids = mutableListOf<PlanNode?>()
+                kids.add(arg)
+                kids.filterNotNull()
+            }
+
+            public override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
+                visitor.visitRexOpNegative(this, ctx)
+
+            internal companion object {
+                @JvmStatic
+                internal fun builder(): RexOpNegativeBuilder = RexOpNegativeBuilder()
+            }
+        }
+
+        internal data class Positive(
+            @JvmField internal val arg: Rex,
+        ) : Op() {
+            public override val children: List<PlanNode> by lazy {
+                val kids = mutableListOf<PlanNode?>()
+                kids.add(arg)
+                kids.filterNotNull()
+            }
+
+            public override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
+                visitor.visitRexOpPositive(this, ctx)
+
+            internal companion object {
+                @JvmStatic
+                internal fun builder(): RexOpPositiveBuilder = RexOpPositiveBuilder()
+            }
+        }
+
+        internal data class Add(
+            @JvmField internal val lhs: Rex,
+            @JvmField internal val rhs: Rex,
+        ) : Op() {
+            public override val children: List<PlanNode> by lazy {
+                val kids = mutableListOf<PlanNode?>()
+                kids.add(lhs)
+                kids.add(rhs)
+                kids.filterNotNull()
+            }
+
+            public override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
+                visitor.visitRexOpAdd(this, ctx)
+
+            internal companion object {
+                @JvmStatic
+                internal fun builder(): RexOpAddBuilder = RexOpAddBuilder()
+            }
+        }
+
+        internal data class Subtract(
+            @JvmField internal val lhs: Rex,
+            @JvmField internal val rhs: Rex,
+        ) : Op() {
+            public override val children: List<PlanNode> by lazy {
+                val kids = mutableListOf<PlanNode?>()
+                kids.add(lhs)
+                kids.add(rhs)
+                kids.filterNotNull()
+            }
+
+            public override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
+                visitor.visitRexOpSubtract(this, ctx)
+
+            internal companion object {
+                @JvmStatic
+                internal fun builder(): RexOpSubtractBuilder = RexOpSubtractBuilder()
+            }
+        }
+
+        internal data class Multiply(
+            @JvmField internal val lhs: Rex,
+            @JvmField internal val rhs: Rex,
+        ) : Op() {
+            public override val children: List<PlanNode> by lazy {
+                val kids = mutableListOf<PlanNode?>()
+                kids.add(lhs)
+                kids.add(rhs)
+                kids.filterNotNull()
+            }
+
+            public override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
+                visitor.visitRexOpMultiply(this, ctx)
+
+            internal companion object {
+                @JvmStatic
+                internal fun builder(): RexOpMultiplyBuilder = RexOpMultiplyBuilder()
+            }
+        }
+
+        internal data class Divide(
+            @JvmField internal val lhs: Rex,
+            @JvmField internal val rhs: Rex,
+        ) : Op() {
+            public override val children: List<PlanNode> by lazy {
+                val kids = mutableListOf<PlanNode?>()
+                kids.add(lhs)
+                kids.add(rhs)
+                kids.filterNotNull()
+            }
+
+            public override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
+                visitor.visitRexOpDivide(this, ctx)
+
+            internal companion object {
+                @JvmStatic
+                internal fun builder(): RexOpDivideBuilder = RexOpDivideBuilder()
+            }
+        }
+
+        internal data class Modulo(
+            @JvmField internal val lhs: Rex,
+            @JvmField internal val rhs: Rex,
+        ) : Op() {
+            public override val children: List<PlanNode> by lazy {
+                val kids = mutableListOf<PlanNode?>()
+                kids.add(lhs)
+                kids.add(rhs)
+                kids.filterNotNull()
+            }
+
+            public override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R =
+                visitor.visitRexOpModulo(this, ctx)
+
+            internal companion object {
+                @JvmStatic
+                internal fun builder(): RexOpModuloBuilder = RexOpModuloBuilder()
             }
         }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/ArithmeticTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/ArithmeticTyper.kt
@@ -1,0 +1,119 @@
+package org.partiql.planner.internal.typer
+
+import org.partiql.planner.internal.TypeFamily
+import org.partiql.planner.internal.TypePrecedence
+import org.partiql.types.PType
+import org.partiql.types.PType.Kind
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * There exists a mirror copy in the eval package as well.
+ */
+internal object ArithmeticTyper {
+
+    /**
+     * Follows SQL-Server for decimals:
+     * Result Precision = max(s1, s2) + max(p1 - s1, p2 - s2) + 1
+     * Result Scale = max(s1, s2)
+     * @return null if the operation is not allowed on the input types.
+     */
+    internal fun add(lhs: PType, rhs: PType): PType? = arithmeticBinary(lhs, rhs) { lDec, rDec ->
+        val precision = max(lDec.scale, rDec.scale) + max(lDec.precision - lDec.scale, rDec.precision - rDec.scale) + 1
+        val scale = max(lDec.scale, rDec.scale)
+        precision to scale
+    }
+
+    /**
+     * Follows SQL-Server for decimals:
+     * Result Precision = max(s1, s2) + max(p1 - s1, p2 - s2) + 1
+     * Result Scale = max(s1, s2)
+     * @return null if the operation is not allowed on the input types.
+     */
+    internal fun subtract(lhs: PType, rhs: PType): PType? = arithmeticBinary(lhs, rhs) { lDec, rDec ->
+        val precision = max(lhs.scale, rhs.scale) + max(lhs.precision - lhs.scale, rhs.precision - rhs.scale) + 1
+        val scale = max(lhs.scale, rhs.scale)
+        precision to scale
+    }
+
+    /**
+     * Follows SQL-Server for decimals:
+     * Result Precision = p1 - s1 + s2 + max(6, s1 + p2 + 1)
+     * Result Scale = max(6, s1 + p2 + 1)
+     * @return null if the operation is not allowed on the input types.
+     */
+    internal fun divide(lhs: PType, rhs: PType): PType? = arithmeticBinary(lhs, rhs) { lDec, rDec ->
+        val precision = lhs.precision - rhs.scale + lhs.scale + max(6, lhs.scale + rhs.precision + 1)
+        val scale = max(6, lhs.scale + rhs.precision + 1)
+        precision to scale
+    }
+
+    /**
+     * Follows SQL-Server for decimals:
+     * Result Precision = p1 + p2 + 1
+     * Result Scale = s1 + s2
+     * @return null if the operation is not allowed on the input types.
+     */
+    internal fun multiply(lhs: PType, rhs: PType): PType? = arithmeticBinary(lhs, rhs) { lDec, rDec ->
+        val precision = lhs.precision + rhs.precision + 1
+        val scale = lhs.scale + rhs.scale
+        precision to scale
+    }
+
+    /**
+     * Follows SQL-Server for decimals:
+     * Result Precision: min(p1 - s1, p2 - s2) + max(s1, s2)
+     * Result Scale: max(s1, s2)
+     * @return null if the operation is not allowed on the input types.
+     */
+    internal fun modulo(lhs: PType, rhs: PType): PType? = arithmeticBinary(lhs, rhs) { lDec, rDec ->
+        val precision = min(lhs.precision - lhs.scale, rhs.precision - rhs.scale) + max(lhs.scale, rhs.scale)
+        val scale = max(lhs.scale, rhs.scale)
+        precision to scale
+    }
+
+    internal fun negative(arg: PType): PType? = arithmeticUnary(arg)
+
+    internal fun positive(arg: PType): PType? = arithmeticUnary(arg)
+
+    private fun arithmeticUnary(arg: PType): PType? {
+        val argMayBeNumber = arg.kind == Kind.DYNAMIC || TypeFamily.NUMBERS.contains(arg.kind)
+        return when (argMayBeNumber) {
+            true -> arg
+            false -> null
+        }
+    }
+
+    private fun arithmeticBinary(
+        lhs: PType,
+        rhs: PType,
+        handleDecimal: (PType, PType) -> Pair<Int, Int>
+    ): PType? {
+        val lhsCannotBeNumber = lhs.kind != Kind.DYNAMIC && !TypeFamily.NUMBERS.contains(lhs.kind)
+        val rhsCannotBeNumber = rhs.kind != Kind.DYNAMIC && !TypeFamily.NUMBERS.contains(rhs.kind)
+        if (lhsCannotBeNumber || rhsCannotBeNumber) {
+            return null
+        }
+        if (lhs.kind == Kind.DYNAMIC || rhs.kind == Kind.DYNAMIC) {
+            return PType.typeDynamic()
+        }
+        val lhsPrecedence = TypePrecedence[lhs.kind]!!
+        val rhsPrecedence = TypePrecedence[rhs.kind]!!
+        val comp = lhsPrecedence.compareTo(rhsPrecedence)
+        when (comp) {
+            -1 -> return rhs
+            1 -> return lhs
+            0 -> if (lhs.kind != Kind.DECIMAL) {
+                return lhs
+            }
+
+            else -> error("This shouldn't have occurred.")
+        }
+        val (precision, scale) = handleDecimal(lhs, rhs)
+        // TODO: Check if this is what we want
+        return when (precision > 38 || scale > 38) {
+            true -> PType.typeDecimalArbitrary()
+            false -> PType.typeDecimal(precision, scale)
+        }
+    }
+}

--- a/partiql-planner/src/main/resources/partiql_plan_internal.ion
+++ b/partiql-planner/src/main/resources/partiql_plan_internal.ion
@@ -128,6 +128,41 @@ rex::{
       }
     ],
 
+    //
+    // START OF SPECIAL OPERATIONS
+    // The following expressions are SQL/PartiQL operations that cannot be directly represented by
+    // user-defined functions. Therefore, they are represented as distinct nodes.
+    //
+    negative::{
+      arg: rex
+    },
+    positive::{
+      arg: rex
+    },
+    add::{
+      lhs: rex,
+      rhs: rex
+    },
+    subtract::{
+      lhs: rex,
+      rhs: rex
+    },
+    multiply::{
+      lhs: rex,
+      rhs: rex
+    },
+    divide::{
+      lhs: rex,
+      rhs: rex
+    },
+    modulo::{
+      lhs: rex,
+      rhs: rex
+    },
+    //
+    // END OF SPECIAL OPERATIONS
+    //
+
     call::[
 
       unresolved::{

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/PlannerErrorReportingTests.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/PlannerErrorReportingTests.kt
@@ -147,7 +147,7 @@ internal class PlannerErrorReportingTests {
                 "1 + MISSING",
                 false,
                 assertOnProblemCount(1, 0),
-                expectedType = PType.typeInt().toCType()
+                expectedType = StaticType.ANY
             ),
             // This will be a non-resolved function error.
             // As plus does not contain a function that match argument type with
@@ -157,7 +157,7 @@ internal class PlannerErrorReportingTests {
                 "1 + MISSING",
                 true,
                 assertOnProblemCount(0, 1),
-                expectedType = PType.typeInt().toCType()
+                expectedType = StaticType.ANY
             ),
             // Attempting to do path navigation(symbol) on missing(which is not tuple)
             //  returns missing in quite mode, and error out in signal mode
@@ -279,13 +279,13 @@ internal class PlannerErrorReportingTests {
                 "1 + not_a_function(1)",
                 false,
                 assertOnProblemCount(0, 1),
-                StaticType.INT4,
+                StaticType.ANY,
             ),
             TestCase(
                 "1 + not_a_function(1)",
                 true,
                 assertOnProblemCount(0, 1),
-                StaticType.INT4,
+                StaticType.ANY,
             ),
 
             TestCase(

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -3422,9 +3422,9 @@ internal class PlanTyperTestsPorted {
                 query = """
                     +MISSING
                 """.trimIndent(),
-                expected = StaticType.DECIMAL, // This is due to it being the highest precedence type
+                expected = StaticType.ANY, // This is due to it being the highest precedence type
                 problemHandler = assertProblemExists(
-                    ProblemGenerator.expressionAlwaysReturnsMissing("Static function always receives MISSING arguments.")
+                    ProblemGenerator.incompatibleTypesForOp("POS", listOf(PType.typeUnknown()))
                 )
             ),
         )


### PR DESCRIPTION
## Description
- Adds arithmetic operators as separate nodes. This allows for us to type the arithmetic operators how we please. I followed [SQL Server's rules for typing](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/arithmetic-operators-transact-sql?view=sql-server-ver16).
- Fixes casts to invalid types for conformance. The conformance tests allow them to pass -- so I made them warnings instead of errors.
- Fixes function resolution (static) for dynamic arguments.
  - Previously, `1 > some_dynamic_value` would result in `Fn.Gt(INT, INT) -> BOOL`. While this had the most number of static exact matches, it didn't necessarily have the most number of runtime exact matches -- causing behavior that would break the gradual guarantee. Fixed this by checking whether any argument is dynamic.
- Simplifies dynamic dispatch (runtime) by following the same rules as function resolution.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **YES**
  - Added nodes specifically for the arithmetic operators.
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.