### PR TITLE
Preserve constraint for decimal, string in dynamic typer

### DIFF
--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -34,6 +34,7 @@ import org.partiql.types.AnyType
 import org.partiql.types.BagType
 import org.partiql.types.DecimalType
 import org.partiql.types.ListType
+import org.partiql.types.NumberConstraint
 import org.partiql.types.SexpType
 import org.partiql.types.StaticType
 import org.partiql.types.StaticType.Companion.ANY
@@ -43,6 +44,7 @@ import org.partiql.types.StaticType.Companion.INT2
 import org.partiql.types.StaticType.Companion.INT4
 import org.partiql.types.StaticType.Companion.INT8
 import org.partiql.types.StaticType.Companion.unionOf
+import org.partiql.types.StringType
 import org.partiql.types.StructType
 import org.partiql.types.TupleConstraint
 import java.util.stream.Stream
@@ -2691,6 +2693,41 @@ class PlanTyperTestsPorted {
                 key = PartiQLTest.Key("basics", "case-when-34"),
                 catalog = "pql",
                 expected = StaticType.ANY
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-35"),
+                catalog = "pql",
+                expected = DecimalType(DecimalType.PrecisionScaleConstraint.Constrained(10, 5))
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-36"),
+                catalog = "pql",
+                expected = DecimalType(DecimalType.PrecisionScaleConstraint.Constrained(10, 5))
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-37"),
+                catalog = "pql",
+                expected = StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(10)))
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-38"),
+                catalog = "pql",
+                expected = StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(10)))
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-39"),
+                catalog = "pql",
+                expected = StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(10)))
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-40"),
+                catalog = "pql",
+                expected = StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(10)))
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-41"),
+                catalog = "pql",
+                expected = StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(10)))
             ),
         )
 

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/pql/t_item.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/pql/t_item.ion
@@ -118,6 +118,53 @@
     {
       name: "t_str",
       type: [ "clob", "string" ],
-    }
+    },
+    // fixed precision decimal
+    {
+      name: "t_decimal_10_5",
+      type: {
+        type: "decimal",
+        precision: 10,
+        scale: 5
+      }
+    },
+    {
+      name: "t_decimal_5_3",
+      type: {
+        type: "decimal",
+        precision: 10,
+        scale: 5
+      }
+    },
+    {
+      name: "t_varchar_10",
+      type: {
+        type: "string",
+        max_length: 10,
+      }
+    },
+    {
+      name: "t_varchar_5",
+      type: {
+        type: "string",
+        max_length: 5,
+      }
+    },
+    {
+      name: "t_char_10",
+      type: {
+        type: "string",
+        max_length: 10,
+        min_length: 10,
+      }
+    },
+    {
+      name: "t_char_5",
+      type: {
+        type: "string",
+        max_length: 5,
+        min_length: 5,
+      }
+    },
   ]
 }

--- a/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
@@ -272,6 +272,56 @@ CASE t_item.t_string
     ELSE t_item.t_any
 END;
 
+--#[case-when-35]
+-- type: decimal(10,5)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_decimal_10_5
+    ELSE null
+END;
+
+--#[case-when-36]
+-- type: decimal(10,5)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_decimal_10_5
+    ELSE t_item.t_decimal_5_3
+END;
+
+--#[case-when-37]
+-- type: varchar(10)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_varchar_10
+    ELSE null
+END;
+
+--#[case-when-38]
+-- type: varchar(10)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_varchar_10
+    ELSE t_item.t_varchar_5
+END;
+
+--#[case-when-39]
+-- type: char(10)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_char_10
+    ELSE null
+END;
+
+--#[case-when-40]
+-- type: char(10)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_char_10
+    ELSE t_item.t_char_5
+END;
+
+--#[case-when-41]
+-- type: varchar(10)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_char_10
+    ELSE t_item.t_varchar_10
+END;
+
+
 -- -----------------------------
 --  (Unused) old tests
 -- -----------------------------

--- a/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/LocalSchema.kt
+++ b/plugins/partiql-local/src/main/kotlin/org/partiql/plugins/local/LocalSchema.kt
@@ -5,6 +5,7 @@ import com.amazon.ionelement.api.ListElement
 import com.amazon.ionelement.api.StringElement
 import com.amazon.ionelement.api.StructElement
 import com.amazon.ionelement.api.SymbolElement
+import com.amazon.ionelement.api.ionInt
 import com.amazon.ionelement.api.ionListOf
 import com.amazon.ionelement.api.ionString
 import com.amazon.ionelement.api.ionStructOf
@@ -23,6 +24,7 @@ import org.partiql.types.IntType
 import org.partiql.types.ListType
 import org.partiql.types.MissingType
 import org.partiql.types.NullType
+import org.partiql.types.NumberConstraint
 import org.partiql.types.SexpType
 import org.partiql.types.StaticType
 import org.partiql.types.StringType
@@ -100,6 +102,8 @@ public fun StructElement.toStaticType(): StaticType {
         "list" -> toListType()
         "sexp" -> toSexpType()
         "struct" -> toStructType()
+        "decimal" -> toDecimalType()
+        "string" -> toStringType()
         else -> error("Unknown complex type $type")
     }
 }
