### PR TITLE
Replaces internal IR ids and paths with the catalog identifiers and names

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ProblemGenerator.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ProblemGenerator.kt
@@ -13,7 +13,7 @@ import org.partiql.planner.internal.ir.rexOpMissing
 import org.partiql.planner.internal.typer.CompilerType
 import org.partiql.types.PType
 import org.partiql.types.StaticType
-import org.partiql.planner.internal.ir.Identifier as InternalIdentifier
+import org.partiql.planner.catalog.Identifier as InternalIdentifier
 
 /**
  * Used to report problems during planning phase.
@@ -53,26 +53,17 @@ internal object ProblemGenerator {
     fun errorRex(trace: Rex.Op, problem: Problem): Rex =
         rex(CompilerType(PType.typeDynamic(), isMissingValue = true), rexOpErr(problem, listOf(trace)))
 
-    private fun InternalIdentifier.debug(): String = when (this) {
-        is InternalIdentifier.Qualified -> (listOf(root.debug()) + steps.map { it.debug() }).joinToString(".")
-        is InternalIdentifier.Symbol -> when (caseSensitivity) {
-            InternalIdentifier.CaseSensitivity.SENSITIVE -> "\"$symbol\""
-            InternalIdentifier.CaseSensitivity.INSENSITIVE -> symbol
-        }
-    }
-
-    fun undefinedFunction(identifier: InternalIdentifier, args: List<StaticType>, location: ProblemLocation = UNKNOWN_PROBLEM_LOCATION): Problem =
-        problem(location, PlanningProblemDetails.UnknownFunction(identifier.debug(), args.map { PType.fromStaticType(it) }))
+    /**
+     * TODO CURRENT TESTS HAVE IDENTIFIERS AS NORMALIZED UPPER.
+     */
+    private fun InternalIdentifier.normalize(): String = toString().uppercase()
 
     fun undefinedFunction(
         args: List<PType>,
-        identifier: org.partiql.planner.internal.ir.Identifier,
+        identifier: InternalIdentifier,
         location: ProblemLocation = UNKNOWN_PROBLEM_LOCATION
     ): Problem =
-        problem(location, PlanningProblemDetails.UnknownFunction(identifier.debug(), args))
-
-    fun undefinedFunction(identifier: String, args: List<StaticType>, location: ProblemLocation = UNKNOWN_PROBLEM_LOCATION): Problem =
-        problem(location, PlanningProblemDetails.UnknownFunction(identifier, args.map { PType.fromStaticType(it) }))
+        problem(location, PlanningProblemDetails.UnknownFunction(identifier.normalize(), args))
 
     fun undefinedFunction(args: List<PType>, identifier: String, location: ProblemLocation = UNKNOWN_PROBLEM_LOCATION): Problem =
         problem(location, PlanningProblemDetails.UnknownFunction(identifier, args))
