### PR TITLE
[v1] Add name method to AstEnum

### DIFF
--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -5634,6 +5634,7 @@ public final class org/partiql/ast/v1/Ast {
 public abstract class org/partiql/ast/v1/AstEnum : org/partiql/ast/v1/AstNode {
 	public fun <init> ()V
 	public abstract fun code ()I
+	public abstract fun name ()Ljava/lang/String;
 }
 
 public abstract class org/partiql/ast/v1/AstNode {
@@ -5875,6 +5876,7 @@ public class org/partiql/ast/v1/DataType : org/partiql/ast/v1/AstEnum {
 	public fun getPrecision ()Ljava/lang/Integer;
 	public fun getScale ()Ljava/lang/Integer;
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/DataType;
 }
 
@@ -5904,6 +5906,7 @@ public class org/partiql/ast/v1/DatetimeField : org/partiql/ast/v1/AstEnum {
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/DatetimeField;
 }
 
@@ -6098,6 +6101,7 @@ public class org/partiql/ast/v1/FromType : org/partiql/ast/v1/AstEnum {
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/FromType;
 }
 
@@ -6152,6 +6156,7 @@ public class org/partiql/ast/v1/GroupByStrategy : org/partiql/ast/v1/AstEnum {
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/GroupByStrategy;
 }
 
@@ -6219,6 +6224,7 @@ public class org/partiql/ast/v1/JoinType : org/partiql/ast/v1/AstEnum {
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/JoinType;
 }
 
@@ -6269,6 +6275,7 @@ public class org/partiql/ast/v1/Nulls : org/partiql/ast/v1/AstEnum {
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/Nulls;
 }
 
@@ -6286,6 +6293,7 @@ public class org/partiql/ast/v1/Order : org/partiql/ast/v1/AstEnum {
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/Order;
 }
 
@@ -6519,6 +6527,10 @@ public class org/partiql/ast/v1/SetOp$Builder {
 }
 
 public class org/partiql/ast/v1/SetOpType : org/partiql/ast/v1/AstEnum {
+	public static final field EXCEPT I
+	public static final field INTERSECT I
+	public static final field UNION I
+	public static final field UNKNOWN I
 	public static fun EXCEPT ()Lorg/partiql/ast/v1/SetOpType;
 	public static fun INTERSECT ()Lorg/partiql/ast/v1/SetOpType;
 	public static fun UNION ()Lorg/partiql/ast/v1/SetOpType;
@@ -6530,6 +6542,7 @@ public class org/partiql/ast/v1/SetOpType : org/partiql/ast/v1/AstEnum {
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/SetOpType;
 }
 
@@ -6547,6 +6560,7 @@ public class org/partiql/ast/v1/SetQuantifier : org/partiql/ast/v1/AstEnum {
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/SetQuantifier;
 }
 
@@ -7320,6 +7334,7 @@ public class org/partiql/ast/v1/expr/Scope : org/partiql/ast/v1/AstEnum {
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/Scope;
 }
 
@@ -7338,6 +7353,7 @@ public class org/partiql/ast/v1/expr/SessionAttribute : org/partiql/ast/v1/AstEn
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/SessionAttribute;
 }
 
@@ -7357,6 +7373,7 @@ public class org/partiql/ast/v1/expr/TrimSpec : org/partiql/ast/v1/AstEnum {
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/TrimSpec;
 }
 
@@ -7375,6 +7392,7 @@ public class org/partiql/ast/v1/expr/WindowFunction : org/partiql/ast/v1/AstEnum
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/expr/WindowFunction;
 }
 
@@ -7402,6 +7420,7 @@ public class org/partiql/ast/v1/graph/GraphDirection : org/partiql/ast/v1/AstEnu
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/graph/GraphDirection;
 }
 
@@ -7644,6 +7663,7 @@ public class org/partiql/ast/v1/graph/GraphRestrictor : org/partiql/ast/v1/AstEn
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/v1/graph/GraphRestrictor;
 }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/AstEnum.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/AstEnum.java
