### PR TITLE
[v1] Add .valueOf and .values methods for enums

### DIFF
--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -5855,6 +5855,7 @@ public class org/partiql/ast/v1/DataType : org/partiql/ast/v1/Enum {
 	public static fun TINYINT ()Lorg/partiql/ast/v1/DataType;
 	public static fun TUPLE ()Lorg/partiql/ast/v1/DataType;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/DataType;
+	public static fun USER_DEFINED ()Lorg/partiql/ast/v1/DataType;
 	public static fun USER_DEFINED (Lorg/partiql/ast/v1/IdentifierChain;)Lorg/partiql/ast/v1/DataType;
 	public static fun VARCHAR ()Lorg/partiql/ast/v1/DataType;
 	public static fun VARCHAR (I)Lorg/partiql/ast/v1/DataType;
@@ -5866,6 +5867,8 @@ public class org/partiql/ast/v1/DataType : org/partiql/ast/v1/Enum {
 	public fun getPrecision ()Ljava/lang/Integer;
 	public fun getScale ()Ljava/lang/Integer;
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/DataType;
+	public static fun values ()[Lorg/partiql/ast/v1/DataType;
 }
 
 public class org/partiql/ast/v1/DatetimeField : org/partiql/ast/v1/Enum {
@@ -5891,6 +5894,8 @@ public class org/partiql/ast/v1/DatetimeField : org/partiql/ast/v1/Enum {
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/DatetimeField;
+	public static fun values ()[Lorg/partiql/ast/v1/DatetimeField;
 }
 
 public abstract interface class org/partiql/ast/v1/Enum {
@@ -6085,6 +6090,8 @@ public class org/partiql/ast/v1/FromType : org/partiql/ast/v1/Enum {
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/FromType;
+	public static fun values ()[Lorg/partiql/ast/v1/FromType;
 }
 
 public class org/partiql/ast/v1/GroupBy : org/partiql/ast/v1/AstNode {
@@ -6135,6 +6142,8 @@ public class org/partiql/ast/v1/GroupByStrategy : org/partiql/ast/v1/Enum {
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/GroupByStrategy;
+	public static fun values ()[Lorg/partiql/ast/v1/GroupByStrategy;
 }
 
 public class org/partiql/ast/v1/Identifier : org/partiql/ast/v1/AstNode {
@@ -6198,6 +6207,8 @@ public class org/partiql/ast/v1/JoinType : org/partiql/ast/v1/Enum {
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/JoinType;
+	public static fun values ()[Lorg/partiql/ast/v1/JoinType;
 }
 
 public class org/partiql/ast/v1/Let : org/partiql/ast/v1/AstNode {
@@ -6244,6 +6255,8 @@ public class org/partiql/ast/v1/Nulls : org/partiql/ast/v1/Enum {
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/Nulls;
+	public static fun values ()[Lorg/partiql/ast/v1/Nulls;
 }
 
 public class org/partiql/ast/v1/Order : org/partiql/ast/v1/Enum {
@@ -6257,6 +6270,8 @@ public class org/partiql/ast/v1/Order : org/partiql/ast/v1/Enum {
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/Order;
+	public static fun values ()[Lorg/partiql/ast/v1/Order;
 }
 
 public class org/partiql/ast/v1/OrderBy : org/partiql/ast/v1/AstNode {
@@ -6497,6 +6512,8 @@ public class org/partiql/ast/v1/SetOpType : org/partiql/ast/v1/Enum {
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/SetOpType;
+	public static fun values ()[Lorg/partiql/ast/v1/SetOpType;
 }
 
 public class org/partiql/ast/v1/SetQuantifier : org/partiql/ast/v1/Enum {
@@ -6510,6 +6527,8 @@ public class org/partiql/ast/v1/SetQuantifier : org/partiql/ast/v1/Enum {
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/SetQuantifier;
+	public static fun values ()[Lorg/partiql/ast/v1/SetQuantifier;
 }
 
 public class org/partiql/ast/v1/Sort : org/partiql/ast/v1/AstNode {
@@ -7279,6 +7298,8 @@ public class org/partiql/ast/v1/expr/Scope : org/partiql/ast/v1/Enum {
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/Scope;
+	public static fun values ()[Lorg/partiql/ast/v1/expr/Scope;
 }
 
 public class org/partiql/ast/v1/expr/SessionAttribute : org/partiql/ast/v1/Enum {
@@ -7293,6 +7314,8 @@ public class org/partiql/ast/v1/expr/SessionAttribute : org/partiql/ast/v1/Enum 
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/SessionAttribute;
+	public static fun values ()[Lorg/partiql/ast/v1/expr/SessionAttribute;
 }
 
 public class org/partiql/ast/v1/expr/TrimSpec : org/partiql/ast/v1/Enum {
@@ -7308,6 +7331,8 @@ public class org/partiql/ast/v1/expr/TrimSpec : org/partiql/ast/v1/Enum {
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/TrimSpec;
+	public static fun values ()[Lorg/partiql/ast/v1/expr/TrimSpec;
 }
 
 public class org/partiql/ast/v1/expr/WindowFunction : org/partiql/ast/v1/Enum {
@@ -7322,6 +7347,8 @@ public class org/partiql/ast/v1/expr/WindowFunction : org/partiql/ast/v1/Enum {
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/WindowFunction;
+	public static fun values ()[Lorg/partiql/ast/v1/expr/WindowFunction;
 }
 
 public class org/partiql/ast/v1/graph/GraphDirection : org/partiql/ast/v1/Enum {
@@ -7345,6 +7372,8 @@ public class org/partiql/ast/v1/graph/GraphDirection : org/partiql/ast/v1/Enum {
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/graph/GraphDirection;
+	public static fun values ()[Lorg/partiql/ast/v1/graph/GraphDirection;
 }
 
 public abstract class org/partiql/ast/v1/graph/GraphLabel : org/partiql/ast/v1/AstNode {
@@ -7583,6 +7612,8 @@ public class org/partiql/ast/v1/graph/GraphRestrictor : org/partiql/ast/v1/Enum 
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/graph/GraphRestrictor;
+	public static fun values ()[Lorg/partiql/ast/v1/graph/GraphRestrictor;
 }
 
 public abstract class org/partiql/ast/v1/graph/GraphSelector : org/partiql/ast/v1/AstNode {

--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -5631,6 +5631,11 @@ public final class org/partiql/ast/v1/Ast {
 	public static final fun sort (Lorg/partiql/ast/v1/expr/Expr;Lorg/partiql/ast/v1/Order;Lorg/partiql/ast/v1/Nulls;)Lorg/partiql/ast/v1/Sort;
 }
 
+public abstract class org/partiql/ast/v1/AstEnum : org/partiql/ast/v1/AstNode {
+	public fun <init> ()V
+	public abstract fun code ()I
+}
+
 public abstract class org/partiql/ast/v1/AstNode {
 	public field tag Ljava/lang/String;
 	public fun <init> ()V
@@ -5737,7 +5742,7 @@ public abstract interface class org/partiql/ast/v1/AstVisitor {
 	public abstract fun visitTableRef (Lorg/partiql/ast/v1/FromTableRef;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
-public class org/partiql/ast/v1/DataType : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/DataType : org/partiql/ast/v1/AstEnum {
 	public static final field BAG I
 	public static final field BIGINT I
 	public static final field BINARY_LARGE_OBJECT I
@@ -5859,19 +5864,21 @@ public class org/partiql/ast/v1/DataType : org/partiql/ast/v1/Enum {
 	public static fun USER_DEFINED (Lorg/partiql/ast/v1/IdentifierChain;)Lorg/partiql/ast/v1/DataType;
 	public static fun VARCHAR ()Lorg/partiql/ast/v1/DataType;
 	public static fun VARCHAR (I)Lorg/partiql/ast/v1/DataType;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getLength ()Ljava/lang/Integer;
 	public fun getName ()Lorg/partiql/ast/v1/IdentifierChain;
 	public fun getPrecision ()Ljava/lang/Integer;
 	public fun getScale ()Ljava/lang/Integer;
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/DataType;
-	public static fun values ()[Lorg/partiql/ast/v1/DataType;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/DataType;
 }
 
-public class org/partiql/ast/v1/DatetimeField : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/DatetimeField : org/partiql/ast/v1/AstEnum {
 	public static final field DAY I
 	public static final field HOUR I
 	public static final field MINUTE I
@@ -5890,16 +5897,14 @@ public class org/partiql/ast/v1/DatetimeField : org/partiql/ast/v1/Enum {
 	public static fun TIMEZONE_MINUTE ()Lorg/partiql/ast/v1/DatetimeField;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/DatetimeField;
 	public static fun YEAR ()Lorg/partiql/ast/v1/DatetimeField;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/DatetimeField;
-	public static fun values ()[Lorg/partiql/ast/v1/DatetimeField;
-}
-
-public abstract interface class org/partiql/ast/v1/Enum {
-	public abstract fun code ()I
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/DatetimeField;
 }
 
 public class org/partiql/ast/v1/Exclude : org/partiql/ast/v1/AstNode {
@@ -6079,19 +6084,21 @@ public abstract class org/partiql/ast/v1/FromTableRef : org/partiql/ast/v1/AstNo
 	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
-public class org/partiql/ast/v1/FromType : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/FromType : org/partiql/ast/v1/AstEnum {
 	public static final field SCAN I
 	public static final field UNKNOWN I
 	public static final field UNPIVOT I
 	public static fun SCAN ()Lorg/partiql/ast/v1/FromType;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/FromType;
 	public static fun UNPIVOT ()Lorg/partiql/ast/v1/FromType;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/FromType;
-	public static fun values ()[Lorg/partiql/ast/v1/FromType;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/FromType;
 }
 
 public class org/partiql/ast/v1/GroupBy : org/partiql/ast/v1/AstNode {
@@ -6131,19 +6138,21 @@ public class org/partiql/ast/v1/GroupBy$Key$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/v1/GroupByStrategy : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/GroupByStrategy : org/partiql/ast/v1/AstEnum {
 	public static final field FULL I
 	public static final field PARTIAL I
 	public static final field UNKNOWN I
 	public static fun FULL ()Lorg/partiql/ast/v1/GroupByStrategy;
 	public static fun PARTIAL ()Lorg/partiql/ast/v1/GroupByStrategy;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/GroupByStrategy;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/GroupByStrategy;
-	public static fun values ()[Lorg/partiql/ast/v1/GroupByStrategy;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/GroupByStrategy;
 }
 
 public class org/partiql/ast/v1/Identifier : org/partiql/ast/v1/AstNode {
@@ -6184,7 +6193,7 @@ public class org/partiql/ast/v1/IdentifierChain$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/v1/JoinType : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/JoinType : org/partiql/ast/v1/AstEnum {
 	public static final field CROSS I
 	public static final field FULL I
 	public static final field FULL_OUTER I
@@ -6203,12 +6212,14 @@ public class org/partiql/ast/v1/JoinType : org/partiql/ast/v1/Enum {
 	public static fun RIGHT ()Lorg/partiql/ast/v1/JoinType;
 	public static fun RIGHT_OUTER ()Lorg/partiql/ast/v1/JoinType;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/JoinType;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/JoinType;
-	public static fun values ()[Lorg/partiql/ast/v1/JoinType;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/JoinType;
 }
 
 public class org/partiql/ast/v1/Let : org/partiql/ast/v1/AstNode {
@@ -6244,34 +6255,38 @@ public class org/partiql/ast/v1/Let$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/v1/Nulls : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/Nulls : org/partiql/ast/v1/AstEnum {
 	public static final field FIRST I
 	public static final field LAST I
 	public static final field UNKNOWN I
 	public static fun FIRST ()Lorg/partiql/ast/v1/Nulls;
 	public static fun LAST ()Lorg/partiql/ast/v1/Nulls;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/Nulls;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/Nulls;
-	public static fun values ()[Lorg/partiql/ast/v1/Nulls;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/Nulls;
 }
 
-public class org/partiql/ast/v1/Order : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/Order : org/partiql/ast/v1/AstEnum {
 	public static final field ASC I
 	public static final field DESC I
 	public static final field UNKNOWN I
 	public static fun ASC ()Lorg/partiql/ast/v1/Order;
 	public static fun DESC ()Lorg/partiql/ast/v1/Order;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/Order;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/Order;
-	public static fun values ()[Lorg/partiql/ast/v1/Order;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/Order;
 }
 
 public class org/partiql/ast/v1/OrderBy : org/partiql/ast/v1/AstNode {
@@ -6503,32 +6518,36 @@ public class org/partiql/ast/v1/SetOp$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/v1/SetOpType : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/SetOpType : org/partiql/ast/v1/AstEnum {
 	public static fun EXCEPT ()Lorg/partiql/ast/v1/SetOpType;
 	public static fun INTERSECT ()Lorg/partiql/ast/v1/SetOpType;
 	public static fun UNION ()Lorg/partiql/ast/v1/SetOpType;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/SetOpType;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/SetOpType;
-	public static fun values ()[Lorg/partiql/ast/v1/SetOpType;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/SetOpType;
 }
 
-public class org/partiql/ast/v1/SetQuantifier : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/SetQuantifier : org/partiql/ast/v1/AstEnum {
 	public static final field ALL I
 	public static final field DISTINCT I
 	public static final field UNKNOWN I
 	public static fun ALL ()Lorg/partiql/ast/v1/SetQuantifier;
 	public static fun DISTINCT ()Lorg/partiql/ast/v1/SetQuantifier;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/SetQuantifier;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/SetQuantifier;
-	public static fun values ()[Lorg/partiql/ast/v1/SetQuantifier;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/SetQuantifier;
 }
 
 public class org/partiql/ast/v1/Sort : org/partiql/ast/v1/AstNode {
@@ -7287,22 +7306,24 @@ public class org/partiql/ast/v1/expr/PathStep$Field : org/partiql/ast/v1/expr/Pa
 	public fun hashCode ()I
 }
 
-public class org/partiql/ast/v1/expr/Scope : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/expr/Scope : org/partiql/ast/v1/AstEnum {
 	public static final field DEFAULT I
 	public static final field LOCAL I
 	public static final field UNKNOWN I
 	public static fun DEFAULT ()Lorg/partiql/ast/v1/expr/Scope;
 	public static fun LOCAL ()Lorg/partiql/ast/v1/expr/Scope;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/expr/Scope;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/Scope;
-	public static fun values ()[Lorg/partiql/ast/v1/expr/Scope;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/Scope;
 }
 
-public class org/partiql/ast/v1/expr/SessionAttribute : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/expr/SessionAttribute : org/partiql/ast/v1/AstEnum {
 	public static final field CURRENT_DATE I
 	public static final field CURRENT_USER I
 	public static final field UNKNOWN I
@@ -7310,15 +7331,17 @@ public class org/partiql/ast/v1/expr/SessionAttribute : org/partiql/ast/v1/Enum 
 	public static fun CURRENT_DATE ()Lorg/partiql/ast/v1/expr/SessionAttribute;
 	public static fun CURRENT_USER ()Lorg/partiql/ast/v1/expr/SessionAttribute;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/expr/SessionAttribute;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/SessionAttribute;
-	public static fun values ()[Lorg/partiql/ast/v1/expr/SessionAttribute;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/SessionAttribute;
 }
 
-public class org/partiql/ast/v1/expr/TrimSpec : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/expr/TrimSpec : org/partiql/ast/v1/AstEnum {
 	public static final field BOTH I
 	public static final field LEADING I
 	public static final field TRAILING I
@@ -7327,15 +7350,17 @@ public class org/partiql/ast/v1/expr/TrimSpec : org/partiql/ast/v1/Enum {
 	public static fun LEADING ()Lorg/partiql/ast/v1/expr/TrimSpec;
 	public static fun TRAILING ()Lorg/partiql/ast/v1/expr/TrimSpec;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/expr/TrimSpec;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/TrimSpec;
-	public static fun values ()[Lorg/partiql/ast/v1/expr/TrimSpec;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/TrimSpec;
 }
 
-public class org/partiql/ast/v1/expr/WindowFunction : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/expr/WindowFunction : org/partiql/ast/v1/AstEnum {
 	public static final field LAG I
 	public static final field LEAD I
 	public static final field UNKNOWN I
@@ -7343,15 +7368,17 @@ public class org/partiql/ast/v1/expr/WindowFunction : org/partiql/ast/v1/Enum {
 	public static fun LAG ()Lorg/partiql/ast/v1/expr/WindowFunction;
 	public static fun LEAD ()Lorg/partiql/ast/v1/expr/WindowFunction;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/expr/WindowFunction;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/WindowFunction;
-	public static fun values ()[Lorg/partiql/ast/v1/expr/WindowFunction;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/WindowFunction;
 }
 
-public class org/partiql/ast/v1/graph/GraphDirection : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/graph/GraphDirection : org/partiql/ast/v1/AstEnum {
 	public static final field LEFT I
 	public static final field LEFT_OR_RIGHT I
 	public static final field LEFT_OR_UNDIRECTED I
@@ -7368,12 +7395,14 @@ public class org/partiql/ast/v1/graph/GraphDirection : org/partiql/ast/v1/Enum {
 	public static fun UNDIRECTED ()Lorg/partiql/ast/v1/graph/GraphDirection;
 	public static fun UNDIRECTED_OR_RIGHT ()Lorg/partiql/ast/v1/graph/GraphDirection;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/graph/GraphDirection;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/graph/GraphDirection;
-	public static fun values ()[Lorg/partiql/ast/v1/graph/GraphDirection;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/graph/GraphDirection;
 }
 
 public abstract class org/partiql/ast/v1/graph/GraphLabel : org/partiql/ast/v1/AstNode {
@@ -7599,7 +7628,7 @@ public class org/partiql/ast/v1/graph/GraphQuantifier$Builder {
 	public fun upper (Ljava/lang/Long;)Lorg/partiql/ast/v1/graph/GraphQuantifier$Builder;
 }
 
-public class org/partiql/ast/v1/graph/GraphRestrictor : org/partiql/ast/v1/Enum {
+public class org/partiql/ast/v1/graph/GraphRestrictor : org/partiql/ast/v1/AstEnum {
 	public static final field ACYCLIC I
 	public static final field SIMPLE I
 	public static final field TRAIL I
@@ -7608,12 +7637,14 @@ public class org/partiql/ast/v1/graph/GraphRestrictor : org/partiql/ast/v1/Enum 
 	public static fun SIMPLE ()Lorg/partiql/ast/v1/graph/GraphRestrictor;
 	public static fun TRAIL ()Lorg/partiql/ast/v1/graph/GraphRestrictor;
 	public static fun UNKNOWN ()Lorg/partiql/ast/v1/graph/GraphRestrictor;
+	public fun accept (Lorg/partiql/ast/v1/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun children ()Ljava/util/Collection;
 	public fun code ()I
+	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public static fun valueOf (Ljava/lang/String;)Lorg/partiql/ast/v1/graph/GraphRestrictor;
-	public static fun values ()[Lorg/partiql/ast/v1/graph/GraphRestrictor;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/graph/GraphRestrictor;
 }
 
 public abstract class org/partiql/ast/v1/graph/GraphSelector : org/partiql/ast/v1/AstNode {

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/AstEnum.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/AstEnum.java
@@ -1,0 +1,8 @@
+package org.partiql.ast.v1;
+
+/**
+ * TODO docs, equals, hashcode
+ */
+public abstract class AstEnum extends AstNode {
+    public abstract int code();
+}

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/DataType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/DataType.java
@@ -1,6 +1,7 @@
 package org.partiql.ast.v1;
 
 import lombok.EqualsAndHashCode;
+import org.jetbrains.annotations.NotNull;
 
 @EqualsAndHashCode(callSuper = false)
 public class DataType implements Enum {
@@ -349,7 +350,11 @@ public class DataType implements Enum {
         return new DataType(INTERVAL);
     }
 
-    public static DataType USER_DEFINED(IdentifierChain name) {
+    public static DataType USER_DEFINED() {
+        return new DataType(USER_DEFINED);
+    }
+
+    public static DataType USER_DEFINED(@NotNull IdentifierChain name) {
         return new DataType(USER_DEFINED, name);
     }
 
@@ -389,6 +394,109 @@ public class DataType implements Enum {
     @Override
     public int code() {
         return code;
+    }
+
+    public static DataType valueOf(String value) {
+        switch (value) {
+            case "NULL": return NULL();
+            case "MISSING": return MISSING();
+            case "BOOL": return BOOL();
+            case "BOOLEAN": return BOOLEAN();
+            case "TINYINT": return TINYINT();
+            case "SMALLINT": return SMALLINT();
+            case "INTEGER2": return INTEGER2();
+            case "INT2": return INT2();
+            case "INTEGER": return INTEGER();
+            case "INT": return INT();
+            case "INTEGER4": return INTEGER4();
+            case "INT4": return INT4();
+            case "INTEGER8": return INTEGER8();
+            case "INT8": return INT8();
+            case "BIGINT": return BIGINT();
+            case "REAL": return REAL();
+            case "DOUBLE_PRECISION": return DOUBLE_PRECISION();
+            case "FLOAT": return FLOAT();
+            case "DECIMAL": return DECIMAL();
+            case "DEC": return DEC();
+            case "NUMERIC": return NUMERIC();
+            case "BIT": return BIT();
+            case "BIT_VARYING": return BIT_VARYING();
+            case "CHAR": return CHAR();
+            case "CHARACTER": return CHARACTER();
+            case "VARCHAR": return VARCHAR();
+            case "CHARACTER_LARGE_OBJECT": return CHARACTER_LARGE_OBJECT();
+            case "CHAR_LARGE_OBJECT": return CHAR_LARGE_OBJECT();
+            case "CHAR_VARYING": return CHAR_VARYING();
+            case "STRING": return STRING();
+            case "SYMBOL": return SYMBOL();
+            case "BLOB": return BLOB();
+            case "BINARY_LARGE_OBJECT": return BINARY_LARGE_OBJECT();
+            case "CLOB": return CLOB();
+            case "DATE": return DATE();
+            case "STRUCT": return STRUCT();
+            case "TUPLE": return TUPLE();
+            case "LIST": return LIST();
+            case "SEXP": return SEXP();
+            case "BAG": return BAG();
+            case "TIME": return TIME();
+            case "TIME_WITH_TIME_ZONE": return TIME_WITH_TIME_ZONE();
+            case "TIMESTAMP": return TIMESTAMP();
+            case "TIMESTAMP_WITH_TIME_ZONE": return TIMESTAMP_WITH_TIME_ZONE();
+            case "INTERVAL": return INTERVAL();
+            case "USER_DEFINED": return USER_DEFINED();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static DataType[] values() {
+        return new DataType[] {
+            NULL(),
+            MISSING(),
+            BOOL(),
+            BOOLEAN(),
+            TINYINT(),
+            SMALLINT(),
+            INTEGER2(),
+            INT2(),
+            INTEGER(),
+            INT(),
+            INTEGER4(),
+            INT4(),
+            INTEGER8(),
+            INT8(),
+            BIGINT(),
+            REAL(),
+            DOUBLE_PRECISION(),
+            FLOAT(),
+            DECIMAL(),
+            DEC(),
+            NUMERIC(),
+            BIT(),
+            BIT_VARYING(),
+            CHAR(),
+            CHARACTER(),
+            VARCHAR(),
+            CHARACTER_LARGE_OBJECT(),
+            CHAR_LARGE_OBJECT(),
+            CHAR_VARYING(),
+            STRING(),
+            SYMBOL(),
+            BLOB(),
+            BINARY_LARGE_OBJECT(),
+            CLOB(),
+            DATE(),
+            STRUCT(),
+            TUPLE(),
+            LIST(),
+            SEXP(),
+            BAG(),
+            TIME(),
+            TIME_WITH_TIME_ZONE(),
+            TIMESTAMP(),
+            TIMESTAMP_WITH_TIME_ZONE(),
+            INTERVAL(),
+            USER_DEFINED()
+        };
     }
 
     /**

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/DataType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/DataType.java
@@ -3,8 +3,12 @@ package org.partiql.ast.v1;
 import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 @EqualsAndHashCode(callSuper = false)
-public class DataType implements Enum {
+public class DataType extends AstEnum {
     public static final int UNKNOWN = 0;
     // <absent types>
     public static final int NULL = 1;
@@ -396,7 +400,58 @@ public class DataType implements Enum {
         return code;
     }
 
-    public static DataType valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        NULL,
+        MISSING,
+        BOOL,
+        BOOLEAN,
+        TINYINT,
+        SMALLINT,
+        INTEGER2,
+        INT2,
+        INTEGER,
+        INT,
+        INTEGER4,
+        INT4,
+        INTEGER8,
+        INT8,
+        BIGINT,
+        REAL,
+        DOUBLE_PRECISION,
+        FLOAT,
+        DECIMAL,
+        DEC,
+        NUMERIC,
+        BIT,
+        BIT_VARYING,
+        CHAR,
+        CHARACTER,
+        VARCHAR,
+        CHARACTER_LARGE_OBJECT,
+        CHAR_LARGE_OBJECT,
+        CHAR_VARYING,
+        STRING,
+        SYMBOL,
+        BLOB,
+        BINARY_LARGE_OBJECT,
+        CLOB,
+        DATE,
+        STRUCT,
+        TUPLE,
+        LIST,
+        SEXP,
+        BAG,
+        TIME,
+        TIME_WITH_TIME_ZONE,
+        TIMESTAMP,
+        TIMESTAMP_WITH_TIME_ZONE,
+        INTERVAL,
+        USER_DEFINED
+    };
+
+    @NotNull
+    public static DataType parse(@NotNull String value) {
         switch (value) {
             case "NULL": return NULL();
             case "MISSING": return MISSING();
@@ -448,55 +503,9 @@ public class DataType implements Enum {
         }
     }
 
-    public static DataType[] values() {
-        return new DataType[] {
-            NULL(),
-            MISSING(),
-            BOOL(),
-            BOOLEAN(),
-            TINYINT(),
-            SMALLINT(),
-            INTEGER2(),
-            INT2(),
-            INTEGER(),
-            INT(),
-            INTEGER4(),
-            INT4(),
-            INTEGER8(),
-            INT8(),
-            BIGINT(),
-            REAL(),
-            DOUBLE_PRECISION(),
-            FLOAT(),
-            DECIMAL(),
-            DEC(),
-            NUMERIC(),
-            BIT(),
-            BIT_VARYING(),
-            CHAR(),
-            CHARACTER(),
-            VARCHAR(),
-            CHARACTER_LARGE_OBJECT(),
-            CHAR_LARGE_OBJECT(),
-            CHAR_VARYING(),
-            STRING(),
-            SYMBOL(),
-            BLOB(),
-            BINARY_LARGE_OBJECT(),
-            CLOB(),
-            DATE(),
-            STRUCT(),
-            TUPLE(),
-            LIST(),
-            SEXP(),
-            BAG(),
-            TIME(),
-            TIME_WITH_TIME_ZONE(),
-            TIMESTAMP(),
-            TIMESTAMP_WITH_TIME_ZONE(),
-            INTERVAL(),
-            USER_DEFINED()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
     }
 
     /**
@@ -529,5 +538,20 @@ public class DataType implements Enum {
      */
     public IdentifierChain getName() {
         return name;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        List<AstNode> kids = new ArrayList<>();
+        if (name != null) {
+            kids.add(name);
+        }
+        return kids;
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/DatetimeField.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/DatetimeField.java
@@ -63,4 +63,31 @@ public class DatetimeField implements Enum {
     public int code() {
         return code;
     }
+
+    public static DatetimeField valueOf(String value) {
+        switch (value) {
+            case "YEAR": return YEAR();
+            case "MONTH": return MONTH();
+            case "DAY": return DAY();
+            case "HOUR": return HOUR();
+            case "MINUTE": return MINUTE();
+            case "SECOND": return SECOND();
+            case "TIMEZONE_HOUR": return TIMEZONE_HOUR();
+            case "TIMEZONE_MINUTE": return TIMEZONE_MINUTE();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static DatetimeField[] values() {
+        return new DatetimeField[] {
+            YEAR(),
+            MONTH(),
+            DAY(),
+            HOUR(),
+            MINUTE(),
+            SECOND(),
+            TIMEZONE_HOUR(),
+            TIMEZONE_MINUTE()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/DatetimeField.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/DatetimeField.java
@@ -1,12 +1,16 @@
 package org.partiql.ast.v1;
 
 import lombok.EqualsAndHashCode;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class DatetimeField implements Enum {
+public class DatetimeField extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int YEAR = 1;
     public static final int MONTH = 2;
@@ -64,7 +68,20 @@ public class DatetimeField implements Enum {
         return code;
     }
 
-    public static DatetimeField valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        YEAR,
+        MONTH,
+        DAY,
+        HOUR,
+        MINUTE,
+        SECOND,
+        TIMEZONE_HOUR,
+        TIMEZONE_MINUTE
+    };
+
+    @NotNull
+    public static DatetimeField parse(@NotNull String value) {
         switch (value) {
             case "YEAR": return YEAR();
             case "MONTH": return MONTH();
@@ -78,16 +95,19 @@ public class DatetimeField implements Enum {
         }
     }
 
-    public static DatetimeField[] values() {
-        return new DatetimeField[] {
-            YEAR(),
-            MONTH(),
-            DAY(),
-            HOUR(),
-            MINUTE(),
-            SECOND(),
-            TIMEZONE_HOUR(),
-            TIMEZONE_MINUTE()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/Enum.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/Enum.java
@@ -1,8 +1,0 @@
-package org.partiql.ast.v1;
-
-/**
- * TODO docs, equals, hashcode
- */
-public interface Enum {
-    int code();
-}

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/FromType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/FromType.java
@@ -33,4 +33,19 @@ public class FromType implements Enum {
     public int code() {
         return code;
     }
+
+    public static FromType valueOf(String value) {
+        switch (value) {
+            case "SCAN": return SCAN();
+            case "UNPIVOT": return UNPIVOT();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static FromType[] values() {
+        return new FromType[] {
+            SCAN(),
+            UNPIVOT()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/FromType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/FromType.java
@@ -1,12 +1,16 @@
 package org.partiql.ast.v1;
 
 import lombok.EqualsAndHashCode;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class FromType implements Enum {
+public class FromType extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int SCAN = 1;
     public static final int UNPIVOT = 2;
@@ -34,7 +38,14 @@ public class FromType implements Enum {
         return code;
     }
 
-    public static FromType valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        SCAN,
+        UNPIVOT
+    };
+
+    @NotNull
+    public static FromType parse(@NotNull String value) {
         switch (value) {
             case "SCAN": return SCAN();
             case "UNPIVOT": return UNPIVOT();
@@ -42,10 +53,19 @@ public class FromType implements Enum {
         }
     }
 
-    public static FromType[] values() {
-        return new FromType[] {
-            SCAN(),
-            UNPIVOT()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/GroupByStrategy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/GroupByStrategy.java
@@ -33,4 +33,19 @@ public class GroupByStrategy implements Enum {
     public int code() {
         return code;
     }
+
+    public static GroupByStrategy valueOf(String value) {
+        switch (value) {
+            case "FULL": return FULL();
+            case "PARTIAL": return PARTIAL();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static GroupByStrategy[] values() {
+        return new GroupByStrategy[] {
+            FULL(),
+            PARTIAL()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/GroupByStrategy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/GroupByStrategy.java
@@ -1,12 +1,16 @@
 package org.partiql.ast.v1;
 
 import lombok.EqualsAndHashCode;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class GroupByStrategy implements Enum {
+public class GroupByStrategy extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int FULL = 1;
     public static final int PARTIAL = 2;
@@ -25,6 +29,12 @@ public class GroupByStrategy implements Enum {
 
     private final int code;
 
+    @NotNull
+    private static final int[] codes = {
+        FULL,
+        PARTIAL
+    };
+
     private GroupByStrategy(int code) {
         this.code = code;
     }
@@ -34,7 +44,8 @@ public class GroupByStrategy implements Enum {
         return code;
     }
 
-    public static GroupByStrategy valueOf(String value) {
+    @NotNull
+    public static GroupByStrategy parse(@NotNull String value) {
         switch (value) {
             case "FULL": return FULL();
             case "PARTIAL": return PARTIAL();
@@ -42,10 +53,19 @@ public class GroupByStrategy implements Enum {
         }
     }
 
-    public static GroupByStrategy[] values() {
-        return new GroupByStrategy[] {
-            FULL(),
-            PARTIAL()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/JoinType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/JoinType.java
@@ -63,4 +63,31 @@ public class JoinType implements Enum {
     public int code() {
         return code;
     }
+
+    public static JoinType valueOf(String value) {
+        switch (value) {
+            case "INNER": return INNER();
+            case "LEFT": return LEFT();
+            case "LEFT_OUTER": return LEFT_OUTER();
+            case "RIGHT": return RIGHT();
+            case "RIGHT_OUTER": return RIGHT_OUTER();
+            case "FULL": return FULL();
+            case "FULL_OUTER": return FULL_OUTER();
+            case "CROSS": return CROSS();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static JoinType[] values() {
+        return new JoinType[] {
+            INNER(),
+            LEFT(),
+            LEFT_OUTER(),
+            RIGHT(),
+            RIGHT_OUTER(),
+            FULL(),
+            FULL_OUTER(),
+            CROSS()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/JoinType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/JoinType.java
@@ -1,12 +1,16 @@
 package org.partiql.ast.v1;
 
 import lombok.EqualsAndHashCode;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class JoinType implements Enum {
+public class JoinType extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int INNER = 1;
     public static final int LEFT = 2;
@@ -64,7 +68,20 @@ public class JoinType implements Enum {
         return code;
     }
 
-    public static JoinType valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        INNER,
+        LEFT,
+        LEFT_OUTER,
+        RIGHT,
+        RIGHT_OUTER,
+        FULL,
+        FULL_OUTER,
+        CROSS
+    };
+
+    @NotNull
+    public static JoinType parse(@NotNull String value) {
         switch (value) {
             case "INNER": return INNER();
             case "LEFT": return LEFT();
@@ -78,16 +95,19 @@ public class JoinType implements Enum {
         }
     }
 
-    public static JoinType[] values() {
-        return new JoinType[] {
-            INNER(),
-            LEFT(),
-            LEFT_OUTER(),
-            RIGHT(),
-            RIGHT_OUTER(),
-            FULL(),
-            FULL_OUTER(),
-            CROSS()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/Nulls.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/Nulls.java
@@ -33,4 +33,20 @@ public class Nulls implements Enum {
     public int code() {
         return code;
     }
+
+    public static Nulls valueOf(String value) {
+        switch (value) {
+            case "UNKNOWN": return UNKNOWN();
+            case "FIRST": return FIRST();
+            case "LAST": return LAST();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static Nulls[] values() {
+        return new Nulls[] {
+            FIRST(),
+            LAST()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/Nulls.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/Nulls.java
@@ -1,12 +1,16 @@
 package org.partiql.ast.v1;
 
 import lombok.EqualsAndHashCode;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class Nulls implements Enum {
+public class Nulls extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int FIRST = 1;
     public static final int LAST = 2;
@@ -34,7 +38,14 @@ public class Nulls implements Enum {
         return code;
     }
 
-    public static Nulls valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        FIRST,
+        LAST
+    };
+
+    @NotNull
+    public static Nulls parse(@NotNull String value) {
         switch (value) {
             case "UNKNOWN": return UNKNOWN();
             case "FIRST": return FIRST();
@@ -43,10 +54,19 @@ public class Nulls implements Enum {
         }
     }
 
-    public static Nulls[] values() {
-        return new Nulls[] {
-            FIRST(),
-            LAST()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/Order.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/Order.java
@@ -30,4 +30,19 @@ public class Order implements Enum {
     public int code() {
         return code;
     }
+
+    public static Order valueOf(String value) {
+        switch (value) {
+            case "ASC": return ASC();
+            case "DESC": return DESC();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static Order[] values() {
+        return new Order[] {
+            ASC(),
+            DESC()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/Order.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/Order.java
@@ -1,9 +1,13 @@
 package org.partiql.ast.v1;
 
 import lombok.EqualsAndHashCode;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
 
 @EqualsAndHashCode(callSuper = false)
-public class Order implements Enum {
+public class Order extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int ASC = 1;
     public static final int DESC = 2;
@@ -31,7 +35,14 @@ public class Order implements Enum {
         return code;
     }
 
-    public static Order valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        ASC,
+        DESC
+    };
+
+    @NotNull
+    public static Order parse(@NotNull String value) {
         switch (value) {
             case "ASC": return ASC();
             case "DESC": return DESC();
@@ -39,10 +50,19 @@ public class Order implements Enum {
         }
     }
 
-    public static Order[] values() {
-        return new Order[] {
-            ASC(),
-            DESC()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/SetOpType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/SetOpType.java
@@ -38,4 +38,22 @@ public class SetOpType implements Enum {
     public int code() {
         return code;
     }
+
+    public static SetOpType valueOf(String value) {
+        switch (value) {
+            case "UNKNOWN": return UNKNOWN();
+            case "UNION": return UNION();
+            case "INTERSECT": return INTERSECT();
+            case "EXCEPT": return EXCEPT();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static SetOpType[] values() {
+        return new SetOpType[] {
+            UNION(),
+            INTERSECT(),
+            EXCEPT()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/SetOpType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/SetOpType.java
@@ -1,12 +1,16 @@
 package org.partiql.ast.v1;
 
 import lombok.EqualsAndHashCode;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class SetOpType implements Enum {
+public class SetOpType extends AstEnum {
     private static final int UNKNOWN = 0;
     private static final int UNION = 1;
     private static final int INTERSECT = 2;
@@ -39,9 +43,16 @@ public class SetOpType implements Enum {
         return code;
     }
 
-    public static SetOpType valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        UNION,
+        INTERSECT,
+        EXCEPT
+    };
+
+    @NotNull
+    public static SetOpType parse(@NotNull String value) {
         switch (value) {
-            case "UNKNOWN": return UNKNOWN();
             case "UNION": return UNION();
             case "INTERSECT": return INTERSECT();
             case "EXCEPT": return EXCEPT();
@@ -49,11 +60,19 @@ public class SetOpType implements Enum {
         }
     }
 
-    public static SetOpType[] values() {
-        return new SetOpType[] {
-            UNION(),
-            INTERSECT(),
-            EXCEPT()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/SetQuantifier.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/SetQuantifier.java
@@ -33,4 +33,19 @@ public class SetQuantifier implements Enum {
     public int code() {
         return code;
     }
+
+    public static SetQuantifier valueOf(String value) {
+        switch (value) {
+            case "ALL": return ALL();
+            case "DISTINCT": return DISTINCT();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static SetQuantifier[] values() {
+        return new SetQuantifier[] {
+            ALL(),
+            DISTINCT()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/SetQuantifier.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/SetQuantifier.java
@@ -1,12 +1,16 @@
 package org.partiql.ast.v1;
 
 import lombok.EqualsAndHashCode;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class SetQuantifier implements Enum {
+public class SetQuantifier extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int ALL = 1;
     public static final int DISTINCT = 2;
@@ -34,7 +38,14 @@ public class SetQuantifier implements Enum {
         return code;
     }
 
-    public static SetQuantifier valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        ALL,
+        DISTINCT
+    };
+
+    @NotNull
+    public static SetQuantifier parse(@NotNull String value) {
         switch (value) {
             case "ALL": return ALL();
             case "DISTINCT": return DISTINCT();
@@ -42,10 +53,19 @@ public class SetQuantifier implements Enum {
         }
     }
 
-    public static SetQuantifier[] values() {
-        return new SetQuantifier[] {
-            ALL(),
-            DISTINCT()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/expr/Scope.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/expr/Scope.java
@@ -34,4 +34,20 @@ public class Scope implements Enum {
     public int code() {
         return code;
     }
+
+    public static Scope valueOf(String value) {
+        switch (value) {
+            case "UNKNOWN": return UNKNOWN();
+            case "DEFAULT": return DEFAULT();
+            case "LOCAL": return LOCAL();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static Scope[] values() {
+        return new Scope[] {
+            DEFAULT(),
+            LOCAL()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/expr/Scope.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/expr/Scope.java
@@ -1,13 +1,19 @@
 package org.partiql.ast.v1.expr;
 
 import lombok.EqualsAndHashCode;
-import org.partiql.ast.v1.Enum;
+import org.jetbrains.annotations.NotNull;
+import org.partiql.ast.v1.AstEnum;
+import org.partiql.ast.v1.AstNode;
+import org.partiql.ast.v1.AstVisitor;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class Scope implements Enum {
+public class Scope extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int DEFAULT = 1;
     public static final int LOCAL = 2;
@@ -35,7 +41,14 @@ public class Scope implements Enum {
         return code;
     }
 
-    public static Scope valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        DEFAULT,
+        LOCAL
+    };
+
+    @NotNull
+    public static Scope parse(@NotNull String value) {
         switch (value) {
             case "UNKNOWN": return UNKNOWN();
             case "DEFAULT": return DEFAULT();
@@ -44,10 +57,19 @@ public class Scope implements Enum {
         }
     }
 
-    public static Scope[] values() {
-        return new Scope[] {
-            DEFAULT(),
-            LOCAL()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/expr/SessionAttribute.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/expr/SessionAttribute.java
@@ -34,4 +34,19 @@ public class SessionAttribute implements Enum {
     public int code() {
         return code;
     }
+
+    public static SessionAttribute valueOf(String value) {
+        switch (value) {
+            case "CURRENT_USER": return CURRENT_USER();
+            case "CURRENT_DATE": return CURRENT_DATE();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static SessionAttribute[] values() {
+        return new SessionAttribute[] {
+            CURRENT_USER(),
+            CURRENT_DATE()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/expr/SessionAttribute.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/expr/SessionAttribute.java
@@ -1,13 +1,19 @@
 package org.partiql.ast.v1.expr;
 
 import lombok.EqualsAndHashCode;
-import org.partiql.ast.v1.Enum;
+import org.jetbrains.annotations.NotNull;
+import org.partiql.ast.v1.AstEnum;
+import org.partiql.ast.v1.AstNode;
+import org.partiql.ast.v1.AstVisitor;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class SessionAttribute implements Enum {
+public class SessionAttribute extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int CURRENT_USER = 1;
     public static final int CURRENT_DATE = 2;
@@ -35,7 +41,14 @@ public class SessionAttribute implements Enum {
         return code;
     }
 
-    public static SessionAttribute valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        CURRENT_USER,
+        CURRENT_DATE
+    };
+
+    @NotNull
+    public static SessionAttribute parse(@NotNull String value) {
         switch (value) {
             case "CURRENT_USER": return CURRENT_USER();
             case "CURRENT_DATE": return CURRENT_DATE();
@@ -43,10 +56,19 @@ public class SessionAttribute implements Enum {
         }
     }
 
-    public static SessionAttribute[] values() {
-        return new SessionAttribute[] {
-            CURRENT_USER(),
-            CURRENT_DATE()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/expr/TrimSpec.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/expr/TrimSpec.java
@@ -36,4 +36,21 @@ public class TrimSpec implements Enum {
     public int code() {
         return code;
     }
+
+    public static TrimSpec valueOf(String value) {
+        switch (value) {
+            case "LEADING": return LEADING();
+            case "TRAILING": return TRAILING();
+            case "BOTH": return BOTH();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static TrimSpec[] values() {
+        return new TrimSpec[] {
+            LEADING(),
+            TRAILING(),
+            BOTH()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/expr/TrimSpec.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/expr/TrimSpec.java
@@ -1,10 +1,16 @@
 package org.partiql.ast.v1.expr;
 
 import lombok.EqualsAndHashCode;
-import org.partiql.ast.v1.Enum;
+import org.jetbrains.annotations.NotNull;
+import org.partiql.ast.v1.AstEnum;
+import org.partiql.ast.v1.AstNode;
+import org.partiql.ast.v1.AstVisitor;
+
+import java.util.Collection;
+import java.util.Collections;
 
 @EqualsAndHashCode(callSuper = false)
-public class TrimSpec implements Enum {
+public class TrimSpec extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int LEADING = 1;
     public static final int TRAILING = 2;
@@ -37,7 +43,15 @@ public class TrimSpec implements Enum {
         return code;
     }
 
-    public static TrimSpec valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        LEADING,
+        TRAILING,
+        BOTH
+    };
+
+    @NotNull
+    public static TrimSpec parse(@NotNull String value) {
         switch (value) {
             case "LEADING": return LEADING();
             case "TRAILING": return TRAILING();
@@ -46,11 +60,19 @@ public class TrimSpec implements Enum {
         }
     }
 
-    public static TrimSpec[] values() {
-        return new TrimSpec[] {
-            LEADING(),
-            TRAILING(),
-            BOTH()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/expr/WindowFunction.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/expr/WindowFunction.java
@@ -34,4 +34,19 @@ public class WindowFunction implements Enum {
     public int code() {
         return code;
     }
+
+    public static WindowFunction valueOf(String value) {
+        switch (value) {
+            case "LAG": return LAG();
+            case "LEAD": return LEAD();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static WindowFunction[] values() {
+        return new WindowFunction[] {
+            LAG(),
+            LEAD()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/expr/WindowFunction.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/expr/WindowFunction.java
@@ -1,13 +1,19 @@
 package org.partiql.ast.v1.expr;
 
 import lombok.EqualsAndHashCode;
-import org.partiql.ast.v1.Enum;
+import org.jetbrains.annotations.NotNull;
+import org.partiql.ast.v1.AstEnum;
+import org.partiql.ast.v1.AstNode;
+import org.partiql.ast.v1.AstVisitor;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class WindowFunction implements Enum {
+public class WindowFunction extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int LAG = 0;
     public static final int LEAD = 0;
@@ -35,7 +41,14 @@ public class WindowFunction implements Enum {
         return code;
     }
 
-    public static WindowFunction valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        LAG,
+        LEAD
+    };
+
+    @NotNull
+    public static WindowFunction parse(@NotNull String value) {
         switch (value) {
             case "LAG": return LAG();
             case "LEAD": return LEAD();
@@ -43,10 +56,19 @@ public class WindowFunction implements Enum {
         }
     }
 
-    public static WindowFunction[] values() {
-        return new WindowFunction[] {
-            LAG(),
-            LEAD()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/graph/GraphDirection.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/graph/GraphDirection.java
@@ -59,4 +59,29 @@ public class GraphDirection implements Enum {
     public int code() {
         return code;
     }
+
+    public static GraphDirection valueOf(String value) {
+        switch (value) {
+            case "LEFT": return LEFT();
+            case "UNDIRECTED": return UNDIRECTED();
+            case "RIGHT": return RIGHT();
+            case "LEFT_OR_UNDIRECTED": return LEFT_OR_UNDIRECTED();
+            case "UNDIRECTED_OR_RIGHT": return UNDIRECTED_OR_RIGHT();
+            case "LEFT_OR_RIGHT": return LEFT_OR_RIGHT();
+            case "LEFT_UNDIRECTED_OR_RIGHT": return LEFT_UNDIRECTED_OR_RIGHT();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static GraphDirection[] values() {
+        return new GraphDirection[] {
+            LEFT(),
+            UNDIRECTED(),
+            RIGHT(),
+            LEFT_OR_UNDIRECTED(),
+            UNDIRECTED_OR_RIGHT(),
+            LEFT_OR_RIGHT(),
+            LEFT_UNDIRECTED_OR_RIGHT()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/graph/GraphDirection.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/graph/GraphDirection.java
@@ -1,13 +1,19 @@
 package org.partiql.ast.v1.graph;
 
 import lombok.EqualsAndHashCode;
-import org.partiql.ast.v1.Enum;
+import org.jetbrains.annotations.NotNull;
+import org.partiql.ast.v1.AstEnum;
+import org.partiql.ast.v1.AstNode;
+import org.partiql.ast.v1.AstVisitor;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class GraphDirection implements Enum {
+public class GraphDirection extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int LEFT = 1;
     public static final int UNDIRECTED = 2;
@@ -51,6 +57,17 @@ public class GraphDirection implements Enum {
 
     private final int code;
 
+    @NotNull
+    private static final int[] codes = {
+        LEFT,
+        UNDIRECTED,
+        RIGHT,
+        LEFT_OR_UNDIRECTED,
+        UNDIRECTED_OR_RIGHT,
+        LEFT_OR_RIGHT,
+        LEFT_UNDIRECTED_OR_RIGHT
+    };
+
     private GraphDirection(int code) {
         this.code = code;
     }
@@ -60,7 +77,8 @@ public class GraphDirection implements Enum {
         return code;
     }
 
-    public static GraphDirection valueOf(String value) {
+    @NotNull
+    public static GraphDirection parse(@NotNull String value) {
         switch (value) {
             case "LEFT": return LEFT();
             case "UNDIRECTED": return UNDIRECTED();
@@ -73,15 +91,19 @@ public class GraphDirection implements Enum {
         }
     }
 
-    public static GraphDirection[] values() {
-        return new GraphDirection[] {
-            LEFT(),
-            UNDIRECTED(),
-            RIGHT(),
-            LEFT_OR_UNDIRECTED(),
-            UNDIRECTED_OR_RIGHT(),
-            LEFT_OR_RIGHT(),
-            LEFT_UNDIRECTED_OR_RIGHT()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/graph/GraphRestrictor.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/graph/GraphRestrictor.java
@@ -39,4 +39,21 @@ public class GraphRestrictor implements Enum {
     public int code() {
         return code;
     }
+
+    public static GraphRestrictor valueOf(String value) {
+        switch (value) {
+            case "TRAIL": return TRAIL();
+            case "ACYCLIC": return ACYCLIC();
+            case "SIMPLE": return SIMPLE();
+            default: return UNKNOWN();
+        }
+    }
+
+    public static GraphRestrictor[] values() {
+        return new GraphRestrictor[] {
+            TRAIL(),
+            ACYCLIC(),
+            SIMPLE()
+        };
+    }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/graph/GraphRestrictor.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/graph/GraphRestrictor.java
@@ -1,13 +1,19 @@
 package org.partiql.ast.v1.graph;
 
 import lombok.EqualsAndHashCode;
-import org.partiql.ast.v1.Enum;
+import org.jetbrains.annotations.NotNull;
+import org.partiql.ast.v1.AstEnum;
+import org.partiql.ast.v1.AstNode;
+import org.partiql.ast.v1.AstVisitor;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class GraphRestrictor implements Enum {
+public class GraphRestrictor extends AstEnum {
     public static final int UNKNOWN = 0;
     public static final int TRAIL = 1;
     public static final int ACYCLIC = 2;
@@ -40,7 +46,15 @@ public class GraphRestrictor implements Enum {
         return code;
     }
 
-    public static GraphRestrictor valueOf(String value) {
+    @NotNull
+    private static final int[] codes = {
+        TRAIL,
+        ACYCLIC,
+        SIMPLE
+    };
+
+    @NotNull
+    public static GraphRestrictor parse(@NotNull String value) {
         switch (value) {
             case "TRAIL": return TRAIL();
             case "ACYCLIC": return ACYCLIC();
@@ -49,11 +63,19 @@ public class GraphRestrictor implements Enum {
         }
     }
 
-    public static GraphRestrictor[] values() {
-        return new GraphRestrictor[] {
-            TRAIL(),
-            ACYCLIC(),
-            SIMPLE()
-        };
+    @NotNull
+    public static int[] codes() {
+        return codes;
+    }
+
+    @NotNull
+    @Override
+    public Collection<AstNode> children() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
+        return null;
     }
 }


### PR DESCRIPTION
## Relevant Issues
- https://github.com/partiql/partiql-lang-kotlin/issues/1610

## Description
- The previous sprout-generated code used Kotlin enum classes which provided some helper methods when working with enum constants -- https://kotlinlang.org/docs/enum-classes.html#working-with-enum-constants. I found I needed these in the partiql-parser migration, particularly `.valueOf(<string>)` and `.values`. This PR adds those two functions to the interface and implements them for existing enum impls.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - No, on v1.

- Any backward-incompatible changes? **[YES]**
  - Adds to the enum interface but on v1

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.