@@ -81,17 +72,17 @@ internal object ProblemGenerator {
         problem(location, PlanningProblemDetails.UndefinedVariable(id, inScopeVariables))
 
     fun incompatibleTypesForOp(actualTypes: List<StaticType>, operator: String, location: ProblemLocation = UNKNOWN_PROBLEM_LOCATION): Problem =
-        problem(location, PlanningProblemDetails.IncompatibleTypesForOp(actualTypes.map { PType.fromStaticType(it) }, operator))
+        problem(location, PlanningProblemDetails.IncompatibleTypesForOp(actualTypes.map { PType.fromStaticType(it) }, operator.uppercase()))
 
     fun incompatibleTypesForOp(
         operator: String,
         actualTypes: List<PType>,
         location: ProblemLocation = UNKNOWN_PROBLEM_LOCATION
     ): Problem =
-        problem(location, PlanningProblemDetails.IncompatibleTypesForOp(actualTypes, operator))
+        problem(location, PlanningProblemDetails.IncompatibleTypesForOp(actualTypes, operator.uppercase()))
 
     fun unresolvedExcludedExprRoot(root: InternalIdentifier, location: ProblemLocation = UNKNOWN_PROBLEM_LOCATION): Problem =
-        problem(location, PlanningProblemDetails.UnresolvedExcludeExprRoot(root.debug()))
+        problem(location, PlanningProblemDetails.UnresolvedExcludeExprRoot(root.toString()))
 
     fun unresolvedExcludedExprRoot(root: String, location: ProblemLocation = UNKNOWN_PROBLEM_LOCATION): Problem =
         problem(location, PlanningProblemDetails.UnresolvedExcludeExprRoot(root))

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -7,7 +7,6 @@ import org.partiql.plan.rexOpCast
 import org.partiql.plan.rexOpErr
 import org.partiql.planner.internal.PlannerFlag
 import org.partiql.planner.internal.ProblemGenerator
-import org.partiql.planner.internal.ir.Identifier
 import org.partiql.planner.internal.ir.PartiQLPlan
 import org.partiql.planner.internal.ir.Ref
 import org.partiql.planner.internal.ir.Rel
@@ -78,7 +77,6 @@ internal class PlanTransform(
          */
         override fun visitRefAgg(node: Ref.Agg, ctx: Unit) = symbols.insert(node)
 
-        @OptIn(PartiQLValueExperimental::class)
         override fun visitRefCast(node: Ref.Cast, ctx: Unit) =
             org.partiql.plan.refCast(node.input, node.target, node.isNullable)
 
@@ -89,23 +87,6 @@ internal class PlanTransform(
             val root = visitRex(node.root, ctx)
             return org.partiql.plan.Statement.Query(root)
         }
-
-        override fun visitIdentifier(node: Identifier, ctx: Unit) =
-            super.visitIdentifier(node, ctx) as org.partiql.plan.Identifier
-
-        override fun visitIdentifierSymbol(node: Identifier.Symbol, ctx: Unit) = org.partiql.plan.Identifier.Symbol(
-            symbol = node.symbol,
-            caseSensitivity = when (node.caseSensitivity) {
-                Identifier.CaseSensitivity.SENSITIVE -> org.partiql.plan.Identifier.CaseSensitivity.SENSITIVE
-                Identifier.CaseSensitivity.INSENSITIVE -> org.partiql.plan.Identifier.CaseSensitivity.INSENSITIVE
-            }
-        )
-
-        override fun visitIdentifierQualified(node: Identifier.Qualified, ctx: Unit) =
-            org.partiql.plan.Identifier.Qualified(
-                root = visitIdentifierSymbol(node.root, ctx),
-                steps = node.steps.map { visitIdentifierSymbol(it, ctx) }
-            )
 
         // EXPRESSIONS
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
@@ -75,7 +75,6 @@ import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.boolValue
 import org.partiql.value.int32Value
 import org.partiql.value.stringValue
-import org.partiql.planner.internal.ir.Identifier as InternalId
 
 /**
  * Lexically scoped state for use in translating an individual SELECT statement.
@@ -366,10 +365,11 @@ internal object RelConverter {
                 schema.add(binding)
                 val args = expr.args.map { arg -> arg.toRex(env) }
                 val id = AstToPlan.convert(expr.function)
-                val name = when (id) {
-                    is InternalId.Qualified -> error("Qualified aggregation calls are not supported.")
-                    is InternalId.Symbol -> id.symbol.lowercase()
+                if (id.hasQualifier()) {
+                    error("Qualified aggregation calls are not supported.")
                 }
+                // lowercase normalize all calls
+                val name = id.getIdentifier().getText().lowercase()
                 if (name == "count" && expr.args.isEmpty()) {
                     relOpAggregateCallUnresolved(
                         name,

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/Symbols.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/Symbols.kt
@@ -28,19 +28,19 @@ internal class Symbols private constructor() {
 
     fun insert(ref: Ref.Obj): CatalogRef = insert(
         catalog = ref.catalog,
-        item = catalogItemValue(ref.path, ref.type),
+        item = catalogItemValue(ref.name.toList(), ref.type),
     )
 
     @OptIn(FnExperimental::class)
     fun insert(ref: Ref.Fn): CatalogRef = insert(
         catalog = ref.catalog,
-        item = catalogItemFn(ref.path, ref.signature.specific),
+        item = catalogItemFn(ref.name.toList(), ref.signature.specific),
     )
 
     @OptIn(FnExperimental::class)
     fun insert(ref: Ref.Agg): CatalogRef = insert(
         catalog = ref.catalog,
-        item = catalogItemAgg(ref.path, ref.signature.specific),
+        item = catalogItemAgg(ref.name.toList(), ref.signature.specific),
     )
 
     private fun insert(catalog: String, item: Catalog.Item): CatalogRef {

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/RexReplacer.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/RexReplacer.kt
@@ -20,6 +20,8 @@ import org.partiql.planner.internal.ir.util.PlanRewriter
 
 /**
  * Uses to replace [Rex]'s within an expression tree.
+ *
+ * TODO remove me?
  */
 internal object RexReplacer {
 

--- a/partiql-planner/src/main/resources/partiql_plan_internal.ion
+++ b/partiql-planner/src/main/resources/partiql_plan_internal.ion
@@ -1,5 +1,7 @@
 imports::{
   kotlin: [
+    identifier::'org.partiql.planner.catalog.Identifier',
+    name::'org.partiql.planner.catalog.Name',
     partiql_value::'org.partiql.value.PartiQLValue',
     partiql_value_type::'org.partiql.planner.internal.typer.CompilerType',
     static_type::'org.partiql.planner.internal.typer.CompilerType',
@@ -21,17 +23,17 @@ parti_q_l_plan::{
 ref::[
   obj::{
     catalog: string,
-    path: list::[string],
+    name: name,
     type: static_type,
   },
   fn::{
     catalog: string,
-    path: list::[string],
+    name: name,
     signature: fn_signature,
   },
   agg::{
     catalog: string,
-    path: list::[string],
+    name: name,
     signature: agg_signature,
   },
   _::[
@@ -54,25 +56,6 @@ statement::[
   query::{
     root: rex,
   },
-]
-
-// Identifiers
-
-identifier::[
-  symbol::{
-    symbol:           string,
-    case_sensitivity: case_sensitivity,
-  },
-  qualified::{
-    root:   symbol,
-    steps:  list::[symbol],
-  },
-  _::[
-    case_sensitivity::[
-      SENSITIVE,
-      INSENSITIVE,
-    ],
-  ],
 ]
 
 // Rex

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTest.kt
@@ -3,11 +3,11 @@ package org.partiql.planner.internal.typer
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.partiql.planner.PartiQLPlanner
+import org.partiql.planner.catalog.Identifier
+import org.partiql.planner.catalog.Name
 import org.partiql.planner.internal.Env
-import org.partiql.planner.internal.ir.Identifier
 import org.partiql.planner.internal.ir.Rex
 import org.partiql.planner.internal.ir.Statement
-import org.partiql.planner.internal.ir.identifierSymbol
 import org.partiql.planner.internal.ir.refObj
 import org.partiql.planner.internal.ir.rex
 import org.partiql.planner.internal.ir.rexOpLit
@@ -317,7 +317,7 @@ class PlanTyperTest {
         return rex(
             type,
             rexOpVarUnresolved(
-                identifierSymbol(name, Identifier.CaseSensitivity.SENSITIVE),
+                Identifier.delimited(name),
                 Rex.Op.Var.Scope.DEFAULT
             )
         )
@@ -326,7 +326,7 @@ class PlanTyperTest {
     private fun global(type: CompilerType, path: List<String>): Rex {
         return rex(
             type,
-            rexOpVarGlobal(refObj(catalog = "pql", path = path, type))
+            rexOpVarGlobal(refObj(catalog = "pql", name = Name.of(path), type))
         )
     }
 

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -42,11 +42,8 @@ import org.partiql.types.PType
 import org.partiql.types.SexpType
 import org.partiql.types.StaticType
 import org.partiql.types.StaticType.Companion.ANY
-import org.partiql.types.StaticType.Companion.DECIMAL
-import org.partiql.types.StaticType.Companion.INT
 import org.partiql.types.StaticType.Companion.INT4
 import org.partiql.types.StaticType.Companion.INT8
-import org.partiql.types.StaticType.Companion.STRING
 import org.partiql.types.StaticType.Companion.STRUCT
 import org.partiql.types.StaticType.Companion.unionOf
 import org.partiql.types.StructType


### PR DESCRIPTION
## Relevant Issues

#1496 

## Description

This PR replaces the internal planner identifiers with the Identifiers and Names used by the Catalog for catalog object resolution. Notably there are no public API changes (no need for API dump) and there are no changes to any test cases. It is a fairly straightforward replacement, and soon the BindingName/BindingPath will be replaced by these to further reduce the redundancy.

## Other Information
- Updated Unreleased Section in CHANGELOG: **No**
- Any backward-incompatible changes? **No**
- Any new external dependencies? **No**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **Yes**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.