### PR TITLE
[v0.14.8-SNAPSHOT] Preserve constraint for decimal, string in dynamic typer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Thank you to all who have contributed!
 -->
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+- Case When Branch inference will preserve type constraint for String Type and Decimal Type, if no coercion is required. 
+### Removed
+
+### Security
+
+### Contributors
+Thank you to all who have contributed!
+
 ## [0.14.7]
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=0.14.7
+version=0.14.8-SNAPSHOT
 
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -35,11 +35,13 @@ import org.partiql.types.AnyType
 import org.partiql.types.BagType
 import org.partiql.types.DecimalType
 import org.partiql.types.ListType
+import org.partiql.types.NumberConstraint
 import org.partiql.types.SexpType
 import org.partiql.types.StaticType
 import org.partiql.types.StaticType.Companion.MISSING
 import org.partiql.types.StaticType.Companion.NULL
 import org.partiql.types.StaticType.Companion.unionOf
+import org.partiql.types.StringType
 import org.partiql.types.StructType
 import org.partiql.types.TupleConstraint
 import java.util.stream.Stream
@@ -2682,6 +2684,41 @@ class PlanTyperTestsPorted {
                 key = PartiQLTest.Key("basics", "case-when-34"),
                 catalog = "pql",
                 expected = StaticType.ANY
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-35"),
+                catalog = "pql",
+                expected = DecimalType(DecimalType.PrecisionScaleConstraint.Constrained(10, 5)).asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-36"),
+                catalog = "pql",
+                expected = DecimalType(DecimalType.PrecisionScaleConstraint.Constrained(10, 5))
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-37"),
+                catalog = "pql",
+                expected = StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(10))).asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-38"),
+                catalog = "pql",
+                expected = StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(10)))
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-39"),
+                catalog = "pql",
+                expected = StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(10))).asNullable()
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-40"),
+                catalog = "pql",
+                expected = StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.Equals(10)))
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-41"),
+                catalog = "pql",
+                expected = StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(10)))
             ),
         )
 

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -2720,6 +2720,36 @@ class PlanTyperTestsPorted {
                 catalog = "pql",
                 expected = StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(10)))
             ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-42"),
+                catalog = "pql",
+                expected = StringType(StringType.StringLengthConstraint.Constrained(NumberConstraint.UpTo(10)))
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-43"),
+                catalog = "pql",
+                expected = StaticType.DECIMAL
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-44"),
+                catalog = "pql",
+                expected = StaticType.DECIMAL
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-45"),
+                catalog = "pql",
+                expected = StaticType.DECIMAL
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-46"),
+                catalog = "pql",
+                expected = StaticType.STRING
+            ),
+            SuccessTestCase(
+                key = PartiQLTest.Key("basics", "case-when-47"),
+                catalog = "pql",
+                expected = StaticType.STRING
+            ),
         )
 
         @JvmStatic

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -2738,15 +2738,10 @@ class PlanTyperTestsPorted {
             SuccessTestCase(
                 key = PartiQLTest.Key("basics", "case-when-45"),
                 catalog = "pql",
-                expected = StaticType.DECIMAL
-            ),
-            SuccessTestCase(
-                key = PartiQLTest.Key("basics", "case-when-46"),
-                catalog = "pql",
                 expected = StaticType.STRING
             ),
             SuccessTestCase(
-                key = PartiQLTest.Key("basics", "case-when-47"),
+                key = PartiQLTest.Key("basics", "case-when-46"),
                 catalog = "pql",
                 expected = StaticType.STRING
             ),

--- a/partiql-planner/src/testFixtures/resources/catalogs/default/pql/t_item.ion
+++ b/partiql-planner/src/testFixtures/resources/catalogs/default/pql/t_item.ion
@@ -179,6 +179,53 @@
     {
       name: "t_str",
       type: [ "clob", "string" ],
-    }
+    },
+    // fixed precision decimal
+    {
+      name: "t_decimal_10_5",
+      type: {
+        type: "decimal",
+        precision: 10,
+        scale: 5
+      }
+    },
+    {
+      name: "t_decimal_5_3",
+      type: {
+        type: "decimal",
+        precision: 10,
+        scale: 5
+      }
+    },
+    {
+      name: "t_varchar_10",
+      type: {
+        type: "string",
+        max_length: 10,
+      }
+    },
+    {
+      name: "t_varchar_5",
+      type: {
+        type: "string",
+        max_length: 5,
+      }
+    },
+    {
+      name: "t_char_10",
+      type: {
+        type: "string",
+        max_length: 10,
+        min_length: 10,
+      }
+    },
+    {
+      name: "t_char_5",
+      type: {
+        type: "string",
+        max_length: 5,
+        min_length: 5,
+      }
+    },
   ]
 }

--- a/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
@@ -341,6 +341,50 @@ CASE t_item.t_string
     ELSE t_item.t_varchar_10
 END;
 
