### PR TITLE
Prepares 1.0.0-rc.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Thank you to all who have contributed!
 -->
 
+## [1.0.0-rc.1]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
+### Contributors
+Thank you to all who have contributed!
+
 ## [0.14.8]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID      | Artifact ID           | Recommended Version |
 |---------------|-----------------------|---------------------|
-| `org.partiql` | `partiql-lang-kotlin` | `0.14.8`            |
+| `org.partiql` | `partiql-lang-kotlin` | `1.0.0-rc.1`        |
 
 
 For Maven builds, add the following to your `pom.xml`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=1.0.0-SNAPSHOT
+version=1.0.0-rc.1
 
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY

--- a/partiql-parser/build.gradle.kts
+++ b/partiql-parser/build.gradle.kts
@@ -76,6 +76,7 @@ tasks.compileTestKotlin {
 tasks.withType<Jar>().configureEach {
     // ensure "generateGrammarSource" is called before "sourcesJar".
     dependsOn(tasks.withType<AntlrTask>())
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
@@ -97,7 +98,7 @@ tasks.processResources {
 publish {
     artifactId = "partiql-parser"
     name = "PartiQL Parser"
-    description = "PartiQL's experimental Parser"
+    description = "PartiQL's Parser"
     // `antlr` dependency configuration adds the ANTLR API configuration (and Maven `compile` dependency scope on
     // publish). It's a known issue w/ the ANTLR gradle plugin. Follow https://github.com/gradle/gradle/issues/820
     // for context. In the maven publishing step, any API or IMPLEMENTATION dependencies w/ "antlr4" non-runtime

--- a/partiql-spi/build.gradle.kts
+++ b/partiql-spi/build.gradle.kts
@@ -41,6 +41,7 @@ components.withType(AdhocComponentWithVariants::class.java).forEach { c ->
 tasks.withType<Javadoc> {
     enabled = false
 }
+
 tasks.withType<Jar> {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/partiql-types/build.gradle.kts
+++ b/partiql-types/build.gradle.kts
@@ -47,7 +47,6 @@ tasks.shadowJar {
     configurations = listOf(project.configurations.shadow.get())
 }
 
-
 // Workaround for https://github.com/johnrengelman/shadow/issues/651
 components.withType(AdhocComponentWithVariants::class.java).forEach { c ->
     c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements.get()) {

--- a/partiql-types/build.gradle.kts
+++ b/partiql-types/build.gradle.kts
@@ -33,9 +33,20 @@ components.withType(AdhocComponentWithVariants::class.java).forEach { c ->
     }
 }
 
+// Need to add this as we have both Java and Kotlin sources. Dokka already handles multi-language projects. If
+// Javadoc is enabled, we end up overwriting index.html (causing compilation errors).
+tasks.withType<Javadoc> {
+    enabled = false
+}
+
+tasks.withType<Jar> {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 tasks.shadowJar {
     configurations = listOf(project.configurations.shadow.get())
 }
+
 
 // Workaround for https://github.com/johnrengelman/shadow/issues/651
 components.withType(AdhocComponentWithVariants::class.java).forEach { c ->


### PR DESCRIPTION
## Description

This PR prepares the 1.0.0-rc.1 release which targets the v1-rc1 branch. Two things need to be done before this is merged.

- [ ] CHANGELOG Notes
- [x] Merge #1605 to v1-rc1

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.