@@ -148,6 +152,27 @@ public fun StructElement.toStructType(): StaticType {
     return StructType(fields, contentClosed, constraints = constraints)
 }
 
+public fun StructElement.toDecimalType(): StaticType {
+    val precision = get("precision").bigIntegerValue.intValueExact()
+    val scale = get("scale").bigIntegerValue.intValueExact()
+    val precisionScaleConstraint = DecimalType.PrecisionScaleConstraint.Constrained(precision, scale)
+    return DecimalType(precisionScaleConstraint)
+}
+
+public fun StructElement.toStringType(): StaticType {
+    return when {
+        getOptional("min_length") != null -> {
+            val length = get("min_length")
+            assert(length == get("max_length")) { "type declaration error: max_length/min_length mismatch" }
+            StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(length.bigIntegerValue.intValueExact())))
+        }
+        else -> {
+            val length = get("max_length")
+            StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(length.bigIntegerValue.intValueExact())))
+        }
+    }
+}
+
 public fun StaticType.toIon(): IonElement = when (this) {
     is AnyOfType -> this.toIon()
     is AnyType -> ionString("any")
@@ -158,7 +183,7 @@ public fun StaticType.toIon(): IonElement = when (this) {
     is ListType -> this.toIon()
     is SexpType -> this.toIon()
     is DateType -> ionString("date")
-    is DecimalType -> ionString("decimal")
+    is DecimalType -> this.toIon()
     is FloatType -> ionString("float64")
     is GraphType -> ionString("graph")
     is IntType -> when (this.rangeConstraint) {
@@ -167,7 +192,7 @@ public fun StaticType.toIon(): IonElement = when (this) {
         IntType.IntRangeConstraint.LONG -> ionString("int64")
         IntType.IntRangeConstraint.UNCONSTRAINED -> ionString("int")
     }
-    is StringType -> ionString("string") // TODO char
+    is StringType -> this.toIon()
     is StructType -> this.toIon()
     is SymbolType -> ionString("symbol")
     is TimeType -> ionString("time")
@@ -218,4 +243,28 @@ private fun StructType.toIon(): IonElement {
         "fields" to ionListOf(fieldTypes),
         "constraints" to ionListOf(constraintSymbols),
     )
+}
+
+private fun DecimalType.toIon(): IonElement = when (val contr = this.precisionScaleConstraint) {
+    is DecimalType.PrecisionScaleConstraint.Constrained -> ionStructOf(
+        "type" to ionString("decimal"),
+        "precision" to ionInt(contr.precision.toLong()),
+        "scale" to ionInt(contr.scale.toLong())
+    )
+    DecimalType.PrecisionScaleConstraint.Unconstrained -> ionString("decimal")
+}
+
+private fun StringType.toIon(): IonElement = when (val constr = this.lengthConstraint) {
+    is StringType.StringLengthConstraint.Constrained -> when (val l = constr.length) {
+        is NumberConstraint.Equals -> ionStructOf(
+            "type" to ionString("string"),
+            "max_length" to ionInt(l.value.toLong()),
+            "min_length" to ionInt(l.value.toLong())
+        )
+        is NumberConstraint.UpTo -> ionStructOf(
+            "type" to ionString("string"),
+            "max_length" to ionInt(l.value.toLong()),
+        )
+    }
+    StringType.StringLengthConstraint.Unconstrained -> ionString("string")
 }


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description

1. Preserve constraint in dynamic typer

Previous, 
```
CASE  WHEN <condition> THEN <DECIMAL(10,5)>
    ELSE null
END;
```
return Decimal Type with arbitrary precision and scale
Similarly: 
```
CASE  WHEN <condition> THEN <VARCHAR(10)>
    ELSE null
END;
```
return String Type with arbitrary length constraint. 
With this PR: 
```
CASE  WHEN <condition> THEN <DECIMAL(10,5)>
    ELSE null
END;
```
returns DECIMAL(10,5).
```
CASE  WHEN <condition> THEN <VARCHAR(10)>
    ELSE null
END;
```
returns VARCHAR(10)

2. Type Constraint Promotion
If the common super type is of single type and require no coercion, the dynamic typer should perform promotion if applicable. 

Consider 
```
CASE  WHEN <condition> THEN <DECIMAL(10,5)>
    ELSE <DECIMAL(5,3)>
END;
```
With type promotion, the return type will be : Decimal(10,5)

Similarly: 
```
CASE  WHEN <condition> THEN <VARCHAR(10)>
    ELSE <VARCHAR(5)>
END;
```

The return type will be VARCHAR(10). 

In addition, because STRING and CHAR share the same runtime type: 

```
CASE  WHEN <condition> THEN <VARCHAR(10)>
    ELSE <CHAR(5)>
END;
```

returns VARCHAR(10) without the need of coercion. 

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - No. 

- Any backward-incompatible changes? **[YES/NO]**
  - < If YES, why? >
  - < For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base. >
No. 

- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >
 No. 

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.