### PR TITLE
Prepares v1.0.0-rc.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Thank you to all who have contributed!
 -->
 
+## [1.0.0-rc.2]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
+### Security
+
+### Contributors
+Thank you to all who have contributed!
+
 ## [1.0.0-rc.1]
 
 ### Added
@@ -1139,6 +1156,8 @@ breaking changes if migrating from v0.9.2. The breaking changes accidentally int
 Initial alpha release of PartiQL.
 
 [Unreleased]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.8...HEAD
+[1.0.0-rc.2]: https://github.com/partiql/partiql-lang-kotlin/compare/v1.0.0-rc.1...v1.0.0-rc.2
+[1.0.0-rc.1]: https://github.com/partiql/partiql-lang-kotlin/compare/v1.0.0-perf.1...v1.0.0-rc.1
 [0.14.8]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.7...v0.14.8
 [0.14.7]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.6...v0.14.7
 [0.14.6]: https://github.com/partiql/partiql-lang-kotlin/compare/v0.14.5...v0.14.6

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project is published to [Maven Central](https://search.maven.org/artifact/o
 
 | Group ID      | Artifact ID           | Recommended Version |
 |---------------|-----------------------|---------------------|
-| `org.partiql` | `partiql-lang-kotlin` | `1.0.0-rc.1`        |
+| `org.partiql` | `partiql-lang-kotlin` | `1.0.0-rc.2`        |
 
 
 For Maven builds, add the following to your `pom.xml`:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=1.0.0-rc.2-SNAPSHOT
+version=1.0.0-rc.2
 
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY

--- a/partiql-ast/build.gradle.kts
+++ b/partiql-ast/build.gradle.kts
@@ -28,15 +28,9 @@ dependencies {
     annotationProcessor(Deps.lombok)
 }
 
-tasks.shadowJar {
-    configurations = listOf(project.configurations.shadow.get())
-}
-
-// Workaround for https://github.com/johnrengelman/shadow/issues/651
-components.withType(AdhocComponentWithVariants::class.java).forEach { c ->
-    c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements.get()) {
-        skip()
-    }
+// TODO: Figure out why this is needed.
+tasks.withType<Jar> {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
 tasks.shadowJar {

--- a/partiql-eval/build.gradle.kts
+++ b/partiql-eval/build.gradle.kts
@@ -47,6 +47,11 @@ tasks.shadowJar {
     configurations = listOf(project.configurations.shadow.get())
 }
 
+// TODO: Figure out why this is needed.
+tasks.withType<Jar> {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 // Workaround for https://github.com/johnrengelman/shadow/issues/651
 components.withType(AdhocComponentWithVariants::class.java).forEach { c ->
     c.withVariantsFromConfiguration(project.configurations.shadowRuntimeElements.get()) {


### PR DESCRIPTION
## Description
- Prepares v1.0.0-rc.2 release
- The draft release notes can be found [here](https://github.com/partiql/partiql-lang-kotlin/releases/tag/untagged-bc42b3ea53c8f1e74302). If you don't have access, I can add the content here (if desired).

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.