### PR TITLE
Add more cast tests

### DIFF
--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -318,9 +318,11 @@ class PlanTyperTestsPorted {
                 query = "CAST(343434534534 AS INT2)",
                 expected = INT2
             ),
-            ErrorTestCase(
-                name = "CAST STRING to INT4",
+            SuccessTestCase(
+                name = "CAST STRING to INT2",
+                catalog = CATALOG_AWS,
                 query = "CAST((SELECT t.breed FROM ddb.pets AS t) AS INT2)",
+                expected = INT2
             ),
         )
 

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/aws/ddb/pets.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/aws/ddb/pets.ion
@@ -11,6 +11,10 @@
       {
         name: "breed",
         type: "string",
+      },
+      {
+        name: "tag",
+        type: "int16",
       }
     ]
   }


### PR DESCRIPTION
## Description
```SQL
CREATE TABLE PETS (
    id INT4,
    breed STRING,
    tag INT2
)
```

Tests:
```SQL
-- #1 should succeed
CAST(true AS INT2) --

-- #2  should fail
CAST((s : STRING) AS LIST)

-- #3 should succeed
CAST((i : INT2) AS INT4)

-- #4 should succeed
CAST((i : INT4) AS INT2)
```

#### Background context
As part of a specification work, we want to make the behavior for the #4 more visible:

 From SQL-99 Section 6.22: <cast specification>:

```
 If SD (source data type) is exact numeric or approximate numeric, then
 Case:
   i) If there is a representation of SV (source value) in the data type TD (target data type) that does not lose any leading si-gnificant digits after rounding or truncating if necessary, then TV is that representation.
 The choice of whether to round or truncate is implementation-defined.
 ii) Otherwise, an exception condition is raised: data exception — numeric value out of
 range.
 ```

We can see this evaluation behavior in PostgresSQL v15:
Ref.: https://www.db-fiddle.com/f/vMY3Srd2bG6f3NshvTp3w1/0

```
-- succeeds
SELECT CAST((1::INT4) AS INT2);

-- fails: `Query Error: error: smallint out of range` SELECT CAST((327686::INT4) AS INT2);
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No, adding tests only.

- Any backward-incompatible changes? **[YES/NO]**
  - No.

- Any new external dependencies? **[YES/NO]**
  - No.

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
  Yes.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.