### PR TITLE
Fixes function invocation for missing arguments

### DIFF
--- a/partiql-eval/src/main/java/org/partiql/eval/value/Datum.java
+++ b/partiql-eval/src/main/java/org/partiql/eval/value/Datum.java
@@ -345,6 +345,9 @@ public interface Datum extends Iterable<Datum> {
     @Deprecated
     default PartiQLValue toPartiQLValue() {
         PType type = this.getType();
+        if (this.isMissing()) {
+            return PartiQL.missingValue();
+        }
         switch (type.getKind()) {
             case BOOL:
                 return this.isNull() ? PartiQL.boolValue(null) : PartiQL.boolValue(this.getBoolean());

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/Compiler.kt
@@ -55,7 +55,6 @@ import org.partiql.plan.Rel
 import org.partiql.plan.Rex
 import org.partiql.plan.Statement
 import org.partiql.plan.debug.PlanPrinter
-import org.partiql.plan.rexOpErr
 import org.partiql.plan.visitor.PlanBaseVisitor
 import org.partiql.spi.fn.Agg
 import org.partiql.spi.fn.FnExperimental
@@ -267,16 +266,7 @@ internal class Compiler(
     }
 
     override fun visitRexOpMissing(node: Rex.Op.Missing, ctx: PType?): Operator {
-        return when (session.mode) {
-            PartiQLEngine.Mode.PERMISSIVE -> {
-                // Make a runtime TypeCheckException.
-                ExprMissing(node.message)
-            }
-            PartiQLEngine.Mode.STRICT -> {
-                // Promote to error.
-                visitRexOpErr(rexOpErr(node.message, node.causes), null)
-            }
-        }
+        return ExprMissing(ctx ?: PType.typeUnknown()) // TODO: Pass a type
     }
 
     // REL

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallStatic.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCallStatic.kt
@@ -1,6 +1,5 @@
 package org.partiql.eval.internal.operator.rex
 
-import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Environment
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.eval.value.Datum
@@ -19,12 +18,17 @@ internal class ExprCallStatic(
      */
     private val nil = { Datum.nullValue(fn.signature.returns) }
 
+    /**
+     * Memoize creation of missing values
+     */
+    private val missing = { Datum.missingValue(fn.signature.returns) }
+
     override fun eval(env: Environment): Datum {
         // Evaluate arguments
         val args = inputs.map { input ->
             val r = input.eval(env)
             if (r.isNull && fn.signature.isNullCall) return nil.invoke()
-            if (r.isMissing && fn.signature.isMissingCall) throw TypeCheckException()
+            if (r.isMissing && fn.signature.isMissingCall) return missing.invoke()
             r.toPartiQLValue()
         }.toTypedArray()
         return Datum.of(fn.invoke(args))

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprMissing.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprMissing.kt
@@ -1,15 +1,15 @@
 package org.partiql.eval.internal.operator.rex
 
-import org.partiql.errors.TypeCheckException
 import org.partiql.eval.internal.Environment
 import org.partiql.eval.internal.operator.Operator
 import org.partiql.eval.value.Datum
+import org.partiql.types.PType
 
 internal class ExprMissing(
-    private val message: String,
+    private val type: PType
 ) : Operator.Expr {
 
     override fun eval(env: Environment): Datum {
-        throw TypeCheckException(message)
+        return Datum.missingValue(type)
     }
 }

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEngineDefaultTest.kt
@@ -1073,6 +1073,20 @@ class PartiQLEngineDefaultTest {
                     structValue("a" to int32Value(1), "b" to int32Value(2))
                 )
             ),
+            // PartiQL Specification Section 7.1 -- Inputs with wrong types Example 28 (1)
+            // According to the Specification, in permissive mode, functions/operators return missing when one of
+            //  the parameters is missing.
+            SuccessTestCase(
+                input = "SELECT VALUE 5 + v FROM <<1, MISSING>> AS v;",
+                expected = bagValue(int32Value(6), missingValue())
+            ),
+            // PartiQL Specification Section 7.1 -- Inputs with wrong types Example 28 (1)
+            // See https://github.com/partiql/partiql-tests/pull/118 for more information.
+            SuccessTestCase(
+                input = "SELECT VALUE 5 + v FROM <<1, MISSING>> AS v;",
+                expected = bagValue(int32Value(6), missingValue()),
+                mode = PartiQLEngine.Mode.STRICT
+            ),
         )
 
         @JvmStatic
@@ -1193,11 +1207,6 @@ class PartiQLEngineDefaultTest {
                 expectedPermissive = structValue(
                     "amzn" to decimalValue(BigDecimal.valueOf(840.05))
                 )
-            ),
-            TypingTestCase(
-                name = "PartiQL Specification Section 7.1 -- Inputs with wrong types Example 28 (1)",
-                input = "SELECT VALUE 5 + v FROM <<1, MISSING>> AS v;",
-                expectedPermissive = bagValue(int32Value(6), missingValue())
             ),
             TypingTestCase(
                 name = "PartiQL Specification Section 7.1 -- Inputs with wrong types Example 28 (3)",

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/EvalExecutor.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/executor/EvalExecutor.kt
@@ -65,6 +65,9 @@ class EvalExecutor(
         if (actual is PartiQLResult.Value && expect is PartiQLResult.Value) {
             return valueComparison(actual.value, expect.value)
         }
+        if (actual is PartiQLResult.Error) {
+            throw actual.cause
+        }
         val errorMessage = buildString {
             appendLine("Cannot compare different types of PartiQLResult.")
             appendLine(" - Expected : $expect")


### PR DESCRIPTION
## Description
- Fixes function invocation for missing arguments and fixes evaluation of `Rex.Op.Missing`.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.