### PR TITLE
[v1] Fix conformance report comment finding

### DIFF
--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -161,7 +161,7 @@ jobs:
           L="$COMMENT_SIZE_LIMIT"
           ARGS="-t $T -bf $BF -bl $BL -bt $BT -tf $TF -tl $TL -tt $TT -o $O -l $L"
           gradle :test:partiql-tests-runner:run --args="$ARGS"
-      # Find comment w/ conformance comparison if previous comment published
+      # Find comment w/ conformance comparison if previous comment  published
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         continue-on-error: true

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -161,7 +161,7 @@ jobs:
           L="$COMMENT_SIZE_LIMIT"
           ARGS="-t $T -bf $BF -bl $BL -bt $BT -tf $TF -tl $TL -tt $TT -o $O -l $L"
           gradle :test:partiql-tests-runner:run --args="$ARGS"
-      # Find comment w/ conformance comparison if previous comment  published
+      # Find comment w/ conformance comparison if previous comment published
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         continue-on-error: true

--- a/.github/workflows/conformance-report.yml
+++ b/.github/workflows/conformance-report.yml
@@ -169,7 +169,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: Conformance
+          body-includes: CROSS-ENGINE-REPORT
       # Create or update (if previous comment exists) with markdown version of comparison report
       - name: Create or update comment
         continue-on-error: true


### PR DESCRIPTION
## Relevant Issues
- Noticed this issue in https://github.com/partiql/partiql-lang-kotlin/pull/1579#issuecomment-2397848467 and https://github.com/partiql/partiql-lang-kotlin/pull/1616

## Description
- Since the update to the conformance comparison report, the GH Actions step to find the previous command was searching for the wrong string. This led to a GH Actions comment for every commit.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - No, v1 branch + no public API or behavioral change

- Any backward-incompatible changes? **[NO]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.