### PR TITLE
Initializes logical plan builders

### DIFF
--- a/partiql-plan/api/partiql-plan.api
+++ b/partiql-plan/api/partiql-plan.api
@@ -2528,10 +2528,20 @@ public abstract interface class org/partiql/plan/v1/Version {
 }
 
 public abstract interface class org/partiql/plan/v1/rel/Rel {
+	public static final field Companion Lorg/partiql/plan/v1/rel/Rel$Companion;
 	public abstract fun accept (Lorg/partiql/plan/v1/rel/RelVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getInputs ()Ljava/util/List;
 	public abstract fun getSchema ()Lorg/partiql/plan/v1/Schema;
 	public abstract fun isOrdered ()Z
+	public static fun scan (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/Rel;
+	public static fun scanIndexed (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/Rel;
+	public static fun unpivot (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/Rel;
+}
+
+public final class org/partiql/plan/v1/rel/Rel$Companion {
+	public final fun scan (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/Rel;
+	public final fun scanIndexed (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/Rel;
+	public final fun unpivot (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/Rel;
 }
 
 public abstract interface class org/partiql/plan/v1/rel/RelAggregate : org/partiql/plan/v1/rel/Rel {
@@ -2549,6 +2559,7 @@ public abstract class org/partiql/plan/v1/rel/RelAggregate$Base : org/partiql/pl
 	public fun getCalls ()Ljava/util/List;
 	public fun getInput ()Lorg/partiql/plan/v1/rel/Rel;
 	public fun getInputs ()Ljava/util/List;
+	public fun getSchema ()Lorg/partiql/plan/v1/Schema;
 	public fun hashCode ()I
 	public fun isOrdered ()Z
 }
@@ -2564,6 +2575,34 @@ public abstract interface class org/partiql/plan/v1/rel/RelAggregateCall {
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getType ()Lorg/partiql/types/PType;
 	public abstract fun isDistinct ()Z
+}
+
+public final class org/partiql/plan/v1/rel/RelBuilder {
+	public static final field Companion Lorg/partiql/plan/v1/rel/RelBuilder$Companion;
+	public synthetic fun <init> (Lorg/partiql/plan/v1/rel/Rel;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun aggregate (Ljava/util/List;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public final fun build ()Lorg/partiql/plan/v1/rel/Rel;
+	public final fun distinct ()Lorg/partiql/plan/v1/rel/RelBuilder;
+	public final fun except (Lorg/partiql/plan/v1/rel/Rel;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public final fun filter (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public final fun intersect (Lorg/partiql/plan/v1/rel/Rel;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public final fun join (Lorg/partiql/plan/v1/rel/Rel;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public final fun limit (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public final fun offset (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public final fun pivot (Lorg/partiql/plan/v1/rex/Rex;Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public final fun project (Ljava/util/List;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public static final fun scan (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public static final fun scanIndexed (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public final fun select (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public final fun sort (Ljava/util/List;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public final fun union (Lorg/partiql/plan/v1/rel/Rel;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public static final fun unpivot (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/RelBuilder;
+}
+
+public final class org/partiql/plan/v1/rel/RelBuilder$Companion {
+	public final fun scan (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public final fun scanIndexed (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/RelBuilder;
+	public final fun unpivot (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rel/RelBuilder;
 }
 
 public abstract interface class org/partiql/plan/v1/rel/RelCollation {
@@ -2631,6 +2670,7 @@ public abstract class org/partiql/plan/v1/rel/RelExcept$Base : org/partiql/plan/
 	public fun getInputs ()Ljava/util/List;
 	public fun getLeft ()Lorg/partiql/plan/v1/rel/Rel;
 	public fun getRight ()Lorg/partiql/plan/v1/rel/Rel;
+	public fun getSchema ()Lorg/partiql/plan/v1/Schema;
 	public fun hashCode ()I
 	public fun isAll ()Z
 	public fun isOrdered ()Z
@@ -2739,6 +2779,7 @@ public abstract class org/partiql/plan/v1/rel/RelIntersect$Base : org/partiql/pl
 	public fun getInputs ()Ljava/util/List;
 	public fun getLeft ()Lorg/partiql/plan/v1/rel/Rel;
 	public fun getRight ()Lorg/partiql/plan/v1/rel/Rel;
+	public fun getSchema ()Lorg/partiql/plan/v1/Schema;
 	public fun hashCode ()I
 	public fun isAll ()Z
 	public fun isOrdered ()Z
@@ -2768,6 +2809,7 @@ public abstract class org/partiql/plan/v1/rel/RelJoin$Base : org/partiql/plan/v1
 	public fun getInputs ()Ljava/util/List;
 	public fun getLeft ()Lorg/partiql/plan/v1/rel/Rel;
 	public fun getRight ()Lorg/partiql/plan/v1/rel/Rel;
+	public fun getSchema ()Lorg/partiql/plan/v1/Schema;
 	public fun getType ()Lorg/partiql/plan/v1/rel/RelJoinType;
 	public fun hashCode ()I
 	public fun isOrdered ()Z
@@ -2860,6 +2902,7 @@ public abstract class org/partiql/plan/v1/rel/RelProject$Base : org/partiql/plan
 	public fun getInput ()Lorg/partiql/plan/v1/rel/Rel;
 	public fun getInputs ()Ljava/util/List;
 	public fun getProjections ()Ljava/util/List;
+	public fun getSchema ()Lorg/partiql/plan/v1/Schema;
 	public fun hashCode ()I
 	public fun isOrdered ()Z
 }
@@ -2883,6 +2926,7 @@ public abstract class org/partiql/plan/v1/rel/RelScan$Base : org/partiql/plan/v1
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getInput ()Lorg/partiql/plan/v1/rex/Rex;
 	public fun getInputs ()Ljava/util/List;
+	public fun getSchema ()Lorg/partiql/plan/v1/Schema;
 	public fun hashCode ()I
 	public fun isOrdered ()Z
 }
@@ -2906,6 +2950,7 @@ public abstract class org/partiql/plan/v1/rel/RelScanIndexed$Base : org/partiql/
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getInput ()Lorg/partiql/plan/v1/rex/Rex;
 	public fun getInputs ()Ljava/util/List;
+	public fun getSchema ()Lorg/partiql/plan/v1/Schema;
 	public fun hashCode ()I
 	public fun isOrdered ()Z
 }
@@ -2921,6 +2966,7 @@ public abstract interface class org/partiql/plan/v1/rel/RelSort : org/partiql/pl
 	public abstract fun getCollations ()Ljava/util/List;
 	public abstract fun getInput ()Lorg/partiql/plan/v1/rel/Rel;
 	public abstract fun getInputs ()Ljava/util/List;
+	public abstract fun getSchema ()Lorg/partiql/plan/v1/Schema;
 	public abstract fun isOrdered ()Z
 }
 
@@ -2931,6 +2977,7 @@ public abstract class org/partiql/plan/v1/rel/RelSort$Base : org/partiql/plan/v1
 	public fun getCollations ()Ljava/util/List;
 	public fun getInput ()Lorg/partiql/plan/v1/rel/Rel;
 	public fun getInputs ()Ljava/util/List;
+	public fun getSchema ()Lorg/partiql/plan/v1/Schema;
 	public fun hashCode ()I
 	public fun isOrdered ()Z
 }
@@ -2938,6 +2985,7 @@ public abstract class org/partiql/plan/v1/rel/RelSort$Base : org/partiql/plan/v1
 public final class org/partiql/plan/v1/rel/RelSort$DefaultImpls {
 	public static fun accept (Lorg/partiql/plan/v1/rel/RelSort;Lorg/partiql/plan/v1/rel/RelVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun getInputs (Lorg/partiql/plan/v1/rel/RelSort;)Ljava/util/List;
+	public static fun getSchema (Lorg/partiql/plan/v1/rel/RelSort;)Lorg/partiql/plan/v1/Schema;
 	public static fun isOrdered (Lorg/partiql/plan/v1/rel/RelSort;)Z
 }
 
@@ -2958,6 +3006,7 @@ public abstract class org/partiql/plan/v1/rel/RelUnion$Base : org/partiql/plan/v
 	public fun getInputs ()Ljava/util/List;
 	public fun getLeft ()Lorg/partiql/plan/v1/rel/Rel;
 	public fun getRight ()Lorg/partiql/plan/v1/rel/Rel;
+	public fun getSchema ()Lorg/partiql/plan/v1/Schema;
 	public fun hashCode ()I
 	public fun isAll ()Z
 	public fun isOrdered ()Z
@@ -2982,6 +3031,7 @@ public abstract class org/partiql/plan/v1/rel/RelUnpivot$Base : org/partiql/plan
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getInput ()Lorg/partiql/plan/v1/rex/Rex;
 	public fun getInputs ()Ljava/util/List;
+	public fun getSchema ()Lorg/partiql/plan/v1/Schema;
 	public fun hashCode ()I
 	public fun isOrdered ()Z
 }
@@ -3034,9 +3084,50 @@ public final class org/partiql/plan/v1/rel/RelVisitor$DefaultImpls {
 }
 
 public abstract interface class org/partiql/plan/v1/rex/Rex {
+	public static final field Companion Lorg/partiql/plan/v1/rex/Rex$Companion;
 	public abstract fun accept (Lorg/partiql/plan/v1/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getOperands ()Ljava/util/List;
 	public abstract fun getType ()Lorg/partiql/types/PType;
+	public static fun lit (I)Lorg/partiql/plan/v1/rex/Rex;
+	public static fun lit (J)Lorg/partiql/plan/v1/rex/Rex;
+	public static fun lit (Ljava/lang/String;)Lorg/partiql/plan/v1/rex/Rex;
+	public static fun lit (Lorg/partiql/eval/value/Datum;)Lorg/partiql/plan/v1/rex/Rex;
+	public static fun lit (Z)Lorg/partiql/plan/v1/rex/Rex;
+}
+
+public final class org/partiql/plan/v1/rex/Rex$Companion {
+	public final fun lit (I)Lorg/partiql/plan/v1/rex/Rex;
+	public final fun lit (J)Lorg/partiql/plan/v1/rex/Rex;
+	public final fun lit (Ljava/lang/String;)Lorg/partiql/plan/v1/rex/Rex;
+	public final fun lit (Lorg/partiql/eval/value/Datum;)Lorg/partiql/plan/v1/rex/Rex;
+	public final fun lit (Z)Lorg/partiql/plan/v1/rex/Rex;
+}
+
+public final class org/partiql/plan/v1/rex/RexBuilder {
+	public static final field Companion Lorg/partiql/plan/v1/rex/RexBuilder$Companion;
+	public final fun cast (Lorg/partiql/types/PType;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public static final fun coalesce (Ljava/util/List;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public static final fun collection (Ljava/util/List;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public final fun index (Lorg/partiql/plan/v1/rex/Rex;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public static final fun lit (Lorg/partiql/eval/value/Datum;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public static final fun local (II)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public final fun path (Ljava/lang/String;Z)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public static synthetic fun path$default (Lorg/partiql/plan/v1/rex/RexBuilder;Ljava/lang/String;ZILjava/lang/Object;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public final fun scan ()Lorg/partiql/plan/v1/rel/RelBuilder;
+	public static final fun spread (Ljava/util/List;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public static final fun struct (Ljava/util/List;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public static final fun subquery (Lorg/partiql/plan/v1/rel/Rel;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public final fun unpivot ()Lorg/partiql/plan/v1/rel/RelBuilder;
+}
+
+public final class org/partiql/plan/v1/rex/RexBuilder$Companion {
+	public final fun coalesce (Ljava/util/List;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public final fun collection (Ljava/util/List;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public final fun lit (Lorg/partiql/eval/value/Datum;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public final fun local (II)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public final fun spread (Ljava/util/List;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public final fun struct (Ljava/util/List;)Lorg/partiql/plan/v1/rex/RexBuilder;
+	public final fun subquery (Lorg/partiql/plan/v1/rel/Rel;)Lorg/partiql/plan/v1/rex/RexBuilder;
 }
 
 public abstract interface class org/partiql/plan/v1/rex/RexCall : org/partiql/plan/v1/rex/Rex {
@@ -3124,6 +3215,7 @@ public abstract class org/partiql/plan/v1/rex/RexCoalesce$Base : org/partiql/pla
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getArgs ()Ljava/util/List;
 	public fun getOperands ()Ljava/util/List;
+	public fun getType ()Lorg/partiql/types/PType;
 	public fun hashCode ()I
 }
 
@@ -3143,6 +3235,7 @@ public abstract class org/partiql/plan/v1/rex/RexCollection$Base : org/partiql/p
 	public fun accept (Lorg/partiql/plan/v1/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getOperands ()Ljava/util/List;
+	public fun getType ()Lorg/partiql/types/PType;
 	public fun getValues ()Ljava/util/List;
 	public fun hashCode ()I
 }
@@ -3178,16 +3271,16 @@ public abstract interface class org/partiql/plan/v1/rex/RexLit : org/partiql/pla
 	public abstract fun accept (Lorg/partiql/plan/v1/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getOperands ()Ljava/util/List;
 	public abstract fun getType ()Lorg/partiql/types/PType;
-	public abstract fun getValue ()Ljava/lang/String;
+	public abstract fun getValue ()Lorg/partiql/eval/value/Datum;
 }
 
 public abstract class org/partiql/plan/v1/rex/RexLit$Base : org/partiql/plan/v1/rex/RexLit {
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Lorg/partiql/eval/value/Datum;)V
 	public fun accept (Lorg/partiql/plan/v1/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getOperands ()Ljava/util/List;
 	public fun getType ()Lorg/partiql/types/PType;
-	public fun getValue ()Ljava/lang/String;
+	public fun getValue ()Lorg/partiql/eval/value/Datum;
 	public fun hashCode ()I
 }
 
@@ -3264,6 +3357,8 @@ public abstract interface class org/partiql/plan/v1/rex/RexSelect : org/partiql/
 	public abstract fun accept (Lorg/partiql/plan/v1/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getConstructor ()Lorg/partiql/plan/v1/rex/Rex;
 	public abstract fun getInput ()Lorg/partiql/plan/v1/rel/Rel;
+	public abstract fun getOperands ()Ljava/util/List;
+	public abstract fun getType ()Lorg/partiql/types/PType;
 }
 
 public abstract class org/partiql/plan/v1/rex/RexSelect$Base : org/partiql/plan/v1/rex/RexSelect {
@@ -3272,11 +3367,15 @@ public abstract class org/partiql/plan/v1/rex/RexSelect$Base : org/partiql/plan/
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getConstructor ()Lorg/partiql/plan/v1/rex/Rex;
 	public fun getInput ()Lorg/partiql/plan/v1/rel/Rel;
+	public fun getOperands ()Ljava/util/List;
+	public fun getType ()Lorg/partiql/types/PType;
 	public fun hashCode ()I
 }
 
 public final class org/partiql/plan/v1/rex/RexSelect$DefaultImpls {
 	public static fun accept (Lorg/partiql/plan/v1/rex/RexSelect;Lorg/partiql/plan/v1/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static fun getOperands (Lorg/partiql/plan/v1/rex/RexSelect;)Ljava/util/List;
+	public static fun getType (Lorg/partiql/plan/v1/rex/RexSelect;)Lorg/partiql/types/PType;
 }
 
 public abstract interface class org/partiql/plan/v1/rex/RexStruct : org/partiql/plan/v1/rex/Rex {
@@ -3319,6 +3418,7 @@ public abstract class org/partiql/plan/v1/rex/RexSubquery$Base : org/partiql/pla
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getInput ()Lorg/partiql/plan/v1/rel/Rel;
 	public fun getOperands ()Ljava/util/List;
+	public fun getType ()Lorg/partiql/types/PType;
 	public fun hashCode ()I
 }
 
@@ -3383,6 +3483,7 @@ public abstract class org/partiql/plan/v1/rex/RexVar$Base : org/partiql/plan/v1/
 	public fun getDepth ()I
 	public fun getOffset ()I
 	public fun getOperands ()Ljava/util/List;
+	public fun getType ()Lorg/partiql/types/PType;
 	public fun hashCode ()I
 }
 

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/Rel.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/Rel.kt
@@ -1,6 +1,7 @@
 package org.partiql.plan.v1.rel
 
 import org.partiql.plan.v1.Schema
+import org.partiql.plan.v1.rex.Rex
 
 /**
  * TODO DOCUMENTATION
@@ -14,4 +15,28 @@ public interface Rel {
     public fun isOrdered(): Boolean
 
     public fun <R, C> accept(visitor: RelVisitor<R, C>, ctx: C): R
+
+    /**
+     * Static build methods for the builder .
+     */
+    public companion object {
+
+        /**
+         * TODO
+         */
+        @JvmStatic
+        public fun scan(rex: Rex): Rel = RelBuilder.scan(rex).build()
+
+        /**
+         * TODO
+         */
+        @JvmStatic
+        public fun scanIndexed(rex: Rex): Rel = RelBuilder.scanIndexed(rex).build()
+
+        /**
+         * TODO
+         */
+        @JvmStatic
+        public fun unpivot(rex: Rex): Rel = RelBuilder.unpivot(rex).build()
+    }
 }

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelAggregate.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelAggregate.kt
@@ -1,7 +1,10 @@
 package org.partiql.plan.v1.rel
 
+import org.partiql.plan.v1.Schema
+
 /**
- * TODO DOCUMENTATION
+ * TODO GROUP STRATEGY
+ * TODO GROUP BY
  */
 public interface RelAggregate : Rel {
 
@@ -18,16 +21,16 @@ public interface RelAggregate : Rel {
     /**
      * Default [RelAggregate] implementation meant for extension.
      */
-    public abstract class Base(input: Rel, collations: List<RelAggregateCall>) : RelAggregate {
+    public abstract class Base(input: Rel, calls: List<RelAggregateCall>) : RelAggregate {
 
         private var _input = input
-        private var _collations = collations
+        private var _calls = calls
 
         private var _inputs: List<Rel>? = null
 
         override fun getInput(): Rel = _input
 
-        override fun getCalls(): List<RelAggregateCall> = _collations
+        override fun getCalls(): List<RelAggregateCall> = _calls
 
         override fun getInputs(): List<Rel> {
             if (_inputs == null) {
@@ -36,18 +39,22 @@ public interface RelAggregate : Rel {
             return _inputs!!
         }
 
+        override fun getSchema(): Schema {
+            TODO("Not yet implemented")
+        }
+
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (other !is RelAggregate) return false
             if (_input != other.getInput()) return false
-            if (_collations != other.getCalls()) return false
+            if (_calls != other.getCalls()) return false
             return true
         }
 
         override fun hashCode(): Int {
             var result = 1
             result = 31 * result + _input.hashCode()
-            result = 31 * result + _collations.hashCode()
+            result = 31 * result + _calls.hashCode()
             return result
         }
     }

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelBuilder.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelBuilder.kt
@@ -1,0 +1,133 @@
+package org.partiql.plan.v1.rel
+
+import org.partiql.plan.v1.rex.Rex
+import org.partiql.plan.v1.rex.RexBuilder
+import org.partiql.plan.v1.rex.RexPivot
+import org.partiql.plan.v1.rex.RexSelect
+
+/**
+ * DataFrame style fluent-builder for PartiQL logical plans.
+ *
+ * TODO schemas and field names.
+ */
+public class RelBuilder private constructor(rel: Rel) {
+
+    // KEEP FINAL TO ENSURE ITS NEVER MUTATED
+    private val _rel: Rel = rel
+
+    /**
+     * Returns the [Rel] created by the builder.
+     */
+    public fun build(): Rel = _rel
+
+    public fun aggregate(calls: List<RelAggregateCall>): RelBuilder {
+        val rel = object : RelAggregate.Base(_rel, calls) {}
+        return RelBuilder(rel)
+    }
+
+    public fun distinct(): RelBuilder {
+        val rel = object : RelDistinct.Base(_rel) {}
+        return RelBuilder(rel)
+    }
+
+    public fun except(rhs: Rel): RelBuilder {
+        val rel = object : RelExcept.Base(_rel, rhs) {}
+        return RelBuilder(rel)
+    }
+
+    public fun filter(condition: Rex): RelBuilder {
+        val rel = object : RelFilter.Base(_rel, condition) {}
+        return RelBuilder(rel)
+    }
+
+    public fun intersect(rhs: Rel): RelBuilder {
+        val rel = object : RelIntersect.Base(_rel, rhs) {}
+        return RelBuilder(rel)
+    }
+
+    /**
+     * TODO other join types.
+     */
+    public fun join(rhs: Rel): RelBuilder {
+        // TEMP!
+        val condition = Rex.lit(true)
+        val type = RelJoinType.INNER
+        // END TEMP!
+        val rel = object : RelJoin.Base(_rel, rhs, condition, type) {}
+        return RelBuilder(rel)
+    }
+
+    public fun limit(limit: Rex): RelBuilder {
+        val rel = object : RelLimit.Base(_rel, limit) {}
+        return RelBuilder(rel)
+    }
+
+    public fun offset(offset: Rex): RelBuilder {
+        val rel = object : RelOffset.Base(_rel, offset) {}
+        return RelBuilder(rel)
+    }
+
+    public fun project(projections: List<Rex>): RelBuilder {
+        val rel = object : RelProject.Base(_rel, projections) {}
+        return RelBuilder(rel)
+    }
+
+    public fun sort(collations: List<RelCollation>): RelBuilder {
+        val rel = object : RelSort.Base(_rel, collations) {}
+        return RelBuilder(rel)
+    }
+
+    public fun union(rhs: Rel): RelBuilder {
+        val rel = object : RelUnion.Base(_rel, rhs) {}
+        return RelBuilder(rel)
+    }
+
+    /**
+     * The SELECT VALUE operator.
+     *
+     * @param constructor
+     * @return
+     */
+    public fun select(constructor: Rex): RexBuilder {
+        val rex = object : RexSelect.Base(_rel, constructor) {}
+        return RexBuilder(rex)
+    }
+
+    /**
+     * The PIVOT relation-expression projection.
+     */
+    public fun pivot(key: Rex, value: Rex): RexBuilder {
+        val rex = object : RexPivot.Base(_rel, key, value) {}
+        return RexBuilder(rex)
+    }
+
+    /**
+     * PlanBuilder constructor remains private, and all logic for the static methods lives here.
+     */
+    public companion object {
+
+        /**
+         * Initialize a [RelScan] builder.
+         */
+        @JvmStatic
+        public fun scan(rex: Rex): RelBuilder {
+            val rel = object : RelScan.Base(rex) {}
+            return RelBuilder(rel)
+        }
+
+        /**
+         * Initialize a [RelScanIndexed] builder.
+         */
+        @JvmStatic
+        public fun scanIndexed(rex: Rex): RelBuilder {
+            val rel = object : RelScanIndexed.Base(rex) {}
+            return RelBuilder(rel)
+        }
+
+        @JvmStatic
+        public fun unpivot(rex: Rex): RelBuilder {
+            val rel = object : RelUnpivot.Base(rex) {}
+            return RelBuilder(rel)
+        }
+    }
+}

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelExcept.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelExcept.kt
@@ -1,5 +1,7 @@
 package org.partiql.plan.v1.rel
 
+import org.partiql.plan.v1.Schema
+
 /**
  * Logical `EXCEPT [ALL|DISTINCT]` operator for set (or multiset) difference.
  */
@@ -44,6 +46,10 @@ public interface RelExcept : Rel {
                 _inputs = listOf(_left, _right)
             }
             return _inputs!!
+        }
+
+        override fun getSchema(): Schema {
+            TODO("Not yet implemented")
         }
 
         override fun isOrdered(): Boolean = false

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelIntersect.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelIntersect.kt
@@ -1,5 +1,7 @@
 package org.partiql.plan.v1.rel
 
+import org.partiql.plan.v1.Schema
+
 /**
  * Logical `INTERSECT [ALL|DISTINCT]` operator for set (or multiset) intersection.
  */
@@ -44,6 +46,10 @@ public interface RelIntersect : Rel {
                 _inputs = listOf(_left, _right)
             }
             return _inputs!!
+        }
+
+        override fun getSchema(): Schema {
+            TODO("Not yet implemented")
         }
 
         override fun isOrdered(): Boolean = false

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelJoin.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelJoin.kt
@@ -1,5 +1,6 @@
 package org.partiql.plan.v1.rel
 
+import org.partiql.plan.v1.Schema
 import org.partiql.plan.v1.rex.Rex
 
 /**
@@ -47,6 +48,10 @@ public interface RelJoin : Rel {
                 _inputs = listOf(_left, _right)
             }
             return _inputs!!
+        }
+
+        override fun getSchema(): Schema {
+            TODO("Not yet implemented")
         }
 
         override fun isOrdered(): Boolean = false

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelProject.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelProject.kt
@@ -1,5 +1,6 @@
 package org.partiql.plan.v1.rel
 
+import org.partiql.plan.v1.Schema
 import org.partiql.plan.v1.rex.Rex
 
 /**
@@ -31,6 +32,10 @@ public interface RelProject : Rel {
         override fun getInput(): Rel = _input
 
         override fun getProjections(): List<Rex> = _projections
+
+        override fun getSchema(): Schema {
+            TODO("Not yet implemented")
+        }
 
         override fun getInputs(): List<Rel> {
             if (_inputs == null) {

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelScan.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelScan.kt
@@ -1,5 +1,6 @@
 package org.partiql.plan.v1.rel
 
+import org.partiql.plan.v1.Schema
 import org.partiql.plan.v1.rex.Rex
 import org.partiql.types.PType
 
@@ -25,6 +26,10 @@ public interface RelScan : Rel {
         private var _input: Rex = input
 
         override fun getInput(): Rex = _input
+
+        override fun getSchema(): Schema {
+            TODO("Implement getSchema for scan")
+        }
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelScanIndexed.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelScanIndexed.kt
@@ -1,5 +1,6 @@
 package org.partiql.plan.v1.rel
 
+import org.partiql.plan.v1.Schema
 import org.partiql.plan.v1.rex.Rex
 
 /**
@@ -24,6 +25,10 @@ public interface RelScanIndexed : Rel {
         private var _input: Rex = input
 
         override fun getInput(): Rex = _input
+
+        override fun getSchema(): Schema {
+            TODO("Not yet implemented")
+        }
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelSort.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelSort.kt
@@ -1,5 +1,7 @@
 package org.partiql.plan.v1.rel
 
+import org.partiql.plan.v1.Schema
+
 /**
  * Logical sort operator.
  */
@@ -10,6 +12,8 @@ public interface RelSort : Rel {
     public fun getCollations(): List<RelCollation>
 
     override fun getInputs(): List<Rel> = listOf(getInput())
+
+    override fun getSchema(): Schema = getInput().getSchema()
 
     override fun isOrdered(): Boolean = true
 
@@ -29,6 +33,8 @@ public interface RelSort : Rel {
         override fun getInput(): Rel = _input
 
         override fun getCollations(): List<RelCollation> = _collations
+
+        override fun getSchema(): Schema = _input.getSchema()
 
         override fun getInputs(): List<Rel> {
             if (_inputs == null) {

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelUnion.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelUnion.kt
@@ -1,5 +1,7 @@
 package org.partiql.plan.v1.rel
 
+import org.partiql.plan.v1.Schema
+
 /**
  * Logical `UNION [ALL|DISTINCT]` operator for set (or multiset) union.
  */
@@ -47,6 +49,10 @@ public interface RelUnion : Rel {
         }
 
         override fun isOrdered(): Boolean = false
+
+        override fun getSchema(): Schema {
+            TODO("Not yet implemented")
+        }
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelUnpivot.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rel/RelUnpivot.kt
@@ -1,5 +1,6 @@
 package org.partiql.plan.v1.rel
 
+import org.partiql.plan.v1.Schema
 import org.partiql.plan.v1.rex.Rex
 
 /**
@@ -29,6 +30,10 @@ public interface RelUnpivot : Rel {
             if (this === other) return true
             if (other == null || other !is RelUnpivot) return false
             return _input == other.getInput()
+        }
+
+        override fun getSchema(): Schema {
+            TODO("Not yet implemented")
         }
 
         override fun hashCode(): Int {

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/Rex.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/Rex.kt
@@ -1,5 +1,6 @@
 package org.partiql.plan.v1.rex
 
+import org.partiql.eval.value.Datum
 import org.partiql.types.PType
 
 /**
@@ -12,4 +13,25 @@ public interface Rex {
     public fun getOperands(): List<Rex>
 
     public fun <R, C> accept(visitor: RexVisitor<R, C>, ctx: C): R
+
+    /**
+     * TODO add more literals once Datum is expanded with more factory methods.
+     */
+    public companion object {
+
+        @JvmStatic
+        public fun lit(value: Boolean): Rex = lit(Datum.boolValue(value))
+
+        @JvmStatic
+        public fun lit(value: Int): Rex = lit(Datum.int32Value(value))
+
+        @JvmStatic
+        public fun lit(value: Long): Rex = lit(Datum.int64Value(value))
+
+        @JvmStatic
+        public fun lit(value: String): Rex = lit(Datum.stringValue(value))
+
+        @JvmStatic
+        public fun lit(value: Datum): Rex = object : RexLit.Base(value) {}
+    }
 }

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexBuilder.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexBuilder.kt
@@ -1,0 +1,120 @@
+package org.partiql.plan.v1.rex
+
+import org.partiql.eval.value.Datum
+import org.partiql.plan.v1.rel.Rel
+import org.partiql.plan.v1.rel.RelBuilder
+import org.partiql.types.PType
+
+/**
+ * DataFrame style fluent-builder for PartiQL logical plans.
+ *
+ * TODO schemas and field names.
+ * TODO call expressions.
+ * TODO list SOME/ANY/ALL CONTAINS etc.
+ */
+public class RexBuilder internal constructor(rex: Rex) {
+
+    // KEEP FINAL TO ENSURE ITS NEVER MUTATED
+    private val _rex = rex
+
+    // TODO CONSIDER BINARY OPERATORS
+
+    /**
+     * The CAST(<_rex> AS <target>) operator.
+     *
+     * @param target
+     * @return
+     */
+    public fun cast(target: PType): RexBuilder {
+        val rex = object : RexCast.Base(_rex, target) {}
+        return RexBuilder(rex)
+    }
+
+    /**
+     * The SCAN expression-to-relation projects — i.e. FROM <rex>
+     *
+     * @return
+     */
+    public fun scan(): RelBuilder = RelBuilder.scan(_rex)
+
+    /**
+     * The pathing expressions for keys and symbols — i.e. <rex>.<key> / <rex>['key']
+     *
+     * @param key           The key expression.
+     * @param insensitive   If true, then a symbol lookup is used.
+     * @return
+     */
+    public fun path(key: String, insensitive: Boolean = false): RexBuilder {
+        TODO("not implemented")
+    }
+
+    public fun index(index: Rex): RexBuilder {
+        TODO("not implemented")
+    }
+
+    /**
+     * The UNPIVOT expression-to-relation projection.
+     */
+    public fun unpivot(): RelBuilder = RelBuilder.unpivot(_rex)
+
+    public companion object {
+
+        /**
+         * TODO NAMING??
+         */
+        @JvmStatic
+        public fun local(depth: Int, offset: Int): RexBuilder {
+            val rex = object : RexVar.Base(depth, offset) {}
+            return RexBuilder(rex)
+        }
+
+        @JvmStatic
+        public fun lit(value: Datum): RexBuilder {
+            val rex = object : RexLit.Base(value) {}
+            return RexBuilder(rex)
+        }
+
+        @JvmStatic
+        public fun collection(values: List<Rex>): RexBuilder {
+            val rex = object : RexCollection.Base(values) {}
+            return RexBuilder(rex)
+        }
+
+        @JvmStatic
+        public fun coalesce(args: List<Rex>): RexBuilder {
+            val rex = object : RexCoalesce.Base(args) {}
+            return RexBuilder(rex)
+        }
+
+        /**
+         * Scalar subquery coercion.
+         */
+        @JvmStatic
+        public fun subquery(rel: Rel): RexBuilder {
+            val rex = object : RexSubquery.Base(rel) {}
+            return RexBuilder(rex)
+        }
+
+        /**
+         * TODO add some vararg and vararg pair overloads.
+         */
+        @JvmStatic
+        public fun struct(fields: List<RexStructField>): RexBuilder {
+            val rex = object : RexStruct.Base(fields) {}
+            return RexBuilder(rex)
+        }
+
+        /**
+         * The TUPLEUNION function (which could just be a scalar function..)
+         *
+         * Spread because it's similar to the struct/dict spread of other languages. { x..., y... }
+         *
+         * TODO NAMING??
+         */
+        @JvmStatic
+        public fun spread(args: List<Rex>): RexBuilder {
+            val rex = object : RexTupleUnion.Base(args) {}
+            return RexBuilder(rex)
+        }
+    }
+}

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexCoalesce.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexCoalesce.kt
@@ -1,5 +1,7 @@
 package org.partiql.plan.v1.rex
 
+import org.partiql.types.PType
+
 /**
  * TODO DOCUMENTATION
  */
@@ -19,6 +21,10 @@ public interface RexCoalesce : Rex {
         public override fun getArgs(): List<Rex> = _args
 
         public override fun getOperands(): List<Rex> = _args
+
+        public override fun getType(): PType {
+            TODO("Not yet implemented")
+        }
 
         public override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexCollection.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexCollection.kt
@@ -1,5 +1,7 @@
 package org.partiql.plan.v1.rex
 
+import org.partiql.types.PType
+
 /**
  * TODO DOCUMENTATION
  */
@@ -22,6 +24,10 @@ interface RexCollection : Rex {
         public override fun getValues(): List<Rex> = _values
 
         public override fun getOperands(): List<Rex> = _values
+
+        override fun getType(): PType {
+            TODO("Not yet implemented")
+        }
 
         public override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexGlobal.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexGlobal.kt
@@ -2,6 +2,7 @@ package org.partiql.plan.v1.rex
 
 /**
  * Global variable references e.g. tables and views.
+ * TODO NAMING?? RexTable??
  */
 interface RexGlobal : Rex {
 

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexLit.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexLit.kt
@@ -1,5 +1,6 @@
 package org.partiql.plan.v1.rex
 
+import org.partiql.eval.value.Datum
 import org.partiql.types.PType
 
 /**
@@ -10,7 +11,7 @@ public interface RexLit : Rex {
     /**
      * TODO REPLACE WITH DATUM
      */
-    public fun getValue(): String
+    public fun getValue(): Datum
 
     public override fun getOperands(): List<Rex> = emptyList()
 
@@ -18,12 +19,12 @@ public interface RexLit : Rex {
 
     public override fun <R, C> accept(visitor: RexVisitor<R, C>, ctx: C): R = visitor.visitLit(this, ctx)
 
-    public abstract class Base(value: String) : RexLit {
+    public abstract class Base(value: Datum) : RexLit {
 
         // DO NOT USE FINAL
         private var _value = value
 
-        public override fun getValue(): String = _value
+        public override fun getValue(): Datum = _value
 
         public override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexSelect.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexSelect.kt
@@ -1,6 +1,7 @@
 package org.partiql.plan.v1.rex
 
 import org.partiql.plan.v1.rel.Rel
+import org.partiql.types.PType
 
 /**
  * TODO DOCUMENTATION
@@ -10,6 +11,10 @@ public interface RexSelect : Rex {
     public fun getInput(): Rel
 
     public fun getConstructor(): Rex
+
+    public override fun getType(): PType = PType.typeBag(getConstructor().getType())
+
+    public override fun getOperands(): List<Rex> = listOf(getConstructor())
 
     public override fun <R, C> accept(visitor: RexVisitor<R, C>, ctx: C): R = visitor.visitSelect(this, ctx)
 
@@ -21,6 +26,10 @@ public interface RexSelect : Rex {
         public override fun getInput(): Rel = _input
 
         public override fun getConstructor(): Rex = _constructor
+
+        public override fun getType(): PType = PType.typeBag(_constructor.getType())
+
+        public override fun getOperands(): List<Rex> = listOf(_constructor)
 
         public override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexSubquery.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexSubquery.kt
@@ -1,6 +1,7 @@
 package org.partiql.plan.v1.rex
 
 import org.partiql.plan.v1.rel.Rel
+import org.partiql.types.PType
 
 /**
  * Scalar subquery coercion.
@@ -19,6 +20,10 @@ public interface RexSubquery : Rex {
         private var _input = input
 
         public override fun getInput(): Rel = _input
+
+        public override fun getType(): PType {
+            TODO("Not yet implemented")
+        }
 
         public override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexVar.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/rex/RexVar.kt
@@ -1,7 +1,10 @@
 package org.partiql.plan.v1.rex
 
+import org.partiql.types.PType
+
 /**
  * TODO DOCUMENTATION
+ * TODO NAMING??
  */
 public interface RexVar : Rex {
 
@@ -31,6 +34,10 @@ public interface RexVar : Rex {
         public override fun getDepth(): Int = _depth
 
         public override fun getOffset(): Int = _offset
+
+        override fun getType(): PType {
+            TODO("Not yet implemented")
+        }
 
         public override fun equals(other: Any?): Boolean {
             if (this === other) return true


### PR DESCRIPTION
## Description

This PR adds dataframe-like fluent builders to the logical plans. We have recurring customer asks of having calcite style algebra builders, and [we have had _some_ offering like this with the generated IRs](https://github.com/partiql/partiql-lang-kotlin/tree/main/partiql-ast), but these were more like convenience methods than actual dataflow builders.

For example, the builders were just POJO-style builders, and the DSL is just kotlin stuff for calling methods. Whereas these are consistent with a dataflow builder.

## Example

**Before**
```kotlin
// SELECT x FROM T

val query = rex(
    type = ..,
    op = RexOpSelect(
        constructor = rex(
            type = ...,
            op = rexOpStruct(fields = listOf(rex(type=..., op=rexopVar)
       input = rel(
           type = ...,
           op = relOpProject(
                projections = ...
               ..
)
```

This is _really_ bad and not user friendly. The highly-detailed and typed resolved plans enabled us to deliver statically resolved and typed plans, but were not conducive to ease-of-use.

This plan abstract is a work-in-progress to regain the simplicity of AST-like plan builders (based upon dataframe style construction) with the finer details hidden behind small interfaces.

**After**
```kotlin
val query = Rel.scan("T").select("x").build()

// all logic for planning/resolution is hidden behind build()
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.