### PR TITLE
Fix antlr dep partiql-lang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Thank you to all who have contributed!
 -->
 
+## [0.14.7]
+
+### Fixed
+- `partiql-lang`'s `PartiQLParserBuilder.standard()` will use the ANTLR dependency from `partiql-parser` to
+prevent `NoSuchMethodError`s
+
 ## [0.14.6]
 
 ### Added
@@ -1087,7 +1093,8 @@ breaking changes if migrating from v0.9.2. The breaking changes accidentally int
 ### Added
 Initial alpha release of PartiQL.
 
-[Unreleased]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.6...HEAD
+[Unreleased]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.7...HEAD
+[0.14.7]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.6...v0.14.7
 [0.14.6]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.5...v0.14.6
 [0.14.5]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.4...v0.14.5
 [0.14.4]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.3...v0.14.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=0.14.6
+version=0.14.7
 
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/shell/ShellHighlighter.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/shell/ShellHighlighter.kt
@@ -13,11 +13,6 @@
  */
 package org.partiql.cli.shell
 
-import org.antlr.v4.runtime.BaseErrorListener
-import org.antlr.v4.runtime.CharStreams
-import org.antlr.v4.runtime.CommonTokenStream
-import org.antlr.v4.runtime.RecognitionException
-import org.antlr.v4.runtime.Recognizer
 import org.jline.reader.Highlighter
 import org.jline.reader.LineReader
 import org.jline.utils.AttributedString
@@ -25,6 +20,11 @@ import org.jline.utils.AttributedStringBuilder
 import org.jline.utils.AttributedStyle
 import org.partiql.parser.antlr.PartiQLParser
 import org.partiql.parser.antlr.PartiQLTokens
+import org.partiql.parser.thirdparty.antlr.v4.runtime.BaseErrorListener
+import org.partiql.parser.thirdparty.antlr.v4.runtime.CharStreams
+import org.partiql.parser.thirdparty.antlr.v4.runtime.CommonTokenStream
+import org.partiql.parser.thirdparty.antlr.v4.runtime.RecognitionException
+import org.partiql.parser.thirdparty.antlr.v4.runtime.Recognizer
 import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
 