+--#[case-when-42]
+-- type: varchar(10)|null
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_char_10
+    ELSE t_item.t_varchar_5
+END;
+
+--#[case-when-43]
+-- type: decimal
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_decimal_10_5
+    ELSE t_item.t_decimal
+END;
+
+--#[case-when-44]
+-- type: decimal
+-- coercion required. Common super type is arbitrary decimal
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_decimal_10_5
+    ELSE t_item.t_int32
+END;
+
+--#[case-when-45]
+-- type: decimal
+-- coercion required. Common super type is arbitrary decimal
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_decimal_10_5
+    ELSE t_item.t_int32
+END;
+
+--#[case-when-46]
+-- type: string -- unconstrained
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_string
+    ELSE t_item.t_varchar_5
+END;
+
+--#[case-when-47]
+-- type: string -- unconstrained
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_string
+    ELSE t_item.t_char_5
+END;
+
 
 -- -----------------------------
 --  (Unused) old tests

--- a/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
@@ -364,21 +364,13 @@ CASE t_item.t_string
 END;
 
 --#[case-when-45]
--- type: decimal
--- coercion required. Common super type is arbitrary decimal
-CASE t_item.t_string
-    WHEN 'a' THEN t_item.t_decimal_10_5
-    ELSE t_item.t_int32
-END;
-
---#[case-when-46]
 -- type: string -- unconstrained
 CASE t_item.t_string
     WHEN 'a' THEN t_item.t_string
     ELSE t_item.t_varchar_5
 END;
 
---#[case-when-47]
+--#[case-when-46]
 -- type: string -- unconstrained
 CASE t_item.t_string
     WHEN 'a' THEN t_item.t_string

--- a/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
+++ b/partiql-planner/src/testFixtures/resources/inputs/basics/case.sql
@@ -292,6 +292,56 @@ CASE t_item.t_string
     ELSE t_item.t_any
 END;
 
+--#[case-when-35]
+-- type: decimal(10,5)|null
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_decimal_10_5
+    ELSE null
+END;
+
+--#[case-when-36]
+-- type: decimal(10,5)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_decimal_10_5
+    ELSE t_item.t_decimal_5_3
+END;
+
+--#[case-when-37]
+-- type: varchar(10)|null
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_varchar_10
+    ELSE null
+END;
+
+--#[case-when-38]
+-- type: varchar(10)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_varchar_10
+    ELSE t_item.t_varchar_5
+END;
+
+--#[case-when-39]
+-- type: char(10)|null
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_char_10
+    ELSE null
+END;
+
+--#[case-when-40]
+-- type: char(10)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_char_10
+    ELSE t_item.t_char_5
+END;
+
+--#[case-when-41]
+-- type: varchar(10)
+CASE t_item.t_string
+    WHEN 'a' THEN t_item.t_char_10
+    ELSE t_item.t_varchar_10
+END;
+
+
 -- -----------------------------
 --  (Unused) old tests
 -- -----------------------------


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
- Base #1549 on tip of v0.14.7. 
- Change version to v0.14.8-SNAPSHOT. (The target branch is not a release branch). 

1. Preserve constraint in dynamic typer

Previous, 
```
CASE  WHEN <condition> THEN <DECIMAL(10,5)>
    ELSE null
END;
```
return Decimal Type with arbitrary precision and scale
Similarly: 
```
CASE  WHEN <condition> THEN <VARCHAR(10)>
    ELSE null
END;
```
return String Type with arbitrary length constraint. 
With this PR: 
```
CASE  WHEN <condition> THEN <DECIMAL(10,5)>
    ELSE null
END;
```
returns DECIMAL(10,5).
```
CASE  WHEN <condition> THEN <VARCHAR(10)>
    ELSE null
END;
```
returns VARCHAR(10)

2. Type Constraint Promotion
If the common super type is of single type and require no coercion, the dynamic typer should perform promotion if applicable. 

Consider 
```
CASE  WHEN <condition> THEN <DECIMAL(10,5)>
    ELSE <DECIMAL(5,3)>
END;
```
With type promotion, the return type will be : Decimal(10,5)

Similarly: 
```
CASE  WHEN <condition> THEN <VARCHAR(10)>
    ELSE <VARCHAR(5)>
END;
```

The return type will be VARCHAR(10). 

In addition, because STRING and CHAR share the same runtime type: 

```
CASE  WHEN <condition> THEN <VARCHAR(10)>
    ELSE <CHAR(5)>
END;
```

returns VARCHAR(10) without the need of coercion. 


## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**
  - Yes. 

- Any backward-incompatible changes? **[YES/NO]**
  - < If YES, why? >
  - < For this purpose, we define backward-incompatible changes as changes that—when consumed—can potentially result in
errors for users that are using our public APIs or the entities that have `public` visibility in our code-base. >
No. 

- Any new external dependencies? **[YES/NO]**
  - < If YES, which ones and why? >
  - < In addition, please also mention any other alternatives you've considered and the reason they've been discarded >
No.

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES/NO]**
Yes.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.