### PR TITLE
Ports evaluation changes to v1 plans

### DIFF
--- a/partiql-plan/api/partiql-plan.api
+++ b/partiql-plan/api/partiql-plan.api
@@ -2853,7 +2853,7 @@ public final class org/partiql/plan/v1/operator/rel/RelExcludePath$Companion {
 public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeStep {
 	public static final field Companion Lorg/partiql/plan/v1/operator/rel/RelExcludeStep$Companion;
 	public static fun collection (Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeCollectionWildcard;
-	public abstract fun getSubsteps ()Ljava/util/List;
+	public abstract fun getSubsteps ()Ljava/util/Collection;
 	public static fun index (ILjava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeIndex;
 	public static fun key (Ljava/lang/String;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeKey;
 	public static fun struct (Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeStructWildcard;

--- a/partiql-plan/api/partiql-plan.api
+++ b/partiql-plan/api/partiql-plan.api
@@ -2501,6 +2501,11 @@ public abstract interface class org/partiql/plan/v1/PartiQLPlan {
 public abstract interface class org/partiql/plan/v1/Schema {
 	public abstract fun getField (Ljava/lang/String;)Lorg/partiql/types/Field;
 	public abstract fun getFields ()Ljava/util/List;
+	public abstract fun getSize ()I
+}
+
+public final class org/partiql/plan/v1/Schema$DefaultImpls {
+	public static fun getSize (Lorg/partiql/plan/v1/Schema;)I
 }
 
 public abstract interface class org/partiql/plan/v1/Statement {
@@ -2518,6 +2523,7 @@ public abstract interface class org/partiql/plan/v1/builder/PlanFactory {
 	public static final field Companion Lorg/partiql/plan/v1/builder/PlanFactory$Companion;
 	public static fun getSTANDARD ()Lorg/partiql/plan/v1/builder/PlanFactory;
 	public abstract fun relAggregate (Lorg/partiql/plan/v1/operator/rel/Rel;Ljava/util/List;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelAggregate;
+	public abstract fun relAggregateCall (Lorg/partiql/spi/fn/Agg;Ljava/util/List;Z)Lorg/partiql/plan/v1/operator/rel/RelAggregateCall;
 	public abstract fun relCorrelate (Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;)Lorg/partiql/plan/v1/operator/rel/RelCorrelate;
 	public abstract fun relCorrelate (Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/RelJoinType;)Lorg/partiql/plan/v1/operator/rel/RelCorrelate;
 	public abstract fun relDistinct (Lorg/partiql/plan/v1/operator/rel/Rel;)Lorg/partiql/plan/v1/operator/rel/RelDistinct;
@@ -2529,7 +2535,7 @@ public abstract interface class org/partiql/plan/v1/builder/PlanFactory {
 	public abstract fun relIntersect (Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;Z)Lorg/partiql/plan/v1/operator/rel/RelIntersect;
 	public abstract fun relIterate (Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rel/RelIterate;
 	public abstract fun relJoin (Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;)Lorg/partiql/plan/v1/operator/rel/RelJoin;
-	public abstract fun relJoin (Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rel/RelJoinType;)Lorg/partiql/plan/v1/operator/rel/RelJoin;
+	public abstract fun relJoin (Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rel/RelJoinType;Lorg/partiql/plan/v1/Schema;Lorg/partiql/plan/v1/Schema;)Lorg/partiql/plan/v1/operator/rel/RelJoin;
 	public abstract fun relLimit (Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rel/RelLimit;
 	public abstract fun relOffset (Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rel/RelOffset;
 	public abstract fun relProject (Lorg/partiql/plan/v1/operator/rel/Rel;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelProject;
@@ -2540,15 +2546,16 @@ public abstract interface class org/partiql/plan/v1/builder/PlanFactory {
 	public abstract fun relUnpivot (Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rel/RelUnpivot;
 	public abstract fun rexArray (Ljava/util/Collection;)Lorg/partiql/plan/v1/operator/rex/RexArray;
 	public abstract fun rexBag (Ljava/util/Collection;)Lorg/partiql/plan/v1/operator/rex/RexBag;
-	public abstract fun rexCall (Lorg/partiql/spi/fn/Fn;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rex/RexCall;
+	public abstract fun rexCall (Ljava/util/List;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rex/RexCallDynamic;
+	public abstract fun rexCall (Lorg/partiql/spi/fn/Fn;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rex/RexCallStatic;
 	public abstract fun rexCase (Ljava/util/List;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rex/RexCase;
 	public abstract fun rexCase (Lorg/partiql/plan/v1/operator/rex/Rex;Ljava/util/List;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rex/RexCase;
 	public abstract fun rexCast (Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/types/PType;)Lorg/partiql/plan/v1/operator/rex/RexCast;
 	public abstract fun rexCoalesce (Ljava/util/List;)Lorg/partiql/plan/v1/operator/rex/RexCoalesce;
-	public abstract fun rexCol (II)Lorg/partiql/plan/v1/operator/rex/RexVar;
 	public abstract fun rexError (Ljava/lang/String;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rex/RexError;
 	public abstract fun rexLit (Lorg/partiql/eval/value/Datum;)Lorg/partiql/plan/v1/operator/rex/RexLit;
 	public abstract fun rexMissing (Ljava/lang/String;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rex/RexMissing;
+	public abstract fun rexNullIf (Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rex/RexNullIf;
 	public abstract fun rexPathIndex (Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rex/RexPathIndex;
 	public abstract fun rexPathKey (Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rex/RexPathKey;
 	public abstract fun rexPathSymbol (Lorg/partiql/plan/v1/operator/rex/Rex;Ljava/lang/String;)Lorg/partiql/plan/v1/operator/rex/RexPathSymbol;
@@ -2563,6 +2570,7 @@ public abstract interface class org/partiql/plan/v1/builder/PlanFactory {
 	public abstract fun rexSubqueryIn (Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rel/Rel;)Lorg/partiql/plan/v1/operator/rex/RexSubqueryIn;
 	public abstract fun rexSubqueryTest (Lorg/partiql/plan/v1/operator/rex/RexSubqueryTest$Test;Lorg/partiql/plan/v1/operator/rel/Rel;)Lorg/partiql/plan/v1/operator/rex/RexSubqueryTest;
 	public abstract fun rexTable (Lorg/partiql/planner/catalog/Table;)Lorg/partiql/plan/v1/operator/rex/RexTable;
+	public abstract fun rexVar (II)Lorg/partiql/plan/v1/operator/rex/RexVar;
 }
 
 public final class org/partiql/plan/v1/builder/PlanFactory$Companion {
@@ -2571,6 +2579,8 @@ public final class org/partiql/plan/v1/builder/PlanFactory$Companion {
 
 public final class org/partiql/plan/v1/builder/PlanFactory$DefaultImpls {
 	public static fun relAggregate (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rel/Rel;Ljava/util/List;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelAggregate;
+	public static fun relAggregateCall (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/spi/fn/Agg;Ljava/util/List;Z)Lorg/partiql/plan/v1/operator/rel/RelAggregateCall;
+	public static synthetic fun relAggregateCall$default (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/spi/fn/Agg;Ljava/util/List;ZILjava/lang/Object;)Lorg/partiql/plan/v1/operator/rel/RelAggregateCall;
 	public static fun relCorrelate (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;)Lorg/partiql/plan/v1/operator/rel/RelCorrelate;
 	public static fun relCorrelate (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/RelJoinType;)Lorg/partiql/plan/v1/operator/rel/RelCorrelate;
 	public static fun relDistinct (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rel/Rel;)Lorg/partiql/plan/v1/operator/rel/RelDistinct;
@@ -2582,7 +2592,8 @@ public final class org/partiql/plan/v1/builder/PlanFactory$DefaultImpls {
 	public static fun relIntersect (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;Z)Lorg/partiql/plan/v1/operator/rel/RelIntersect;
 	public static fun relIterate (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rel/RelIterate;
 	public static fun relJoin (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;)Lorg/partiql/plan/v1/operator/rel/RelJoin;
-	public static fun relJoin (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rel/RelJoinType;)Lorg/partiql/plan/v1/operator/rel/RelJoin;
+	public static fun relJoin (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rel/RelJoinType;Lorg/partiql/plan/v1/Schema;Lorg/partiql/plan/v1/Schema;)Lorg/partiql/plan/v1/operator/rel/RelJoin;
+	public static synthetic fun relJoin$default (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rel/RelJoinType;Lorg/partiql/plan/v1/Schema;Lorg/partiql/plan/v1/Schema;ILjava/lang/Object;)Lorg/partiql/plan/v1/operator/rel/RelJoin;
 	public static fun relLimit (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rel/RelLimit;
 	public static fun relOffset (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rel/Rel;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rel/RelOffset;
 	public static fun relProject (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rel/Rel;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelProject;
@@ -2593,15 +2604,16 @@ public final class org/partiql/plan/v1/builder/PlanFactory$DefaultImpls {
 	public static fun relUnpivot (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rel/RelUnpivot;
 	public static fun rexArray (Lorg/partiql/plan/v1/builder/PlanFactory;Ljava/util/Collection;)Lorg/partiql/plan/v1/operator/rex/RexArray;
 	public static fun rexBag (Lorg/partiql/plan/v1/builder/PlanFactory;Ljava/util/Collection;)Lorg/partiql/plan/v1/operator/rex/RexBag;
-	public static fun rexCall (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/spi/fn/Fn;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rex/RexCall;
+	public static fun rexCall (Lorg/partiql/plan/v1/builder/PlanFactory;Ljava/util/List;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rex/RexCallDynamic;
+	public static fun rexCall (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/spi/fn/Fn;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rex/RexCallStatic;
 	public static fun rexCase (Lorg/partiql/plan/v1/builder/PlanFactory;Ljava/util/List;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rex/RexCase;
 	public static fun rexCase (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rex/Rex;Ljava/util/List;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rex/RexCase;
 	public static fun rexCast (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/types/PType;)Lorg/partiql/plan/v1/operator/rex/RexCast;
 	public static fun rexCoalesce (Lorg/partiql/plan/v1/builder/PlanFactory;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rex/RexCoalesce;
-	public static fun rexCol (Lorg/partiql/plan/v1/builder/PlanFactory;II)Lorg/partiql/plan/v1/operator/rex/RexVar;
 	public static fun rexError (Lorg/partiql/plan/v1/builder/PlanFactory;Ljava/lang/String;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rex/RexError;
 	public static fun rexLit (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/eval/value/Datum;)Lorg/partiql/plan/v1/operator/rex/RexLit;
 	public static fun rexMissing (Lorg/partiql/plan/v1/builder/PlanFactory;Ljava/lang/String;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rex/RexMissing;
+	public static fun rexNullIf (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rex/RexNullIf;
 	public static fun rexPathIndex (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rex/RexPathIndex;
 	public static fun rexPathKey (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rex/Rex;)Lorg/partiql/plan/v1/operator/rex/RexPathKey;
 	public static fun rexPathSymbol (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rex/Rex;Ljava/lang/String;)Lorg/partiql/plan/v1/operator/rex/RexPathSymbol;
@@ -2616,6 +2628,7 @@ public final class org/partiql/plan/v1/builder/PlanFactory$DefaultImpls {
 	public static fun rexSubqueryIn (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rex/Rex;Lorg/partiql/plan/v1/operator/rel/Rel;)Lorg/partiql/plan/v1/operator/rex/RexSubqueryIn;
 	public static fun rexSubqueryTest (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/plan/v1/operator/rex/RexSubqueryTest$Test;Lorg/partiql/plan/v1/operator/rel/Rel;)Lorg/partiql/plan/v1/operator/rex/RexSubqueryTest;
 	public static fun rexTable (Lorg/partiql/plan/v1/builder/PlanFactory;Lorg/partiql/planner/catalog/Table;)Lorg/partiql/plan/v1/operator/rex/RexTable;
+	public static fun rexVar (Lorg/partiql/plan/v1/builder/PlanFactory;II)Lorg/partiql/plan/v1/operator/rex/RexVar;
 }
 
 public final class org/partiql/plan/v1/builder/RelBuilder {
@@ -2720,9 +2733,8 @@ public final class org/partiql/plan/v1/operator/rel/RelAggregate$DefaultImpls {
 }
 
 public abstract interface class org/partiql/plan/v1/operator/rel/RelAggregateCall {
+	public abstract fun getAgg ()Lorg/partiql/spi/fn/Agg;
 	public abstract fun getArgs ()Ljava/util/List;
-	public abstract fun getName ()Ljava/lang/String;
-	public abstract fun getType ()Lorg/partiql/types/PType;
 	public abstract fun isDistinct ()Z
 }
 
@@ -2816,30 +2828,55 @@ public final class org/partiql/plan/v1/operator/rel/RelExclude$DefaultImpls {
 	public static fun isOrdered (Lorg/partiql/plan/v1/operator/rel/RelExclude;)Z
 }
 
-public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludePath {
-	public abstract fun getRoot ()Lorg/partiql/plan/v1/operator/rex/RexVar;
-	public abstract fun getSteps ()Lorg/partiql/plan/v1/operator/rel/RelExcludeStep;
+public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeCollectionWildcard : org/partiql/plan/v1/operator/rel/RelExcludeStep {
 }
 
-public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeStep {
-	public abstract fun getSubsteps ()Ljava/util/List;
-}
-
-public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeStep$CollectionWildcard : org/partiql/plan/v1/operator/rel/RelExcludeStep {
-}
-
-public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeStep$Index : org/partiql/plan/v1/operator/rel/RelExcludeStep {
+public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeIndex : org/partiql/plan/v1/operator/rel/RelExcludeStep {
 	public abstract fun getIndex ()I
 }
 
-public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeStep$Key : org/partiql/plan/v1/operator/rel/RelExcludeStep {
+public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeKey : org/partiql/plan/v1/operator/rel/RelExcludeStep {
 	public abstract fun getKey ()Ljava/lang/String;
 }
 
-public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeStep$StructWildcard : org/partiql/plan/v1/operator/rel/RelExcludeStep {
+public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludePath {
+	public static final field Companion Lorg/partiql/plan/v1/operator/rel/RelExcludePath$Companion;
+	public abstract fun getRoot ()Lorg/partiql/plan/v1/operator/rex/RexVar;
+	public abstract fun getSteps ()Ljava/util/Collection;
+	public static fun of (Lorg/partiql/plan/v1/operator/rex/RexVar;Ljava/util/Collection;)Lorg/partiql/plan/v1/operator/rel/RelExcludePath;
 }
 
-public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeStep$Symbol : org/partiql/plan/v1/operator/rel/RelExcludeStep {
+public final class org/partiql/plan/v1/operator/rel/RelExcludePath$Companion {
+	public final fun of (Lorg/partiql/plan/v1/operator/rex/RexVar;Ljava/util/Collection;)Lorg/partiql/plan/v1/operator/rel/RelExcludePath;
+}
+
+public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeStep {
+	public static final field Companion Lorg/partiql/plan/v1/operator/rel/RelExcludeStep$Companion;
+	public static fun collection (Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeCollectionWildcard;
+	public abstract fun getSubsteps ()Ljava/util/List;
+	public static fun index (ILjava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeIndex;
+	public static fun key (Ljava/lang/String;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeKey;
+	public static fun struct (Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeStructWildcard;
+	public static fun symbol (Ljava/lang/String;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeSymbol;
+}
+
+public final class org/partiql/plan/v1/operator/rel/RelExcludeStep$Companion {
+	public final fun collection (Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeCollectionWildcard;
+	public static synthetic fun collection$default (Lorg/partiql/plan/v1/operator/rel/RelExcludeStep$Companion;Ljava/util/List;ILjava/lang/Object;)Lorg/partiql/plan/v1/operator/rel/RelExcludeCollectionWildcard;
+	public final fun index (ILjava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeIndex;
+	public static synthetic fun index$default (Lorg/partiql/plan/v1/operator/rel/RelExcludeStep$Companion;ILjava/util/List;ILjava/lang/Object;)Lorg/partiql/plan/v1/operator/rel/RelExcludeIndex;
+	public final fun key (Ljava/lang/String;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeKey;
+	public static synthetic fun key$default (Lorg/partiql/plan/v1/operator/rel/RelExcludeStep$Companion;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/partiql/plan/v1/operator/rel/RelExcludeKey;
+	public final fun struct (Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeStructWildcard;
+	public static synthetic fun struct$default (Lorg/partiql/plan/v1/operator/rel/RelExcludeStep$Companion;Ljava/util/List;ILjava/lang/Object;)Lorg/partiql/plan/v1/operator/rel/RelExcludeStructWildcard;
+	public final fun symbol (Ljava/lang/String;Ljava/util/List;)Lorg/partiql/plan/v1/operator/rel/RelExcludeSymbol;
+	public static synthetic fun symbol$default (Lorg/partiql/plan/v1/operator/rel/RelExcludeStep$Companion;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/partiql/plan/v1/operator/rel/RelExcludeSymbol;
+}
+
+public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeStructWildcard : org/partiql/plan/v1/operator/rel/RelExcludeStep {
+}
+
+public abstract interface class org/partiql/plan/v1/operator/rel/RelExcludeSymbol : org/partiql/plan/v1/operator/rel/RelExcludeStep {
 	public abstract fun getSymbol ()Ljava/lang/String;
 }
 
@@ -2893,7 +2930,9 @@ public abstract interface class org/partiql/plan/v1/operator/rel/RelJoin : org/p
 	public abstract fun getCondition ()Lorg/partiql/plan/v1/operator/rex/Rex;
 	public abstract fun getJoinType ()Lorg/partiql/plan/v1/operator/rel/RelJoinType;
 	public abstract fun getLeft ()Lorg/partiql/plan/v1/operator/rel/Rel;
+	public abstract fun getLeftSchema ()Lorg/partiql/plan/v1/Schema;
 	public abstract fun getRight ()Lorg/partiql/plan/v1/operator/rel/Rel;
+	public abstract fun getRightSchema ()Lorg/partiql/plan/v1/Schema;
 	public abstract fun isOrdered ()Z
 }
 
@@ -3100,16 +3139,28 @@ public final class org/partiql/plan/v1/operator/rex/RexBag$DefaultImpls {
 	public static fun getChildren (Lorg/partiql/plan/v1/operator/rex/RexBag;)Ljava/util/Collection;
 }
 
-public abstract interface class org/partiql/plan/v1/operator/rex/RexCall : org/partiql/plan/v1/operator/rex/Rex {
+public abstract interface class org/partiql/plan/v1/operator/rex/RexCallDynamic : org/partiql/plan/v1/operator/rex/Rex {
+	public abstract fun accept (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getArgs ()Ljava/util/List;
+	public abstract fun getChildren ()Ljava/util/Collection;
+	public abstract fun getFunctions ()Ljava/util/List;
+}
+
+public final class org/partiql/plan/v1/operator/rex/RexCallDynamic$DefaultImpls {
+	public static fun accept (Lorg/partiql/plan/v1/operator/rex/RexCallDynamic;Lorg/partiql/plan/v1/operator/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static fun getChildren (Lorg/partiql/plan/v1/operator/rex/RexCallDynamic;)Ljava/util/Collection;
+}
+
+public abstract interface class org/partiql/plan/v1/operator/rex/RexCallStatic : org/partiql/plan/v1/operator/rex/Rex {
 	public abstract fun accept (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getArgs ()Ljava/util/List;
 	public abstract fun getChildren ()Ljava/util/Collection;
 	public abstract fun getFunction ()Lorg/partiql/spi/fn/Fn;
 }
 
-public final class org/partiql/plan/v1/operator/rex/RexCall$DefaultImpls {
-	public static fun accept (Lorg/partiql/plan/v1/operator/rex/RexCall;Lorg/partiql/plan/v1/operator/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	public static fun getChildren (Lorg/partiql/plan/v1/operator/rex/RexCall;)Ljava/util/Collection;
+public final class org/partiql/plan/v1/operator/rex/RexCallStatic$DefaultImpls {
+	public static fun accept (Lorg/partiql/plan/v1/operator/rex/RexCallStatic;Lorg/partiql/plan/v1/operator/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static fun getChildren (Lorg/partiql/plan/v1/operator/rex/RexCallStatic;)Ljava/util/Collection;
 }
 
 public abstract interface class org/partiql/plan/v1/operator/rex/RexCase : org/partiql/plan/v1/operator/rex/Rex {
@@ -3192,6 +3243,20 @@ public final class org/partiql/plan/v1/operator/rex/RexMissing$DefaultImpls {
 	public static fun accept (Lorg/partiql/plan/v1/operator/rex/RexMissing;Lorg/partiql/plan/v1/operator/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun getChildren (Lorg/partiql/plan/v1/operator/rex/RexMissing;)Ljava/util/Collection;
 	public static fun getType (Lorg/partiql/plan/v1/operator/rex/RexMissing;)Lorg/partiql/types/PType;
+}
+
+public abstract interface class org/partiql/plan/v1/operator/rex/RexNullIf : org/partiql/plan/v1/operator/rex/Rex {
+	public abstract fun accept (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getChildren ()Ljava/util/Collection;
+	public abstract fun getNullifier ()Lorg/partiql/plan/v1/operator/rex/Rex;
+	public abstract fun getType ()Lorg/partiql/types/PType;
+	public abstract fun getValue ()Lorg/partiql/plan/v1/operator/rex/Rex;
+}
+
+public final class org/partiql/plan/v1/operator/rex/RexNullIf$DefaultImpls {
+	public static fun accept (Lorg/partiql/plan/v1/operator/rex/RexNullIf;Lorg/partiql/plan/v1/operator/rex/RexVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public static fun getChildren (Lorg/partiql/plan/v1/operator/rex/RexNullIf;)Ljava/util/Collection;
+	public static fun getType (Lorg/partiql/plan/v1/operator/rex/RexNullIf;)Lorg/partiql/types/PType;
 }
 
 public abstract interface class org/partiql/plan/v1/operator/rex/RexPathIndex : org/partiql/plan/v1/operator/rex/Rex {
@@ -3385,13 +3450,15 @@ public abstract interface class org/partiql/plan/v1/operator/rex/RexVisitor {
 	public abstract fun visit (Lorg/partiql/plan/v1/operator/rex/Rex;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitArray (Lorg/partiql/plan/v1/operator/rex/RexArray;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitBag (Lorg/partiql/plan/v1/operator/rex/RexBag;Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun visitCall (Lorg/partiql/plan/v1/operator/rex/RexCall;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitCallDynamic (Lorg/partiql/plan/v1/operator/rex/RexCallDynamic;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitCallStatic (Lorg/partiql/plan/v1/operator/rex/RexCallStatic;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitCase (Lorg/partiql/plan/v1/operator/rex/RexCase;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitCast (Lorg/partiql/plan/v1/operator/rex/RexCast;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitCoalesce (Lorg/partiql/plan/v1/operator/rex/RexCoalesce;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitError (Lorg/partiql/plan/v1/operator/rex/RexError;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitLit (Lorg/partiql/plan/v1/operator/rex/RexLit;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitMissing (Lorg/partiql/plan/v1/operator/rex/RexMissing;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun visitNullIf (Lorg/partiql/plan/v1/operator/rex/RexNullIf;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitPathIndex (Lorg/partiql/plan/v1/operator/rex/RexPathIndex;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitPathKey (Lorg/partiql/plan/v1/operator/rex/RexPathKey;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun visitPathSymbol (Lorg/partiql/plan/v1/operator/rex/RexPathSymbol;Ljava/lang/Object;)Ljava/lang/Object;
@@ -3412,13 +3479,15 @@ public final class org/partiql/plan/v1/operator/rex/RexVisitor$DefaultImpls {
 	public static fun visit (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/Rex;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun visitArray (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexArray;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun visitBag (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexBag;Ljava/lang/Object;)Ljava/lang/Object;
-	public static fun visitCall (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexCall;Ljava/lang/Object;)Ljava/lang/Object;
+	public static fun visitCallDynamic (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexCallDynamic;Ljava/lang/Object;)Ljava/lang/Object;
+	public static fun visitCallStatic (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexCallStatic;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun visitCase (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexCase;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun visitCast (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexCast;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun visitCoalesce (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexCoalesce;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun visitError (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexError;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun visitLit (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexLit;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun visitMissing (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexMissing;Ljava/lang/Object;)Ljava/lang/Object;
+	public static fun visitNullIf (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexNullIf;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun visitPathIndex (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexPathIndex;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun visitPathKey (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexPathKey;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun visitPathSymbol (Lorg/partiql/plan/v1/operator/rex/RexVisitor;Lorg/partiql/plan/v1/operator/rex/RexPathSymbol;Ljava/lang/Object;)Ljava/lang/Object;

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/Schema.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/Schema.kt
@@ -7,6 +7,8 @@ import org.partiql.types.Field
  */
 public interface Schema {
 
+    public fun getSize(): Int = getFields().size
+
     public fun getFields(): List<Field>
 
     public fun getField(name: String): Field

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/builder/PlanFactory.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/builder/PlanFactory.kt
@@ -433,14 +433,11 @@ public interface PlanFactory {
     public fun rexLit(value: Datum): RexLit = RexLitImpl(value)
 
     /**
-<<<<<<< HEAD
-=======
-     * TODO REMOVE ME
+     * Create a [RexNullIf] instance.
      */
     public fun rexNullIf(value: Rex, nullifier: Rex): RexNullIf = RexNullIfImpl(value, nullifier)
 
     /**
->>>>>>> c2cc48d5 (Ports evaluation changes to v1 plans)
      * Create a [RexPathIndex] instance.
      *
      * @param operand

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/builder/RexBuilder.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/builder/RexBuilder.kt
@@ -36,7 +36,7 @@ public class RexBuilder private constructor(rex: Builder) {
 
         @JvmStatic
         public fun col(depth: Int, offset: Int): RexBuilder = RexBuilder {
-            it.rexCol(depth, offset)
+            it.rexVar(depth, offset)
         }
 
         @JvmStatic

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelAggregateCall.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelAggregateCall.kt
@@ -1,18 +1,35 @@
 package org.partiql.plan.v1.operator.rel
 
 import org.partiql.plan.v1.operator.rex.Rex
-import org.partiql.types.PType
+import org.partiql.spi.fn.Agg
 
 /**
  * TODO DOCUMENTATION
  */
 public interface RelAggregateCall {
 
-    public fun isDistinct(): Boolean
-
-    public fun getName(): String
-
-    public fun getType(): PType
+    public fun getAgg(): Agg
 
     public fun getArgs(): List<Rex>
+
+    public fun isDistinct(): Boolean
+}
+
+/**
+ * Internal standard implementation of [RelAggregateCall].
+ *
+ * DO NOT USE FINAL.
+ *
+ * @property agg
+ * @property args
+ * @property isDistinct
+ */
+internal class RelAggregateCallImpl(
+    private var agg: Agg,
+    private var args: List<Rex>,
+    private var isDistinct: Boolean,
+) : RelAggregateCall {
+    override fun getAgg(): Agg = agg
+    override fun getArgs(): List<Rex> = args
+    override fun isDistinct(): Boolean = isDistinct
 }

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelExcludePath.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelExcludePath.kt
@@ -3,11 +3,31 @@ package org.partiql.plan.v1.operator.rel
 import org.partiql.plan.v1.operator.rex.RexVar
 
 /**
- * TODO DOCUMENTATION
+ * Logical representation of an EXCLUDE path.
  */
 public interface RelExcludePath {
 
     public fun getRoot(): RexVar
 
-    public fun getSteps(): RelExcludeStep
+    public fun getSteps(): Collection<RelExcludeStep>
+
+    public companion object {
+
+        @JvmStatic
+        public fun of(root: RexVar, steps: Collection<RelExcludeStep>): RelExcludePath = RelExcludePathImpl(root, steps)
+    }
+}
+
+/**
+ * Internal standard implementation of [RelExcludePath].
+ *
+ * @property root
+ * @property steps
+ */
+internal class RelExcludePathImpl(
+    private var root: RexVar,
+    private var steps: Collection<RelExcludeStep>,
+) : RelExcludePath {
+    override fun getRoot(): RexVar = root
+    override fun getSteps(): Collection<RelExcludeStep> = steps
 }

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelExcludeStep.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelExcludeStep.kt
@@ -5,7 +5,7 @@ package org.partiql.plan.v1.operator.rel
  */
 public interface RelExcludeStep {
 
-    public fun getSubsteps(): List<RelExcludeStep>
+    public fun getSubsteps(): Collection<RelExcludeStep>
 
     companion object {
 
@@ -42,7 +42,7 @@ private data class RelExcludeIndexImpl(
     private val index: Int,
     private val substeps: List<RelExcludeStep> = emptyList(),
 ) : RelExcludeIndex {
-    override fun getSubsteps(): List<RelExcludeStep> = substeps
+    override fun getSubsteps(): Collection<RelExcludeStep> = substeps
     override fun getIndex(): Int = index
 }
 
@@ -53,6 +53,15 @@ public interface RelExcludeKey : RelExcludeStep {
     public fun getKey(): String
 }
 
+// TODO hashcode/equals without data class
+private data class RelExcludeKeyImpl(
+    private val key: String,
+    private val substeps: List<RelExcludeStep> = emptyList(),
+) : RelExcludeKey {
+    override fun getSubsteps(): Collection<RelExcludeStep> = substeps
+    override fun getKey(): String = key
+}
+
 /**
  * Logical representation of an EXCLUDE path symbol step.
  */
@@ -60,10 +69,26 @@ public interface RelExcludeSymbol : RelExcludeStep {
     public fun getSymbol(): String
 }
 
+// TODO hashcode/equals without data class
+private data class RelExcludeSymbolImpl(
+    private val symbol: String,
+    private val substeps: List<RelExcludeStep> = emptyList(),
+) : RelExcludeSymbol {
+    override fun getSubsteps(): Collection<RelExcludeStep> = substeps
+    override fun getSymbol(): String = symbol
+}
+
 /**
  * Logical representation of an EXCLUDE struct wildcard step.
  */
 public interface RelExcludeStructWildcard : RelExcludeStep
+
+// TODO hashcode/equals without data class
+private data class RelExcludeStructWildcardImpl(
+    private val substeps: List<RelExcludeStep> = emptyList(),
+) : RelExcludeStructWildcard {
+    override fun getSubsteps(): Collection<RelExcludeStep> = substeps
+}
 
 /**
  * Logical representation of an EXCLUDE collection wildcard step.
@@ -71,33 +96,8 @@ public interface RelExcludeStructWildcard : RelExcludeStep
 public interface RelExcludeCollectionWildcard : RelExcludeStep
 
 // TODO hashcode/equals without data class
-private data class RelExcludeKeyImpl(
-    private val key: String,
-    private val substeps: List<RelExcludeStep> = emptyList(),
-) : RelExcludeKey {
-    override fun getSubsteps(): List<RelExcludeStep> = substeps
-    override fun getKey(): String = key
-}
-
-// TODO hashcode/equals without data class
-private data class RelExcludeSymbolImpl(
-    private val symbol: String,
-    private val substeps: List<RelExcludeStep> = emptyList(),
-) : RelExcludeSymbol {
-    override fun getSubsteps(): List<RelExcludeStep> = substeps
-    override fun getSymbol(): String = symbol
-}
-
-// TODO hashcode/equals without data class
-private data class RelExcludeStructWildcardImpl(
-    private val substeps: List<RelExcludeStep> = emptyList(),
-) : RelExcludeStructWildcard {
-    override fun getSubsteps(): List<RelExcludeStep> = substeps
-}
-
-// TODO hashcode/equals without data class
 private data class RelExcludeCollectionWildcardImpl(
     private val substeps: List<RelExcludeStep> = emptyList(),
 ) : RelExcludeCollectionWildcard {
-    override fun getSubsteps(): List<RelExcludeStep> = substeps
+    override fun getSubsteps(): Collection<RelExcludeStep> = substeps
 }

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelExcludeStep.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelExcludeStep.kt
@@ -1,40 +1,103 @@
 package org.partiql.plan.v1.operator.rel
 
 /**
- * TODO DOCUMENTATION
+ * Logical EXCLUDE step, one of: index, key, symbol, struct wildcard, or collection wildcard.
  */
 public interface RelExcludeStep {
 
     public fun getSubsteps(): List<RelExcludeStep>
 
-    /**
-     * TODO DOCUMENTATION
-     */
-    public interface Index : RelExcludeStep {
-        public fun getIndex(): Int
+    companion object {
+
+        @JvmStatic
+        public fun index(index: Int, substeps: List<RelExcludeStep> = emptyList()): RelExcludeIndex =
+            RelExcludeIndexImpl(index, substeps)
+
+        @JvmStatic
+        public fun key(key: String, substeps: List<RelExcludeStep> = emptyList()): RelExcludeKey =
+            RelExcludeKeyImpl(key, substeps)
+
+        @JvmStatic
+        public fun symbol(symbol: String, substeps: List<RelExcludeStep> = emptyList()): RelExcludeSymbol =
+            RelExcludeSymbolImpl(symbol, substeps)
+
+        @JvmStatic
+        public fun struct(substeps: List<RelExcludeStep> = emptyList()): RelExcludeStructWildcard =
+            RelExcludeStructWildcardImpl(substeps)
+
+        @JvmStatic
+        public fun collection(substeps: List<RelExcludeStep> = emptyList()): RelExcludeCollectionWildcard =
+            RelExcludeCollectionWildcardImpl(substeps)
     }
+}
 
-    /**
-     * TODO DOCUMENTATION
-     */
-    public interface Key : RelExcludeStep {
-        public fun getKey(): String
-    }
+/**
+ * Logical representation of an EXCLUDE path index step.
+ */
+public interface RelExcludeIndex : RelExcludeStep {
+    public fun getIndex(): Int
+}
 
-    /**
-     * TODO DOCUMENTATION
-     */
-    public interface Symbol : RelExcludeStep {
-        public fun getSymbol(): String
-    }
+private data class RelExcludeIndexImpl(
+    private val index: Int,
+    private val substeps: List<RelExcludeStep> = emptyList(),
+) : RelExcludeIndex {
+    override fun getSubsteps(): List<RelExcludeStep> = substeps
+    override fun getIndex(): Int = index
+}
 
-    /**
-     * TODO DOCUMENTATION
-     */
-    public interface StructWildcard : RelExcludeStep
+/**
+ * Logical representation of an EXCLUDE path key step.
+ */
+public interface RelExcludeKey : RelExcludeStep {
+    public fun getKey(): String
+}
 
-    /**
-     * TODO DOCUMENTATION
-     */
-    public interface CollectionWildcard : RelExcludeStep
+/**
+ * Logical representation of an EXCLUDE path symbol step.
+ */
+public interface RelExcludeSymbol : RelExcludeStep {
+    public fun getSymbol(): String
+}
+
+/**
+ * Logical representation of an EXCLUDE struct wildcard step.
+ */
+public interface RelExcludeStructWildcard : RelExcludeStep
+
+/**
+ * Logical representation of an EXCLUDE collection wildcard step.
+ */
+public interface RelExcludeCollectionWildcard : RelExcludeStep
+
+// TODO hashcode/equals without data class
+private data class RelExcludeKeyImpl(
+    private val key: String,
+    private val substeps: List<RelExcludeStep> = emptyList(),
+) : RelExcludeKey {
+    override fun getSubsteps(): List<RelExcludeStep> = substeps
+    override fun getKey(): String = key
+}
+
+// TODO hashcode/equals without data class
+private data class RelExcludeSymbolImpl(
+    private val symbol: String,
+    private val substeps: List<RelExcludeStep> = emptyList(),
+) : RelExcludeSymbol {
+    override fun getSubsteps(): List<RelExcludeStep> = substeps
+    override fun getSymbol(): String = symbol
+}
+
+// TODO hashcode/equals without data class
+private data class RelExcludeStructWildcardImpl(
+    private val substeps: List<RelExcludeStep> = emptyList(),
+) : RelExcludeStructWildcard {
+    override fun getSubsteps(): List<RelExcludeStep> = substeps
+}
+
+// TODO hashcode/equals without data class
+private data class RelExcludeCollectionWildcardImpl(
+    private val substeps: List<RelExcludeStep> = emptyList(),
+) : RelExcludeCollectionWildcard {
+    override fun getSubsteps(): List<RelExcludeStep> = substeps
 }

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelJoin.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelJoin.kt
@@ -10,7 +10,13 @@ public interface RelJoin : Rel {
 
     public fun getLeft(): Rel
 
+    // TODO REMOVE ME TEMPORARY
+    public fun getLeftSchema(): Schema?
+
     public fun getRight(): Rel
+
+    // TODO REMOVE ME TEMPORARY
+    public fun getRightSchema(): Schema?
 
     public fun getCondition(): Rex?
 
@@ -26,13 +32,22 @@ public interface RelJoin : Rel {
 /**
  * Default [RelJoin] implementation.
  */
-internal class RelJoinImpl(left: Rel, right: Rel, condition: Rex?, joinType: RelJoinType) : RelJoin {
+internal class RelJoinImpl(
+    left: Rel,
+    right: Rel,
+    condition: Rex?,
+    joinType: RelJoinType,
+    leftSchema: Schema?,
+    rightSchema: Schema?,
+) : RelJoin {
 
     // DO NOT USE FINAL
     private var _left = left
     private var _right = right
     private var _condition = condition
     private var _joinType = joinType
+    private var _leftSchema = leftSchema
+    private var _rightSchema = rightSchema
 
     private var _children: List<Rel>? = null
 
@@ -43,6 +58,10 @@ internal class RelJoinImpl(left: Rel, right: Rel, condition: Rex?, joinType: Rel
     override fun getCondition(): Rex? = _condition
 
     override fun getJoinType(): RelJoinType = _joinType
+
+    override fun getLeftSchema(): Schema? = _leftSchema
+
+    override fun getRightSchema(): Schema? = _rightSchema
 
     override fun getChildren(): Collection<Rel> {
         if (_children == null) {

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelJoin.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelJoin.kt
@@ -10,12 +10,12 @@ public interface RelJoin : Rel {
 
     public fun getLeft(): Rel
 
-    // TODO REMOVE ME TEMPORARY
+    // TODO REMOVE ME TEMPORARY – https://github.com/partiql/partiql-lang-kotlin/issues/1575
     public fun getLeftSchema(): Schema?
 
     public fun getRight(): Rel
 
-    // TODO REMOVE ME TEMPORARY
+    // TODO REMOVE ME TEMPORARY – https://github.com/partiql/partiql-lang-kotlin/issues/1575
     public fun getRightSchema(): Schema?
 
     public fun getCondition(): Rex?

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelScan.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rel/RelScan.kt
@@ -2,7 +2,6 @@ package org.partiql.plan.v1.operator.rel
 
 import org.partiql.plan.v1.Schema
 import org.partiql.plan.v1.operator.rex.Rex
-import org.partiql.types.PType
 
 /**
  * Logical scan corresponding to the clause `FROM <expression> AS <v>`.
@@ -13,7 +12,7 @@ public interface RelScan : Rel {
 
     override fun getChildren(): Collection<Rel> = emptyList()
 
-    override fun isOrdered(): Boolean = getInput().getType().kind == PType.Kind.ARRAY
+    override fun isOrdered(): Boolean = false
 
     override fun <R, C> accept(visitor: RelVisitor<R, C>, ctx: C): R = visitor.visitScan(this, ctx)
 }

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rex/RexBag.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rex/RexBag.kt
@@ -26,9 +26,7 @@ internal class RexBagImpl(values: Collection<Rex>) : RexBag {
 
     override fun getChildren(): Collection<Rex> = _values
 
-    override fun getType(): PType {
-        TODO("Not yet implemented")
-    }
+    override fun getType(): PType = PType.bag()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rex/RexCallDynamic.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rex/RexCallDynamic.kt
@@ -1,0 +1,46 @@
+package org.partiql.plan.v1.operator.rex
+
+import org.partiql.spi.fn.Fn
+import org.partiql.types.PType
+
+/**
+ * Logical operator for a dynamic scalar function call.
+ */
+public interface RexCallDynamic : Rex {
+
+    /**
+     * Returns the function to invoke.
+     *
+     * @return
+     */
+    public fun getFunctions(): List<Fn>
+
+    /**
+     * Returns the list of function arguments.
+     */
+    public fun getArgs(): List<Rex>
+
+    override fun getChildren(): Collection<Rex> = getArgs()
+
+    override fun <R, C> accept(visitor: RexVisitor<R, C>, ctx: C): R = visitor.visitCallDynamic(this, ctx)
+}
+
+/**
+ * Default [RexCallDynamic] implementation meant for extension.
+ */
+internal class RexCallDynamicImpl(functions: List<Fn>, args: List<Rex>) : RexCallDynamic {
+
+    // DO NOT USE FINAL
+    private var _functions = functions
+    private var _args = args
+
+    override fun getFunctions(): List<Fn> = _functions
+
+    override fun getArgs(): List<Rex> = _args
+
+    override fun getType(): PType {
+        TODO("Function .getType()")
+    }
+
+    override fun getChildren(): Collection<Rex> = _args
+}

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rex/RexCallStatic.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rex/RexCallStatic.kt
@@ -4,9 +4,9 @@ import org.partiql.spi.fn.Fn
 import org.partiql.types.PType
 
 /**
- * Scalar function calls.
+ * Logical operator for a scalar function call.
  */
-public interface RexCall : Rex {
+public interface RexCallStatic : Rex {
 
     /**
      * Returns the function to invoke.
@@ -22,13 +22,13 @@ public interface RexCall : Rex {
 
     override fun getChildren(): Collection<Rex> = getArgs()
 
-    override fun <R, C> accept(visitor: RexVisitor<R, C>, ctx: C): R = visitor.visitCall(this, ctx)
+    override fun <R, C> accept(visitor: RexVisitor<R, C>, ctx: C): R = visitor.visitCallStatic(this, ctx)
 }
 
 /**
- * Default [RexCall] implementation meant for extension.
+ * Default [RexCallStatic] implementation meant for extension.
  */
-internal class RexCallImpl(function: Fn, args: List<Rex>) : RexCall {
+internal class RexCallStaticImpl(function: Fn, args: List<Rex>) : RexCallStatic {
 
     // DO NOT USE FINAL
     private var _function = function

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rex/RexNullIf.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rex/RexNullIf.kt
@@ -3,7 +3,7 @@ package org.partiql.plan.v1.operator.rex
 import org.partiql.types.PType
 
 /**
- * TODO REMOVE ME AFTER EVALUATOR MERGE
+ * Logical operator for the SQL NULLIF special form.
  */
 public interface RexNullIf : Rex {
 

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rex/RexNullIf.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rex/RexNullIf.kt
@@ -1,0 +1,51 @@
+package org.partiql.plan.v1.operator.rex
+
+import org.partiql.types.PType
+
+/**
+ * TODO REMOVE ME AFTER EVALUATOR MERGE
+ */
+public interface RexNullIf : Rex {
+
+    public fun getValue(): Rex
+
+    public fun getNullifier(): Rex
+
+    override fun getType(): PType = PType.bag(getNullifier().getType())
+
+    override fun getChildren(): Collection<Rex> = listOf(getNullifier())
+
+    override fun <R, C> accept(visitor: RexVisitor<R, C>, ctx: C): R = visitor.visitNullIf(this, ctx)
+}
+
+/**
+ * Internal
+ */
+internal class RexNullIfImpl(value: Rex, nullifier: Rex) : RexNullIf {
+
+    // DO NOT USE FINAL
+    private var _value = value
+    private var _nullifier = nullifier
+
+    override fun getValue(): Rex = _value
+
+    override fun getNullifier(): Rex = _nullifier
+
+    override fun getType(): PType = PType.bag(_nullifier.getType())
+
+    override fun getChildren(): Collection<Rex> = listOf(_nullifier)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is RexNullIf) return false
+        if (_value != other.getValue()) return false
+        if (_nullifier != other.getNullifier()) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = _value.hashCode()
+        result = 31 * result + _nullifier.hashCode()
+        return result
+    }
+}

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rex/RexVisitor.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/v1/operator/rex/RexVisitor.kt
@@ -23,7 +23,9 @@ public interface RexVisitor<R, C> {
 
     public fun visitBag(rex: RexBag, ctx: C): R = defaultVisit(rex, ctx)
 
-    public fun visitCall(rex: RexCall, ctx: C): R = defaultVisit(rex, ctx)
+    public fun visitCallStatic(rex: RexCallStatic, ctx: C): R = defaultVisit(rex, ctx)
+
+    public fun visitCallDynamic(rex: RexCallDynamic, ctx: C): R = defaultVisit(rex, ctx)
 
     public fun visitCase(rex: RexCase, ctx: C): R = defaultVisit(rex, ctx)
 
@@ -36,6 +38,8 @@ public interface RexVisitor<R, C> {
     public fun visitLit(rex: RexLit, ctx: C): R = defaultVisit(rex, ctx)
 
     public fun visitMissing(rex: RexMissing, ctx: C): R = defaultVisit(rex, ctx)
+
+    public fun visitNullIf(rex: RexNullIf, ctx: C): R = defaultVisit(rex, ctx)
 
     public fun visitPathIndex(rex: RexPathIndex, ctx: C): R = defaultVisit(rex, ctx)
 


### PR DESCRIPTION
## Relevant Issues

#1548 

## Description

This PR applies the modifications to the v1.plan package which we needed to switch the intermediate representation used for execution.

It adds,
- dynamic calls
- exclude
- paths
- nullif

There are cleanup TODOs for several things we needed to pass existing tests with minimal changes, these include
- removal of nullif?
- fix subqueries in planner
- join schemas?

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.