@@ -141,12 +141,12 @@ internal class ShellHighlighter : Highlighter {
             msg: String?,
             e: RecognitionException?
         ) {
-            if (offendingSymbol != null && offendingSymbol is org.antlr.v4.runtime.Token && offendingSymbol.type != PartiQLParser.EOF) {
+            if (offendingSymbol != null && offendingSymbol is org.partiql.parser.thirdparty.antlr.v4.runtime.Token && offendingSymbol.type != PartiQLParser.EOF) {
                 throw OffendingSymbolException(offendingSymbol)
             }
         }
 
-        class OffendingSymbolException(val offendingSymbol: org.antlr.v4.runtime.Token) : Exception()
+        class OffendingSymbolException(val offendingSymbol: org.partiql.parser.thirdparty.antlr.v4.runtime.Token) : Exception()
     }
 
     private fun getTokenStream(input: String): CommonTokenStream {

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
 
 dependencies {
     api(project(":partiql-ast"))
-    api(project(":partiql-parser"))
+    api(project(":partiql-parser", configuration = "shadow"))
     api(project(":partiql-plan"))
     api(project(":partiql-planner"))
     api(project(":partiql-spi"))
@@ -36,7 +36,6 @@ dependencies {
     api(Deps.ionElement)
     api(Deps.ionJava)
     api(Deps.ionSchema)
-    shadow(Deps.antlrRuntime)
     implementation(Deps.csv)
     implementation(Deps.kotlinReflect)
     implementation(Deps.kotlinxCoroutines)
@@ -52,15 +51,8 @@ dependencies {
     testImplementation(Deps.kotlinxCoroutinesTest)
 }
 
-val relocations = mapOf(
-    "org.antlr" to "org.partiql.lang.thirdparty.antlr"
-)
-
 tasks.shadowJar {
     configurations = listOf(project.configurations.shadow.get())
-    for ((from, to) in relocations) {
-        relocate(from, to)
-    }
 }
 
 // Workaround for https://github.com/johnrengelman/shadow/issues/651

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigParser.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigParser.kt
@@ -14,19 +14,6 @@
 
 package org.partiql.lang.syntax.impl
 
-import org.antlr.v4.runtime.BailErrorStrategy
-import org.antlr.v4.runtime.BaseErrorListener
-import org.antlr.v4.runtime.CharStreams
-import org.antlr.v4.runtime.CommonTokenStream
-import org.antlr.v4.runtime.ParserRuleContext
-import org.antlr.v4.runtime.RecognitionException
-import org.antlr.v4.runtime.Recognizer
-import org.antlr.v4.runtime.Token
-import org.antlr.v4.runtime.TokenSource
-import org.antlr.v4.runtime.TokenStream
-import org.antlr.v4.runtime.atn.PredictionMode
-import org.antlr.v4.runtime.misc.ParseCancellationException
-import org.antlr.v4.runtime.tree.ParseTree
 import org.partiql.errors.ErrorCode
 import org.partiql.errors.Property
 import org.partiql.errors.PropertyValueMap
@@ -41,6 +28,19 @@ import org.partiql.lang.util.getAntlrDisplayString
 import org.partiql.lang.util.getIonValue
 import org.partiql.parser.antlr.PartiQLParser
 import org.partiql.parser.antlr.PartiQLTokens
+import org.partiql.parser.thirdparty.antlr.v4.runtime.BailErrorStrategy
+import org.partiql.parser.thirdparty.antlr.v4.runtime.BaseErrorListener
+import org.partiql.parser.thirdparty.antlr.v4.runtime.CharStreams
+import org.partiql.parser.thirdparty.antlr.v4.runtime.CommonTokenStream
+import org.partiql.parser.thirdparty.antlr.v4.runtime.ParserRuleContext
+import org.partiql.parser.thirdparty.antlr.v4.runtime.RecognitionException
+import org.partiql.parser.thirdparty.antlr.v4.runtime.Recognizer
+import org.partiql.parser.thirdparty.antlr.v4.runtime.Token
+import org.partiql.parser.thirdparty.antlr.v4.runtime.TokenSource
+import org.partiql.parser.thirdparty.antlr.v4.runtime.TokenStream
+import org.partiql.parser.thirdparty.antlr.v4.runtime.atn.PredictionMode
+import org.partiql.parser.thirdparty.antlr.v4.runtime.misc.ParseCancellationException
+import org.partiql.parser.thirdparty.antlr.v4.runtime.tree.ParseTree
 import java.io.InputStream
 import java.nio.channels.ClosedByInterruptException
 import java.nio.charset.StandardCharsets

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/syntax/impl/PartiQLPigVisitor.kt
@@ -33,9 +33,6 @@ import com.amazon.ionelement.api.ionNull
 import com.amazon.ionelement.api.ionString
 import com.amazon.ionelement.api.ionSymbol
 import com.amazon.ionelement.api.loadSingleElement
-import org.antlr.v4.runtime.ParserRuleContext
-import org.antlr.v4.runtime.Token
-import org.antlr.v4.runtime.tree.TerminalNode
 import org.partiql.errors.ErrorCode
 import org.partiql.errors.Property
 import org.partiql.errors.PropertyValueMap
@@ -62,6 +59,9 @@ import org.partiql.lang.util.getPrecisionFromTimeString
 import org.partiql.lang.util.unaryMinus
 import org.partiql.parser.antlr.PartiQLParser
 import org.partiql.parser.antlr.PartiQLParserBaseVisitor
+import org.partiql.parser.thirdparty.antlr.v4.runtime.ParserRuleContext
+import org.partiql.parser.thirdparty.antlr.v4.runtime.Token
+import org.partiql.parser.thirdparty.antlr.v4.runtime.tree.TerminalNode
 import org.partiql.pig.runtime.SymbolPrimitive
 import org.partiql.value.datetime.DateTimeException
 import org.partiql.value.datetime.TimeZone

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/util/AntlrUtilities.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/util/AntlrUtilities.kt
@@ -26,13 +26,13 @@ import com.amazon.ionelement.api.ionString
 import com.amazon.ionelement.api.ionSymbol
 import com.amazon.ionelement.api.loadSingleElement
 import com.amazon.ionelement.api.toIonValue
-import org.antlr.v4.runtime.Token
-import org.antlr.v4.runtime.tree.TerminalNode
 import org.partiql.errors.ErrorCode
 import org.partiql.errors.Property
 import org.partiql.errors.PropertyValueMap
 import org.partiql.lang.syntax.ParserException
 import org.partiql.parser.antlr.PartiQLParser
+import org.partiql.parser.thirdparty.antlr.v4.runtime.Token
+import org.partiql.parser.thirdparty.antlr.v4.runtime.tree.TerminalNode
 import java.math.BigInteger
 
 // workaround until ErrorAndErrorContexts no longer uses IonSystem

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/impl/PartiQLPigParserSpyTest.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/impl/PartiQLPigParserSpyTest.kt
@@ -19,12 +19,12 @@ import com.amazon.ion.system.IonSystemBuilder
 import io.mockk.every
 import io.mockk.spyk
 import io.mockk.verify
-import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.junit.Assert
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.syntax.ParserException
+import org.partiql.parser.thirdparty.antlr.v4.runtime.misc.ParseCancellationException
 
 /**
  * This test class is used for spying the [PartiQLPigParser].

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/impl/PartiQLPigParserThreadInterruptTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/syntax/impl/PartiQLPigParserThreadInterruptTests.kt
@@ -17,10 +17,6 @@ package org.partiql.lang.syntax.impl
 import com.amazon.ionelement.api.ionInt
 import io.mockk.every
 import io.mockk.spyk
-import org.antlr.v4.runtime.CharStreams
-import org.antlr.v4.runtime.CommonToken
-import org.antlr.v4.runtime.Token
-import org.antlr.v4.runtime.TokenSource
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
@@ -32,6 +28,10 @@ import org.partiql.lang.domains.PartiqlAst
 import org.partiql.lang.eval.CompileOptions
 import org.partiql.lang.eval.visitors.VisitorTransformBase
 import org.partiql.parser.antlr.PartiQLTokens
+import org.partiql.parser.thirdparty.antlr.v4.runtime.CharStreams
+import org.partiql.parser.thirdparty.antlr.v4.runtime.CommonToken
+import org.partiql.parser.thirdparty.antlr.v4.runtime.Token
+import org.partiql.parser.thirdparty.antlr.v4.runtime.TokenSource
 import java.io.InputStream
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.concurrent.thread


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Tries fixing the `partiql-lang` dependency on `partiql-parser`
- Since the ANTLR shading change (https://github.com/partiql/partiql-lang-kotlin/pull/1439), any call to the `PartiQLParserBuilder.standard()` from the Maven release of 0.14.6 would result in a `NoSuchMethodError` when attempting to parse. This was due to a `partiql-lang` using its own ANTLR dependency rather than `partiql-parser`'s shaded ANTLR dependency.
  - It was not detected sooner in the normal gradle build because we would previously only generate the shaded ANTLR dependency when publishing the jars to Maven.
  - We should have been using this [configuration](https://gradleup.com/shadow/multi-project/#depending-on-the-shadow-jar-from-another-project) provided by the shadow plugin for multi-project builds.
- Simple reproduction case for previous failure w/ v0.14.6
```
// in build.gradle.kts
dependencies {
    implementation("org.partiql:partiql-lang-kotlin:0.14.6")
}
```

```
// in Main.kt
import org.partiql.lang.syntax.PartiQLParserBuilder

fun main(args: Array<String>) {
    val input = "SELECT 1 FROM <<>>"
    val parser = PartiQLParserBuilder.standard().build()
    println(parser.parseAstStatement(input))
}

```
above results in the following error:
```
Exception in thread "main" org.partiql.lang.syntax.ParserException: Unhandled exception.
	Evaluator Error: at line <UNKNOWN>, column <UNKNOWN>: internal error, <UNKNOWN> : <UNKNOWN>

	at org.partiql.lang.syntax.impl.PartiQLPigParser.parseAstStatement(PartiQLPigParser.kt:74)
	at MainKt.main(Main.kt:6)
Caused by: java.lang.NoSuchMethodError: 'void org.partiql.parser.antlr.PartiQLTokens.<init>(org.partiql.lang.thirdparty.antlr.v4.runtime.CharStream)'
	at org.partiql.lang.syntax.impl.PartiQLPigParser.createTokenStream$partiql_lang(PartiQLPigParser.kt:111)
	at org.partiql.lang.syntax.impl.PartiQLPigParser.parseQuery$partiql_lang(PartiQLPigParser.kt:95)
	at org.partiql.lang.syntax.impl.PartiQLPigParser.parseQuery(PartiQLPigParser.kt:85)
	at org.partiql.lang.syntax.impl.PartiQLPigParser.parseAstStatement(PartiQLPigParser.kt:58)
	... 1 more
```

Note that when using the `PartiQLParserBuilder.experimental...` rather than `PartiQLParserBuilder.standard...`, the query parses without errors.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.