### PR TITLE
[v1] Migrate parser to new AST

### DIFF
--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -5593,7 +5593,7 @@ public final class org/partiql/ast/v1/Ast {
 	public static final fun exprWindowOver (Ljava/util/List;Ljava/util/List;)Lorg/partiql/ast/v1/expr/ExprWindow$Over;
 	public static final fun from (Ljava/util/List;)Lorg/partiql/ast/v1/From;
 	public static final fun fromExpr (Lorg/partiql/ast/v1/expr/Expr;Lorg/partiql/ast/v1/FromType;Lorg/partiql/ast/v1/Identifier;Lorg/partiql/ast/v1/Identifier;)Lorg/partiql/ast/v1/FromExpr;
-	public static final fun fromJoin (Lorg/partiql/ast/v1/From;Lorg/partiql/ast/v1/From;Lorg/partiql/ast/v1/JoinType;Lorg/partiql/ast/v1/expr/Expr;)Lorg/partiql/ast/v1/FromJoin;
+	public static final fun fromJoin (Lorg/partiql/ast/v1/FromTableRef;Lorg/partiql/ast/v1/FromTableRef;Lorg/partiql/ast/v1/JoinType;Lorg/partiql/ast/v1/expr/Expr;)Lorg/partiql/ast/v1/FromJoin;
 	public static final fun graphLabelConj (Lorg/partiql/ast/v1/graph/GraphLabel;Lorg/partiql/ast/v1/graph/GraphLabel;)Lorg/partiql/ast/v1/graph/GraphLabel$Conj;
 	public static final fun graphLabelDisj (Lorg/partiql/ast/v1/graph/GraphLabel;Lorg/partiql/ast/v1/graph/GraphLabel;)Lorg/partiql/ast/v1/graph/GraphLabel$Disj;
 	public static final fun graphLabelName (Ljava/lang/String;)Lorg/partiql/ast/v1/graph/GraphLabel$Name;
@@ -5743,7 +5743,11 @@ public abstract interface class org/partiql/ast/v1/AstVisitor {
 	public abstract fun visitTableRef (Lorg/partiql/ast/v1/FromTableRef;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
+<<<<<<< Updated upstream
 public class org/partiql/ast/v1/DataType : org/partiql/ast/v1/AstEnum {
+=======
+public class org/partiql/ast/v1/DataType : org/partiql/ast/v1/AstNode, org/partiql/ast/v1/Enum {
+>>>>>>> Stashed changes
 	public static final field BAG I
 	public static final field BIGINT I
 	public static final field BINARY_LARGE_OBJECT I
@@ -6062,9 +6066,9 @@ public class org/partiql/ast/v1/FromExpr$Builder {
 public class org/partiql/ast/v1/FromJoin : org/partiql/ast/v1/FromTableRef {
 	public final field condition Lorg/partiql/ast/v1/expr/Expr;
 	public final field joinType Lorg/partiql/ast/v1/JoinType;
-	public final field lhs Lorg/partiql/ast/v1/From;
-	public final field rhs Lorg/partiql/ast/v1/From;
-	public fun <init> (Lorg/partiql/ast/v1/From;Lorg/partiql/ast/v1/From;Lorg/partiql/ast/v1/JoinType;Lorg/partiql/ast/v1/expr/Expr;)V
+	public final field lhs Lorg/partiql/ast/v1/FromTableRef;
+	public final field rhs Lorg/partiql/ast/v1/FromTableRef;
+	public fun <init> (Lorg/partiql/ast/v1/FromTableRef;Lorg/partiql/ast/v1/FromTableRef;Lorg/partiql/ast/v1/JoinType;Lorg/partiql/ast/v1/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/v1/FromJoin$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
@@ -6077,8 +6081,8 @@ public class org/partiql/ast/v1/FromJoin$Builder {
 	public fun build ()Lorg/partiql/ast/v1/FromJoin;
 	public fun condition (Lorg/partiql/ast/v1/expr/Expr;)Lorg/partiql/ast/v1/FromJoin$Builder;
 	public fun joinType (Lorg/partiql/ast/v1/JoinType;)Lorg/partiql/ast/v1/FromJoin$Builder;
-	public fun lhs (Lorg/partiql/ast/v1/From;)Lorg/partiql/ast/v1/FromJoin$Builder;
-	public fun rhs (Lorg/partiql/ast/v1/From;)Lorg/partiql/ast/v1/FromJoin$Builder;
+	public fun lhs (Lorg/partiql/ast/v1/FromTableRef;)Lorg/partiql/ast/v1/FromJoin$Builder;
+	public fun rhs (Lorg/partiql/ast/v1/FromTableRef;)Lorg/partiql/ast/v1/FromJoin$Builder;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -6204,6 +6208,7 @@ public class org/partiql/ast/v1/JoinType : org/partiql/ast/v1/AstEnum {
 	public static final field FULL_OUTER I
 	public static final field INNER I
 	public static final field LEFT I
+	public static final field LEFT_CROSS I
 	public static final field LEFT_OUTER I
 	public static final field RIGHT I
 	public static final field RIGHT_OUTER I
@@ -6213,6 +6218,7 @@ public class org/partiql/ast/v1/JoinType : org/partiql/ast/v1/AstEnum {
 	public static fun FULL_OUTER ()Lorg/partiql/ast/v1/JoinType;
 	public static fun INNER ()Lorg/partiql/ast/v1/JoinType;
 	public static fun LEFT ()Lorg/partiql/ast/v1/JoinType;
+	public static fun LEFT_CROSS ()Lorg/partiql/ast/v1/JoinType;
 	public static fun LEFT_OUTER ()Lorg/partiql/ast/v1/JoinType;
 	public static fun RIGHT ()Lorg/partiql/ast/v1/JoinType;
 	public static fun RIGHT_OUTER ()Lorg/partiql/ast/v1/JoinType;

--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -5743,11 +5743,7 @@ public abstract interface class org/partiql/ast/v1/AstVisitor {
 	public abstract fun visitTableRef (Lorg/partiql/ast/v1/FromTableRef;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
-<<<<<<< Updated upstream
 public class org/partiql/ast/v1/DataType : org/partiql/ast/v1/AstEnum {
-=======
-public class org/partiql/ast/v1/DataType : org/partiql/ast/v1/AstNode, org/partiql/ast/v1/Enum {
->>>>>>> Stashed changes
 	public static final field BAG I
 	public static final field BIGINT I
 	public static final field BINARY_LARGE_OBJECT I

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/Ast.kt
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/Ast.kt
@@ -402,7 +402,7 @@ public object Ast {
     }
 
     @JvmStatic
-    public fun fromJoin(lhs: From, rhs: From, joinType: JoinType?, condition: Expr?): FromJoin {
+    public fun fromJoin(lhs: FromTableRef, rhs: FromTableRef, joinType: JoinType?, condition: Expr?): FromJoin {
         return FromJoin(lhs, rhs, joinType, condition)
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/FromJoin.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/FromJoin.java
@@ -17,10 +17,10 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = false)
 public class FromJoin extends FromTableRef {
     @NotNull
-    public final From lhs;
+    public final FromTableRef lhs;
 
     @NotNull
-    public final From rhs;
+    public final FromTableRef rhs;
 
     @Nullable
     public final JoinType joinType;
@@ -28,7 +28,7 @@ public class FromJoin extends FromTableRef {
     @Nullable
     public final Expr condition;
 
-    public FromJoin(@NotNull From lhs, @NotNull From rhs, @Nullable JoinType joinType, @Nullable Expr condition) {
+    public FromJoin(@NotNull FromTableRef lhs, @NotNull FromTableRef rhs, @Nullable JoinType joinType, @Nullable Expr condition) {
         this.lhs = lhs;
         this.rhs = rhs;
         this.joinType = joinType;

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/JoinType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/JoinType.java
@@ -20,6 +20,7 @@ public class JoinType extends AstEnum {
     public static final int FULL = 6;
     public static final int FULL_OUTER = 7;
     public static final int CROSS = 8;
+    public static final int LEFT_CROSS = 9;
 
     public static JoinType UNKNOWN() {
         return new JoinType(UNKNOWN);
@@ -57,6 +58,10 @@ public class JoinType extends AstEnum {
         return new JoinType(CROSS);
     }
 
+    public static JoinType LEFT_CROSS() {
+        return new JoinType(LEFT_CROSS);
+    }
+
     private final int code;
 
     private JoinType(int code) {
@@ -80,6 +85,7 @@ public class JoinType extends AstEnum {
             case FULL: return "FULL";
             case FULL_OUTER: return "FULL_OUTER";
             case CROSS: return "CROSS";
+            case LEFT_CROSS: return "LEFT_CROSS";
             default: return "UNKNOWN";
         }
     }
@@ -93,7 +99,8 @@ public class JoinType extends AstEnum {
         RIGHT_OUTER,
         FULL,
         FULL_OUTER,
-        CROSS
+        CROSS,
+        LEFT_CROSS
     };
 
     @NotNull
@@ -107,6 +114,7 @@ public class JoinType extends AstEnum {
             case "FULL": return FULL();
             case "FULL_OUTER": return FULL_OUTER();
             case "CROSS": return CROSS();
+            case "LEFT_CROSS": return LEFT_CROSS();
             default: return UNKNOWN();
         }
     }

--- a/partiql-eval/src/main/java/org/partiql/eval/compiler/PartiQLCompiler.java
+++ b/partiql-eval/src/main/java/org/partiql/eval/compiler/PartiQLCompiler.java
@@ -2,8 +2,8 @@ package org.partiql.eval.compiler;
 
 import org.jetbrains.annotations.NotNull;
 import org.partiql.eval.Mode;
-import org.partiql.eval.internal.compiler.StandardCompiler;
 import org.partiql.eval.Statement;
+import org.partiql.eval.internal.compiler.StandardCompiler;
 import org.partiql.plan.Plan;
 import org.partiql.spi.Context;
 

--- a/partiql-parser/api/partiql-parser.api
+++ b/partiql-parser/api/partiql-parser.api
@@ -108,6 +108,7 @@ public abstract interface class org/partiql/parser/V1PartiQLParser {
 	public static final field Companion Lorg/partiql/parser/V1PartiQLParser$Companion;
 	public static fun builder ()Lorg/partiql/parser/V1PartiQLParserBuilder;
 	public abstract fun parse (Ljava/lang/String;)Lorg/partiql/parser/V1PartiQLParser$Result;
+	public abstract fun parse (Ljava/lang/String;Lorg/partiql/spi/Context;)Lorg/partiql/parser/V1PartiQLParser$Result;
 	public static fun standard ()Lorg/partiql/parser/V1PartiQLParser;
 }
 
@@ -116,7 +117,12 @@ public final class org/partiql/parser/V1PartiQLParser$Companion {
 	public final fun standard ()Lorg/partiql/parser/V1PartiQLParser;
 }
 
+public final class org/partiql/parser/V1PartiQLParser$DefaultImpls {
+	public static fun parse (Lorg/partiql/parser/V1PartiQLParser;Ljava/lang/String;)Lorg/partiql/parser/V1PartiQLParser$Result;
+}
+
 public final class org/partiql/parser/V1PartiQLParser$Result {
+	public static final field Companion Lorg/partiql/parser/V1PartiQLParser$Result$Companion;
 	public fun <init> (Ljava/lang/String;Lorg/partiql/ast/v1/Statement;Lorg/partiql/parser/SourceLocations;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lorg/partiql/ast/v1/Statement;
@@ -129,6 +135,9 @@ public final class org/partiql/parser/V1PartiQLParser$Result {
 	public final fun getSource ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/parser/V1PartiQLParser$Result$Companion {
 }
 
 public final class org/partiql/parser/V1PartiQLParserBuilder {

--- a/partiql-parser/api/partiql-parser.api
+++ b/partiql-parser/api/partiql-parser.api
@@ -104,3 +104,35 @@ public final class org/partiql/parser/SourceLocations : java/util/Map, kotlin/jv
 	public final fun values ()Ljava/util/Collection;
 }
 
+public abstract interface class org/partiql/parser/V1PartiQLParser {
+	public static final field Companion Lorg/partiql/parser/V1PartiQLParser$Companion;
+	public static fun builder ()Lorg/partiql/parser/V1PartiQLParserBuilder;
+	public abstract fun parse (Ljava/lang/String;)Lorg/partiql/parser/V1PartiQLParser$Result;
+	public static fun standard ()Lorg/partiql/parser/V1PartiQLParser;
+}
+
+public final class org/partiql/parser/V1PartiQLParser$Companion {
+	public final fun builder ()Lorg/partiql/parser/V1PartiQLParserBuilder;
+	public final fun standard ()Lorg/partiql/parser/V1PartiQLParser;
+}
+
+public final class org/partiql/parser/V1PartiQLParser$Result {
+	public fun <init> (Ljava/lang/String;Lorg/partiql/ast/v1/Statement;Lorg/partiql/parser/SourceLocations;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lorg/partiql/ast/v1/Statement;
+	public final fun component3 ()Lorg/partiql/parser/SourceLocations;
+	public final fun copy (Ljava/lang/String;Lorg/partiql/ast/v1/Statement;Lorg/partiql/parser/SourceLocations;)Lorg/partiql/parser/V1PartiQLParser$Result;
+	public static synthetic fun copy$default (Lorg/partiql/parser/V1PartiQLParser$Result;Ljava/lang/String;Lorg/partiql/ast/v1/Statement;Lorg/partiql/parser/SourceLocations;ILjava/lang/Object;)Lorg/partiql/parser/V1PartiQLParser$Result;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocations ()Lorg/partiql/parser/SourceLocations;
+	public final fun getRoot ()Lorg/partiql/ast/v1/Statement;
+	public final fun getSource ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/partiql/parser/V1PartiQLParserBuilder {
+	public fun <init> ()V
+	public final fun build ()Lorg/partiql/parser/V1PartiQLParser;
+}
+

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/V1PartiQLParser.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/V1PartiQLParser.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.parser
+
+import org.partiql.ast.v1.Statement
+import org.partiql.parser.internal.V1PartiQLParserDefault
+
+public interface V1PartiQLParser {
+
+    @Throws(PartiQLSyntaxException::class, InterruptedException::class)
+    public fun parse(source: String): Result
+
+    public data class Result(
+        val source: String,
+        val root: Statement,
+        val locations: SourceLocations,
+    )
+
+    public companion object {
+
+        @JvmStatic
+        public fun builder(): V1PartiQLParserBuilder = V1PartiQLParserBuilder()
+
+        @JvmStatic
+        public fun standard(): V1PartiQLParser = V1PartiQLParserDefault()
+    }
+}

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/V1PartiQLParser.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/V1PartiQLParser.kt
@@ -14,19 +14,51 @@
 
 package org.partiql.parser
 
+import org.partiql.ast.v1.Query
 import org.partiql.ast.v1.Statement
+import org.partiql.ast.v1.expr.ExprLit
 import org.partiql.parser.internal.V1PartiQLParserDefault
+import org.partiql.spi.Context
+import org.partiql.spi.errors.PErrorListenerException
+import org.partiql.value.PartiQLValueExperimental
+import org.partiql.value.nullValue
 
 public interface V1PartiQLParser {
 
-    @Throws(PartiQLSyntaxException::class, InterruptedException::class)
-    public fun parse(source: String): Result
+    /**
+     * Parses the [source] into an AST.
+     * @param source the user's input
+     * @param ctx a configuration object for the parser
+     * @throws PErrorListenerException when the [org.partiql.spi.errors.PErrorListener] defined in the [ctx] throws an
+     * [PErrorListenerException], this method halts execution and propagates the exception.
+     */
+    @Throws(PErrorListenerException::class)
+    public fun parse(source: String, ctx: Context): Result
+
+    /**
+     * Parses the [source] into an AST.
+     * @param source the user's input
+     * @throws PErrorListenerException when the [org.partiql.spi.errors.PErrorListener] defined in the context throws an
+     * [PErrorListenerException], this method halts execution and propagates the exception.
+     */
+    @Throws(PErrorListenerException::class)
+    public fun parse(source: String): Result {
+        return parse(source, Context.standard())
+    }
 
     public data class Result(
         val source: String,
         val root: Statement,
         val locations: SourceLocations,
-    )
+    ) {
+        public companion object {
+            @OptIn(PartiQLValueExperimental::class)
+            internal fun empty(source: String): Result {
+                val locations = SourceLocations.Mutable().toMap()
+                return Result(source, Query(ExprLit(nullValue())), locations)
+            }
+        }
+    }
 
     public companion object {
 

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/V1PartiQLParser.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/V1PartiQLParser.kt
@@ -23,6 +23,7 @@ import org.partiql.spi.errors.PErrorListenerException
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.nullValue
 
+// TODO migrate public interfaces and classes to Java https://github.com/partiql/partiql-lang-kotlin/issues/1632
 public interface V1PartiQLParser {
 
     /**

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/V1PartiQLParserBuilder.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/V1PartiQLParserBuilder.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.partiql.parser
+
+import org.partiql.parser.internal.V1PartiQLParserDefault
+
+/**
+ * A builder class to instantiate a [V1PartiQLParser].
+ */
+public class V1PartiQLParserBuilder {
+
+    public fun build(): V1PartiQLParser {
+        return V1PartiQLParserDefault()
+    }
+}

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/V1PartiQLParserBuilder.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/V1PartiQLParserBuilder.kt
@@ -17,7 +17,9 @@ package org.partiql.parser
 import org.partiql.parser.internal.V1PartiQLParserDefault
 
 /**
- * A builder class to instantiate a [V1PartiQLParser].
+ * A builder class to instantiate a [V1PartiQLParser]. https://github.com/partiql/partiql-lang-kotlin/issues/1632
+ *
+ * TODO replace with Lombok builder once [V1PartiQLParser] is migrated to Java.
  */
 public class V1PartiQLParserBuilder {
 

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/V1PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/V1PartiQLParserDefault.kt
@@ -30,162 +30,138 @@ import org.antlr.v4.runtime.TokenStream
 import org.antlr.v4.runtime.atn.PredictionMode
 import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.antlr.v4.runtime.tree.TerminalNode
-import org.partiql.ast.AstNode
-import org.partiql.ast.DatetimeField
-import org.partiql.ast.Exclude
-import org.partiql.ast.Expr
-import org.partiql.ast.From
-import org.partiql.ast.GraphMatch
-import org.partiql.ast.GroupBy
-import org.partiql.ast.Identifier
-import org.partiql.ast.Let
-import org.partiql.ast.Path
-import org.partiql.ast.Select
-import org.partiql.ast.SetOp
-import org.partiql.ast.SetQuantifier
-import org.partiql.ast.Sort
-import org.partiql.ast.Statement
-import org.partiql.ast.TableDefinition
-import org.partiql.ast.Type
-import org.partiql.ast.exclude
-import org.partiql.ast.excludeItem
-import org.partiql.ast.excludeStepCollIndex
-import org.partiql.ast.excludeStepCollWildcard
-import org.partiql.ast.excludeStepStructField
-import org.partiql.ast.excludeStepStructWildcard
-import org.partiql.ast.exprAnd
-import org.partiql.ast.exprBetween
-import org.partiql.ast.exprCall
-import org.partiql.ast.exprCase
-import org.partiql.ast.exprCaseBranch
-import org.partiql.ast.exprCast
-import org.partiql.ast.exprCoalesce
-import org.partiql.ast.exprCollection
-import org.partiql.ast.exprDateAdd
-import org.partiql.ast.exprDateDiff
-import org.partiql.ast.exprExtract
-import org.partiql.ast.exprInCollection
-import org.partiql.ast.exprIsType
-import org.partiql.ast.exprLike
-import org.partiql.ast.exprLit
-import org.partiql.ast.exprMatch
-import org.partiql.ast.exprNot
-import org.partiql.ast.exprNullIf
-import org.partiql.ast.exprOperator
-import org.partiql.ast.exprOr
-import org.partiql.ast.exprOverlay
-import org.partiql.ast.exprParameter
-import org.partiql.ast.exprPath
-import org.partiql.ast.exprPathStepIndex
-import org.partiql.ast.exprPathStepSymbol
-import org.partiql.ast.exprPathStepUnpivot
-import org.partiql.ast.exprPathStepWildcard
-import org.partiql.ast.exprPosition
-import org.partiql.ast.exprQuerySet
-import org.partiql.ast.exprSessionAttribute
-import org.partiql.ast.exprStruct
-import org.partiql.ast.exprStructField
-import org.partiql.ast.exprSubstring
-import org.partiql.ast.exprTrim
-import org.partiql.ast.exprVar
-import org.partiql.ast.exprVariant
-import org.partiql.ast.exprWindow
-import org.partiql.ast.exprWindowOver
-import org.partiql.ast.fromJoin
-import org.partiql.ast.fromValue
-import org.partiql.ast.graphMatch
-import org.partiql.ast.graphMatchLabelConj
-import org.partiql.ast.graphMatchLabelDisj
-import org.partiql.ast.graphMatchLabelName
-import org.partiql.ast.graphMatchLabelNegation
-import org.partiql.ast.graphMatchLabelWildcard
-import org.partiql.ast.graphMatchPattern
-import org.partiql.ast.graphMatchPatternPartEdge
-import org.partiql.ast.graphMatchPatternPartNode
-import org.partiql.ast.graphMatchPatternPartPattern
-import org.partiql.ast.graphMatchQuantifier
-import org.partiql.ast.graphMatchSelectorAllShortest
-import org.partiql.ast.graphMatchSelectorAny
-import org.partiql.ast.graphMatchSelectorAnyK
-import org.partiql.ast.graphMatchSelectorAnyShortest
-import org.partiql.ast.graphMatchSelectorShortestK
-import org.partiql.ast.graphMatchSelectorShortestKGroup
-import org.partiql.ast.groupBy
-import org.partiql.ast.groupByKey
-import org.partiql.ast.identifierQualified
-import org.partiql.ast.identifierSymbol
-import org.partiql.ast.let
-import org.partiql.ast.letBinding
-import org.partiql.ast.orderBy
-import org.partiql.ast.path
-import org.partiql.ast.pathStepIndex
-import org.partiql.ast.pathStepSymbol
-import org.partiql.ast.queryBodySFW
-import org.partiql.ast.queryBodySetOp
-import org.partiql.ast.selectPivot
-import org.partiql.ast.selectProject
-import org.partiql.ast.selectProjectItemAll
-import org.partiql.ast.selectProjectItemExpression
-import org.partiql.ast.selectStar
-import org.partiql.ast.selectValue
-import org.partiql.ast.setOp
-import org.partiql.ast.sort
-import org.partiql.ast.statementDDLCreateIndex
-import org.partiql.ast.statementDDLCreateTable
-import org.partiql.ast.statementDDLDropIndex
-import org.partiql.ast.statementDDLDropTable
-import org.partiql.ast.statementExplain
-import org.partiql.ast.statementExplainTargetDomain
-import org.partiql.ast.statementQuery
-import org.partiql.ast.tableDefinition
-import org.partiql.ast.tableDefinitionColumn
-import org.partiql.ast.tableDefinitionColumnConstraint
-import org.partiql.ast.tableDefinitionColumnConstraintBodyNotNull
-import org.partiql.ast.tableDefinitionColumnConstraintBodyNullable
-import org.partiql.ast.typeAny
-import org.partiql.ast.typeBag
-import org.partiql.ast.typeBlob
-import org.partiql.ast.typeBool
-import org.partiql.ast.typeChar
-import org.partiql.ast.typeClob
-import org.partiql.ast.typeCustom
-import org.partiql.ast.typeDate
-import org.partiql.ast.typeDecimal
-import org.partiql.ast.typeFloat32
-import org.partiql.ast.typeFloat64
-import org.partiql.ast.typeInt2
-import org.partiql.ast.typeInt4
-import org.partiql.ast.typeInt8
-import org.partiql.ast.typeList
-import org.partiql.ast.typeMissing
-import org.partiql.ast.typeNullType
-import org.partiql.ast.typeNumeric
-import org.partiql.ast.typeReal
-import org.partiql.ast.typeSexp
-import org.partiql.ast.typeString
-import org.partiql.ast.typeStruct
-import org.partiql.ast.typeSymbol
-import org.partiql.ast.typeTime
-import org.partiql.ast.typeTimeWithTz
-import org.partiql.ast.typeTimestamp
-import org.partiql.ast.typeTimestampWithTz
-import org.partiql.ast.typeTuple
-import org.partiql.ast.typeVarchar
+import org.partiql.ast.v1.Ast
+import org.partiql.ast.v1.Ast.exclude
+import org.partiql.ast.v1.Ast.excludePath
+import org.partiql.ast.v1.Ast.excludeStepCollIndex
+import org.partiql.ast.v1.Ast.excludeStepCollWildcard
+import org.partiql.ast.v1.Ast.excludeStepStructField
+import org.partiql.ast.v1.Ast.excludeStepStructWildcard
+import org.partiql.ast.v1.Ast.explain
+import org.partiql.ast.v1.Ast.exprAnd
+import org.partiql.ast.v1.Ast.exprArray
+import org.partiql.ast.v1.Ast.exprBag
+import org.partiql.ast.v1.Ast.exprBetween
+import org.partiql.ast.v1.Ast.exprCall
+import org.partiql.ast.v1.Ast.exprCase
+import org.partiql.ast.v1.Ast.exprCaseBranch
+import org.partiql.ast.v1.Ast.exprCast
+import org.partiql.ast.v1.Ast.exprCoalesce
+import org.partiql.ast.v1.Ast.exprExtract
+import org.partiql.ast.v1.Ast.exprInCollection
+import org.partiql.ast.v1.Ast.exprIsType
+import org.partiql.ast.v1.Ast.exprLike
+import org.partiql.ast.v1.Ast.exprLit
+import org.partiql.ast.v1.Ast.exprMatch
+import org.partiql.ast.v1.Ast.exprNot
+import org.partiql.ast.v1.Ast.exprNullIf
+import org.partiql.ast.v1.Ast.exprOperator
+import org.partiql.ast.v1.Ast.exprOr
+import org.partiql.ast.v1.Ast.exprOverlay
+import org.partiql.ast.v1.Ast.exprParameter
+import org.partiql.ast.v1.Ast.exprPath
+import org.partiql.ast.v1.Ast.exprPathStepAllElements
+import org.partiql.ast.v1.Ast.exprPathStepAllFields
+import org.partiql.ast.v1.Ast.exprPathStepElement
+import org.partiql.ast.v1.Ast.exprPathStepField
+import org.partiql.ast.v1.Ast.exprPosition
+import org.partiql.ast.v1.Ast.exprQuerySet
+import org.partiql.ast.v1.Ast.exprSessionAttribute
+import org.partiql.ast.v1.Ast.exprStruct
+import org.partiql.ast.v1.Ast.exprStructField
+import org.partiql.ast.v1.Ast.exprSubstring
+import org.partiql.ast.v1.Ast.exprTrim
+import org.partiql.ast.v1.Ast.exprVarRef
+import org.partiql.ast.v1.Ast.exprVariant
+import org.partiql.ast.v1.Ast.exprWindow
+import org.partiql.ast.v1.Ast.exprWindowOver
+import org.partiql.ast.v1.Ast.from
+import org.partiql.ast.v1.Ast.fromExpr
+import org.partiql.ast.v1.Ast.fromJoin
+import org.partiql.ast.v1.Ast.graphLabelConj
+import org.partiql.ast.v1.Ast.graphLabelDisj
+import org.partiql.ast.v1.Ast.graphLabelName
+import org.partiql.ast.v1.Ast.graphLabelNegation
+import org.partiql.ast.v1.Ast.graphLabelWildcard
+import org.partiql.ast.v1.Ast.graphMatch
+import org.partiql.ast.v1.Ast.graphMatchEdge
+import org.partiql.ast.v1.Ast.graphMatchNode
+import org.partiql.ast.v1.Ast.graphMatchPattern
+import org.partiql.ast.v1.Ast.graphPattern
+import org.partiql.ast.v1.Ast.graphQuantifier
+import org.partiql.ast.v1.Ast.graphSelectorAllShortest
+import org.partiql.ast.v1.Ast.graphSelectorAny
+import org.partiql.ast.v1.Ast.graphSelectorAnyK
+import org.partiql.ast.v1.Ast.graphSelectorAnyShortest
+import org.partiql.ast.v1.Ast.graphSelectorShortestK
+import org.partiql.ast.v1.Ast.graphSelectorShortestKGroup
+import org.partiql.ast.v1.Ast.groupBy
+import org.partiql.ast.v1.Ast.groupByKey
+import org.partiql.ast.v1.Ast.identifier
+import org.partiql.ast.v1.Ast.identifierChain
+import org.partiql.ast.v1.Ast.letBinding
+import org.partiql.ast.v1.Ast.orderBy
+import org.partiql.ast.v1.Ast.query
+import org.partiql.ast.v1.Ast.queryBodySFW
+import org.partiql.ast.v1.Ast.queryBodySetOp
+import org.partiql.ast.v1.Ast.selectItemExpr
+import org.partiql.ast.v1.Ast.selectItemStar
+import org.partiql.ast.v1.Ast.selectList
+import org.partiql.ast.v1.Ast.selectPivot
+import org.partiql.ast.v1.Ast.selectStar
+import org.partiql.ast.v1.Ast.selectValue
+import org.partiql.ast.v1.Ast.setOp
+import org.partiql.ast.v1.Ast.sort
+import org.partiql.ast.v1.AstNode
+import org.partiql.ast.v1.DataType
+import org.partiql.ast.v1.DatetimeField
+import org.partiql.ast.v1.Exclude
+import org.partiql.ast.v1.ExcludeStep
+import org.partiql.ast.v1.From
+import org.partiql.ast.v1.FromTableRef
+import org.partiql.ast.v1.FromType
+import org.partiql.ast.v1.GroupBy
+import org.partiql.ast.v1.GroupByStrategy
+import org.partiql.ast.v1.Identifier
+import org.partiql.ast.v1.IdentifierChain
+import org.partiql.ast.v1.JoinType
+import org.partiql.ast.v1.Let
+import org.partiql.ast.v1.Nulls
+import org.partiql.ast.v1.Order
+import org.partiql.ast.v1.Select
+import org.partiql.ast.v1.SelectItem
+import org.partiql.ast.v1.SetOpType
+import org.partiql.ast.v1.SetQuantifier
+import org.partiql.ast.v1.Sort
+import org.partiql.ast.v1.Statement
+import org.partiql.ast.v1.expr.Expr
+import org.partiql.ast.v1.expr.ExprArray
+import org.partiql.ast.v1.expr.ExprBag
+import org.partiql.ast.v1.expr.ExprCall
+import org.partiql.ast.v1.expr.ExprPath
+import org.partiql.ast.v1.expr.ExprQuerySet
+import org.partiql.ast.v1.expr.PathStep
+import org.partiql.ast.v1.expr.Scope
+import org.partiql.ast.v1.expr.SessionAttribute
+import org.partiql.ast.v1.expr.TrimSpec
+import org.partiql.ast.v1.expr.WindowFunction
+import org.partiql.ast.v1.graph.GraphDirection
+import org.partiql.ast.v1.graph.GraphLabel
+import org.partiql.ast.v1.graph.GraphPart
+import org.partiql.ast.v1.graph.GraphPattern
+import org.partiql.ast.v1.graph.GraphQuantifier
+import org.partiql.ast.v1.graph.GraphRestrictor
+import org.partiql.ast.v1.graph.GraphSelector
 import org.partiql.parser.PartiQLLexerException
-import org.partiql.parser.PartiQLParser
 import org.partiql.parser.PartiQLParserException
+import org.partiql.parser.PartiQLSyntaxException
 import org.partiql.parser.SourceLocation
 import org.partiql.parser.SourceLocations
+import org.partiql.parser.V1PartiQLParser
+import org.partiql.parser.internal.antlr.PartiQLParser
 import org.partiql.parser.internal.antlr.PartiQLParserBaseVisitor
 import org.partiql.parser.internal.util.DateTimeUtils
-import org.partiql.spi.Context
-import org.partiql.spi.errors.PError
-import org.partiql.spi.errors.PErrorKind
-import org.partiql.spi.errors.PErrorListener
-import org.partiql.spi.errors.PErrorListenerException
-import org.partiql.value.NumericValue
 import org.partiql.value.PartiQLValueExperimental
-import org.partiql.value.StringValue
 import org.partiql.value.boolValue
 import org.partiql.value.dateValue
 import org.partiql.value.datetime.DateTimeException
@@ -227,59 +203,55 @@ import org.partiql.parser.internal.antlr.PartiQLTokens as GeneratedLexer
  * The [PredictionMode.LL] mode is capable of parsing all valid inputs for a grammar,
  * but is slower than [PredictionMode.SLL]. Upon seeing a syntax error, this parser throws a [PartiQLParserException].
  */
-internal class PartiQLParserDefault : PartiQLParser {
+internal class V1PartiQLParserDefault : V1PartiQLParser {
 
-    @Throws(PErrorListenerException::class)
-    override fun parse(source: String, ctx: Context): PartiQLParser.Result {
+    @Throws(PartiQLSyntaxException::class, InterruptedException::class)
+    override fun parse(source: String): V1PartiQLParser.Result {
         try {
-            return parse(source, ctx.errorListener)
-        } catch (e: PErrorListenerException) {
-            throw e
+            return V1PartiQLParserDefault.parse(source)
         } catch (throwable: Throwable) {
-            val error = PError.INTERNAL_ERROR(PErrorKind.SYNTAX(), null, throwable)
-            ctx.errorListener.report(error)
-            return PartiQLParser.Result.empty(source)
+            throw PartiQLSyntaxException.wrap(throwable)
         }
     }
 
     companion object {
 
         /**
-         * To reduce latency costs, the [PartiQLParserDefault] attempts to use [PredictionMode.SLL] and falls back to
+         * To reduce latency costs, the [V1PartiQLParserDefault] attempts to use [PredictionMode.SLL] and falls back to
          * [PredictionMode.LL] if a [ParseCancellationException] is thrown by the [BailErrorStrategy].
          */
-        private fun parse(source: String, listener: PErrorListener): PartiQLParser.Result = try {
-            parse(source, PredictionMode.SLL, listener)
+        private fun parse(source: String): V1PartiQLParser.Result = try {
+            parse(source, PredictionMode.SLL)
         } catch (ex: ParseCancellationException) {
-            parse(source, PredictionMode.LL, listener)
+            parse(source, PredictionMode.LL)
         }
 
         /**
          * Parses an input string [source] using the given prediction mode.
          */
-        private fun parse(source: String, mode: PredictionMode, listener: PErrorListener): PartiQLParser.Result {
-            val tokens = createTokenStream(source, listener)
+        private fun parse(source: String, mode: PredictionMode): V1PartiQLParser.Result {
+            val tokens = createTokenStream(source)
             val parser = InterruptibleParser(tokens)
             parser.reset()
             parser.removeErrorListeners()
             parser.interpreter.predictionMode = mode
             when (mode) {
                 PredictionMode.SLL -> parser.errorHandler = BailErrorStrategy()
-                PredictionMode.LL -> parser.addErrorListener(ParseErrorListener(listener))
+                PredictionMode.LL -> parser.addErrorListener(ParseErrorListener())
                 else -> throw IllegalArgumentException("Unsupported parser mode: $mode")
             }
             val tree = parser.root()
             return Visitor.translate(source, tokens, tree)
         }
 
-        private fun createTokenStream(source: String, listener: PErrorListener): CountingTokenStream {
+        private fun createTokenStream(source: String): CountingTokenStream {
             val queryStream = source.byteInputStream(StandardCharsets.UTF_8)
             val inputStream = try {
                 CharStreams.fromStream(queryStream)
             } catch (ex: ClosedByInterruptException) {
                 throw InterruptedException()
             }
-            val handler = TokenizeErrorListener(listener)
+            val handler = TokenizeErrorListener()
             val lexer = GeneratedLexer(inputStream)
             lexer.removeErrorListeners()
             lexer.addErrorListener(handler)
@@ -290,7 +262,7 @@ internal class PartiQLParserDefault : PartiQLParser {
     /**
      * Catches Lexical errors (unidentified tokens) and throws a [PartiQLParserException]
      */
-    private class TokenizeErrorListener(private val listener: PErrorListener) : BaseErrorListener() {
+    private class TokenizeErrorListener : BaseErrorListener() {
         @Throws(PartiQLParserException::class)
         override fun syntaxError(
             recognizer: Recognizer<*, *>?,
@@ -302,9 +274,19 @@ internal class PartiQLParserDefault : PartiQLParser {
         ) {
             if (offendingSymbol is Token) {
                 val token = offendingSymbol.text
-                val location = org.partiql.spi.SourceLocation(line.toLong(), charPositionInLine + 1L, token.length.toLong())
-                val error = PErrors.unrecognizedToken(location, token)
-                listener.report(error)
+                val tokenType = GeneratedParser.VOCABULARY.getSymbolicName(offendingSymbol.type)
+                throw PartiQLLexerException(
+                    token = token,
+                    tokenType = tokenType,
+                    message = msg,
+                    cause = e,
+                    location = SourceLocation(
+                        line = line,
+                        offset = charPositionInLine + 1,
+                        length = token.length,
+                        lengthLegacy = token.length,
+                    ),
+                )
             } else {
                 throw IllegalArgumentException("Offending symbol is not a Token.")
             }
@@ -314,7 +296,7 @@ internal class PartiQLParserDefault : PartiQLParser {
     /**
      * Catches Parser errors (malformed syntax) and throws a [PartiQLParserException]
      */
-    private class ParseErrorListener(private val listener: PErrorListener) : BaseErrorListener() {
+    private class ParseErrorListener : BaseErrorListener() {
 
         private val rules = GeneratedParser.ruleNames.asList()
 
@@ -328,12 +310,22 @@ internal class PartiQLParserDefault : PartiQLParser {
             e: RecognitionException?,
         ) {
             if (offendingSymbol is Token) {
-                val rule = e?.ctx?.toString(rules) ?: "UNKNOWN" // TODO: Do we want to display the offending rule?
+                val rule = e?.ctx?.toString(rules) ?: "UNKNOWN"
                 val token = offendingSymbol.text
                 val tokenType = GeneratedParser.VOCABULARY.getSymbolicName(offendingSymbol.type)
-                val location = org.partiql.spi.SourceLocation(line.toLong(), charPositionInLine + 1L, token.length.toLong())
-                val error = PErrors.unexpectedToken(location, tokenType, null)
-                listener.report(error)
+                throw PartiQLParserException(
+                    rule = rule,
+                    token = token,
+                    tokenType = tokenType,
+                    message = msg,
+                    cause = e,
+                    location = SourceLocation(
+                        line = line,
+                        offset = charPositionInLine + 1,
+                        length = msg.length,
+                        lengthLegacy = offendingSymbol.text.length,
+                    ),
+                )
             } else {
                 throw IllegalArgumentException("Offending symbol is not a Token.")
             }
@@ -393,11 +385,11 @@ internal class PartiQLParserDefault : PartiQLParser {
                 source: String,
                 tokens: CountingTokenStream,
                 tree: GeneratedParser.RootContext,
-            ): PartiQLParser.Result {
+            ): V1PartiQLParser.Result {
                 val locations = SourceLocations.Mutable()
                 val visitor = Visitor(tokens, locations, tokens.parameterIndexes)
                 val root = visitor.visitAs<AstNode>(tree) as Statement
-                return PartiQLParser.Result(
+                return V1PartiQLParser.Result(
                     source = source,
                     root = root,
                     locations = locations.toMap(),
@@ -493,12 +485,13 @@ internal class PartiQLParserDefault : PartiQLParser {
                             }
                         }
                     }
-                    statementExplain(
-                        target = statementExplainTargetDomain(
-                            statement = visit(ctx.statement()) as Statement,
-                            type = type,
-                            format = format,
+                    explain(
+                        // TODO get rid of usage of PartiQLValue https://github.com/partiql/partiql-lang-kotlin/issues/1589
+                        options = mapOf(
+                            "type" to stringValue(type),
+                            "format" to stringValue(format)
                         ),
+                        statement = visit(ctx.statement()) as Statement,
                     )
                 }
             }
@@ -516,102 +509,102 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitByIdent(ctx: GeneratedParser.ByIdentContext) = visitSymbolPrimitive(ctx.symbolPrimitive())
 
-        private fun visitSymbolPrimitive(ctx: GeneratedParser.SymbolPrimitiveContext): Identifier.Symbol =
+        private fun visitSymbolPrimitive(ctx: GeneratedParser.SymbolPrimitiveContext): Identifier =
             when (ctx) {
                 is GeneratedParser.IdentifierQuotedContext -> visitIdentifierQuoted(ctx)
                 is GeneratedParser.IdentifierUnquotedContext -> visitIdentifierUnquoted(ctx)
                 else -> throw error(ctx, "Invalid symbol reference.")
             }
 
-        override fun visitIdentifierQuoted(ctx: GeneratedParser.IdentifierQuotedContext): Identifier.Symbol = translate(ctx) {
-            identifierSymbol(
+        override fun visitIdentifierQuoted(ctx: GeneratedParser.IdentifierQuotedContext): Identifier = translate(ctx) {
+            identifier(
                 ctx.IDENTIFIER_QUOTED().getStringValue(),
-                Identifier.CaseSensitivity.SENSITIVE
+                true
             )
         }
 
-        override fun visitIdentifierUnquoted(ctx: GeneratedParser.IdentifierUnquotedContext): Identifier.Symbol = translate(ctx) {
-            identifierSymbol(
+        override fun visitIdentifierUnquoted(ctx: GeneratedParser.IdentifierUnquotedContext): Identifier = translate(ctx) {
+            identifier(
                 ctx.text,
-                Identifier.CaseSensitivity.INSENSITIVE
+                false
             )
         }
 
         override fun visitQualifiedName(ctx: GeneratedParser.QualifiedNameContext) = translate(ctx) {
             val qualifier = ctx.qualifier.map { visitSymbolPrimitive(it) }
-            val name = visitSymbolPrimitive(ctx.name)
+            val name = identifierChain(visitSymbolPrimitive(ctx.name), null)
             if (qualifier.isEmpty()) {
                 name
             } else {
-                val root = qualifier.first()
-                val steps = qualifier.drop(1) + listOf(name)
-                identifierQualified(root, steps)
+                qualifier.reversed().fold(name) { acc, id ->
+                    identifierChain(root = id, next = acc)
+                }
             }
         }
 
         /**
          *
-         * DATA DEFINITION LANGUAGE (DDL)
+         * DATA DEFINITION LANGUAGE (DDL) -- deleted in v1; will be added before final v1 release
          *
          */
 
-        override fun visitQueryDdl(ctx: GeneratedParser.QueryDdlContext): AstNode = visitDdl(ctx.ddl())
-
-        override fun visitDropTable(ctx: GeneratedParser.DropTableContext) = translate(ctx) {
-            val table = visitQualifiedName(ctx.qualifiedName())
-            statementDDLDropTable(table)
-        }
-
-        override fun visitDropIndex(ctx: GeneratedParser.DropIndexContext) = translate(ctx) {
-            val table = visitSymbolPrimitive(ctx.on)
-            val index = visitSymbolPrimitive(ctx.target)
-            statementDDLDropIndex(index, table)
-        }
-
-        override fun visitCreateTable(ctx: GeneratedParser.CreateTableContext) = translate(ctx) {
-            val table = visitQualifiedName(ctx.qualifiedName())
-            val definition = ctx.tableDef()?.let { visitTableDef(it) }
-            statementDDLCreateTable(table, definition)
-        }
-
-        override fun visitCreateIndex(ctx: GeneratedParser.CreateIndexContext) = translate(ctx) {
-            // TODO add index name to ANTLR grammar
-            val name: Identifier? = null
-            val table = visitSymbolPrimitive(ctx.symbolPrimitive())
-            val fields = ctx.pathSimple().map { path -> visitPathSimple(path) }
-            statementDDLCreateIndex(name, table, fields)
-        }
-
-        override fun visitTableDef(ctx: GeneratedParser.TableDefContext) = translate(ctx) {
-            // Column Definitions are the only thing we currently allow as table definition parts
-            val columns = ctx.tableDefPart().filterIsInstance<GeneratedParser.ColumnDeclarationContext>().map {
-                visitColumnDeclaration(it)
-            }
-            tableDefinition(columns)
-        }
-
-        override fun visitColumnDeclaration(ctx: GeneratedParser.ColumnDeclarationContext) = translate(ctx) {
-            val name = visitSymbolPrimitive(ctx.columnName().symbolPrimitive()).symbol
-            val type = visit(ctx.type()) as Type
-            val constraints = ctx.columnConstraint().map {
-                visitColumnConstraint(it)
-            }
-            tableDefinitionColumn(name, type, constraints)
-        }
-
-        override fun visitColumnConstraint(ctx: GeneratedParser.ColumnConstraintContext) = translate(ctx) {
-            val identifier = ctx.columnConstraintName()?.let { symbolToString(it.symbolPrimitive()) }
-            val body = visit(ctx.columnConstraintDef()) as TableDefinition.Column.Constraint.Body
-            tableDefinitionColumnConstraint(identifier, body)
-        }
-
-        override fun visitColConstrNotNull(ctx: GeneratedParser.ColConstrNotNullContext) = translate(ctx) {
-            tableDefinitionColumnConstraintBodyNotNull()
-        }
-
-        override fun visitColConstrNull(ctx: GeneratedParser.ColConstrNullContext) = translate(ctx) {
-            tableDefinitionColumnConstraintBodyNullable()
-        }
+//        override fun visitQueryDdl(ctx: GeneratedParser.QueryDdlContext): AstNode = visitDdl(ctx.ddl())
+//
+//        override fun visitDropTable(ctx: GeneratedParser.DropTableContext) = translate(ctx) {
+//            val table = visitQualifiedName(ctx.qualifiedName())
+//            statementDDLDropTable(table)
+//        }
+//
+//        override fun visitDropIndex(ctx: GeneratedParser.DropIndexContext) = translate(ctx) {
+//            val table = visitSymbolPrimitive(ctx.on)
+//            val index = visitSymbolPrimitive(ctx.target)
+//            statementDDLDropIndex(index, table)
+//        }
+//
+//        override fun visitCreateTable(ctx: GeneratedParser.CreateTableContext) = translate(ctx) {
+//            val table = visitQualifiedName(ctx.qualifiedName())
+//            val definition = ctx.tableDef()?.let { visitTableDef(it) }
+//            statementDDLCreateTable(table, definition)
+//        }
+//
+//        override fun visitCreateIndex(ctx: GeneratedParser.CreateIndexContext) = translate(ctx) {
+//            // TODO add index name to ANTLR grammar
+//            val name: Identifier? = null
+//            val table = visitSymbolPrimitive(ctx.symbolPrimitive())
+//            val fields = ctx.pathSimple().map { path -> visitPathSimple(path) }
+//            statementDDLCreateIndex(name, table, fields)
+//        }
+//
+//        override fun visitTableDef(ctx: GeneratedParser.TableDefContext) = translate(ctx) {
+//            // Column Definitions are the only thing we currently allow as table definition parts
+//            val columns = ctx.tableDefPart().filterIsInstance<GeneratedParser.ColumnDeclarationContext>().map {
+//                visitColumnDeclaration(it)
+//            }
+//            tableDefinition(columns)
+//        }
+//
+//        override fun visitColumnDeclaration(ctx: GeneratedParser.ColumnDeclarationContext) = translate(ctx) {
+//            val name = visitSymbolPrimitive(ctx.columnName().symbolPrimitive()).symbol
+//            val type = visit(ctx.type()) as Type
+//            val constraints = ctx.columnConstraint().map {
+//                visitColumnConstraint(it)
+//            }
+//            tableDefinitionColumn(name, type, constraints)
+//        }
+//
+//        override fun visitColumnConstraint(ctx: GeneratedParser.ColumnConstraintContext) = translate(ctx) {
+//            val identifier = ctx.columnConstraintName()?.let { symbolToString(it.symbolPrimitive()) }
+//            val body = visit(ctx.columnConstraintDef()) as TableDefinition.Column.Constraint.Body
+//            tableDefinitionColumnConstraint(identifier, body)
+//        }
+//
+//        override fun visitColConstrNotNull(ctx: GeneratedParser.ColConstrNotNullContext) = translate(ctx) {
+//            tableDefinitionColumnConstraintBodyNotNull()
+//        }
+//
+//        override fun visitColConstrNull(ctx: GeneratedParser.ColConstrNullContext) = translate(ctx) {
+//            tableDefinitionColumnConstraintBodyNullable()
+//        }
 
         /**
          *
@@ -732,36 +725,24 @@ internal class PartiQLParserDefault : PartiQLParser {
             throw error(ctx, "DML no longer supported in the default PartiQLParser.")
         }
 
+        // "simple paths" used by previous DDL's CREATE INDEX
         override fun visitPathSimple(ctx: GeneratedParser.PathSimpleContext) = translate(ctx) {
-            val root = visitSymbolPrimitive(ctx.symbolPrimitive())
-            val steps = visitOrEmpty<Path.Step>(ctx.pathSimpleSteps())
-            path(root, steps)
+            throw error(ctx, "DDL no longer supported in the default PartiQLParser.")
         }
 
+        // "simple paths" used by previous DDL's CREATE INDEX
         override fun visitPathSimpleLiteral(ctx: GeneratedParser.PathSimpleLiteralContext) = translate(ctx) {
-            val v = visit(ctx.literal())
-            if (v !is Expr.Lit) {
-                throw error(ctx, "Expected a path element literal")
-            }
-            when (val i = v.value) {
-                is NumericValue<*> -> pathStepIndex(i.toInt32().value!!)
-                is StringValue -> pathStepSymbol(
-                    identifierSymbol(
-                        i.value!!, Identifier.CaseSensitivity.SENSITIVE
-                    )
-                )
-                else -> throw error(ctx, "Expected an integer or string literal, found literal ${i.type}")
-            }
+            throw error(ctx, "DDL no longer supported in the default PartiQLParser.")
         }
 
+        // "simple paths" used by previous DDL's CREATE INDEX
         override fun visitPathSimpleSymbol(ctx: GeneratedParser.PathSimpleSymbolContext) = translate(ctx) {
-            val identifier = visitSymbolPrimitive(ctx.symbolPrimitive())
-            pathStepSymbol(identifier)
+            throw error(ctx, "DDL no longer supported in the default PartiQLParser.")
         }
 
+        // "simple paths" used by previous DDL's CREATE INDEX
         override fun visitPathSimpleDotSymbol(ctx: GeneratedParser.PathSimpleDotSymbolContext) = translate(ctx) {
-            val identifier = visitSymbolPrimitive(ctx.symbolPrimitive())
-            pathStepSymbol(identifier)
+            throw error(ctx, "DDL no longer supported in the default PartiQLParser.")
         }
 
         /**
@@ -783,7 +764,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitDql(ctx: GeneratedParser.DqlContext) = translate(ctx) {
             val expr = visitAs<Expr>(ctx.expr())
-            statementQuery(expr)
+            query(expr)
         }
 
         override fun visitQueryBase(ctx: GeneratedParser.QueryBaseContext): AstNode = visit(ctx.exprSelect())
@@ -821,9 +802,9 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitSelectItems(ctx: GeneratedParser.SelectItemsContext) = translate(ctx) {
-            val items = visitOrEmpty<Select.Project.Item>(ctx.projectionItems().projectionItem())
+            val items = visitOrEmpty<SelectItem>(ctx.projectionItems().projectionItem())
             val setq = convertSetQuantifier(ctx.setQuantifierStrategy())
-            selectProject(items, setq)
+            selectList(items, setq)
         }
 
         override fun visitSelectPivot(ctx: GeneratedParser.SelectPivotContext) = translate(ctx) {
@@ -841,10 +822,10 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitProjectionItem(ctx: GeneratedParser.ProjectionItemContext) = translate(ctx) {
             val expr = visitExpr(ctx.expr())
             val alias = ctx.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
-            if (expr is Expr.Path) {
+            if (expr is ExprPath) {
                 convertPathToProjectionItem(ctx, expr, alias)
             } else {
-                selectProjectItemExpression(expr, alias)
+                selectItemExpr(expr, alias)
             }
         }
 
@@ -879,7 +860,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitLetClause(ctx: GeneratedParser.LetClauseContext) = translate(ctx) {
             val bindings = visitOrEmpty<Let.Binding>(ctx.letBinding())
-            let(bindings)
+            Ast.let(bindings)
         }
 
         override fun visitLetBinding(ctx: GeneratedParser.LetBindingContext) = translate(ctx) {
@@ -903,14 +884,14 @@ internal class PartiQLParserDefault : PartiQLParser {
             val expr = visitAs<Expr>(ctx.expr())
             val dir = when {
                 ctx.dir == null -> null
-                ctx.dir.type == GeneratedParser.ASC -> Sort.Dir.ASC
-                ctx.dir.type == GeneratedParser.DESC -> Sort.Dir.DESC
+                ctx.dir.type == GeneratedParser.ASC -> Order.ASC()
+                ctx.dir.type == GeneratedParser.DESC -> Order.DESC()
                 else -> throw error(ctx.dir, "Invalid ORDER BY direction; expected ASC or DESC")
             }
             val nulls = when {
                 ctx.nulls == null -> null
-                ctx.nulls.type == GeneratedParser.FIRST -> Sort.Nulls.FIRST
-                ctx.nulls.type == GeneratedParser.LAST -> Sort.Nulls.LAST
+                ctx.nulls.type == GeneratedParser.FIRST -> Nulls.FIRST()
+                ctx.nulls.type == GeneratedParser.LAST -> Nulls.LAST()
                 else -> throw error(ctx.nulls, "Invalid ORDER BY null ordering; expected FIRST or LAST")
             }
             sort(expr, dir, nulls)
@@ -923,7 +904,7 @@ internal class PartiQLParserDefault : PartiQLParser {
          */
 
         override fun visitGroupClause(ctx: GeneratedParser.GroupClauseContext) = translate(ctx) {
-            val strategy = if (ctx.PARTIAL() != null) GroupBy.Strategy.PARTIAL else GroupBy.Strategy.FULL
+            val strategy = if (ctx.PARTIAL() != null) GroupByStrategy.PARTIAL() else GroupByStrategy.FULL()
             val keys = visitOrEmpty<GroupBy.Key>(ctx.groupKey())
             val alias = ctx.groupAlias()?.symbolPrimitive()?.let { visitSymbolPrimitive(it) }
             groupBy(strategy, keys, alias)
@@ -947,9 +928,9 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitExcludeExpr(ctx: GeneratedParser.ExcludeExprContext) = translate(ctx) {
             val rootId = visitSymbolPrimitive(ctx.symbolPrimitive())
-            val root = exprVar(rootId, Expr.Var.Scope.DEFAULT)
-            val steps = visitOrEmpty<Exclude.Step>(ctx.excludeExprSteps())
-            excludeItem(root, steps)
+            val root = exprVarRef(identifierChain(rootId, null), Scope.DEFAULT())
+            val steps = visitOrEmpty<ExcludeStep>(ctx.excludeExprSteps())
+            excludePath(root, steps)
         }
 
         override fun visitExcludeExprTupleAttr(ctx: GeneratedParser.ExcludeExprTupleAttrContext) = translate(ctx) {
@@ -966,10 +947,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitExcludeExprCollectionAttr(ctx: GeneratedParser.ExcludeExprCollectionAttrContext) =
             translate(ctx) {
                 val attr = ctx.attr.getStringValue()
-                val identifier = identifierSymbol(
-                    attr,
-                    Identifier.CaseSensitivity.SENSITIVE,
-                )
+                val identifier = identifier(attr, true)
                 excludeStepStructField(identifier)
             }
 
@@ -990,14 +968,14 @@ internal class PartiQLParserDefault : PartiQLParser {
          */
         override fun visitBagOp(ctx: GeneratedParser.BagOpContext) = translate(ctx) {
             val setq = when {
-                ctx.ALL() != null -> SetQuantifier.ALL
-                ctx.DISTINCT() != null -> SetQuantifier.DISTINCT
+                ctx.ALL() != null -> SetQuantifier.ALL()
+                ctx.DISTINCT() != null -> SetQuantifier.DISTINCT()
                 else -> null
             }
             val op = when (ctx.op.type) {
-                GeneratedParser.UNION -> setOp(SetOp.Type.UNION, setq)
-                GeneratedParser.INTERSECT -> setOp(SetOp.Type.INTERSECT, setq)
-                GeneratedParser.EXCEPT -> setOp(SetOp.Type.EXCEPT, setq)
+                GeneratedParser.UNION -> setOp(SetOpType.UNION(), setq)
+                GeneratedParser.INTERSECT -> setOp(SetOpType.INTERSECT(), setq)
+                GeneratedParser.EXCEPT -> setOp(SetOpType.EXCEPT(), setq)
                 else -> error("Unsupported bag op token ${ctx.op}")
             }
             val lhs = visitAs<Expr>(ctx.lhs)
@@ -1007,15 +985,15 @@ internal class PartiQLParserDefault : PartiQLParser {
             val limit = ctx.limit?.let { visitAs<Expr>(it) }
             val offset = ctx.offset?.let { visitAs<Expr>(it) }
             exprQuerySet(
-                body = queryBodySetOp(
-                    type = op,
-                    isOuter = outer,
-                    lhs = lhs,
-                    rhs = rhs
+                queryBodySetOp(
+                    op,
+                    outer,
+                    lhs,
+                    rhs
                 ),
-                orderBy = orderBy,
-                limit = limit,
-                offset = offset,
+                orderBy,
+                limit,
+                offset,
             )
         }
 
@@ -1027,28 +1005,28 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitGpmlPattern(ctx: GeneratedParser.GpmlPatternContext) = translate(ctx) {
             val pattern = visitMatchPattern(ctx.matchPattern())
-            val selector = visitOrNull<GraphMatch.Selector>(ctx.matchSelector())
+            val selector = visitOrNull<GraphSelector>(ctx.matchSelector())
             graphMatch(listOf(pattern), selector)
         }
 
         override fun visitGpmlPatternList(ctx: GeneratedParser.GpmlPatternListContext) = translate(ctx) {
             val patterns = ctx.matchPattern().map { pattern -> visitMatchPattern(pattern) }
-            val selector = visitOrNull<GraphMatch.Selector>(ctx.matchSelector())
+            val selector = visitOrNull<GraphSelector>(ctx.matchSelector())
             graphMatch(patterns, selector)
         }
 
         override fun visitMatchPattern(ctx: GeneratedParser.MatchPatternContext) = translate(ctx) {
-            val parts = visitOrEmpty<GraphMatch.Pattern.Part>(ctx.graphPart())
+            val parts = visitOrEmpty<GraphPart>(ctx.graphPart())
             val restrictor = ctx.restrictor?.let {
                 when (ctx.restrictor.text.lowercase()) {
-                    "trail" -> GraphMatch.Restrictor.TRAIL
-                    "acyclic" -> GraphMatch.Restrictor.ACYCLIC
-                    "simple" -> GraphMatch.Restrictor.SIMPLE
+                    "trail" -> GraphRestrictor.TRAIL()
+                    "acyclic" -> GraphRestrictor.ACYCLIC()
+                    "simple" -> GraphRestrictor.SIMPLE()
                     else -> throw error(ctx.restrictor, "Unrecognized pattern restrictor")
                 }
             }
-            val variable = visitOrNull<Identifier.Symbol>(ctx.variable)?.symbol
-            graphMatchPattern(restrictor, null, variable, null, parts)
+            val variable = visitOrNull<Identifier>(ctx.variable)?.symbol
+            graphPattern(restrictor, null, variable, null, parts)
         }
 
         override fun visitPatternPathVariable(ctx: GeneratedParser.PatternPathVariableContext) =
@@ -1056,161 +1034,175 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitSelectorBasic(ctx: GeneratedParser.SelectorBasicContext) = translate(ctx) {
             when (ctx.mod.type) {
-                GeneratedParser.ANY -> graphMatchSelectorAnyShortest()
-                GeneratedParser.ALL -> graphMatchSelectorAllShortest()
+                GeneratedParser.ANY -> graphSelectorAnyShortest()
+                GeneratedParser.ALL -> graphSelectorAllShortest()
                 else -> throw error(ctx, "Unsupported match selector.")
             }
         }
 
         override fun visitSelectorAny(ctx: GeneratedParser.SelectorAnyContext) = translate(ctx) {
             when (ctx.k) {
-                null -> graphMatchSelectorAny()
-                else -> graphMatchSelectorAnyK(ctx.k.text.toLong())
+                null -> graphSelectorAny()
+                else -> graphSelectorAnyK(ctx.k.text.toLong())
             }
         }
 
         override fun visitSelectorShortest(ctx: GeneratedParser.SelectorShortestContext) = translate(ctx) {
             val k = ctx.k.text.toLong()
             when (ctx.GROUP()) {
-                null -> graphMatchSelectorShortestK(k)
-                else -> graphMatchSelectorShortestKGroup(k)
+                null -> graphSelectorShortestK(k)
+                else -> graphSelectorShortestKGroup(k)
             }
         }
 
         override fun visitLabelSpecOr(ctx: GeneratedParser.LabelSpecOrContext) = translate(ctx) {
-            val lhs = visit(ctx.labelSpec()) as GraphMatch.Label
-            val rhs = visit(ctx.labelTerm()) as GraphMatch.Label
-            graphMatchLabelDisj(lhs, rhs)
+            val lhs = visit(ctx.labelSpec()) as GraphLabel
+            val rhs = visit(ctx.labelTerm()) as GraphLabel
+            graphLabelDisj(lhs, rhs)
         }
 
         override fun visitLabelTermAnd(ctx: GeneratedParser.LabelTermAndContext) = translate(ctx) {
-            val lhs = visit(ctx.labelTerm()) as GraphMatch.Label
-            val rhs = visit(ctx.labelFactor()) as GraphMatch.Label
-            graphMatchLabelConj(lhs, rhs)
+            val lhs = visit(ctx.labelTerm()) as GraphLabel
+            val rhs = visit(ctx.labelFactor()) as GraphLabel
+            graphLabelConj(lhs, rhs)
         }
 
         override fun visitLabelFactorNot(ctx: GeneratedParser.LabelFactorNotContext) = translate(ctx) {
-            val arg = visit(ctx.labelPrimary()) as GraphMatch.Label
-            graphMatchLabelNegation(arg)
+            val arg = visit(ctx.labelPrimary()) as GraphLabel
+            graphLabelNegation(arg)
         }
 
         override fun visitLabelPrimaryName(ctx: GeneratedParser.LabelPrimaryNameContext) = translate(ctx) {
             val x = visitSymbolPrimitive(ctx.symbolPrimitive())
-            graphMatchLabelName(x.symbol)
+            graphLabelName(x.symbol)
         }
 
         override fun visitLabelPrimaryWild(ctx: GeneratedParser.LabelPrimaryWildContext) = translate(ctx) {
-            graphMatchLabelWildcard()
+            graphLabelWildcard()
         }
 
         override fun visitLabelPrimaryParen(ctx: GeneratedParser.LabelPrimaryParenContext) =
-            visit(ctx.labelSpec()) as GraphMatch.Label
+            visit(ctx.labelSpec()) as GraphLabel
 
         override fun visitPattern(ctx: GeneratedParser.PatternContext) = translate(ctx) {
             val restrictor = visitRestrictor(ctx.restrictor)
-            val variable = visitOrNull<Identifier.Symbol>(ctx.variable)?.symbol
+            val variable = visitOrNull<Identifier>(ctx.variable)?.symbol
             val prefilter = ctx.where?.let { visitExpr(it.expr()) }
             val quantifier = ctx.quantifier?.let { visitPatternQuantifier(it) }
-            val parts = visitOrEmpty<GraphMatch.Pattern.Part>(ctx.graphPart())
-            graphMatchPattern(restrictor, prefilter, variable, quantifier, parts)
+            val parts = visitOrEmpty<GraphPart>(ctx.graphPart())
+            graphPattern(restrictor, prefilter, variable, quantifier, parts)
         }
 
         override fun visitEdgeAbbreviated(ctx: GeneratedParser.EdgeAbbreviatedContext) = translate(ctx) {
             val direction = visitEdge(ctx.edgeAbbrev())
-            val quantifier = visitOrNull<GraphMatch.Quantifier>(ctx.quantifier)
-            graphMatchPatternPartEdge(direction, quantifier, null, null, null)
+            val quantifier = visitOrNull<GraphQuantifier>(ctx.quantifier)
+            graphMatchEdge(direction, quantifier, null, null, null)
         }
 
+        private fun GraphPart.Edge.copy(
+            direction: GraphDirection? = null,
+            quantifier: GraphQuantifier? = null,
+            prefilter: Expr? = null,
+            variable: String? = null,
+            label: GraphLabel? = null,
+        ) = graphMatchEdge(
+            direction = direction ?: this.direction,
+            quantifier = quantifier ?: this.quantifier,
+            prefilter = prefilter ?: this.prefilter,
+            variable = variable ?: this.variable,
+            label = label ?: this.label,
+        )
+
         override fun visitEdgeWithSpec(ctx: GeneratedParser.EdgeWithSpecContext) = translate(ctx) {
-            val quantifier = visitOrNull<GraphMatch.Quantifier>(ctx.quantifier)
-            val edge = visitOrNull<GraphMatch.Pattern.Part.Edge>(ctx.edgeWSpec())
+            val quantifier = visitOrNull<GraphQuantifier>(ctx.quantifier)
+            val edge = visitOrNull<GraphPart.Edge>(ctx.edgeWSpec())
             edge!!.copy(quantifier = quantifier)
         }
 
         override fun visitEdgeSpec(ctx: GeneratedParser.EdgeSpecContext) = translate(ctx) {
-            val placeholderDirection = GraphMatch.Direction.RIGHT
-            val variable = visitOrNull<Identifier.Symbol>(ctx.symbolPrimitive())?.symbol
+            val placeholderDirection = GraphDirection.RIGHT()
+            val variable = visitOrNull<Identifier>(ctx.symbolPrimitive())?.symbol
             val prefilter = ctx.whereClause()?.let { visitExpr(it.expr()) }
-            val label = visitOrNull<GraphMatch.Label>(ctx.labelSpec())
-            graphMatchPatternPartEdge(placeholderDirection, null, prefilter, variable, label)
+            val label = visitOrNull<GraphLabel>(ctx.labelSpec())
+            graphMatchEdge(placeholderDirection, null, prefilter, variable, label)
         }
 
         override fun visitEdgeSpecLeft(ctx: GeneratedParser.EdgeSpecLeftContext): AstNode {
             val edge = visitEdgeSpec(ctx.edgeSpec())
-            return edge.copy(direction = GraphMatch.Direction.LEFT)
+            return edge.copy(direction = GraphDirection.LEFT())
         }
 
         override fun visitEdgeSpecRight(ctx: GeneratedParser.EdgeSpecRightContext): AstNode {
             val edge = visitEdgeSpec(ctx.edgeSpec())
-            return edge.copy(direction = GraphMatch.Direction.RIGHT)
+            return edge.copy(direction = GraphDirection.RIGHT())
         }
 
         override fun visitEdgeSpecBidirectional(ctx: GeneratedParser.EdgeSpecBidirectionalContext): AstNode {
             val edge = visitEdgeSpec(ctx.edgeSpec())
-            return edge.copy(direction = GraphMatch.Direction.LEFT_OR_RIGHT)
+            return edge.copy(direction = GraphDirection.LEFT_OR_RIGHT())
         }
 
         override fun visitEdgeSpecUndirectedBidirectional(ctx: GeneratedParser.EdgeSpecUndirectedBidirectionalContext): AstNode {
             val edge = visitEdgeSpec(ctx.edgeSpec())
-            return edge.copy(direction = GraphMatch.Direction.LEFT_UNDIRECTED_OR_RIGHT)
+            return edge.copy(direction = GraphDirection.LEFT_UNDIRECTED_OR_RIGHT())
         }
 
         override fun visitEdgeSpecUndirected(ctx: GeneratedParser.EdgeSpecUndirectedContext): AstNode {
             val edge = visitEdgeSpec(ctx.edgeSpec())
-            return edge.copy(direction = GraphMatch.Direction.UNDIRECTED)
+            return edge.copy(direction = GraphDirection.UNDIRECTED())
         }
 
         override fun visitEdgeSpecUndirectedLeft(ctx: GeneratedParser.EdgeSpecUndirectedLeftContext): AstNode {
             val edge = visitEdgeSpec(ctx.edgeSpec())
-            return edge.copy(direction = GraphMatch.Direction.LEFT_OR_UNDIRECTED)
+            return edge.copy(direction = GraphDirection.LEFT_OR_UNDIRECTED())
         }
 
         override fun visitEdgeSpecUndirectedRight(ctx: GeneratedParser.EdgeSpecUndirectedRightContext): AstNode {
             val edge = visitEdgeSpec(ctx.edgeSpec())
-            return edge.copy(direction = GraphMatch.Direction.UNDIRECTED_OR_RIGHT)
+            return edge.copy(direction = GraphDirection.UNDIRECTED_OR_RIGHT())
         }
 
-        private fun visitEdge(ctx: GeneratedParser.EdgeAbbrevContext): GraphMatch.Direction = when {
-            ctx.TILDE() != null && ctx.ANGLE_RIGHT() != null -> GraphMatch.Direction.UNDIRECTED_OR_RIGHT
-            ctx.TILDE() != null && ctx.ANGLE_LEFT() != null -> GraphMatch.Direction.LEFT_OR_UNDIRECTED
-            ctx.TILDE() != null -> GraphMatch.Direction.UNDIRECTED
-            ctx.MINUS() != null && ctx.ANGLE_LEFT() != null && ctx.ANGLE_RIGHT() != null -> GraphMatch.Direction.LEFT_OR_RIGHT
-            ctx.MINUS() != null && ctx.ANGLE_LEFT() != null -> GraphMatch.Direction.LEFT
-            ctx.MINUS() != null && ctx.ANGLE_RIGHT() != null -> GraphMatch.Direction.RIGHT
-            ctx.MINUS() != null -> GraphMatch.Direction.LEFT_UNDIRECTED_OR_RIGHT
+        private fun visitEdge(ctx: GeneratedParser.EdgeAbbrevContext): GraphDirection = when {
+            ctx.TILDE() != null && ctx.ANGLE_RIGHT() != null -> GraphDirection.UNDIRECTED_OR_RIGHT()
+            ctx.TILDE() != null && ctx.ANGLE_LEFT() != null -> GraphDirection.LEFT_OR_UNDIRECTED()
+            ctx.TILDE() != null -> GraphDirection.UNDIRECTED()
+            ctx.MINUS() != null && ctx.ANGLE_LEFT() != null && ctx.ANGLE_RIGHT() != null -> GraphDirection.LEFT_OR_RIGHT()
+            ctx.MINUS() != null && ctx.ANGLE_LEFT() != null -> GraphDirection.LEFT()
+            ctx.MINUS() != null && ctx.ANGLE_RIGHT() != null -> GraphDirection.RIGHT()
+            ctx.MINUS() != null -> GraphDirection.LEFT_UNDIRECTED_OR_RIGHT()
             else -> throw error(ctx, "Unsupported edge type")
         }
 
-        override fun visitGraphPart(ctx: GeneratedParser.GraphPartContext): GraphMatch.Pattern.Part {
+        override fun visitGraphPart(ctx: GeneratedParser.GraphPartContext): GraphPart {
             val part = super.visitGraphPart(ctx)
-            if (part is GraphMatch.Pattern) {
-                return translate(ctx) { graphMatchPatternPartPattern(part) }
+            if (part is GraphPattern) {
+                return translate(ctx) { graphMatchPattern(part) }
             }
-            return part as GraphMatch.Pattern.Part
+            return part as GraphPart
         }
 
         override fun visitPatternQuantifier(ctx: GeneratedParser.PatternQuantifierContext) = translate(ctx) {
             when {
-                ctx.quant == null -> graphMatchQuantifier(ctx.lower.text.toLong(), ctx.upper?.text?.toLong())
-                ctx.quant.type == GeneratedParser.PLUS -> graphMatchQuantifier(1L, null)
-                ctx.quant.type == GeneratedParser.ASTERISK -> graphMatchQuantifier(0L, null)
+                ctx.quant == null -> graphQuantifier(ctx.lower.text.toLong(), ctx.upper?.text?.toLong())
+                ctx.quant.type == GeneratedParser.PLUS -> graphQuantifier(1L, null)
+                ctx.quant.type == GeneratedParser.ASTERISK -> graphQuantifier(0L, null)
                 else -> throw error(ctx, "Unsupported quantifier")
             }
         }
 
         override fun visitNode(ctx: GeneratedParser.NodeContext) = translate(ctx) {
-            val variable = visitOrNull<Identifier.Symbol>(ctx.symbolPrimitive())?.symbol
+            val variable = visitOrNull<Identifier>(ctx.symbolPrimitive())?.symbol
             val prefilter = ctx.whereClause()?.let { visitExpr(it.expr()) }
-            val label = visitOrNull<GraphMatch.Label>(ctx.labelSpec())
-            graphMatchPatternPartNode(prefilter, variable, label)
+            val label = visitOrNull<GraphLabel>(ctx.labelSpec())
+            graphMatchNode(prefilter, variable, label)
         }
 
-        private fun visitRestrictor(ctx: GeneratedParser.PatternRestrictorContext?): GraphMatch.Restrictor? {
+        private fun visitRestrictor(ctx: GeneratedParser.PatternRestrictorContext?): GraphRestrictor? {
             if (ctx == null) return null
             return when (ctx.restrictor.text.lowercase()) {
-                "trail" -> GraphMatch.Restrictor.TRAIL
-                "acyclic" -> GraphMatch.Restrictor.ACYCLIC
-                "simple" -> GraphMatch.Restrictor.SIMPLE
+                "trail" -> GraphRestrictor.TRAIL()
+                "acyclic" -> GraphRestrictor.ACYCLIC()
+                "simple" -> GraphRestrictor.SIMPLE()
                 else -> throw error(ctx, "Unrecognized pattern restrictor")
             }
         }
@@ -1220,28 +1212,88 @@ internal class PartiQLParserDefault : PartiQLParser {
          * TABLE REFERENCES & JOINS & FROM CLAUSE
          *
          */
+        override fun visitFromClause(ctx: GeneratedParser.FromClauseContext): From = translate(ctx) {
+            val tableRefs = visitOrEmpty<FromTableRef>(ctx.tableReference())
+            from(tableRefs)
+        }
 
-        override fun visitFromClause(ctx: GeneratedParser.FromClauseContext) = translate(ctx) {
-            val tableRefs = visitOrEmpty<From>(ctx.tableReference())
-            tableRefs.drop(1).fold(tableRefs.first()) { acc, tableRef ->
-                fromJoin(acc, tableRef, From.Join.Type.CROSS, null)
+        override fun visitTableBaseRefSymbol(ctx: PartiQLParser.TableBaseRefSymbolContext): FromTableRef = translate(ctx) {
+            val expr = visitAs<Expr>(ctx.source)
+            val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive())
+            fromExpr(expr, FromType.SCAN(), asAlias, null)
+        }
+
+        override fun visitTableBaseRefClauses(ctx: PartiQLParser.TableBaseRefClausesContext): FromTableRef = translate(ctx) {
+            val expr = visitAs<Expr>(ctx.source)
+            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            fromExpr(expr, FromType.SCAN(), asAlias, atAlias)
+        }
+
+        override fun visitTableBaseRefMatch(ctx: PartiQLParser.TableBaseRefMatchContext): FromTableRef = translate(ctx) {
+            val expr = visitAs<Expr>(ctx.source)
+            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            fromExpr(expr, FromType.SCAN(), asAlias, atAlias)
+        }
+
+        override fun visitTableUnpivot(ctx: PartiQLParser.TableUnpivotContext): FromTableRef = translate(ctx) {
+            val expr = visitAs<Expr>(ctx.expr())
+            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
+            fromExpr(expr, FromType.UNPIVOT(), asAlias, atAlias)
+        }
+
+        override fun visitTableWrapped(ctx: PartiQLParser.TableWrappedContext): FromTableRef = translate(ctx) {
+            visitAs<FromTableRef>(ctx.tableReference())
+        }
+
+        override fun visitTableLeftCrossJoin(ctx: PartiQLParser.TableLeftCrossJoinContext): FromTableRef = translate(ctx) {
+            val lhs = visitAs<FromTableRef>(ctx.lhs)
+            val rhs = visitAs<FromTableRef>(ctx.rhs)
+            // PartiQL spec defines equivalence of
+            // l LEFT CROSS JOIN r <=> l LEFT JOIN r ON TRUE
+            // The other join types combined w/ CROSS JOIN are unspecified -- https://github.com/partiql/partiql-lang-kotlin/issues/1013
+            fromJoin(lhs, rhs, JoinType.LEFT_CROSS(), null)
+        }
+
+        override fun visitTableCrossJoin(ctx: PartiQLParser.TableCrossJoinContext): FromTableRef = translate(ctx) {
+            val lhs = visitAs<FromTableRef>(ctx.lhs)
+            val rhs = visitAs<FromTableRef>(ctx.rhs)
+            fromJoin(lhs, rhs, JoinType.CROSS(), null)
+        }
+
+        override fun visitTableQualifiedJoin(ctx: PartiQLParser.TableQualifiedJoinContext): FromTableRef = translate(ctx) {
+            val lhs = visitAs<FromTableRef>(ctx.lhs)
+            val rhs = visitAs<FromTableRef>(ctx.rhs)
+            val type = convertJoinType(ctx.joinType())
+            val condition = ctx.joinSpec()?.let { visitExpr(it.expr()) }
+            fromJoin(lhs, rhs, type, condition)
+        }
+
+        private fun convertJoinType(ctx: GeneratedParser.JoinTypeContext?): JoinType? {
+            if (ctx == null) return null
+            return when (ctx.mod.type) {
+                GeneratedParser.INNER -> JoinType.INNER()
+                GeneratedParser.LEFT -> when (ctx.OUTER()) {
+                    null -> JoinType.LEFT()
+                    else -> JoinType.LEFT_OUTER()
+                }
+                GeneratedParser.RIGHT -> when (ctx.OUTER()) {
+                    null -> JoinType.RIGHT()
+                    else -> JoinType.RIGHT_OUTER()
+                }
+                GeneratedParser.FULL -> when (ctx.OUTER()) {
+                    null -> JoinType.FULL()
+                    else -> JoinType.FULL_OUTER()
+                }
+                GeneratedParser.OUTER -> {
+                    // TODO https://github.com/partiql/partiql-spec/issues/41
+                    // TODO https://github.com/partiql/partiql-lang-kotlin/issues/1013
+                    JoinType.FULL_OUTER()
+                }
+                else -> null
             }
-        }
-
-        override fun visitTableBaseRefClauses(ctx: GeneratedParser.TableBaseRefClausesContext) = translate(ctx) {
-            val expr = visitAs<Expr>(ctx.source)
-            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
-        }
-
-        override fun visitTableBaseRefMatch(ctx: GeneratedParser.TableBaseRefMatchContext) = translate(ctx) {
-            val expr = visitAs<Expr>(ctx.source)
-            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            fromValue(expr, From.Value.Type.SCAN, asAlias, atAlias, byAlias)
         }
 
         /**
@@ -1257,72 +1309,6 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitFromClauseSimpleImplicit(ctx: GeneratedParser.FromClauseSimpleImplicitContext) = translate(ctx) {
             throw error(ctx, "DML no longer supported in the default PartiQLParser.")
         }
-
-        override fun visitTableUnpivot(ctx: GeneratedParser.TableUnpivotContext) = translate(ctx) {
-            val expr = visitAs<Expr>(ctx.expr())
-            val asAlias = ctx.asIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val atAlias = ctx.atIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            val byAlias = ctx.byIdent()?.let { visitSymbolPrimitive(it.symbolPrimitive()) }
-            fromValue(expr, From.Value.Type.UNPIVOT, asAlias, atAlias, byAlias)
-        }
-
-        override fun visitTableLeftCrossJoin(ctx: org.partiql.parser.internal.antlr.PartiQLParser.TableLeftCrossJoinContext) = translate(ctx) {
-            val lhs = visitAs<From>(ctx.lhs)
-            val rhs = visitAs<From>(ctx.rhs)
-            // PartiQL spec defines equivalence of
-            // l LEFT CROSS JOIN r <=> l LEFT JOIN r ON TRUE
-            // The other join types combined w/ CROSS JOIN are unspecified -- https://github.com/partiql/partiql-lang-kotlin/issues/1013
-            fromJoin(lhs, rhs, From.Join.Type.LEFT, null)
-        }
-
-        override fun visitTableCrossJoin(ctx: GeneratedParser.TableCrossJoinContext) = translate(ctx) {
-            val lhs = visitAs<From>(ctx.lhs)
-            val rhs = visitAs<From>(ctx.rhs)
-            fromJoin(lhs, rhs, From.Join.Type.CROSS, null)
-        }
-
-        private fun convertJoinType(ctx: GeneratedParser.JoinTypeContext?): From.Join.Type? {
-            if (ctx == null) return null
-            return when (ctx.mod.type) {
-                GeneratedParser.INNER -> From.Join.Type.INNER
-                GeneratedParser.LEFT -> when (ctx.OUTER()) {
-                    null -> From.Join.Type.LEFT
-                    else -> From.Join.Type.LEFT_OUTER
-                }
-                GeneratedParser.RIGHT -> when (ctx.OUTER()) {
-                    null -> From.Join.Type.RIGHT
-                    else -> From.Join.Type.RIGHT_OUTER
-                }
-                GeneratedParser.FULL -> when (ctx.OUTER()) {
-                    null -> From.Join.Type.FULL
-                    else -> From.Join.Type.FULL_OUTER
-                }
-                GeneratedParser.OUTER -> {
-                    // TODO https://github.com/partiql/partiql-spec/issues/41
-                    // TODO https://github.com/partiql/partiql-lang-kotlin/issues/1013
-                    From.Join.Type.FULL_OUTER
-                }
-                else -> null
-            }
-        }
-
-        override fun visitTableQualifiedJoin(ctx: GeneratedParser.TableQualifiedJoinContext) = translate(ctx) {
-            val lhs = visitAs<From>(ctx.lhs)
-            val rhs = visitAs<From>(ctx.rhs)
-            val type = convertJoinType(ctx.joinType())
-            val condition = ctx.joinSpec()?.let { visitExpr(it.expr()) }
-            fromJoin(lhs, rhs, type, condition)
-        }
-
-        override fun visitTableBaseRefSymbol(ctx: GeneratedParser.TableBaseRefSymbolContext) = translate(ctx) {
-            val expr = visitAs<Expr>(ctx.source)
-            val asAlias = visitSymbolPrimitive(ctx.symbolPrimitive())
-            fromValue(expr, From.Value.Type.SCAN, asAlias, null, null)
-        }
-
-        override fun visitTableWrapped(ctx: GeneratedParser.TableWrappedContext): AstNode = visit(ctx.tableReference())
-
-        override fun visitJoinSpec(ctx: GeneratedParser.JoinSpecContext) = visitExpr(ctx.expr())
 
         /**
          * SIMPLE EXPRESSIONS
@@ -1419,11 +1405,11 @@ internal class PartiQLParserDefault : PartiQLParser {
             val lhs = visitAs<Expr>(ctx.lhs)
             val rhs = visitAs<Expr>(ctx.rhs ?: ctx.expr()).let {
                 // Wrap rhs in an array unless it's a query or already a collection
-                if (it is Expr.QuerySet || it is Expr.Collection || ctx.PAREN_LEFT() == null) {
+                if (it is ExprQuerySet || it is ExprArray || it is ExprBag || ctx.PAREN_LEFT() == null) {
                     it
                 } else {
                     // IN ( expr )
-                    exprCollection(Expr.Collection.Type.LIST, listOf(it))
+                    exprArray(listOf(it))
                 }
             }
             val not = ctx.NOT() != null
@@ -1432,7 +1418,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitPredicateIs(ctx: GeneratedParser.PredicateIsContext) = translate(ctx) {
             val value = visitAs<Expr>(ctx.lhs)
-            val type = visitAs<Type>(ctx.type())
+            val type = visitAs<DataType>(ctx.type())
             val not = ctx.NOT() != null
             exprIsType(value, type, not)
         }
@@ -1464,25 +1450,37 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitVariableIdentifier(ctx: GeneratedParser.VariableIdentifierContext) = translate(ctx) {
             val symbol = ctx.ident.getStringValue()
-            val case = when (ctx.ident.type) {
-                GeneratedParser.IDENTIFIER -> Identifier.CaseSensitivity.INSENSITIVE
-                else -> Identifier.CaseSensitivity.SENSITIVE
+            val isDelimited = when (ctx.ident.type) {
+                GeneratedParser.IDENTIFIER -> false
+                else -> true
             }
             val scope = when (ctx.qualifier) {
-                null -> Expr.Var.Scope.DEFAULT
-                else -> Expr.Var.Scope.LOCAL
+                null -> Scope.DEFAULT()
+                else -> Scope.LOCAL()
             }
-            exprVar(identifierSymbol(symbol, case), scope)
+            exprVarRef(
+                identifierChain(
+                    root = identifier(symbol, isDelimited),
+                    next = null
+                ),
+                scope
+            )
         }
 
         override fun visitVariableKeyword(ctx: GeneratedParser.VariableKeywordContext) = translate(ctx) {
             val symbol = ctx.key.text
-            val case = Identifier.CaseSensitivity.INSENSITIVE
+            val isDelimited = false
             val scope = when (ctx.qualifier) {
-                null -> Expr.Var.Scope.DEFAULT
-                else -> Expr.Var.Scope.LOCAL
+                null -> Scope.DEFAULT()
+                else -> Scope.LOCAL()
             }
-            exprVar(identifierSymbol(symbol, case), scope)
+            exprVarRef(
+                identifierChain(
+                    root = identifier(symbol, isDelimited),
+                    next = null
+                ),
+                scope
+            )
         }
 
         override fun visitParameter(ctx: GeneratedParser.ParameterContext) = translate(ctx) {
@@ -1493,52 +1491,43 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitSequenceConstructor(ctx: GeneratedParser.SequenceConstructorContext) = translate(ctx) {
-            val expressions = visitOrEmpty<Expr>(ctx.expr())
-            val type = when (ctx.datatype.type) {
-                GeneratedParser.LIST -> Expr.Collection.Type.LIST
-                GeneratedParser.SEXP -> Expr.Collection.Type.SEXP
-                else -> throw error(ctx.datatype, "Invalid sequence type")
-            }
-            exprCollection(type, expressions)
+            error("Sequence constructor not supported")
+        }
+
+        private fun PathStep.copy(next: PathStep?) = when (this) {
+            is PathStep.Element -> exprPathStepElement(this.element, next)
+            is PathStep.Field -> exprPathStepField(this.field, next)
+            is PathStep.AllElements -> exprPathStepAllElements(next)
+            is PathStep.AllFields -> exprPathStepAllFields(next)
+            else -> error("Unsupported PathStep: $this")
         }
 
         override fun visitExprPrimaryPath(ctx: GeneratedParser.ExprPrimaryPathContext) = translate(ctx) {
             val base = visitAs<Expr>(ctx.exprPrimary())
-            val steps = ctx.pathStep().map { visit(it) as Expr.Path.Step }
+            val init: PathStep? = null
+            val steps = ctx.pathStep().reversed().fold(init) { acc, step ->
+                val stepExpr = visit(step) as PathStep
+                stepExpr.copy(acc)
+            }
             exprPath(base, steps)
         }
 
         override fun visitPathStepIndexExpr(ctx: GeneratedParser.PathStepIndexExprContext) = translate(ctx) {
             val key = visitAs<Expr>(ctx.key)
-            exprPathStepIndex(key)
+            exprPathStepElement(key, null)
         }
 
         override fun visitPathStepDotExpr(ctx: GeneratedParser.PathStepDotExprContext) = translate(ctx) {
             val symbol = visitSymbolPrimitive(ctx.symbolPrimitive())
-            exprPathStepSymbol(symbol)
+            exprPathStepField(symbol, null)
         }
 
         override fun visitPathStepIndexAll(ctx: GeneratedParser.PathStepIndexAllContext) = translate(ctx) {
-            exprPathStepWildcard()
+            exprPathStepAllElements(null)
         }
 
         override fun visitPathStepDotAll(ctx: GeneratedParser.PathStepDotAllContext) = translate(ctx) {
-            exprPathStepUnpivot()
-        }
-
-        override fun visitValues(ctx: GeneratedParser.ValuesContext) = translate(ctx) {
-            val rows = visitOrEmpty<Expr.Collection>(ctx.valueRow())
-            exprCollection(Expr.Collection.Type.BAG, rows)
-        }
-
-        override fun visitValueRow(ctx: GeneratedParser.ValueRowContext) = translate(ctx) {
-            val expressions = visitOrEmpty<Expr>(ctx.expr())
-            exprCollection(Expr.Collection.Type.LIST, expressions)
-        }
-
-        override fun visitValueList(ctx: GeneratedParser.ValueListContext) = translate(ctx) {
-            val expressions = visitOrEmpty<Expr>(ctx.expr())
-            exprCollection(Expr.Collection.Type.LIST, expressions)
+            exprPathStepAllFields(null)
         }
 
         override fun visitExprGraphMatchMany(ctx: GeneratedParser.ExprGraphMatchManyContext) = translate(ctx) {
@@ -1554,12 +1543,12 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitExprTermCurrentUser(ctx: GeneratedParser.ExprTermCurrentUserContext) = translate(ctx) {
-            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_USER)
+            exprSessionAttribute(SessionAttribute.CURRENT_USER())
         }
 
         override fun visitExprTermCurrentDate(ctx: GeneratedParser.ExprTermCurrentDateContext) =
             translate(ctx) {
-                exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_DATE)
+                exprSessionAttribute(SessionAttribute.CURRENT_DATE())
             }
 
         /**
@@ -1593,7 +1582,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitCast(ctx: GeneratedParser.CastContext) = translate(ctx) {
             val expr = visitExpr(ctx.expr())
-            val type = visitAs<Type>(ctx.type())
+            val type = visitAs<DataType>(ctx.type())
             exprCast(expr, type)
         }
 
@@ -1613,13 +1602,14 @@ internal class PartiQLParserDefault : PartiQLParser {
                         GeneratedParser.MOD -> exprOperator("%", args[0], args[1])
                         GeneratedParser.CHARACTER_LENGTH, GeneratedParser.CHAR_LENGTH -> {
                             val path = ctx.qualifiedName().qualifier.map { visitSymbolPrimitive(it) }
-                            val name = identifierSymbol("char_length", Identifier.CaseSensitivity.INSENSITIVE)
+                            val name = identifierChain(identifier("char_length", false), null)
                             if (path.isEmpty()) {
-                                exprCall(name, args, setq = null) // setq = null for scalar fn
+                                exprCall(name, args, null) // setq = null for scalar fn
                             } else {
-                                val root = path.first()
-                                val steps = path.drop(1) + listOf(name)
-                                exprCall(identifierQualified(root, steps), args, setq = null)
+                                val function = path.reversed().fold(name) { acc, id ->
+                                    identifierChain(root = id, next = acc)
+                                }
+                                exprCall(function, args, setq = null)
                             }
                         }
                         else -> visitNonReservedFunctionCall(ctx, args)
@@ -1628,7 +1618,7 @@ internal class PartiQLParserDefault : PartiQLParser {
                 else -> visitNonReservedFunctionCall(ctx, args)
             }
         }
-        private fun visitNonReservedFunctionCall(ctx: GeneratedParser.FunctionCallContext, args: List<Expr>): Expr.Call {
+        private fun visitNonReservedFunctionCall(ctx: GeneratedParser.FunctionCallContext, args: List<Expr>): ExprCall {
             val function = visitQualifiedName(ctx.qualifiedName())
             return exprCall(function, args, convertSetQuantifier(ctx.setQuantifierStrategy()))
         }
@@ -1640,16 +1630,18 @@ internal class PartiQLParserDefault : PartiQLParser {
          */
 
         override fun visitDateFunction(ctx: GeneratedParser.DateFunctionContext) = translate(ctx) {
-            val field = try {
-                DatetimeField.valueOf(ctx.dt.text.uppercase())
+            try {
+                DatetimeField.valueOf(ctx.dt.text)
             } catch (ex: IllegalArgumentException) {
                 throw error(ctx.dt, "Expected one of: ${DatetimeField.values().joinToString()}", ex)
             }
             val lhs = visitExpr(ctx.expr(0))
             val rhs = visitExpr(ctx.expr(1))
+            // TODO change to not use PartiQLValue -- https://github.com/partiql/partiql-lang-kotlin/issues/1589
+            val fieldLit = exprLit(stringValue(ctx.dt.text.uppercase()))
             when {
-                ctx.DATE_ADD() != null -> exprDateAdd(field, lhs, rhs)
-                ctx.DATE_DIFF() != null -> exprDateDiff(field, lhs, rhs)
+                ctx.DATE_ADD() != null -> exprCall(identifierChain(identifier("DATE_ADD", false), null), listOf(fieldLit, lhs, rhs), null)
+                ctx.DATE_DIFF() != null -> exprCall(identifierChain(identifier("DATE_DIFF", false), null), listOf(fieldLit, lhs, rhs), null)
                 else -> throw error(ctx, "Expected DATE_ADD or DATE_DIFF")
             }
         }
@@ -1660,7 +1652,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitSubstring(ctx: GeneratedParser.SubstringContext) = translate(ctx) {
             if (ctx.FROM() == null) {
                 // normal form
-                val function = "SUBSTRING".toIdentifier()
+                val function = "SUBSTRING".toIdentifierChain()
                 val args = visitOrEmpty<Expr>(ctx.expr())
                 exprCall(function, args, setq = null) // setq = null for scalar fn
             } else {
@@ -1678,7 +1670,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitPosition(ctx: GeneratedParser.PositionContext) = translate(ctx) {
             if (ctx.IN() == null) {
                 // normal form
-                val function = "POSITION".toIdentifier()
+                val function = "POSITION".toIdentifierChain()
                 val args = visitOrEmpty<Expr>(ctx.expr())
                 exprCall(function, args, setq = null) // setq = null for scalar fn
             } else {
@@ -1696,7 +1688,7 @@ internal class PartiQLParserDefault : PartiQLParser {
             // TODO: figure out why do we have a normalized form for overlay?
             if (ctx.PLACING() == null) {
                 // normal form
-                val function = "OVERLAY".toIdentifier()
+                val function = "OVERLAY".toIdentifierChain()
                 val args = arrayOfNulls<Expr>(4).also {
                     visitOrEmpty<Expr>(ctx.expr()).forEachIndexed { index, expr ->
                         it[index] = expr
@@ -1728,9 +1720,9 @@ internal class PartiQLParserDefault : PartiQLParser {
         override fun visitTrimFunction(ctx: GeneratedParser.TrimFunctionContext) = translate(ctx) {
             val spec = ctx.mod?.let {
                 try {
-                    Expr.Trim.Spec.valueOf(it.text.uppercase())
+                    TrimSpec.valueOf(it.text.uppercase())
                 } catch (ex: IllegalArgumentException) {
-                    throw error(it, "Expected on of: ${Expr.Trim.Spec.values().joinToString()}", ex)
+                    throw error(it, "Expected on of: ${TrimSpec.values().joinToString()}", ex)
                 }
             }
             val (chars, value) = when (ctx.expr().size) {
@@ -1747,8 +1739,8 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitLagLeadFunction(ctx: GeneratedParser.LagLeadFunctionContext) = translate(ctx) {
             val function = when {
-                ctx.LAG() != null -> Expr.Window.Function.LAG
-                ctx.LEAD() != null -> Expr.Window.Function.LEAD
+                ctx.LAG() != null -> WindowFunction.LAG()
+                ctx.LEAD() != null -> WindowFunction.LEAD()
                 else -> throw error(ctx, "Expected LAG or LEAD")
             }
             val expression = visitExpr(ctx.expr(0))
@@ -1781,7 +1773,7 @@ internal class PartiQLParserDefault : PartiQLParser {
                 throw error(ctx, "Invalid bag expression")
             }
             val expressions = visitOrEmpty<Expr>(ctx.expr())
-            exprCollection(Expr.Collection.Type.BAG, expressions)
+            exprBag(expressions)
         }
 
         override fun visitLiteralDecimal(ctx: GeneratedParser.LiteralDecimalContext) = translate(ctx) {
@@ -1796,7 +1788,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitArray(ctx: GeneratedParser.ArrayContext) = translate(ctx) {
             val expressions = visitOrEmpty<Expr>(ctx.expr())
-            exprCollection(Expr.Collection.Type.ARRAY, expressions)
+            exprArray(expressions)
         }
 
         override fun visitLiteralNull(ctx: GeneratedParser.LiteralNullContext) = translate(ctx) {
@@ -1910,51 +1902,67 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitTypeAtomic(ctx: GeneratedParser.TypeAtomicContext) = translate(ctx) {
             when (ctx.datatype.type) {
-                GeneratedParser.NULL -> typeNullType()
-                GeneratedParser.BOOL, GeneratedParser.BOOLEAN -> typeBool()
-                GeneratedParser.SMALLINT, GeneratedParser.INT2, GeneratedParser.INTEGER2 -> typeInt2()
+                GeneratedParser.NULL -> DataType.NULL()
+                GeneratedParser.BOOL -> DataType.BOOLEAN()
+                GeneratedParser.BOOLEAN -> DataType.BOOL()
+                GeneratedParser.SMALLINT -> DataType.SMALLINT()
+                GeneratedParser.INT2 -> DataType.INT2()
+                GeneratedParser.INTEGER2 -> DataType.INTEGER2()
                 // TODO, we have INT aliased to INT4 when it should be visa-versa.
-                GeneratedParser.INT4, GeneratedParser.INTEGER4 -> typeInt4()
-                GeneratedParser.INT, GeneratedParser.INTEGER -> typeInt4()
-                GeneratedParser.BIGINT, GeneratedParser.INT8, GeneratedParser.INTEGER8 -> typeInt8()
-                GeneratedParser.FLOAT -> typeFloat32()
-                GeneratedParser.DOUBLE -> typeFloat64()
-                GeneratedParser.REAL -> typeReal()
-                GeneratedParser.TIMESTAMP -> typeTimestamp(null)
-                GeneratedParser.CHAR, GeneratedParser.CHARACTER -> typeChar(null)
-                GeneratedParser.MISSING -> typeMissing()
-                GeneratedParser.STRING -> typeString(null)
-                GeneratedParser.SYMBOL -> typeSymbol()
+                GeneratedParser.INT4 -> DataType.INT4()
+                GeneratedParser.INTEGER4 -> DataType.INTEGER4()
+                GeneratedParser.INT -> DataType.INT()
+                GeneratedParser.INTEGER -> DataType.INTEGER()
+                GeneratedParser.BIGINT -> DataType.BIGINT()
+                GeneratedParser.INT8 -> DataType.INT8()
+                GeneratedParser.INTEGER8 -> DataType.INTEGER8()
+                GeneratedParser.FLOAT -> DataType.FLOAT()
+                GeneratedParser.DOUBLE -> TODO() // not sure if DOUBLE is to be supported
+                GeneratedParser.REAL -> DataType.REAL()
+                GeneratedParser.TIMESTAMP -> DataType.TIMESTAMP()
+                GeneratedParser.CHAR -> DataType.CHAR()
+                GeneratedParser.CHARACTER -> DataType.CHARACTER()
+                GeneratedParser.MISSING -> DataType.MISSING()
+                GeneratedParser.STRING -> DataType.STRING()
+                GeneratedParser.SYMBOL -> DataType.SYMBOL()
                 // TODO https://github.com/partiql/partiql-lang-kotlin/issues/1125
-                GeneratedParser.BLOB -> typeBlob(null)
-                GeneratedParser.CLOB -> typeClob(null)
-                GeneratedParser.DATE -> typeDate()
-                GeneratedParser.STRUCT -> typeStruct()
-                GeneratedParser.TUPLE -> typeTuple()
-                GeneratedParser.LIST -> typeList()
-                GeneratedParser.SEXP -> typeSexp()
-                GeneratedParser.BAG -> typeBag()
-                GeneratedParser.ANY -> typeAny()
-                else -> throw error(ctx, "Unknown atomic type.")
+                GeneratedParser.BLOB -> DataType.BLOB()
+                GeneratedParser.CLOB -> DataType.CLOB()
+                GeneratedParser.DATE -> DataType.DATE()
+                GeneratedParser.STRUCT -> DataType.STRUCT()
+                GeneratedParser.TUPLE -> DataType.TUPLE()
+                GeneratedParser.LIST -> DataType.LIST()
+                GeneratedParser.SEXP -> DataType.SEXP()
+                GeneratedParser.BAG -> DataType.BAG()
+                GeneratedParser.ANY -> TODO() // not sure if ANY is to be supported
+                else -> throw error(ctx, "Unknown atomic type.") // TODO other types included in parser
             }
         }
 
-        override fun visitTypeVarChar(ctx: GeneratedParser.TypeVarCharContext) = translate(ctx) {
-            val n = ctx.arg0?.text?.toInt()
-            typeVarchar(n)
+        override fun visitTypeVarChar(ctx: GeneratedParser.TypeVarCharContext): DataType = translate(ctx) {
+            when (val n = ctx.arg0?.text?.toInt()) {
+                null -> DataType.VARCHAR()
+                else -> DataType.VARCHAR(n)
+            }
         }
 
         override fun visitTypeArgSingle(ctx: GeneratedParser.TypeArgSingleContext) = translate(ctx) {
             val n = ctx.arg0?.text?.toInt()
             when (ctx.datatype.type) {
                 GeneratedParser.FLOAT -> when (n) {
-                    null -> typeFloat64()
-                    32 -> typeFloat32()
-                    64 -> typeFloat64()
+                    null -> DataType.FLOAT(64)
+                    32 -> DataType.FLOAT(32)
+                    64 -> DataType.FLOAT(64)
                     else -> throw error(ctx.datatype, "Invalid FLOAT precision. Expected 32 or 64")
                 }
-                GeneratedParser.CHAR, GeneratedParser.CHARACTER -> typeChar(n)
-                GeneratedParser.VARCHAR -> typeVarchar(n)
+                GeneratedParser.CHAR, GeneratedParser.CHARACTER -> when (n) {
+                    null -> DataType.CHAR()
+                    else -> DataType.CHAR(n)
+                }
+                GeneratedParser.VARCHAR -> when (n) {
+                    null -> DataType.VARCHAR()
+                    else -> DataType.VARCHAR(n)
+                }
                 else -> throw error(ctx.datatype, "Invalid datatype")
             }
         }
@@ -1963,8 +1971,24 @@ internal class PartiQLParserDefault : PartiQLParser {
             val arg0 = ctx.arg0?.text?.toInt()
             val arg1 = ctx.arg1?.text?.toInt()
             when (ctx.datatype.type) {
-                GeneratedParser.DECIMAL, GeneratedParser.DEC -> typeDecimal(arg0, arg1)
-                GeneratedParser.NUMERIC -> typeNumeric(arg0, arg1)
+                GeneratedParser.DECIMAL -> when {
+                    arg0 == null && arg1 == null -> DataType.DECIMAL()
+                    arg0 != null && arg1 == null -> DataType.DECIMAL(arg0)
+                    arg0 != null && arg1 != null -> DataType.DECIMAL(arg0, arg1)
+                    else -> error("Invalid parameters for decimal")
+                }
+                GeneratedParser.DEC -> when {
+                    arg0 == null && arg1 == null -> DataType.DEC()
+                    arg0 != null && arg1 == null -> DataType.DEC(arg0)
+                    arg0 != null && arg1 != null -> DataType.DEC(arg0, arg1)
+                    else -> error("Invalid parameters for dec")
+                }
+                GeneratedParser.NUMERIC -> when {
+                    arg0 == null && arg1 == null -> DataType.NUMERIC()
+                    arg0 != null && arg1 == null -> DataType.NUMERIC(arg0)
+                    arg0 != null && arg1 != null -> DataType.NUMERIC(arg0, arg1)
+                    else -> error("Invalid parameters for decimal")
+                }
                 else -> throw error(ctx.datatype, "Invalid datatype")
             }
         }
@@ -1978,19 +2002,31 @@ internal class PartiQLParserDefault : PartiQLParser {
 
             when (ctx.datatype.type) {
                 GeneratedParser.TIME -> when (ctx.ZONE()) {
-                    null -> typeTime(precision)
-                    else -> typeTimeWithTz(precision)
+                    null -> when (precision) {
+                        null -> DataType.TIME()
+                        else -> DataType.TIME(precision)
+                    }
+                    else -> when (precision) {
+                        null -> DataType.TIME_WITH_TIME_ZONE()
+                        else -> DataType.TIME_WITH_TIME_ZONE(precision)
+                    }
                 }
                 GeneratedParser.TIMESTAMP -> when (ctx.ZONE()) {
-                    null -> typeTimestamp(precision)
-                    else -> typeTimestampWithTz(precision)
+                    null -> when (precision) {
+                        null -> DataType.TIMESTAMP()
+                        else -> DataType.TIMESTAMP(precision)
+                    }
+                    else -> when (precision) {
+                        null -> DataType.TIMESTAMP_WITH_TIME_ZONE()
+                        else -> DataType.TIMESTAMP_WITH_TIME_ZONE(precision)
+                    }
                 }
                 else -> throw error(ctx.datatype, "Invalid datatype")
             }
         }
 
         override fun visitTypeCustom(ctx: GeneratedParser.TypeCustomContext) = translate(ctx) {
-            typeCustom(ctx.text.uppercase())
+            DataType.USER_DEFINED(ctx.text.uppercase().toIdentifierChain())
         }
 
         private inline fun <reified T : AstNode> visitOrEmpty(ctx: List<ParserRuleContext>?): List<T> = when {
@@ -2017,8 +2053,8 @@ internal class PartiQLParserDefault : PartiQLParser {
          */
         private fun convertSetQuantifier(ctx: GeneratedParser.SetQuantifierStrategyContext?): SetQuantifier? = when {
             ctx == null -> null
-            ctx.ALL() != null -> SetQuantifier.ALL
-            ctx.DISTINCT() != null -> SetQuantifier.DISTINCT
+            ctx.ALL() != null -> SetQuantifier.ALL()
+            ctx.DISTINCT() != null -> SetQuantifier.DISTINCT()
             else -> throw error(ctx, "Expected set quantifier ALL or DISTINCT")
         }
 
@@ -2080,39 +2116,55 @@ internal class PartiQLParserDefault : PartiQLParser {
          *      SELECT foo.*.bar FROM foo
          * ```
          */
-        protected fun convertPathToProjectionItem(ctx: ParserRuleContext, path: Expr.Path, alias: Identifier.Symbol?) =
+        protected fun convertPathToProjectionItem(ctx: ParserRuleContext, path: ExprPath, alias: Identifier?) =
             translate(ctx) {
-                val steps = mutableListOf<Expr.Path.Step>()
+                val steps = mutableListOf<PathStep>()
                 var containsIndex = false
-                path.steps.forEachIndexed { index, step ->
+                var curStep = path.next
+                var last = curStep
+                while (curStep != null) {
+                    val isLastStep = curStep.next == null
                     // Only last step can have a '.*'
-                    if (step is Expr.Path.Step.Unpivot && index != path.steps.lastIndex) {
+                    if (curStep is PathStep.AllFields && !isLastStep) {
                         throw error(ctx, "Projection item cannot unpivot unless at end.")
                     }
                     // No step can have an indexed wildcard: '[*]'
-                    if (step is Expr.Path.Step.Wildcard) {
+                    if (curStep is PathStep.AllElements) {
                         throw error(ctx, "Projection item cannot index using wildcard.")
                     }
                     // TODO If the last step is '.*', no indexing is allowed
                     // if (step.metas.containsKey(IsPathIndexMeta.TAG)) {
                     //     containsIndex = true
                     // }
-                    if (step !is Expr.Path.Step.Unpivot) {
-                        steps.add(step)
+                    if (curStep !is PathStep.AllFields) {
+                        steps.add(curStep)
                     }
-                }
-                if (path.steps.last() is Expr.Path.Step.Unpivot && containsIndex) {
-                    throw error(ctx, "Projection item use wildcard with any indexing.")
+
+                    if (isLastStep && curStep is PathStep.AllFields && containsIndex) {
+                        throw error(ctx, "Projection item use wildcard with any indexing.")
+                    }
+                    last = curStep
+                    curStep = curStep.next
                 }
                 when {
-                    path.steps.last() is Expr.Path.Step.Unpivot && steps.isEmpty() -> {
-                        selectProjectItemAll(path.root)
+                    last is PathStep.AllFields && steps.isEmpty() -> {
+                        selectItemStar(path.root)
                     }
-                    path.steps.last() is Expr.Path.Step.Unpivot -> {
-                        selectProjectItemAll(exprPath(path.root, steps))
+                    last is PathStep.AllFields -> {
+                        val init: PathStep? = null
+                        val newSteps = steps.reversed().fold(init) { acc, step ->
+                            when (step) {
+                                is PathStep.Element -> PathStep.Element(step.element, acc)
+                                is PathStep.Field -> PathStep.Field(step.field, acc)
+                                is PathStep.AllElements -> PathStep.AllElements(acc)
+                                is PathStep.AllFields -> PathStep.AllFields(acc)
+                                else -> error("Unexpected path step")
+                            }
+                        }
+                        selectItemStar(exprPath(path.root, newSteps))
                     }
                     else -> {
-                        selectProjectItemExpression(path, alias)
+                        selectItemExpr(path, alias)
                     }
                 }
             }
@@ -2127,10 +2179,9 @@ internal class PartiQLParserDefault : PartiQLParser {
             else -> throw error(this, "Unsupported token for grabbing string value.")
         }
 
-        private fun String.toIdentifier(): Identifier.Symbol = identifierSymbol(
-            symbol = this,
-            caseSensitivity = Identifier.CaseSensitivity.INSENSITIVE,
-        )
+        private fun String.toIdentifier(): Identifier = identifier(this, false)
+
+        private fun String.toIdentifierChain(): IdentifierChain = identifierChain(root = this.toIdentifier(), next = null)
 
         private fun String.toBigInteger() = BigInteger(this, 10)
 

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserBagOpTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserBagOpTests.kt
@@ -1,13 +1,24 @@
 package org.partiql.parser.internal
 
 import org.junit.jupiter.api.Test
-import org.partiql.ast.AstNode
-import org.partiql.ast.Expr
-import org.partiql.ast.From
-import org.partiql.ast.SetOp
-import org.partiql.ast.SetQuantifier
-import org.partiql.ast.builder.AstBuilder
-import org.partiql.ast.builder.ast
+import org.partiql.ast.v1.Ast.exprBag
+import org.partiql.ast.v1.Ast.exprLit
+import org.partiql.ast.v1.Ast.exprQuerySet
+import org.partiql.ast.v1.Ast.exprStruct
+import org.partiql.ast.v1.Ast.exprStructField
+import org.partiql.ast.v1.Ast.from
+import org.partiql.ast.v1.Ast.fromExpr
+import org.partiql.ast.v1.Ast.query
+import org.partiql.ast.v1.Ast.queryBodySFW
+import org.partiql.ast.v1.Ast.queryBodySetOp
+import org.partiql.ast.v1.Ast.selectStar
+import org.partiql.ast.v1.Ast.setOp
+import org.partiql.ast.v1.AstNode
+import org.partiql.ast.v1.FromType
+import org.partiql.ast.v1.SetOpType
+import org.partiql.ast.v1.SetQuantifier
+import org.partiql.ast.v1.expr.Expr
+import org.partiql.ast.v1.expr.ExprQuerySet
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.int32Value
 import org.partiql.value.stringValue
@@ -15,110 +26,137 @@ import kotlin.test.assertEquals
 
 class PartiQLParserBagOpTests {
 
-    private val parser = PartiQLParserDefault()
+    private val parser = V1PartiQLParserDefault()
 
-    private fun query(block: AstBuilder.() -> Expr) = ast { statementQuery { expr = block() } }
+    private fun queryBody(body: () -> Expr) = query(body())
 
     @OptIn(PartiQLValueExperimental::class)
-    private fun createSFW(i: Int): Expr.QuerySet =
-        ast {
-            exprQuerySet {
-                body = queryBodySFW {
-                    select = selectStar()
-                    from = fromValue {
-                        expr = exprCollection {
-                            type = Expr.Collection.Type.BAG
-                            values = mutableListOf(
-                                exprStruct {
-                                    fields = mutableListOf(
-                                        exprStructField {
-                                            name = exprLit { value = stringValue("a") }
-                                            value = exprLit { value = int32Value(i) }
-                                        }
+    private fun createSFW(i: Int): ExprQuerySet =
+        exprQuerySet(
+            body = queryBodySFW(
+                select = selectStar(setq = null),
+                from = from(
+                    tableRefs = listOf(
+                        fromExpr(
+                            expr = exprBag(
+                                values = mutableListOf(
+                                    exprStruct(
+                                        fields = mutableListOf(
+                                            exprStructField(
+                                                name = exprLit(value = stringValue("a")),
+                                                value = exprLit(value = int32Value(i))
+                                            )
+                                        )
                                     )
-                                }
-                            )
-                        }
-                        type = From.Value.Type.SCAN
-                    }
-                }
-            }
-        }
+                                )
+                            ),
+                            fromType = FromType.SCAN(),
+                            asAlias = null,
+                            atAlias = null
+                        )
+                    )
+                ),
+                exclude = null,
+                let = null,
+                where = null,
+                groupBy = null,
+                having = null,
+            ),
+            orderBy = null,
+            limit = null,
+            offset = null
+        )
 
     @OptIn(PartiQLValueExperimental::class)
-    private fun createLit(i: Int) = ast { exprLit { value = int32Value(i) } }
+    private fun createLit(i: Int) = exprLit(int32Value(i))
 
     // SQL Union
     @Test
     fun sqlUnion() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> UNION SELECT * FROM <<{'a': 2}>>",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.UNION
-                    }
-                    lhs = createSFW(1)
-                    rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.UNION(),
+                        setq = null
+                    ),
+                    lhs = createSFW(1),
+                    rhs = createSFW(2),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun sqlUnionMultiple() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> UNION ALL SELECT * FROM <<{'a': 2}>> UNION DISTINCT SELECT * FROM <<{'a': 3}>>",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.UNION
-                        setq = SetQuantifier.DISTINCT
-                    }
-                    lhs = exprQuerySet {
-                        body = queryBodySetOp {
-                            type = setOp {
-                                type = SetOp.Type.UNION
-                                setq = SetQuantifier.ALL
-                            }
-                            lhs = createSFW(1)
-                            rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.UNION(),
+                        setq = SetQuantifier.DISTINCT()
+                    ),
+                    lhs = exprQuerySet(
+                        body = queryBodySetOp(
+                            type = setOp(
+                                setOpType = SetOpType.UNION(),
+                                setq = SetQuantifier.ALL()
+                            ),
+                            lhs = createSFW(1),
+                            rhs = createSFW(2),
                             isOuter = false
-                        }
-                    }
-                    rhs = createSFW(3)
+                        ),
+                        orderBy = null,
+                        limit = null,
+                        offset = null
+                    ),
+                    rhs = createSFW(3),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun sqlUnionMultipleRight() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> UNION ALL (SELECT * FROM <<{'a': 2}>> UNION DISTINCT SELECT * FROM <<{'a': 3}>>)",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.UNION
-                        setq = SetQuantifier.ALL
-                    }
-                    lhs = createSFW(1)
-                    rhs = exprQuerySet {
-                        body = queryBodySetOp {
-                            type = setOp {
-                                type = SetOp.Type.UNION
-                                setq = SetQuantifier.DISTINCT
-                            }
-                            lhs = createSFW(2)
-                            rhs = createSFW(3)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.UNION(),
+                        setq = SetQuantifier.ALL()
+                    ),
+                    lhs = createSFW(1),
+                    rhs = exprQuerySet(
+                        body = queryBodySetOp(
+                            type = setOp(
+                                setOpType = SetOpType.UNION(),
+                                setq = SetQuantifier.DISTINCT()
+                            ),
+                            lhs = createSFW(2),
+                            rhs = createSFW(3),
                             isOuter = false
-                        }
-                        isOuter = false
-                    }
-                }
-            }
+                        ),
+                        orderBy = null,
+                        limit = null,
+                        offset = null
+                    ),
+                    isOuter = false
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
@@ -126,90 +164,110 @@ class PartiQLParserBagOpTests {
     @Test
     fun outerUnion() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> OUTER UNION SELECT * FROM <<{'a': 2}>>",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.UNION
-                    }
-                    lhs = createSFW(1)
-                    rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.UNION(),
+                        setq = null
+                    ),
+                    lhs = createSFW(1),
+                    rhs = createSFW(2),
                     isOuter = true
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun outerUnionNonSpecified() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> UNION 2",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.UNION
-                    }
-                    lhs = createSFW(1)
-                    rhs = createLit(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.UNION(),
+                        setq = null
+                    ),
+                    lhs = createSFW(1),
+                    rhs = createLit(2),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun sqlUnionAndOuterUnion() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> UNION ALL SELECT * FROM <<{'a': 2}>> UNION DISTINCT 3",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.UNION
-                        setq = SetQuantifier.DISTINCT
-                    }
-                    lhs = exprQuerySet {
-                        body = queryBodySetOp {
-                            type = setOp {
-                                type = SetOp.Type.UNION
-                                setq = SetQuantifier.ALL
-                            }
-                            lhs = createSFW(1)
-                            rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.UNION(),
+                        setq = SetQuantifier.DISTINCT()
+                    ),
+                    lhs = exprQuerySet(
+                        body = queryBodySetOp(
+                            type = setOp(
+                                setOpType = SetOpType.UNION(),
+                                setq = SetQuantifier.ALL()
+                            ),
+                            lhs = createSFW(1),
+                            rhs = createSFW(2),
                             isOuter = false
-                        }
-                    }
-                    rhs = createLit(3)
+                        ),
+                        orderBy = null,
+                        limit = null,
+                        offset = null
+                    ),
+                    rhs = createLit(3),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun outerUnionAndSQLUnion() = assertExpression(
         "1 UNION ALL SELECT * FROM <<{'a': 2}>> UNION DISTINCT SELECT * FROM <<{'a': 3}>>",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.UNION
-                        setq = SetQuantifier.DISTINCT
-                    }
-                    lhs = exprQuerySet {
-                        body = queryBodySetOp {
-                            type = setOp {
-                                type = SetOp.Type.UNION
-                                setq = SetQuantifier.ALL
-                            }
-                            lhs = createLit(1)
-                            rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.UNION(),
+                        setq = SetQuantifier.DISTINCT()
+                    ),
+                    lhs = exprQuerySet(
+                        body = queryBodySetOp(
+                            type = setOp(
+                                setOpType = SetOpType.UNION(),
+                                setq = SetQuantifier.ALL()
+                            ),
+                            lhs = createLit(1),
+                            rhs = createSFW(2),
                             isOuter = false
-                        }
-                    }
-                    rhs = createSFW(3)
+                        ),
+                        orderBy = null,
+                        limit = null,
+                        offset = null
+                    ),
+                    rhs = createSFW(3),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
@@ -217,73 +275,89 @@ class PartiQLParserBagOpTests {
     @Test
     fun sqlExcept() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> EXCEPT SELECT * FROM <<{'a': 2}>>",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.EXCEPT
-                    }
-                    lhs = createSFW(1)
-                    rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.EXCEPT(),
+                        setq = null
+                    ),
+                    lhs = createSFW(1),
+                    rhs = createSFW(2),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun sqlExceptMultiple() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> EXCEPT ALL SELECT * FROM <<{'a': 2}>> EXCEPT DISTINCT SELECT * FROM <<{'a': 3}>>",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.EXCEPT
-                        setq = SetQuantifier.DISTINCT
-                    }
-                    lhs = exprQuerySet {
-                        body = queryBodySetOp {
-                            type = setOp {
-                                type = SetOp.Type.EXCEPT
-                                setq = SetQuantifier.ALL
-                            }
-                            lhs = createSFW(1)
-                            rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.EXCEPT(),
+                        setq = SetQuantifier.DISTINCT()
+                    ),
+                    lhs = exprQuerySet(
+                        body = queryBodySetOp(
+                            type = setOp(
+                                setOpType = SetOpType.EXCEPT(),
+                                setq = SetQuantifier.ALL()
+                            ),
+                            lhs = createSFW(1),
+                            rhs = createSFW(2),
                             isOuter = false
-                        }
-                    }
-                    rhs = createSFW(3)
+                        ),
+                        orderBy = null,
+                        limit = null,
+                        offset = null
+                    ),
+                    rhs = createSFW(3),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun sqlExceptMultipleRight() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> EXCEPT ALL (SELECT * FROM <<{'a': 2}>> EXCEPT DISTINCT SELECT * FROM <<{'a': 3}>>)",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.EXCEPT
-                        setq = SetQuantifier.ALL
-                    }
-                    lhs = createSFW(1)
-                    rhs = exprQuerySet {
-                        body = queryBodySetOp {
-                            type = setOp {
-                                type = SetOp.Type.EXCEPT
-                                setq = SetQuantifier.DISTINCT
-                            }
-                            lhs = createSFW(2)
-                            rhs = createSFW(3)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.EXCEPT(),
+                        setq = SetQuantifier.ALL()
+                    ),
+                    lhs = createSFW(1),
+                    rhs = exprQuerySet(
+                        body = queryBodySetOp(
+                            type = setOp(
+                                setOpType = SetOpType.EXCEPT(),
+                                setq = SetQuantifier.DISTINCT()
+                            ),
+                            lhs = createSFW(2),
+                            rhs = createSFW(3),
                             isOuter = false
-                        }
-                    }
+                        ),
+                        orderBy = null,
+                        limit = null,
+                        offset = null
+                    ),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
@@ -291,90 +365,112 @@ class PartiQLParserBagOpTests {
     @Test
     fun outerExcept() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> OUTER EXCEPT SELECT * FROM <<{'a': 2}>>",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.EXCEPT
-                    }
-                    lhs = createSFW(1)
-                    rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.EXCEPT(),
+                        setq = null
+                    ),
+                    lhs = createSFW(1),
+                    rhs = createSFW(2),
                     isOuter = true
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun outerExceptNonSpecified() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> EXCEPT 2",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.EXCEPT
-                    }
-                    lhs = createSFW(1)
-                    rhs = createLit(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.EXCEPT(),
+                        setq = null
+                    ),
+                    lhs = createSFW(1),
+                    rhs = createLit(2),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun sqlExceptAndOuterExcept() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> EXCEPT ALL SELECT * FROM <<{'a': 2}>> EXCEPT DISTINCT 3",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.EXCEPT
-                        setq = SetQuantifier.DISTINCT
-                    }
-                    lhs = exprQuerySet {
-                        body = queryBodySetOp {
-                            type = setOp {
-                                type = SetOp.Type.EXCEPT
-                                setq = SetQuantifier.ALL
-                            }
-                            lhs = createSFW(1)
-                            rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.EXCEPT(),
+                        setq = SetQuantifier.DISTINCT()
+                    ),
+                    lhs = exprQuerySet(
+                        body = queryBodySetOp(
+                            type = setOp(
+                                setOpType = SetOpType.EXCEPT(),
+                                setq = SetQuantifier.ALL()
+                            ),
+                            lhs = createSFW(1),
+                            rhs = createSFW(2),
                             isOuter = false
-                        }
-                    }
-                    rhs = createLit(3)
+                        ),
+                        orderBy = null,
+                        limit = null,
+                        offset = null
+                    ),
+                    rhs = createLit(3),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun outerExceptAndSQLExcept() = assertExpression(
         "1 EXCEPT ALL SELECT * FROM <<{'a': 2}>> EXCEPT DISTINCT SELECT * FROM <<{'a': 3}>>",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.EXCEPT
-                        setq = SetQuantifier.DISTINCT
-                    }
-                    lhs = exprQuerySet {
-                        body = queryBodySetOp {
-                            type = setOp {
-                                type = SetOp.Type.EXCEPT
-                                setq = SetQuantifier.ALL
-                            }
-                            lhs = createLit(1)
-                            rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.EXCEPT(),
+                        setq = SetQuantifier.DISTINCT()
+                    ),
+                    lhs = exprQuerySet(
+                        body = queryBodySetOp(
+                            type = setOp(
+                                setOpType = SetOpType.EXCEPT(),
+                                setq = SetQuantifier.ALL()
+                            ),
+                            lhs = createLit(1),
+                            rhs = createSFW(2),
                             isOuter = false
-                        }
-                    }
-                    rhs = createSFW(3)
+                        ),
+                        orderBy = null,
+                        limit = null,
+                        offset = null
+                    ),
+                    rhs = createSFW(3),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
@@ -382,73 +478,89 @@ class PartiQLParserBagOpTests {
     @Test
     fun sqlIntersect() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> INTERSECT SELECT * FROM <<{'a': 2}>>",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.INTERSECT
-                    }
-                    lhs = createSFW(1)
-                    rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.INTERSECT(),
+                        setq = null
+                    ),
+                    lhs = createSFW(1),
+                    rhs = createSFW(2),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun sqlIntersectMultiple() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> INTERSECT ALL SELECT * FROM <<{'a': 2}>> INTERSECT DISTINCT SELECT * FROM <<{'a': 3}>>",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.INTERSECT
-                        setq = SetQuantifier.DISTINCT
-                    }
-                    lhs = exprQuerySet {
-                        body = queryBodySetOp {
-                            type = setOp {
-                                type = SetOp.Type.INTERSECT
-                                setq = SetQuantifier.ALL
-                            }
-                            lhs = createSFW(1)
-                            rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.INTERSECT(),
+                        setq = SetQuantifier.DISTINCT()
+                    ),
+                    lhs = exprQuerySet(
+                        body = queryBodySetOp(
+                            type = setOp(
+                                setOpType = SetOpType.INTERSECT(),
+                                setq = SetQuantifier.ALL()
+                            ),
+                            lhs = createSFW(1),
+                            rhs = createSFW(2),
                             isOuter = false
-                        }
-                    }
-                    rhs = createSFW(3)
+                        ),
+                        orderBy = null,
+                        limit = null,
+                        offset = null
+                    ),
+                    rhs = createSFW(3),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun sqlIntersectMultipleRight() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> INTERSECT ALL (SELECT * FROM <<{'a': 2}>> INTERSECT DISTINCT SELECT * FROM <<{'a': 3}>>)",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.INTERSECT
-                        setq = SetQuantifier.ALL
-                    }
-                    lhs = createSFW(1)
-                    rhs = exprQuerySet {
-                        body = queryBodySetOp {
-                            type = setOp {
-                                type = SetOp.Type.INTERSECT
-                                setq = SetQuantifier.DISTINCT
-                            }
-                            lhs = createSFW(2)
-                            rhs = createSFW(3)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.INTERSECT(),
+                        setq = SetQuantifier.ALL()
+                    ),
+                    lhs = createSFW(1),
+                    rhs = exprQuerySet(
+                        body = queryBodySetOp(
+                            type = setOp(
+                                setOpType = SetOpType.INTERSECT(),
+                                setq = SetQuantifier.DISTINCT()
+                            ),
+                            lhs = createSFW(2),
+                            rhs = createSFW(3),
                             isOuter = false
-                        }
-                    }
+                        ),
+                        orderBy = null,
+                        limit = null,
+                        offset = null
+                    ),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
@@ -456,90 +568,110 @@ class PartiQLParserBagOpTests {
     @Test
     fun outerIntersect() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> OUTER INTERSECT SELECT * FROM <<{'a': 2}>>",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.INTERSECT
-                    }
-                    lhs = createSFW(1)
-                    rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.INTERSECT(),
+                        setq = null
+                    ),
+                    lhs = createSFW(1),
+                    rhs = createSFW(2),
                     isOuter = true
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun outerIntersectNonSpecified() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> INTERSECT 2",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.INTERSECT
-                    }
-                    lhs = createSFW(1)
-                    rhs = createLit(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.INTERSECT(),
+                        setq = null
+                    ),
+                    lhs = createSFW(1),
+                    rhs = createLit(2),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun sqlIntersectAndOuterIntersect() = assertExpression(
         "SELECT * FROM <<{'a': 1}>> INTERSECT ALL SELECT * FROM <<{'a': 2}>> INTERSECT DISTINCT 3",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.INTERSECT
-                        setq = SetQuantifier.DISTINCT
-                    }
-                    lhs = exprQuerySet {
-                        body = queryBodySetOp {
-                            type = setOp {
-                                type = SetOp.Type.INTERSECT
-                                setq = SetQuantifier.ALL
-                            }
-                            lhs = createSFW(1)
-                            rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.INTERSECT(),
+                        setq = SetQuantifier.DISTINCT()
+                    ),
+                    lhs = exprQuerySet(
+                        body = queryBodySetOp(
+                            type = setOp(
+                                setOpType = SetOpType.INTERSECT(),
+                                setq = SetQuantifier.ALL()
+                            ),
+                            lhs = createSFW(1),
+                            rhs = createSFW(2),
                             isOuter = false
-                        }
-                    }
-                    rhs = createLit(3)
+                        ),
+                        orderBy = null,
+                        limit = null,
+                        offset = null
+                    ),
+                    rhs = createLit(3),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 
     @Test
     fun outerIntersectAndSQLIntersect() = assertExpression(
         "1 INTERSECT ALL SELECT * FROM <<{'a': 2}>> INTERSECT DISTINCT SELECT * FROM <<{'a': 3}>>",
-        query {
-            exprQuerySet {
-                body = queryBodySetOp {
-                    type = setOp {
-                        type = SetOp.Type.INTERSECT
-                        setq = SetQuantifier.DISTINCT
-                    }
-                    lhs = exprQuerySet {
-                        body = queryBodySetOp {
-                            type = setOp {
-                                type = SetOp.Type.INTERSECT
-                                setq = SetQuantifier.ALL
-                            }
-                            lhs = createLit(1)
-                            rhs = createSFW(2)
+        queryBody {
+            exprQuerySet(
+                body = queryBodySetOp(
+                    type = setOp(
+                        setOpType = SetOpType.INTERSECT(),
+                        setq = SetQuantifier.DISTINCT()
+                    ),
+                    lhs = exprQuerySet(
+                        body = queryBodySetOp(
+                            type = setOp(
+                                setOpType = SetOpType.INTERSECT(),
+                                setq = SetQuantifier.ALL()
+                            ),
+                            lhs = createLit(1),
+                            rhs = createSFW(2),
                             isOuter = false
-                        }
-                    }
-                    rhs = createSFW(3)
+                        ),
+                        orderBy = null,
+                        limit = null,
+                        offset = null
+                    ),
+                    rhs = createSFW(3),
                     isOuter = false
-                }
-            }
+                ),
+                orderBy = null,
+                limit = null,
+                offset = null
+            )
         }
     )
 

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserDDLTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserDDLTests.kt
@@ -1,22 +1,11 @@
 package org.partiql.parser.internal
 
-import org.junit.jupiter.api.extension.ExtensionContext
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.ArgumentsProvider
-import org.junit.jupiter.params.provider.ArgumentsSource
-import org.partiql.ast.AstNode
-import org.partiql.ast.Identifier
-import org.partiql.ast.identifierQualified
-import org.partiql.ast.identifierSymbol
-import org.partiql.ast.statementDDLCreateTable
-import org.partiql.ast.statementDDLDropTable
-import java.util.stream.Stream
+import org.partiql.ast.v1.AstNode
 import kotlin.test.assertEquals
 
 class PartiQLParserDDLTests {
 
-    private val parser = PartiQLParserDefault()
+    private val parser = V1PartiQLParserDefault()
 
     data class SuccessTestCase(
         val description: String? = null,
@@ -24,107 +13,108 @@ class PartiQLParserDDLTests {
         val node: AstNode
     )
 
-    @ArgumentsSource(TestProvider::class)
-    @ParameterizedTest
-    fun errorTests(tc: SuccessTestCase) = assertExpression(tc.query, tc.node)
-
-    class TestProvider : ArgumentsProvider {
-        val createTableTests = listOf(
-            SuccessTestCase(
-                "CREATE TABLE with unqualified case insensitive name",
-                "CREATE TABLE foo",
-                statementDDLCreateTable(
-                    identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
-                    null
-                )
-            ),
-            // Support Case Sensitive identifier as table name
-            // Subsequent process may need to change
-            // See: https://www.db-fiddle.com/f/9A8mknSNYuRGLfkqkLeiHD/0 for reference.
-            SuccessTestCase(
-                "CREATE TABLE with unqualified case sensitive name",
-                "CREATE TABLE \"foo\"",
-                statementDDLCreateTable(
-                    identifierSymbol("foo", Identifier.CaseSensitivity.SENSITIVE),
-                    null
-                )
-            ),
-            SuccessTestCase(
-                "CREATE TABLE with qualified case insensitive name",
-                "CREATE TABLE myCatalog.mySchema.foo",
-                statementDDLCreateTable(
-                    identifierQualified(
-                        identifierSymbol("myCatalog", Identifier.CaseSensitivity.INSENSITIVE),
-                        listOf(
-                            identifierSymbol("mySchema", Identifier.CaseSensitivity.INSENSITIVE),
-                            identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
-                        )
-                    ),
-                    null
-                )
-            ),
-            SuccessTestCase(
-                "CREATE TABLE with qualified name with mixed case sensitivity",
-                "CREATE TABLE myCatalog.\"mySchema\".foo",
-                statementDDLCreateTable(
-                    identifierQualified(
-                        identifierSymbol("myCatalog", Identifier.CaseSensitivity.INSENSITIVE),
-                        listOf(
-                            identifierSymbol("mySchema", Identifier.CaseSensitivity.SENSITIVE),
-                            identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
-                        )
-                    ),
-                    null
-                )
-            ),
-        )
-
-        val dropTableTests = listOf(
-            SuccessTestCase(
-                "DROP TABLE with unqualified case insensitive name",
-                "DROP TABLE foo",
-                statementDDLDropTable(
-                    identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
-                )
-            ),
-            SuccessTestCase(
-                "DROP TABLE with unqualified case sensitive name",
-                "DROP TABLE \"foo\"",
-                statementDDLDropTable(
-                    identifierSymbol("foo", Identifier.CaseSensitivity.SENSITIVE),
-                )
-            ),
-            SuccessTestCase(
-                "DROP TABLE with qualified case insensitive name",
-                "DROP TABLE myCatalog.mySchema.foo",
-                statementDDLDropTable(
-                    identifierQualified(
-                        identifierSymbol("myCatalog", Identifier.CaseSensitivity.INSENSITIVE),
-                        listOf(
-                            identifierSymbol("mySchema", Identifier.CaseSensitivity.INSENSITIVE),
-                            identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
-                        )
-                    ),
-                )
-            ),
-            SuccessTestCase(
-                "DROP TABLE with qualified name with mixed case sensitivity",
-                "DROP TABLE myCatalog.\"mySchema\".foo",
-                statementDDLDropTable(
-                    identifierQualified(
-                        identifierSymbol("myCatalog", Identifier.CaseSensitivity.INSENSITIVE),
-                        listOf(
-                            identifierSymbol("mySchema", Identifier.CaseSensitivity.SENSITIVE),
-                            identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
-                        )
-                    ),
-                )
-            ),
-        )
-
-        override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> =
-            (createTableTests + dropTableTests).map { Arguments.of(it) }.stream()
-    }
+    // DDL not yet supported in v1 AST
+//    @ArgumentsSource(TestProvider::class)
+//    @ParameterizedTest
+//    fun errorTests(tc: SuccessTestCase) = assertExpression(tc.query, tc.node)
+//
+//    class TestProvider : ArgumentsProvider {
+//        val createTableTests = listOf(
+//            SuccessTestCase(
+//                "CREATE TABLE with unqualified case insensitive name",
+//                "CREATE TABLE foo",
+//                statementDDLCreateTable(
+//                    identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
+//                    null
+//                )
+//            ),
+//            // Support Case Sensitive identifier as table name
+//            // Subsequent process may need to change
+//            // See: https://www.db-fiddle.com/f/9A8mknSNYuRGLfkqkLeiHD/0 for reference.
+//            SuccessTestCase(
+//                "CREATE TABLE with unqualified case sensitive name",
+//                "CREATE TABLE \"foo\"",
+//                statementDDLCreateTable(
+//                    identifierSymbol("foo", Identifier.CaseSensitivity.SENSITIVE),
+//                    null
+//                )
+//            ),
+//            SuccessTestCase(
+//                "CREATE TABLE with qualified case insensitive name",
+//                "CREATE TABLE myCatalog.mySchema.foo",
+//                statementDDLCreateTable(
+//                    identifierQualified(
+//                        identifierSymbol("myCatalog", Identifier.CaseSensitivity.INSENSITIVE),
+//                        listOf(
+//                            identifierSymbol("mySchema", Identifier.CaseSensitivity.INSENSITIVE),
+//                            identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
+//                        )
+//                    ),
+//                    null
+//                )
+//            ),
+//            SuccessTestCase(
+//                "CREATE TABLE with qualified name with mixed case sensitivity",
+//                "CREATE TABLE myCatalog.\"mySchema\".foo",
+//                statementDDLCreateTable(
+//                    identifierQualified(
+//                        identifierSymbol("myCatalog", Identifier.CaseSensitivity.INSENSITIVE),
+//                        listOf(
+//                            identifierSymbol("mySchema", Identifier.CaseSensitivity.SENSITIVE),
+//                            identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
+//                        )
+//                    ),
+//                    null
+//                )
+//            ),
+//        )
+//
+//        val dropTableTests = listOf(
+//            SuccessTestCase(
+//                "DROP TABLE with unqualified case insensitive name",
+//                "DROP TABLE foo",
+//                statementDDLDropTable(
+//                    identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
+//                )
+//            ),
+//            SuccessTestCase(
+//                "DROP TABLE with unqualified case sensitive name",
+//                "DROP TABLE \"foo\"",
+//                statementDDLDropTable(
+//                    identifierSymbol("foo", Identifier.CaseSensitivity.SENSITIVE),
+//                )
+//            ),
+//            SuccessTestCase(
+//                "DROP TABLE with qualified case insensitive name",
+//                "DROP TABLE myCatalog.mySchema.foo",
+//                statementDDLDropTable(
+//                    identifierQualified(
+//                        identifierSymbol("myCatalog", Identifier.CaseSensitivity.INSENSITIVE),
+//                        listOf(
+//                            identifierSymbol("mySchema", Identifier.CaseSensitivity.INSENSITIVE),
+//                            identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
+//                        )
+//                    ),
+//                )
+//            ),
+//            SuccessTestCase(
+//                "DROP TABLE with qualified name with mixed case sensitivity",
+//                "DROP TABLE myCatalog.\"mySchema\".foo",
+//                statementDDLDropTable(
+//                    identifierQualified(
+//                        identifierSymbol("myCatalog", Identifier.CaseSensitivity.INSENSITIVE),
+//                        listOf(
+//                            identifierSymbol("mySchema", Identifier.CaseSensitivity.SENSITIVE),
+//                            identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
+//                        )
+//                    ),
+//                )
+//            ),
+//        )
+//
+//        override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> =
+//            (createTableTests + dropTableTests).map { Arguments.of(it) }.stream()
+//    }
 
     private fun assertExpression(input: String, expected: AstNode) {
         val result = parser.parse(input)

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserFunctionCallTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserFunctionCallTests.kt
@@ -1,27 +1,26 @@
 package org.partiql.parser.internal
 
 import org.junit.jupiter.api.Test
-import org.partiql.ast.AstNode
-import org.partiql.ast.Expr
-import org.partiql.ast.Identifier
-import org.partiql.ast.exprCall
-import org.partiql.ast.identifierQualified
-import org.partiql.ast.identifierSymbol
-import org.partiql.ast.statementQuery
+import org.partiql.ast.v1.Ast.exprCall
+import org.partiql.ast.v1.Ast.identifier
+import org.partiql.ast.v1.Ast.identifierChain
+import org.partiql.ast.v1.Ast.query
+import org.partiql.ast.v1.AstNode
+import org.partiql.ast.v1.expr.Expr
 import kotlin.test.assertEquals
 
 class PartiQLParserFunctionCallTests {
 
-    private val parser = PartiQLParserDefault()
+    private val parser = V1PartiQLParserDefault()
 
-    private inline fun query(body: () -> Expr) = statementQuery(body())
+    private inline fun queryBody(body: () -> Expr) = query(body())
 
     @Test
     fun callUnqualifiedNonReservedInsensitive() = assertExpression(
         "foo()",
-        query {
+        queryBody {
             exprCall(
-                function = identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
+                function = identifierChain(identifier("foo", false), null),
                 args = emptyList(),
                 setq = null
             )
@@ -31,9 +30,9 @@ class PartiQLParserFunctionCallTests {
     @Test
     fun callUnqualifiedNonReservedSensitive() = assertExpression(
         "\"foo\"()",
-        query {
+        queryBody {
             exprCall(
-                function = identifierSymbol("foo", Identifier.CaseSensitivity.SENSITIVE),
+                function = identifierChain(identifier("foo", true), null),
                 args = emptyList(),
                 setq = null
             )
@@ -43,9 +42,9 @@ class PartiQLParserFunctionCallTests {
     @Test
     fun callUnqualifiedReservedInsensitive() = assertExpression(
         "upper()",
-        query {
+        queryBody {
             exprCall(
-                function = identifierSymbol("upper", Identifier.CaseSensitivity.INSENSITIVE),
+                function = identifierChain(identifier("upper", false), null),
                 args = emptyList(),
                 setq = null
             )
@@ -55,9 +54,9 @@ class PartiQLParserFunctionCallTests {
     @Test
     fun callUnqualifiedReservedSensitive() = assertExpression(
         "\"upper\"()",
-        query {
+        queryBody {
             exprCall(
-                function = identifierSymbol("upper", Identifier.CaseSensitivity.SENSITIVE),
+                function = identifierChain(identifier("upper", true), null),
                 args = emptyList(),
                 setq = null
             )
@@ -67,13 +66,13 @@ class PartiQLParserFunctionCallTests {
     @Test
     fun callQualifiedNonReservedInsensitive() = assertExpression(
         "my_catalog.my_schema.foo()",
-        query {
+        queryBody {
             exprCall(
-                function = identifierQualified(
-                    root = identifierSymbol("my_catalog", Identifier.CaseSensitivity.INSENSITIVE),
-                    steps = listOf(
-                        identifierSymbol("my_schema", Identifier.CaseSensitivity.INSENSITIVE),
-                        identifierSymbol("foo", Identifier.CaseSensitivity.INSENSITIVE),
+                function = identifierChain(
+                    root = identifier("my_catalog", false),
+                    next = identifierChain(
+                        root = identifier("my_schema", false),
+                        next = identifierChain(identifier("foo", false), null),
                     )
                 ),
                 args = emptyList(),
@@ -85,13 +84,13 @@ class PartiQLParserFunctionCallTests {
     @Test
     fun callQualifiedNonReservedSensitive() = assertExpression(
         "my_catalog.my_schema.\"foo\"()",
-        query {
+        queryBody {
             exprCall(
-                function = identifierQualified(
-                    root = identifierSymbol("my_catalog", Identifier.CaseSensitivity.INSENSITIVE),
-                    steps = listOf(
-                        identifierSymbol("my_schema", Identifier.CaseSensitivity.INSENSITIVE),
-                        identifierSymbol("foo", Identifier.CaseSensitivity.SENSITIVE),
+                function = identifierChain(
+                    root = identifier("my_catalog", false),
+                    next = identifierChain(
+                        identifier("my_schema", false),
+                        identifierChain(identifier("foo", true), null),
                     )
                 ),
                 args = emptyList(),
@@ -103,13 +102,13 @@ class PartiQLParserFunctionCallTests {
     @Test
     fun callQualifiedReservedInsensitive() = assertExpression(
         "my_catalog.my_schema.upper()",
-        query {
+        queryBody {
             exprCall(
-                function = identifierQualified(
-                    root = identifierSymbol("my_catalog", Identifier.CaseSensitivity.INSENSITIVE),
-                    steps = listOf(
-                        identifierSymbol("my_schema", Identifier.CaseSensitivity.INSENSITIVE),
-                        identifierSymbol("upper", Identifier.CaseSensitivity.INSENSITIVE),
+                function = identifierChain(
+                    root = identifier("my_catalog", false),
+                    next = identifierChain(
+                        identifier("my_schema", false),
+                        identifierChain(identifier("upper", false), null),
                     )
                 ),
                 args = emptyList(),
@@ -121,13 +120,13 @@ class PartiQLParserFunctionCallTests {
     @Test
     fun callQualifiedReservedSensitive() = assertExpression(
         "my_catalog.my_schema.\"upper\"()",
-        query {
+        queryBody {
             exprCall(
-                function = identifierQualified(
-                    root = identifierSymbol("my_catalog", Identifier.CaseSensitivity.INSENSITIVE),
-                    steps = listOf(
-                        identifierSymbol("my_schema", Identifier.CaseSensitivity.INSENSITIVE),
-                        identifierSymbol("upper", Identifier.CaseSensitivity.SENSITIVE),
+                function = identifierChain(
+                    root = identifier("my_catalog", false),
+                    next = identifierChain(
+                        identifier("my_schema", false),
+                        identifierChain(identifier("upper", true), null),
                     )
                 ),
                 args = emptyList(),

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserOperatorTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserOperatorTests.kt
@@ -1,11 +1,11 @@
 package org.partiql.parser.internal
 
 import org.junit.jupiter.api.Test
-import org.partiql.ast.AstNode
-import org.partiql.ast.Expr
-import org.partiql.ast.exprLit
-import org.partiql.ast.exprOperator
-import org.partiql.ast.statementQuery
+import org.partiql.ast.v1.Ast.exprLit
+import org.partiql.ast.v1.Ast.exprOperator
+import org.partiql.ast.v1.Ast.query
+import org.partiql.ast.v1.AstNode
+import org.partiql.ast.v1.expr.Expr
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.int32Value
 import kotlin.test.assertEquals
@@ -13,14 +13,14 @@ import kotlin.test.assertEquals
 @OptIn(PartiQLValueExperimental::class)
 class PartiQLParserOperatorTests {
 
-    private val parser = PartiQLParserDefault()
+    private val parser = V1PartiQLParserDefault()
 
-    private inline fun query(body: () -> Expr) = statementQuery(body())
+    private inline fun queryBody(body: () -> Expr) = query(body())
 
     @Test
     fun builtinUnaryOperator() = assertExpression(
         "-2",
-        query {
+        queryBody {
             exprOperator(
                 symbol = "-",
                 lhs = null,
@@ -32,7 +32,7 @@ class PartiQLParserOperatorTests {
     @Test
     fun builtinBinaryOperator() = assertExpression(
         "1 <= 2",
-        query {
+        queryBody {
             exprOperator(
                 symbol = "<=",
                 lhs = exprLit(int32Value(1)),
@@ -44,7 +44,7 @@ class PartiQLParserOperatorTests {
     @Test
     fun customUnaryOperator() = assertExpression(
         "==!2",
-        query {
+        queryBody {
             exprOperator(
                 symbol = "==!",
                 lhs = null,
@@ -56,7 +56,7 @@ class PartiQLParserOperatorTests {
     @Test
     fun customBinaryOperator() = assertExpression(
         "1 ==! 2",
-        query {
+        queryBody {
             exprOperator(
                 symbol = "==!",
                 lhs = exprLit(int32Value(1)),

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserSessionAttributeTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserSessionAttributeTests.kt
@@ -1,12 +1,13 @@
 package org.partiql.parser.internal
 
 import org.junit.jupiter.api.Test
-import org.partiql.ast.AstNode
-import org.partiql.ast.Expr
-import org.partiql.ast.exprLit
-import org.partiql.ast.exprOperator
-import org.partiql.ast.exprSessionAttribute
-import org.partiql.ast.statementQuery
+import org.partiql.ast.v1.Ast.exprLit
+import org.partiql.ast.v1.Ast.exprOperator
+import org.partiql.ast.v1.Ast.exprSessionAttribute
+import org.partiql.ast.v1.Ast.query
+import org.partiql.ast.v1.AstNode
+import org.partiql.ast.v1.expr.Expr
+import org.partiql.ast.v1.expr.SessionAttribute
 import org.partiql.value.PartiQLValueExperimental
 import org.partiql.value.int32Value
 import kotlin.test.assertEquals
@@ -14,42 +15,42 @@ import kotlin.test.assertEquals
 @OptIn(PartiQLValueExperimental::class)
 class PartiQLParserSessionAttributeTests {
 
-    private val parser = PartiQLParserDefault()
+    private val parser = V1PartiQLParserDefault()
 
-    private inline fun query(body: () -> Expr) = statementQuery(body())
+    private inline fun queryBody(body: () -> Expr) = query(body())
 
     @Test
     fun currentUserUpperCase() = assertExpression(
         "CURRENT_USER",
-        query {
-            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_USER)
+        queryBody {
+            exprSessionAttribute(SessionAttribute.CURRENT_USER())
         }
     )
 
     @Test
     fun currentUserMixedCase() = assertExpression(
         "CURRENT_user",
-        query {
-            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_USER)
+        queryBody {
+            exprSessionAttribute(SessionAttribute.CURRENT_USER())
         }
     )
 
     @Test
     fun currentUserLowerCase() = assertExpression(
         "current_user",
-        query {
-            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_USER)
+        queryBody {
+            exprSessionAttribute(SessionAttribute.CURRENT_USER())
         }
     )
 
     @Test
     fun currentUserEquals() = assertExpression(
         "1 = current_user",
-        query {
+        queryBody {
             exprOperator(
                 symbol = "=",
                 lhs = exprLit(int32Value(1)),
-                rhs = exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_USER)
+                rhs = exprSessionAttribute(SessionAttribute.CURRENT_USER())
             )
         }
     )
@@ -57,24 +58,24 @@ class PartiQLParserSessionAttributeTests {
     @Test
     fun currentDateUpperCase() = assertExpression(
         "CURRENT_DATE",
-        query {
-            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_DATE)
+        queryBody {
+            exprSessionAttribute(SessionAttribute.CURRENT_DATE())
         }
     )
 
     @Test
     fun currentDateMixedCase() = assertExpression(
         "CURRENT_date",
-        query {
-            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_DATE)
+        queryBody {
+            exprSessionAttribute(SessionAttribute.CURRENT_DATE())
         }
     )
 
     @Test
     fun currentDateLowerCase() = assertExpression(
         "current_date",
-        query {
-            exprSessionAttribute(Expr.SessionAttribute.Attribute.CURRENT_DATE)
+        queryBody {
+            exprSessionAttribute(SessionAttribute.CURRENT_DATE())
         }
     )
 


### PR DESCRIPTION
## Relevant Issues
- https://github.com/partiql/partiql-lang-kotlin/issues/1610

## Description
- Migrates the partiql-parser to use the new AST

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - On v1 branch

- Any backward-incompatible changes? **[NO]**
  - Some changes but on v1 and hasn't been release yet

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.