@@ -1,8 +1,13 @@
 package org.partiql.ast.v1;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * TODO docs, equals, hashcode
  */
 public abstract class AstEnum extends AstNode {
     public abstract int code();
+
+    @NotNull
+    public abstract String name();
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/DataType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/DataType.java
@@ -401,52 +401,108 @@ public class DataType extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case NULL: return "NULL";
+            case MISSING: return "MISSING";
+            case CHARACTER: return "CHARACTER";
+            case CHAR: return "CHAR";
+            case CHARACTER_VARYING: return "CHARACTER_VARYING";
+            case CHAR_VARYING: return "CHAR_VARYING";
+            case VARCHAR: return "VARCHAR";
+            case CHARACTER_LARGE_OBJECT: return "CHARACTER_LARGE_OBJECT";
+            case CHAR_LARGE_OBJECT: return "CHAR_LARGE_OBJECT";
+            case CLOB: return "CLOB";
+            case STRING: return "STRING";
+            case SYMBOL: return "SYMBOL";
+            case BLOB: return "BLOB";
+            case BINARY_LARGE_OBJECT: return "BINARY_LARGE_OBJECT";
+            case BIT: return "BIT";
+            case BIT_VARYING: return "BIT_VARYING";
+            case NUMERIC: return "NUMERIC";
+            case DECIMAL: return "DECIMAL";
+            case DEC: return "DEC";
+            case BIGINT: return "BIGINT";
+            case INT8: return "INT8";
+            case INTEGER8: return "INTEGER8";
+            case INT4: return "INT4";
+            case INTEGER4: return "INTEGER4";
+            case INTEGER: return "INTEGER";
+            case INT: return "INT";
+            case INT2: return "INT2";
+            case INTEGER2: return "INTEGER2";
+            case SMALLINT: return "SMALLINT";
+            case TINYINT: return "TINYINT";
+            case FLOAT: return "FLOAT";
+            case REAL: return "REAL";
+            case DOUBLE_PRECISION: return "DOUBLE_PRECISION";
+            case BOOLEAN: return "BOOLEAN";
+            case BOOL: return "BOOL";
+            case DATE: return "DATE";
+            case TIME: return "TIME";
+            case TIME_WITH_TIME_ZONE: return "TIME_WITH_TIME_ZONE";
+            case TIMESTAMP: return "TIMESTAMP";
+            case TIMESTAMP_WITH_TIME_ZONE: return "TIMESTAMP_WITH_TIME_ZONE";
+            case INTERVAL: return "INTERVAL";
+            case STRUCT: return "STRUCT";
+            case TUPLE: return "TUPLE";
+            case LIST: return "LIST";
+            case BAG: return "BAG";
+            case SEXP: return "SEXP";
+            case USER_DEFINED: return "USER_DEFINED";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     private static final int[] codes = {
         NULL,
         MISSING,
-        BOOL,
-        BOOLEAN,
-        TINYINT,
-        SMALLINT,
-        INTEGER2,
-        INT2,
-        INTEGER,
-        INT,
-        INTEGER4,
-        INT4,
-        INTEGER8,
-        INT8,
-        BIGINT,
-        REAL,
-        DOUBLE_PRECISION,
-        FLOAT,
-        DECIMAL,
-        DEC,
-        NUMERIC,
-        BIT,
-        BIT_VARYING,
-        CHAR,
         CHARACTER,
+        CHAR,
+        CHARACTER_VARYING,
+        CHAR_VARYING,
         VARCHAR,
         CHARACTER_LARGE_OBJECT,
         CHAR_LARGE_OBJECT,
-        CHAR_VARYING,
+        CLOB,
         STRING,
         SYMBOL,
         BLOB,
         BINARY_LARGE_OBJECT,
-        CLOB,
+        BIT,
+        BIT_VARYING,
+        NUMERIC,
+        DECIMAL,
+        DEC,
+        BIGINT,
+        INT8,
+        INTEGER8,
+        INT4,
+        INTEGER4,
+        INTEGER,
+        INT,
+        INT2,
+        INTEGER2,
+        SMALLINT,
+        TINYINT,
+        FLOAT,
+        REAL,
+        DOUBLE_PRECISION,
+        BOOLEAN,
+        BOOL,
         DATE,
-        STRUCT,
-        TUPLE,
-        LIST,
-        SEXP,
-        BAG,
         TIME,
         TIME_WITH_TIME_ZONE,
         TIMESTAMP,
         TIMESTAMP_WITH_TIME_ZONE,
         INTERVAL,
+        STRUCT,
+        TUPLE,
+        LIST,
+        BAG,
+        SEXP,
         USER_DEFINED
     };
 

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/DatetimeField.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/DatetimeField.java
@@ -69,6 +69,22 @@ public class DatetimeField extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case YEAR: return "YEAR";
+            case MONTH: return "MONTH";
+            case DAY: return "DAY";
+            case HOUR: return "HOUR";
+            case MINUTE: return "MINUTE";
+            case SECOND: return "SECOND";
+            case TIMEZONE_HOUR: return "TIMEZONE_HOUR";
+            case TIMEZONE_MINUTE: return "TIMEZONE_MINUTE";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     private static final int[] codes = {
         YEAR,
         MONTH,

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/FromType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/FromType.java
@@ -39,6 +39,16 @@ public class FromType extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case SCAN: return "SCAN";
+            case UNPIVOT: return "UNPIVOT";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     private static final int[] codes = {
         SCAN,
         UNPIVOT

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/GroupByStrategy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/GroupByStrategy.java
@@ -45,6 +45,16 @@ public class GroupByStrategy extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case FULL: return "FULL";
+            case PARTIAL: return "PARTIAL";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     public static GroupByStrategy parse(@NotNull String value) {
         switch (value) {
             case "FULL": return FULL();

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/JoinType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/JoinType.java
@@ -69,6 +69,22 @@ public class JoinType extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case INNER: return "INNER";
+            case LEFT: return "LEFT";
+            case LEFT_OUTER: return "LEFT_OUTER";
+            case RIGHT: return "RIGHT";
+            case RIGHT_OUTER: return "RIGHT_OUTER";
+            case FULL: return "FULL";
+            case FULL_OUTER: return "FULL_OUTER";
+            case CROSS: return "CROSS";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     private static final int[] codes = {
         INNER,
         LEFT,

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/Nulls.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/Nulls.java
@@ -39,6 +39,16 @@ public class Nulls extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case FIRST: return "FIRST";
+            case LAST: return "LAST";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     private static final int[] codes = {
         FIRST,
         LAST

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/Order.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/Order.java
@@ -36,6 +36,16 @@ public class Order extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case ASC: return "ASC";
+            case DESC: return "DESC";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     private static final int[] codes = {
         ASC,
         DESC

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/SetOpType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/SetOpType.java
@@ -11,10 +11,10 @@ import java.util.Collections;
  */
 @EqualsAndHashCode(callSuper = false)
 public class SetOpType extends AstEnum {
-    private static final int UNKNOWN = 0;
-    private static final int UNION = 1;
-    private static final int INTERSECT = 2;
-    private static final int EXCEPT = 3;
+    public static final int UNKNOWN = 0;
+    public static final int UNION = 1;
+    public static final int INTERSECT = 2;
+    public static final int EXCEPT = 3;
 
     public static SetOpType UNKNOWN() {
         return new SetOpType(UNKNOWN);
@@ -41,6 +41,17 @@ public class SetOpType extends AstEnum {
     @Override
     public int code() {
         return code;
+    }
+
+    @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case UNION: return "UNION";
+            case INTERSECT: return "INTERSECT";
+            case EXCEPT: return "EXCEPT";
+            default: return "UNKNOWN";
+        }
     }
 
     @NotNull

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/SetQuantifier.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/SetQuantifier.java
@@ -39,6 +39,16 @@ public class SetQuantifier extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case ALL: return "ALL";
+            case DISTINCT: return "DISTINCT";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     private static final int[] codes = {
         ALL,
         DISTINCT

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/expr/Scope.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/expr/Scope.java
@@ -42,6 +42,16 @@ public class Scope extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case DEFAULT: return "DEFAULT";
+            case LOCAL: return "LOCAL";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     private static final int[] codes = {
         DEFAULT,
         LOCAL

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/expr/SessionAttribute.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/expr/SessionAttribute.java
@@ -42,6 +42,16 @@ public class SessionAttribute extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case CURRENT_USER: return "CURRENT_USER";
+            case CURRENT_DATE: return "CURRENT_DATE";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     private static final int[] codes = {
         CURRENT_USER,
         CURRENT_DATE

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/expr/TrimSpec.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/expr/TrimSpec.java
@@ -44,6 +44,17 @@ public class TrimSpec extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case LEADING: return "LEADING";
+            case TRAILING: return "TRAILING";
+            case BOTH: return "BOTH";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     private static final int[] codes = {
         LEADING,
         TRAILING,

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/expr/WindowFunction.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/expr/WindowFunction.java
@@ -15,8 +15,8 @@ import java.util.Collections;
 @EqualsAndHashCode(callSuper = false)
 public class WindowFunction extends AstEnum {
     public static final int UNKNOWN = 0;
-    public static final int LAG = 0;
-    public static final int LEAD = 0;
+    public static final int LAG = 1;
+    public static final int LEAD = 2;
 
     public static WindowFunction UNKNOWN() {
         return new WindowFunction(UNKNOWN);
@@ -39,6 +39,16 @@ public class WindowFunction extends AstEnum {
     @Override
     public int code() {
         return code;
+    }
+
+    @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case LAG: return "LAG";
+            case LEAD: return "LEAD";
+            default: return "UNKNOWN";
+        }
     }
 
     @NotNull

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/graph/GraphDirection.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/graph/GraphDirection.java
@@ -78,6 +78,21 @@ public class GraphDirection extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case LEFT: return "LEFT";
+            case UNDIRECTED: return "UNDIRECTED";
+            case RIGHT: return "RIGHT";
+            case LEFT_OR_UNDIRECTED: return "LEFT_OR_UNDIRECTED";
+            case UNDIRECTED_OR_RIGHT: return "UNDIRECTED_OR_RIGHT";
+            case LEFT_OR_RIGHT: return "LEFT_OR_RIGHT";
+            case LEFT_UNDIRECTED_OR_RIGHT: return "LEFT_UNDIRECTED_OR_RIGHT";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     public static GraphDirection parse(@NotNull String value) {
         switch (value) {
             case "LEFT": return LEFT();

--- a/partiql-ast/src/main/java/org/partiql/ast/v1/graph/GraphRestrictor.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/v1/graph/GraphRestrictor.java
@@ -47,6 +47,17 @@ public class GraphRestrictor extends AstEnum {
     }
 
     @NotNull
+    @Override
+    public String name() {
+        switch (code) {
+            case TRAIL: return "TRAIL";
+            case ACYCLIC: return "ACYCLIC";
+            case SIMPLE: return "SIMPLE";
+            default: return "UNKNOWN";
+        }
+    }
+
+    @NotNull
     private static final int[] codes = {
         TRAIL,
         ACYCLIC,


### PR DESCRIPTION
## Relevant Issues
- https://github.com/partiql/partiql-lang-kotlin/issues/1610

## Description
- Adds a `.name` method to every `AstEnum`. This is part of normal enum classes but was missing from our `AstEnum` abstract class definition.
- Some other minor `AstEnum` implementation fixes

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - No, on  v1

- Any backward-incompatible changes? **[No]**

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.