### PR TITLE
[v1] Upgrade to Kotlin 1.9

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,11 +25,11 @@ repositories {
 object Versions {
     const val binaryCompatibilityValidator = "0.14.0"
     const val detekt = "1.20.0-RC2"
-    const val dokka = "1.6.10"
-    const val kotlin = "1.6.20"
+    const val dokka = "1.9.20"
+    const val kotlin = "1.9.20"
     const val ktlintGradle = "10.2.1"
     const val nexusPublish = "2.0.0"
-    const val pig = "0.6.1"
+    const val pig = "0.6.3"
     const val shadow = "8.1.1"
 }
 

--- a/buildSrc/src/main/kotlin/partiql.versions.kt
+++ b/buildSrc/src/main/kotlin/partiql.versions.kt
@@ -18,9 +18,9 @@
 
 object Versions {
     // Language
-    const val kotlin = "1.6.20"
-    const val kotlinLanguage = "1.6"
-    const val kotlinApi = "1.6"
+    const val kotlin = "1.9.20"
+    const val kotlinLanguage = "1.9"
+    const val kotlinApi = "1.9"
     const val jvmTarget = "1.8"
 
     // Dependencies
@@ -45,9 +45,9 @@ object Versions {
     const val kotlinxCollections = "0.3.5"
     const val picoCli = "4.7.0"
     const val kasechange = "1.3.0"
-    const val pig = "0.6.2"
-    const val kotlinxCoroutines = "1.6.0"
-    const val kotlinxCoroutinesJdk8 = "1.6.0"
+    const val pig = "0.6.3"
+    const val kotlinxCoroutines = "1.8.1"
+    const val kotlinxCoroutinesJdk8 = "1.8.1"
     const val ktlint = "0.42.1" // we're on an old version of ktlint. TODO upgrade https://github.com/partiql/partiql-lang-kotlin/issues/1418
 
     // Testing
@@ -59,7 +59,7 @@ object Versions {
     const val junit4Params = "1.1.1"
     const val mockito = "4.5.0"
     const val mockk = "1.11.0"
-    const val kotlinxCoroutinesTest = "1.6.0"
+    const val kotlinxCoroutinesTest = "1.8.1"
 }
 
 object Deps {

--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -152,6 +152,7 @@ public final class org/partiql/ast/DatetimeField : java/lang/Enum {
 	public static final field TIMEZONE_HOUR Lorg/partiql/ast/DatetimeField;
 	public static final field TIMEZONE_MINUTE Lorg/partiql/ast/DatetimeField;
 	public static final field YEAR Lorg/partiql/ast/DatetimeField;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/DatetimeField;
 	public static fun values ()[Lorg/partiql/ast/DatetimeField;
 }
@@ -464,6 +465,7 @@ public final class org/partiql/ast/Expr$Collection$Type : java/lang/Enum {
 	public static final field LIST Lorg/partiql/ast/Expr$Collection$Type;
 	public static final field SEXP Lorg/partiql/ast/Expr$Collection$Type;
 	public static final field VALUES Lorg/partiql/ast/Expr$Collection$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/Expr$Collection$Type;
 	public static fun values ()[Lorg/partiql/ast/Expr$Collection$Type;
 }
@@ -962,6 +964,7 @@ public final class org/partiql/ast/Expr$SessionAttribute : org/partiql/ast/Expr 
 public final class org/partiql/ast/Expr$SessionAttribute$Attribute : java/lang/Enum {
 	public static final field CURRENT_DATE Lorg/partiql/ast/Expr$SessionAttribute$Attribute;
 	public static final field CURRENT_USER Lorg/partiql/ast/Expr$SessionAttribute$Attribute;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/Expr$SessionAttribute$Attribute;
 	public static fun values ()[Lorg/partiql/ast/Expr$SessionAttribute$Attribute;
 }
@@ -1060,6 +1063,7 @@ public final class org/partiql/ast/Expr$Trim$Spec : java/lang/Enum {
 	public static final field BOTH Lorg/partiql/ast/Expr$Trim$Spec;
 	public static final field LEADING Lorg/partiql/ast/Expr$Trim$Spec;
 	public static final field TRAILING Lorg/partiql/ast/Expr$Trim$Spec;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/Expr$Trim$Spec;
 	public static fun values ()[Lorg/partiql/ast/Expr$Trim$Spec;
 }
@@ -1126,6 +1130,7 @@ public final class org/partiql/ast/Expr$Var$Companion {
 public final class org/partiql/ast/Expr$Var$Scope : java/lang/Enum {
 	public static final field DEFAULT Lorg/partiql/ast/Expr$Var$Scope;
 	public static final field LOCAL Lorg/partiql/ast/Expr$Var$Scope;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/Expr$Var$Scope;
 	public static fun values ()[Lorg/partiql/ast/Expr$Var$Scope;
 }
@@ -1160,6 +1165,7 @@ public final class org/partiql/ast/Expr$Window$Companion {
 public final class org/partiql/ast/Expr$Window$Function : java/lang/Enum {
 	public static final field LAG Lorg/partiql/ast/Expr$Window$Function;
 	public static final field LEAD Lorg/partiql/ast/Expr$Window$Function;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/Expr$Window$Function;
 	public static fun values ()[Lorg/partiql/ast/Expr$Window$Function;
 }
@@ -1224,6 +1230,7 @@ public final class org/partiql/ast/From$Join$Type : java/lang/Enum {
 	public static final field LEFT_OUTER Lorg/partiql/ast/From$Join$Type;
 	public static final field RIGHT Lorg/partiql/ast/From$Join$Type;
 	public static final field RIGHT_OUTER Lorg/partiql/ast/From$Join$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/From$Join$Type;
 	public static fun values ()[Lorg/partiql/ast/From$Join$Type;
 }
@@ -1258,6 +1265,7 @@ public final class org/partiql/ast/From$Value$Companion {
 public final class org/partiql/ast/From$Value$Type : java/lang/Enum {
 	public static final field SCAN Lorg/partiql/ast/From$Value$Type;
 	public static final field UNPIVOT Lorg/partiql/ast/From$Value$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/From$Value$Type;
 	public static fun values ()[Lorg/partiql/ast/From$Value$Type;
 }
@@ -1291,6 +1299,7 @@ public final class org/partiql/ast/GraphMatch$Direction : java/lang/Enum {
 	public static final field RIGHT Lorg/partiql/ast/GraphMatch$Direction;
 	public static final field UNDIRECTED Lorg/partiql/ast/GraphMatch$Direction;
 	public static final field UNDIRECTED_OR_RIGHT Lorg/partiql/ast/GraphMatch$Direction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/GraphMatch$Direction;
 	public static fun values ()[Lorg/partiql/ast/GraphMatch$Direction;
 }
@@ -1525,6 +1534,7 @@ public final class org/partiql/ast/GraphMatch$Restrictor : java/lang/Enum {
 	public static final field ACYCLIC Lorg/partiql/ast/GraphMatch$Restrictor;
 	public static final field SIMPLE Lorg/partiql/ast/GraphMatch$Restrictor;
 	public static final field TRAIL Lorg/partiql/ast/GraphMatch$Restrictor;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/GraphMatch$Restrictor;
 	public static fun values ()[Lorg/partiql/ast/GraphMatch$Restrictor;
 }
@@ -1700,6 +1710,7 @@ public final class org/partiql/ast/GroupBy$Key$Companion {
 public final class org/partiql/ast/GroupBy$Strategy : java/lang/Enum {
 	public static final field FULL Lorg/partiql/ast/GroupBy$Strategy;
 	public static final field PARTIAL Lorg/partiql/ast/GroupBy$Strategy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/GroupBy$Strategy;
 	public static fun values ()[Lorg/partiql/ast/GroupBy$Strategy;
 }
@@ -1711,6 +1722,7 @@ public abstract class org/partiql/ast/Identifier : org/partiql/ast/AstNode {
 public final class org/partiql/ast/Identifier$CaseSensitivity : java/lang/Enum {
 	public static final field INSENSITIVE Lorg/partiql/ast/Identifier$CaseSensitivity;
 	public static final field SENSITIVE Lorg/partiql/ast/Identifier$CaseSensitivity;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/Identifier$CaseSensitivity;
 	public static fun values ()[Lorg/partiql/ast/Identifier$CaseSensitivity;
 }
@@ -2094,6 +2106,7 @@ public final class org/partiql/ast/SetOp$Type : java/lang/Enum {
 	public static final field EXCEPT Lorg/partiql/ast/SetOp$Type;
 	public static final field INTERSECT Lorg/partiql/ast/SetOp$Type;
 	public static final field UNION Lorg/partiql/ast/SetOp$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/SetOp$Type;
 	public static fun values ()[Lorg/partiql/ast/SetOp$Type;
 }
@@ -2101,6 +2114,7 @@ public final class org/partiql/ast/SetOp$Type : java/lang/Enum {
 public final class org/partiql/ast/SetQuantifier : java/lang/Enum {
 	public static final field ALL Lorg/partiql/ast/SetQuantifier;
 	public static final field DISTINCT Lorg/partiql/ast/SetQuantifier;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/SetQuantifier;
 	public static fun values ()[Lorg/partiql/ast/SetQuantifier;
 }
@@ -2131,6 +2145,7 @@ public final class org/partiql/ast/Sort$Companion {
 public final class org/partiql/ast/Sort$Dir : java/lang/Enum {
 	public static final field ASC Lorg/partiql/ast/Sort$Dir;
 	public static final field DESC Lorg/partiql/ast/Sort$Dir;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/Sort$Dir;
 	public static fun values ()[Lorg/partiql/ast/Sort$Dir;
 }
@@ -2138,6 +2153,7 @@ public final class org/partiql/ast/Sort$Dir : java/lang/Enum {
 public final class org/partiql/ast/Sort$Nulls : java/lang/Enum {
 	public static final field FIRST Lorg/partiql/ast/Sort$Nulls;
 	public static final field LAST Lorg/partiql/ast/Sort$Nulls;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/Sort$Nulls;
 	public static fun values ()[Lorg/partiql/ast/Sort$Nulls;
 }
@@ -5304,6 +5320,7 @@ public final class org/partiql/ast/sql/SqlLayout$Indent$Type : java/lang/Enum {
 	public static final field SPACE Lorg/partiql/ast/sql/SqlLayout$Indent$Type;
 	public static final field TAB Lorg/partiql/ast/sql/SqlLayout$Indent$Type;
 	public final fun getChar ()C
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/sql/SqlLayout$Indent$Type;
 	public static fun values ()[Lorg/partiql/ast/sql/SqlLayout$Indent$Type;
 }

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/helpers/ToLegacyAst.kt
@@ -812,7 +812,7 @@ private class AstTranslator(val metas: Map<String, MetaContainer>) : AstBaseVisi
 
     override fun visitLetBinding(node: Let.Binding, ctx: Ctx) = translate(node) { metas ->
         val expr = visitExpr(node.expr, ctx)
-        val name = node.asAlias?.symbol
+        val name = node.asAlias.symbol
         letBinding(expr, name, metas)
     }
 

--- a/partiql-eval/api/partiql-eval.api
+++ b/partiql-eval/api/partiql-eval.api
@@ -14,6 +14,7 @@ public final class org/partiql/eval/PartiQLEngine$Companion {
 public final class org/partiql/eval/PartiQLEngine$Mode : java/lang/Enum {
 	public static final field PERMISSIVE Lorg/partiql/eval/PartiQLEngine$Mode;
 	public static final field STRICT Lorg/partiql/eval/PartiQLEngine$Mode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/eval/PartiQLEngine$Mode;
 	public static fun values ()[Lorg/partiql/eval/PartiQLEngine$Mode;
 }

--- a/partiql-lang/api/partiql-lang.api
+++ b/partiql-lang/api/partiql-lang.api
@@ -353,6 +353,7 @@ public final class org/partiql/lang/eval/BindingCase : java/lang/Enum {
 	public static final field Companion Lorg/partiql/lang/eval/BindingCase$Companion;
 	public static final field INSENSITIVE Lorg/partiql/lang/eval/BindingCase;
 	public static final field SENSITIVE Lorg/partiql/lang/eval/BindingCase;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toSymbol (Lcom/amazon/ion/IonSystem;)Lcom/amazon/ion/IonSymbol;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/BindingCase;
 	public static fun values ()[Lorg/partiql/lang/eval/BindingCase;
@@ -552,6 +553,7 @@ public final class org/partiql/lang/eval/CoverageStructure$Branch {
 public final class org/partiql/lang/eval/CoverageStructure$Branch$Outcome : java/lang/Enum {
 	public static final field FALSE Lorg/partiql/lang/eval/CoverageStructure$Branch$Outcome;
 	public static final field TRUE Lorg/partiql/lang/eval/CoverageStructure$Branch$Outcome;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/CoverageStructure$Branch$Outcome;
 	public static fun values ()[Lorg/partiql/lang/eval/CoverageStructure$Branch$Outcome;
 }
@@ -560,6 +562,7 @@ public final class org/partiql/lang/eval/CoverageStructure$Branch$Type : java/la
 	public static final field CASE_WHEN Lorg/partiql/lang/eval/CoverageStructure$Branch$Type;
 	public static final field HAVING Lorg/partiql/lang/eval/CoverageStructure$Branch$Type;
 	public static final field WHERE Lorg/partiql/lang/eval/CoverageStructure$Branch$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/CoverageStructure$Branch$Type;
 	public static fun values ()[Lorg/partiql/lang/eval/CoverageStructure$Branch$Type;
 }
@@ -586,6 +589,7 @@ public final class org/partiql/lang/eval/CoverageStructure$BranchCondition$Outco
 	public static final field MISSING Lorg/partiql/lang/eval/CoverageStructure$BranchCondition$Outcome;
 	public static final field NULL Lorg/partiql/lang/eval/CoverageStructure$BranchCondition$Outcome;
 	public static final field TRUE Lorg/partiql/lang/eval/CoverageStructure$BranchCondition$Outcome;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/CoverageStructure$BranchCondition$Outcome;
 	public static fun values ()[Lorg/partiql/lang/eval/CoverageStructure$BranchCondition$Outcome;
 }
@@ -604,6 +608,7 @@ public final class org/partiql/lang/eval/CoverageStructure$BranchCondition$Type 
 	public static final field NEQ Lorg/partiql/lang/eval/CoverageStructure$BranchCondition$Type;
 	public static final field NOT Lorg/partiql/lang/eval/CoverageStructure$BranchCondition$Type;
 	public static final field OR Lorg/partiql/lang/eval/CoverageStructure$BranchCondition$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/CoverageStructure$BranchCondition$Type;
 	public static fun values ()[Lorg/partiql/lang/eval/CoverageStructure$BranchCondition$Type;
 }
@@ -821,6 +826,7 @@ public final class org/partiql/lang/eval/ExprValueType : java/lang/Enum {
 	public static final field SYMBOL Lorg/partiql/lang/eval/ExprValueType;
 	public static final field TIME Lorg/partiql/lang/eval/ExprValueType;
 	public static final field TIMESTAMP Lorg/partiql/lang/eval/ExprValueType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun isDirectlyComparableTo (Lorg/partiql/lang/eval/ExprValueType;)Z
 	public final fun isLob ()Z
 	public final fun isNumber ()Z
@@ -865,6 +871,7 @@ public final class org/partiql/lang/eval/NaturalExprValueComparators : java/lang
 	public static final field NULLS_LAST_DESC Lorg/partiql/lang/eval/NaturalExprValueComparators;
 	public synthetic fun compare (Ljava/lang/Object;Ljava/lang/Object;)I
 	public fun compare (Lorg/partiql/lang/eval/ExprValue;Lorg/partiql/lang/eval/ExprValue;)I
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/NaturalExprValueComparators;
 	public static fun values ()[Lorg/partiql/lang/eval/NaturalExprValueComparators;
 }
@@ -962,6 +969,7 @@ public final class org/partiql/lang/eval/PartiqlAstExtensionsKt {
 public final class org/partiql/lang/eval/ProjectionIterationBehavior : java/lang/Enum {
 	public static final field FILTER_MISSING Lorg/partiql/lang/eval/ProjectionIterationBehavior;
 	public static final field UNFILTERED Lorg/partiql/lang/eval/ProjectionIterationBehavior;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/ProjectionIterationBehavior;
 	public static fun values ()[Lorg/partiql/lang/eval/ProjectionIterationBehavior;
 }
@@ -1035,6 +1043,7 @@ public final class org/partiql/lang/eval/StandardNamesKt {
 public final class org/partiql/lang/eval/StructOrdering : java/lang/Enum {
 	public static final field ORDERED Lorg/partiql/lang/eval/StructOrdering;
 	public static final field UNORDERED Lorg/partiql/lang/eval/StructOrdering;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/StructOrdering;
 	public static fun values ()[Lorg/partiql/lang/eval/StructOrdering;
 }
@@ -1073,12 +1082,14 @@ public final class org/partiql/lang/eval/ThunkOptions$Companion {
 public final class org/partiql/lang/eval/ThunkReturnTypeAssertions : java/lang/Enum {
 	public static final field DISABLED Lorg/partiql/lang/eval/ThunkReturnTypeAssertions;
 	public static final field ENABLED Lorg/partiql/lang/eval/ThunkReturnTypeAssertions;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/ThunkReturnTypeAssertions;
 	public static fun values ()[Lorg/partiql/lang/eval/ThunkReturnTypeAssertions;
 }
 
 public final class org/partiql/lang/eval/TypedOpBehavior : java/lang/Enum {
 	public static final field HONOR_PARAMETERS Lorg/partiql/lang/eval/TypedOpBehavior;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/TypedOpBehavior;
 	public static fun values ()[Lorg/partiql/lang/eval/TypedOpBehavior;
 }
@@ -1086,6 +1097,7 @@ public final class org/partiql/lang/eval/TypedOpBehavior : java/lang/Enum {
 public final class org/partiql/lang/eval/TypingMode : java/lang/Enum {
 	public static final field LEGACY Lorg/partiql/lang/eval/TypingMode;
 	public static final field PERMISSIVE Lorg/partiql/lang/eval/TypingMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/TypingMode;
 	public static fun values ()[Lorg/partiql/lang/eval/TypingMode;
 }
@@ -1093,6 +1105,7 @@ public final class org/partiql/lang/eval/TypingMode : java/lang/Enum {
 public final class org/partiql/lang/eval/UndefinedVariableBehavior : java/lang/Enum {
 	public static final field ERROR Lorg/partiql/lang/eval/UndefinedVariableBehavior;
 	public static final field MISSING Lorg/partiql/lang/eval/UndefinedVariableBehavior;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/UndefinedVariableBehavior;
 	public static fun values ()[Lorg/partiql/lang/eval/UndefinedVariableBehavior;
 }
@@ -1101,6 +1114,7 @@ public abstract class org/partiql/lang/eval/VisitorTransformMode : java/lang/Enu
 	public static final field DEFAULT Lorg/partiql/lang/eval/VisitorTransformMode;
 	public static final field NONE Lorg/partiql/lang/eval/VisitorTransformMode;
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/VisitorTransformMode;
 	public static fun values ()[Lorg/partiql/lang/eval/VisitorTransformMode;
 }
@@ -1184,6 +1198,7 @@ public final class org/partiql/lang/eval/io/DelimitedValues$ConversionMode : jav
 	public static final field NONE Lorg/partiql/lang/eval/io/DelimitedValues$ConversionMode;
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public abstract fun convert (Ljava/lang/String;)Lorg/partiql/lang/eval/ExprValue;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/io/DelimitedValues$ConversionMode;
 	public static fun values ()[Lorg/partiql/lang/eval/io/DelimitedValues$ConversionMode;
 }
@@ -1382,6 +1397,7 @@ public final class org/partiql/lang/eval/physical/operators/RelationalOperatorKi
 	public static final field SORT Lorg/partiql/lang/eval/physical/operators/RelationalOperatorKind;
 	public static final field UNPIVOT Lorg/partiql/lang/eval/physical/operators/RelationalOperatorKind;
 	public static final field WINDOW Lorg/partiql/lang/eval/physical/operators/RelationalOperatorKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/physical/operators/RelationalOperatorKind;
 	public static fun values ()[Lorg/partiql/lang/eval/physical/operators/RelationalOperatorKind;
 }
@@ -1496,6 +1512,7 @@ public abstract interface class org/partiql/lang/eval/relation/RelationScope {
 public final class org/partiql/lang/eval/relation/RelationType : java/lang/Enum {
 	public static final field BAG Lorg/partiql/lang/eval/relation/RelationType;
 	public static final field LIST Lorg/partiql/lang/eval/relation/RelationType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/relation/RelationType;
 	public static fun values ()[Lorg/partiql/lang/eval/relation/RelationType;
 }
@@ -1605,6 +1622,7 @@ public final class org/partiql/lang/eval/visitors/StaticTypeVisitorTransform : o
 public final class org/partiql/lang/eval/visitors/StaticTypeVisitorTransformConstraints : java/lang/Enum {
 	public static final field PREVENT_GLOBALS_EXCEPT_IN_FROM Lorg/partiql/lang/eval/visitors/StaticTypeVisitorTransformConstraints;
 	public static final field PREVENT_GLOBALS_IN_NESTED_QUERIES Lorg/partiql/lang/eval/visitors/StaticTypeVisitorTransformConstraints;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/eval/visitors/StaticTypeVisitorTransformConstraints;
 	public static fun values ()[Lorg/partiql/lang/eval/visitors/StaticTypeVisitorTransformConstraints;
 }
@@ -1652,6 +1670,7 @@ public final class org/partiql/lang/graph/DirSpec : java/lang/Enum {
 	public static final field Dir_UR Lorg/partiql/lang/graph/DirSpec;
 	public static final field Dir_U_ Lorg/partiql/lang/graph/DirSpec;
 	public static final field Dir__R Lorg/partiql/lang/graph/DirSpec;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getWantLeft ()Z
 	public final fun getWantRight ()Z
 	public final fun getWantUndir ()Z
@@ -1924,6 +1943,7 @@ public final class org/partiql/lang/planner/DmlAction : java/lang/Enum {
 	public static final field DELETE Lorg/partiql/lang/planner/DmlAction;
 	public static final field INSERT Lorg/partiql/lang/planner/DmlAction;
 	public static final field REPLACE Lorg/partiql/lang/planner/DmlAction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/planner/DmlAction;
 	public static fun values ()[Lorg/partiql/lang/planner/DmlAction;
 }
@@ -2402,6 +2422,7 @@ public final class org/partiql/lang/types/TypedOpParameter {
 public final class org/partiql/lang/types/UnknownArguments : java/lang/Enum {
 	public static final field PASS_THRU Lorg/partiql/lang/types/UnknownArguments;
 	public static final field PROPAGATE Lorg/partiql/lang/types/UnknownArguments;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/lang/types/UnknownArguments;
 	public static fun values ()[Lorg/partiql/lang/types/UnknownArguments;
 }

--- a/partiql-lang/build.gradle.kts
+++ b/partiql-lang/build.gradle.kts
@@ -62,6 +62,12 @@ dependencies {
     testFixturesImplementation(Deps.mockk)
 }
 
+tasks.compileTestFixturesKotlin {
+    kotlinOptions.jvmTarget = Versions.jvmTarget
+    kotlinOptions.apiVersion = Versions.kotlinApi
+    kotlinOptions.languageVersion = Versions.kotlinLanguage
+}
+
 tasks.shadowJar {
     configurations = listOf(project.configurations.shadow.get())
 }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/ast/passes/StatementRedactor.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/ast/passes/StatementRedactor.kt
@@ -319,6 +319,7 @@ private class StatementRedactionVisitor(
                     if (!skipRedaction(it.first, safeFieldNames)) {
                         redactExpr(it.second)
                     } else { /* intentionally blank */ }
+                else -> {}
             }
         }
     }

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/ast/passes/inference/StaticTypeExtensions.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/ast/passes/inference/StaticTypeExtensions.kt
@@ -76,6 +76,7 @@ internal fun StaticType.cast(targetType: StaticType): StaticType {
             is SingleType, is AnyType -> flattened.cast(targetType)
             is AnyOfType -> AnyOfType(flattened.types.map { it.cast(targetType) }.toSet()).flatten()
         }
+        else -> {}
     }
 
     // single source type
@@ -199,16 +200,21 @@ internal fun StaticType.cast(targetType: StaticType): StaticType {
                 }
                 is ClobType -> when (this) {
                     is ClobType, is BlobType -> return targetType
+                    else -> {}
                 }
                 is BlobType -> when (this) {
                     is ClobType, is BlobType -> return targetType
+                    else -> {}
                 }
                 is CollectionType -> when (this) {
                     is CollectionType -> return targetType
+                    else -> {}
                 }
                 is StructType -> when (this) {
                     is StructType -> return targetType
+                    else -> {}
                 }
+                else -> {}
             }
             // TODO:  support non-permissive mode(s) here by throwing an exception to indicate cast is not possible
             return StaticType.MISSING

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/PartiqlAstSanityValidator.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/eval/visitors/PartiqlAstSanityValidator.kt
@@ -140,6 +140,7 @@ class PartiqlAstSanityValidator : PartiqlAst.Visitor() {
                 is PartiqlAst.Projection.ProjectValue, is PartiqlAst.Projection.ProjectList -> {
                     // use of group by with SELECT & SELECT VALUE is supported
                 }
+                else -> {}
             }
         }
 

--- a/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
+++ b/partiql-lang/src/main/kotlin/org/partiql/lang/prettyprint/QueryPrettyPrinter.kt
@@ -60,6 +60,7 @@ class QueryPrettyPrinter {
             is PartiqlAst.Statement.Ddl -> writeAstNode(node, sb)
             is PartiqlAst.Statement.Dml -> writeAstNode(node, sb)
             is PartiqlAst.Statement.Exec -> writeAstNode(node, sb)
+            else -> {}
         }
     }
 
@@ -655,6 +656,7 @@ class QueryPrettyPrinter {
         when (sortSpec.orderingSpec) {
             is PartiqlAst.OrderingSpec.Asc -> sb.append(" ASC")
             is PartiqlAst.OrderingSpec.Desc -> sb.append(" DESC")
+            else -> {}
         }
     }
 
@@ -857,7 +859,8 @@ class QueryPrettyPrinter {
             is PartiqlAst.Type.TimestampType -> sb.append("TIMESTAMP")
             is PartiqlAst.Type.TupleType -> sb.append("TUPLE")
             // TODO: Support formatting CustomType
-            is PartiqlAst.Type.CustomType -> error("CustomType is not supported yet. ")
+            is PartiqlAst.Type.CustomType -> error("CustomType is not supported yet.")
+            is PartiqlAst.Type.TimestampWithTimeZoneType -> error("TimestampWithTimeZoneType is not supported yet.")
         }
     }
 

--- a/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerNAryTests.kt
+++ b/partiql-lang/src/test/kotlin/org/partiql/lang/eval/EvaluatingCompilerNAryTests.kt
@@ -193,6 +193,7 @@ class EvaluatingCompilerNAryTests : EvaluatorTestBase() {
                                 expected = false
                                 break@loop
                             }
+                            else -> {}
                         }
                         current = it
                     }

--- a/partiql-plan/api/partiql-plan.api
+++ b/partiql-plan/api/partiql-plan.api
@@ -93,6 +93,7 @@ public abstract class org/partiql/plan/Identifier : org/partiql/plan/PlanNode {
 public final class org/partiql/plan/Identifier$CaseSensitivity : java/lang/Enum {
 	public static final field INSENSITIVE Lorg/partiql/plan/Identifier$CaseSensitivity;
 	public static final field SENSITIVE Lorg/partiql/plan/Identifier$CaseSensitivity;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/Identifier$CaseSensitivity;
 	public static fun values ()[Lorg/partiql/plan/Identifier$CaseSensitivity;
 }
@@ -373,6 +374,7 @@ public final class org/partiql/plan/Rel$Op$Aggregate$Companion {
 public final class org/partiql/plan/Rel$Op$Aggregate$Strategy : java/lang/Enum {
 	public static final field FULL Lorg/partiql/plan/Rel$Op$Aggregate$Strategy;
 	public static final field PARTIAL Lorg/partiql/plan/Rel$Op$Aggregate$Strategy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/Rel$Op$Aggregate$Strategy;
 	public static fun values ()[Lorg/partiql/plan/Rel$Op$Aggregate$Strategy;
 }
@@ -678,6 +680,7 @@ public final class org/partiql/plan/Rel$Op$Join$Type : java/lang/Enum {
 	public static final field INNER Lorg/partiql/plan/Rel$Op$Join$Type;
 	public static final field LEFT Lorg/partiql/plan/Rel$Op$Join$Type;
 	public static final field RIGHT Lorg/partiql/plan/Rel$Op$Join$Type;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/Rel$Op$Join$Type;
 	public static fun values ()[Lorg/partiql/plan/Rel$Op$Join$Type;
 }
@@ -809,6 +812,7 @@ public final class org/partiql/plan/Rel$Op$Sort$Order : java/lang/Enum {
 	public static final field ASC_NULLS_LAST Lorg/partiql/plan/Rel$Op$Sort$Order;
 	public static final field DESC_NULLS_FIRST Lorg/partiql/plan/Rel$Op$Sort$Order;
 	public static final field DESC_NULLS_LAST Lorg/partiql/plan/Rel$Op$Sort$Order;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/Rel$Op$Sort$Order;
 	public static fun values ()[Lorg/partiql/plan/Rel$Op$Sort$Order;
 }
@@ -878,6 +882,7 @@ public final class org/partiql/plan/Rel$Op$Unpivot$Companion {
 
 public final class org/partiql/plan/Rel$Prop : java/lang/Enum {
 	public static final field ORDERED Lorg/partiql/plan/Rel$Prop;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/Rel$Prop;
 	public static fun values ()[Lorg/partiql/plan/Rel$Prop;
 }
@@ -1370,6 +1375,7 @@ public final class org/partiql/plan/Rex$Op$Subquery : org/partiql/plan/Rex$Op {
 public final class org/partiql/plan/Rex$Op$Subquery$Coercion : java/lang/Enum {
 	public static final field ROW Lorg/partiql/plan/Rex$Op$Subquery$Coercion;
 	public static final field SCALAR Lorg/partiql/plan/Rex$Op$Subquery$Coercion;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/Rex$Op$Subquery$Coercion;
 	public static fun values ()[Lorg/partiql/plan/Rex$Op$Subquery$Coercion;
 }
@@ -1421,6 +1427,7 @@ public final class org/partiql/plan/Rex$Op$Var$Companion {
 public final class org/partiql/plan/SetQuantifier : java/lang/Enum {
 	public static final field ALL Lorg/partiql/plan/SetQuantifier;
 	public static final field DISTINCT Lorg/partiql/plan/SetQuantifier;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/SetQuantifier;
 	public static fun values ()[Lorg/partiql/plan/SetQuantifier;
 }
@@ -2748,6 +2755,7 @@ public final class org/partiql/plan/v1/operator/rel/RelCollation$Nulls : java/la
 	public static final field FIRST Lorg/partiql/plan/v1/operator/rel/RelCollation$Nulls;
 	public static final field LAST Lorg/partiql/plan/v1/operator/rel/RelCollation$Nulls;
 	public static final field OTHER Lorg/partiql/plan/v1/operator/rel/RelCollation$Nulls;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/v1/operator/rel/RelCollation$Nulls;
 	public static fun values ()[Lorg/partiql/plan/v1/operator/rel/RelCollation$Nulls;
 }
@@ -2756,6 +2764,7 @@ public final class org/partiql/plan/v1/operator/rel/RelCollation$Order : java/la
 	public static final field ASC Lorg/partiql/plan/v1/operator/rel/RelCollation$Order;
 	public static final field DESC Lorg/partiql/plan/v1/operator/rel/RelCollation$Order;
 	public static final field OTHER Lorg/partiql/plan/v1/operator/rel/RelCollation$Order;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/v1/operator/rel/RelCollation$Order;
 	public static fun values ()[Lorg/partiql/plan/v1/operator/rel/RelCollation$Order;
 }
@@ -2947,6 +2956,7 @@ public final class org/partiql/plan/v1/operator/rel/RelJoinType : java/lang/Enum
 	public static final field INNER Lorg/partiql/plan/v1/operator/rel/RelJoinType;
 	public static final field LEFT Lorg/partiql/plan/v1/operator/rel/RelJoinType;
 	public static final field RIGHT Lorg/partiql/plan/v1/operator/rel/RelJoinType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/v1/operator/rel/RelJoinType;
 	public static fun values ()[Lorg/partiql/plan/v1/operator/rel/RelJoinType;
 }
@@ -3376,6 +3386,7 @@ public final class org/partiql/plan/v1/operator/rex/RexSubqueryComp$Comp : java/
 	public static final field LT Lorg/partiql/plan/v1/operator/rex/RexSubqueryComp$Comp;
 	public static final field NE Lorg/partiql/plan/v1/operator/rex/RexSubqueryComp$Comp;
 	public static final field OTHER Lorg/partiql/plan/v1/operator/rex/RexSubqueryComp$Comp;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/v1/operator/rex/RexSubqueryComp$Comp;
 	public static fun values ()[Lorg/partiql/plan/v1/operator/rex/RexSubqueryComp$Comp;
 }
@@ -3389,6 +3400,7 @@ public final class org/partiql/plan/v1/operator/rex/RexSubqueryComp$Quantifier :
 	public static final field ANY Lorg/partiql/plan/v1/operator/rex/RexSubqueryComp$Quantifier;
 	public static final field OTHER Lorg/partiql/plan/v1/operator/rex/RexSubqueryComp$Quantifier;
 	public static final field SOME Lorg/partiql/plan/v1/operator/rex/RexSubqueryComp$Quantifier;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/v1/operator/rex/RexSubqueryComp$Quantifier;
 	public static fun values ()[Lorg/partiql/plan/v1/operator/rex/RexSubqueryComp$Quantifier;
 }
@@ -3417,6 +3429,7 @@ public final class org/partiql/plan/v1/operator/rex/RexSubqueryTest$Test : java/
 	public static final field EXISTS Lorg/partiql/plan/v1/operator/rex/RexSubqueryTest$Test;
 	public static final field OTHER Lorg/partiql/plan/v1/operator/rex/RexSubqueryTest$Test;
 	public static final field UNIQUE Lorg/partiql/plan/v1/operator/rex/RexSubqueryTest$Test;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/plan/v1/operator/rex/RexSubqueryTest$Test;
 	public static fun values ()[Lorg/partiql/plan/v1/operator/rex/RexSubqueryTest$Test;
 }

--- a/partiql-planner/build.gradle.kts
+++ b/partiql-planner/build.gradle.kts
@@ -1,4 +1,5 @@
-import org.jetbrains.dokka.utilities.relativeTo
+import kotlin.io.path.relativeTo
+import kotlin.io.path.toPath
 
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -62,7 +63,7 @@ tasks.register("generateResourcePath") {
         resourceDir.walk().forEach { file ->
             if (!file.isDirectory) {
                 if (file.extension == "ion" || file.extension == "sql") {
-                    val toAppend = file.toURI().relativeTo(resourceDir.toURI())
+                    val toAppend = file.toURI().toPath().relativeTo(resourceDir.toURI().toPath())
                     pathFile.appendText("$toAppend\n")
                 }
             }
@@ -81,6 +82,12 @@ tasks.register("generateResourcePath") {
 tasks.processTestResources {
     dependsOn("generateResourcePath")
     from("src/testFixtures/resources")
+}
+
+tasks.compileTestFixturesKotlin {
+    kotlinOptions.jvmTarget = Versions.jvmTarget
+    kotlinOptions.apiVersion = Versions.kotlinApi
+    kotlinOptions.languageVersion = Versions.kotlinLanguage
 }
 
 publish {

--- a/partiql-spi/api/partiql-spi.api
+++ b/partiql-spi/api/partiql-spi.api
@@ -16,6 +16,7 @@ public final class org/partiql/errors/ErrorAndErrorContextsKt {
 public final class org/partiql/errors/ErrorBehaviorInPermissiveMode : java/lang/Enum {
 	public static final field RETURN_MISSING Lorg/partiql/errors/ErrorBehaviorInPermissiveMode;
 	public static final field THROW_EXCEPTION Lorg/partiql/errors/ErrorBehaviorInPermissiveMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/errors/ErrorBehaviorInPermissiveMode;
 	public static fun values ()[Lorg/partiql/errors/ErrorBehaviorInPermissiveMode;
 }
@@ -25,6 +26,7 @@ public final class org/partiql/errors/ErrorCategory : java/lang/Enum {
 	public static final field LEXER Lorg/partiql/errors/ErrorCategory;
 	public static final field PARSER Lorg/partiql/errors/ErrorCategory;
 	public static final field SEMANTIC Lorg/partiql/errors/ErrorCategory;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getMessage ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/errors/ErrorCategory;
 	public static fun values ()[Lorg/partiql/errors/ErrorCategory;
@@ -126,6 +128,7 @@ public class org/partiql/errors/ErrorCode : java/lang/Enum {
 	protected fun detailMessagePrefix ()Ljava/lang/String;
 	protected fun detailMessageSuffix (Lorg/partiql/errors/PropertyValueMap;)Ljava/lang/String;
 	public final fun getCategory ()Lorg/partiql/errors/ErrorCategory;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getErrorBehaviorInPermissiveMode ()Lorg/partiql/errors/ErrorBehaviorInPermissiveMode;
 	public fun getErrorMessage (Lorg/partiql/errors/PropertyValueMap;)Ljava/lang/String;
 	public final fun getProperties ()Ljava/util/Set;
@@ -182,6 +185,7 @@ public final class org/partiql/errors/ProblemLocation {
 public final class org/partiql/errors/ProblemSeverity : java/lang/Enum {
 	public static final field ERROR Lorg/partiql/errors/ProblemSeverity;
 	public static final field WARNING Lorg/partiql/errors/ProblemSeverity;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/errors/ProblemSeverity;
 	public static fun values ()[Lorg/partiql/errors/ProblemSeverity;
 }
@@ -217,6 +221,7 @@ public final class org/partiql/errors/Property : java/lang/Enum {
 	public static final field TOKEN_DESCRIPTION Lorg/partiql/errors/Property;
 	public static final field TOKEN_STRING Lorg/partiql/errors/Property;
 	public static final field TOKEN_VALUE Lorg/partiql/errors/Property;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getPropertyName ()Ljava/lang/String;
 	public final fun getPropertyType ()Lorg/partiql/errors/PropertyType;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/errors/Property;
@@ -229,6 +234,7 @@ public final class org/partiql/errors/PropertyType : java/lang/Enum {
 	public static final field LONG_CLASS Lorg/partiql/errors/PropertyType;
 	public static final field STRING_CLASS Lorg/partiql/errors/PropertyType;
 	public static final field TOKEN_CLASS Lorg/partiql/errors/PropertyType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getType ()Ljava/lang/Class;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/errors/PropertyType;
 	public static fun values ()[Lorg/partiql/errors/PropertyType;
@@ -1084,6 +1090,7 @@ public final class org/partiql/value/PartiQLValueType : java/lang/Enum {
 	public static final field SYMBOL Lorg/partiql/value/PartiQLValueType;
 	public static final field TIME Lorg/partiql/value/PartiQLValueType;
 	public static final field TIMESTAMP Lorg/partiql/value/PartiQLValueType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun toPType ()Lorg/partiql/types/PType;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/value/PartiQLValueType;
 	public static fun values ()[Lorg/partiql/value/PartiQLValueType;
@@ -1455,6 +1462,7 @@ public final class org/partiql/value/io/PartiQLValueIonReaderBuilder$Companion {
 public final class org/partiql/value/io/PartiQLValueIonReaderBuilder$SourceDataFormat : java/lang/Enum {
 	public static final field IonForPartiQL Lorg/partiql/value/io/PartiQLValueIonReaderBuilder$SourceDataFormat;
 	public static final field IonGeneric Lorg/partiql/value/io/PartiQLValueIonReaderBuilder$SourceDataFormat;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/value/io/PartiQLValueIonReaderBuilder$SourceDataFormat;
 	public static fun values ()[Lorg/partiql/value/io/PartiQLValueIonReaderBuilder$SourceDataFormat;
 }

--- a/partiql-types/api/partiql-types.api
+++ b/partiql-types/api/partiql-types.api
@@ -230,6 +230,7 @@ public final class org/partiql/types/IntType$IntRangeConstraint : java/lang/Enum
 	public static final field LONG Lorg/partiql/types/IntType$IntRangeConstraint;
 	public static final field SHORT Lorg/partiql/types/IntType$IntRangeConstraint;
 	public static final field UNCONSTRAINED Lorg/partiql/types/IntType$IntRangeConstraint;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public final fun getNumBytes ()I
 	public final fun getValidRange ()Lkotlin/ranges/LongRange;
 	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/types/IntType$IntRangeConstraint;


### PR DESCRIPTION
## Relevant Issues
- None. Kotlin 1.8+ will be helpful for the other task I'm working on to add simpler AST classes, specifically support for the `@Builder` Lombok annotation.

## Description
Upgrades v1 branch of PLK to Kotlin 1.9. Not sure yet which version of Kotlin we want to support for v1 since there are [Kotlin releases](https://kotlinlang.org/docs/releases.html#release-details) after 1.9.

Summary of changes required to get existing code working
- Upgrade related dependencies (Kotlinx coroutines, Dokka) to later version
- Upgrade PIG dependency to 0.6.3 -- 0.6.2 does not work in Kotlin 1.7 and later since `?.` operator on non-null types gives an error
- `partiql-planner` relied on Dokka's `relativeTo` -- changed to use Kotlin standard's `relativeTo`
- Re-run of `apiDump` since Kotlin 1.9 added additional functions to `enum class`es
- Make the `testFixtures` Java + Kotlin target explicit rather than implicit

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - No, v1 branch.

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**
  - No new dependencies but upgrades a few existing dependencies.
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.