### PR TITLE
[v1] Refactor AstNode getChildren() method; change tag to be mutable int

### DIFF
--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -122,10 +122,11 @@ public abstract class org/partiql/ast/AstEnum : org/partiql/ast/AstNode {
 }
 
 public abstract class org/partiql/ast/AstNode {
-	public field tag Ljava/lang/String;
 	public fun <init> ()V
 	public abstract fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun getChildren ()Ljava/util/List;
+	public fun getTag ()I
+	public fun setTag (I)V
 }
 
 public abstract class org/partiql/ast/AstRewriter : org/partiql/ast/AstVisitor {

--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -125,7 +125,7 @@ public abstract class org/partiql/ast/AstNode {
 	public field tag Ljava/lang/String;
 	public fun <init> ()V
 	public abstract fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun children ()Ljava/util/Collection;
+	public abstract fun getChildren ()Ljava/util/List;
 }
 
 public abstract class org/partiql/ast/AstRewriter : org/partiql/ast/AstVisitor {
@@ -591,10 +591,10 @@ public class org/partiql/ast/DataType : org/partiql/ast/AstEnum {
 	public static fun VARCHAR (I)Lorg/partiql/ast/DataType;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun getElementType ()Lorg/partiql/ast/DataType;
 	public fun getFields ()Ljava/util/List;
 	public fun getLength ()Ljava/lang/Integer;
@@ -615,8 +615,8 @@ public class org/partiql/ast/DataType$StructField : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/DataType;ZLjava/util/List;Ljava/lang/String;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -641,10 +641,10 @@ public class org/partiql/ast/DatetimeField : org/partiql/ast/AstEnum {
 	public static fun YEAR ()Lorg/partiql/ast/DatetimeField;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/DatetimeField;
@@ -656,8 +656,8 @@ public class org/partiql/ast/Exclude : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Exclude$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -674,8 +674,8 @@ public class org/partiql/ast/ExcludePath : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ExcludePath$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -696,8 +696,8 @@ public class org/partiql/ast/ExcludeStep$CollIndex : org/partiql/ast/ExcludeStep
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ExcludeStep$CollIndex$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -712,8 +712,8 @@ public class org/partiql/ast/ExcludeStep$CollWildcard : org/partiql/ast/ExcludeS
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ExcludeStep$CollWildcard$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -728,8 +728,8 @@ public class org/partiql/ast/ExcludeStep$StructField : org/partiql/ast/ExcludeSt
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ExcludeStep$StructField$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -744,8 +744,8 @@ public class org/partiql/ast/ExcludeStep$StructWildcard : org/partiql/ast/Exclud
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ExcludeStep$StructWildcard$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -761,8 +761,8 @@ public class org/partiql/ast/Explain : org/partiql/ast/Statement {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Explain$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -779,8 +779,8 @@ public class org/partiql/ast/From : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/From$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -799,8 +799,8 @@ public class org/partiql/ast/FromExpr : org/partiql/ast/FromTableRef {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/FromExpr$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -822,8 +822,8 @@ public class org/partiql/ast/FromJoin : org/partiql/ast/FromTableRef {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/FromJoin$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -849,10 +849,10 @@ public class org/partiql/ast/FromType : org/partiql/ast/AstEnum {
 	public static fun UNPIVOT ()Lorg/partiql/ast/FromType;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/FromType;
@@ -866,8 +866,8 @@ public class org/partiql/ast/GroupBy : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/GroupBy$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -885,7 +885,7 @@ public class org/partiql/ast/GroupBy$Key : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/Identifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/GroupBy$Key$Builder;
-	public fun children ()Ljava/util/Collection;
+	public fun getChildren ()Ljava/util/List;
 }
 
 public class org/partiql/ast/GroupBy$Key$Builder {
@@ -904,10 +904,10 @@ public class org/partiql/ast/GroupByStrategy : org/partiql/ast/AstEnum {
 	public static fun UNKNOWN ()Lorg/partiql/ast/GroupByStrategy;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/GroupByStrategy;
@@ -920,8 +920,8 @@ public class org/partiql/ast/Identifier : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Identifier$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -939,8 +939,8 @@ public class org/partiql/ast/IdentifierChain : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/IdentifierChain$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -974,10 +974,10 @@ public class org/partiql/ast/JoinType : org/partiql/ast/AstEnum {
 	public static fun UNKNOWN ()Lorg/partiql/ast/JoinType;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/JoinType;
@@ -989,8 +989,8 @@ public class org/partiql/ast/Let : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Let$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1000,7 +1000,7 @@ public class org/partiql/ast/Let$Binding : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/Identifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Let$Binding$Builder;
-	public fun children ()Ljava/util/Collection;
+	public fun getChildren ()Ljava/util/List;
 }
 
 public class org/partiql/ast/Let$Binding$Builder {
@@ -1032,12 +1032,12 @@ public class org/partiql/ast/Literal : org/partiql/ast/AstEnum {
 	public static fun bool (Z)Lorg/partiql/ast/Literal;
 	public fun booleanValue ()Z
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public fun dataType ()Lorg/partiql/ast/DataType;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun exactNum (Ljava/lang/String;)Lorg/partiql/ast/Literal;
 	public static fun exactNum (Ljava/math/BigDecimal;)Lorg/partiql/ast/Literal;
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public static fun intNum (I)Lorg/partiql/ast/Literal;
 	public static fun intNum (J)Lorg/partiql/ast/Literal;
@@ -1061,10 +1061,10 @@ public class org/partiql/ast/Nulls : org/partiql/ast/AstEnum {
 	public static fun UNKNOWN ()Lorg/partiql/ast/Nulls;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/Nulls;
@@ -1079,10 +1079,10 @@ public class org/partiql/ast/Order : org/partiql/ast/AstEnum {
 	public static fun UNKNOWN ()Lorg/partiql/ast/Order;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/Order;
@@ -1094,8 +1094,8 @@ public class org/partiql/ast/OrderBy : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/OrderBy$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1111,8 +1111,8 @@ public class org/partiql/ast/Query : org/partiql/ast/Statement {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Query$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1138,8 +1138,8 @@ public class org/partiql/ast/QueryBody$SFW : org/partiql/ast/QueryBody {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/QueryBody$SFW$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1164,8 +1164,8 @@ public class org/partiql/ast/QueryBody$SetOp : org/partiql/ast/QueryBody {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/QueryBody$SetOp$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1193,8 +1193,8 @@ public class org/partiql/ast/SelectItem$Expr : org/partiql/ast/SelectItem {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SelectItem$Expr$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1211,8 +1211,8 @@ public class org/partiql/ast/SelectItem$Star : org/partiql/ast/SelectItem {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SelectItem$Star$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1229,8 +1229,8 @@ public class org/partiql/ast/SelectList : org/partiql/ast/Select {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SelectList$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1248,8 +1248,8 @@ public class org/partiql/ast/SelectPivot : org/partiql/ast/Select {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SelectPivot$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1266,8 +1266,8 @@ public class org/partiql/ast/SelectStar : org/partiql/ast/Select {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SelectStar$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1284,8 +1284,8 @@ public class org/partiql/ast/SelectValue : org/partiql/ast/Select {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SelectValue$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1303,8 +1303,8 @@ public class org/partiql/ast/SetOp : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SetOp$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1326,10 +1326,10 @@ public class org/partiql/ast/SetOpType : org/partiql/ast/AstEnum {
 	public static fun UNKNOWN ()Lorg/partiql/ast/SetOpType;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/SetOpType;
@@ -1344,10 +1344,10 @@ public class org/partiql/ast/SetQuantifier : org/partiql/ast/AstEnum {
 	public static fun UNKNOWN ()Lorg/partiql/ast/SetQuantifier;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/SetQuantifier;
@@ -1361,8 +1361,8 @@ public class org/partiql/ast/Sort : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Sort$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1381,7 +1381,7 @@ public abstract class org/partiql/ast/Statement : org/partiql/ast/AstNode {
 public abstract class org/partiql/ast/ddl/AttributeConstraint : org/partiql/ast/AstNode {
 	public final field name Lorg/partiql/ast/IdentifierChain;
 	protected fun <init> (Lorg/partiql/ast/IdentifierChain;)V
-	public fun children ()Ljava/util/Collection;
+	public fun getChildren ()Ljava/util/List;
 }
 
 public class org/partiql/ast/ddl/AttributeConstraint$Check : org/partiql/ast/ddl/AttributeConstraint {
@@ -1389,8 +1389,8 @@ public class org/partiql/ast/ddl/AttributeConstraint$Check : org/partiql/ast/ddl
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1422,8 +1422,8 @@ public class org/partiql/ast/ddl/ColumnDefinition : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ddl/ColumnDefinition$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1447,8 +1447,8 @@ public class org/partiql/ast/ddl/CreateTable : org/partiql/ast/ddl/Ddl {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ddl/CreateTable$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1473,8 +1473,8 @@ public class org/partiql/ast/ddl/KeyValue : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ddl/KeyValue$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1491,8 +1491,8 @@ public class org/partiql/ast/ddl/PartitionBy : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ddl/PartitionBy$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1513,8 +1513,8 @@ public class org/partiql/ast/ddl/TableConstraint$Unique : org/partiql/ast/ddl/Ta
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Ljava/util/List;Z)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1526,8 +1526,8 @@ public final class org/partiql/ast/dml/ConflictAction$DoNothing : org/partiql/as
 	public fun <init> ()V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/ConflictAction$DoNothing$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1542,8 +1542,8 @@ public final class org/partiql/ast/dml/ConflictAction$DoReplace : org/partiql/as
 	public fun <init> (Lorg/partiql/ast/dml/DoReplaceAction;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/ConflictAction$DoReplace$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1560,8 +1560,8 @@ public final class org/partiql/ast/dml/ConflictAction$DoUpdate : org/partiql/ast
 	public fun <init> (Lorg/partiql/ast/dml/DoUpdateAction;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/ConflictAction$DoUpdate$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1581,8 +1581,8 @@ public final class org/partiql/ast/dml/ConflictTarget$Constraint : org/partiql/a
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/ConflictTarget$Constraint$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1597,8 +1597,8 @@ public final class org/partiql/ast/dml/ConflictTarget$Index : org/partiql/ast/dm
 	public fun <init> (Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/ConflictTarget$Index$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1614,8 +1614,8 @@ public final class org/partiql/ast/dml/Delete : org/partiql/ast/Statement {
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/Delete$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1634,8 +1634,8 @@ public final class org/partiql/ast/dml/DoReplaceAction$Excluded : org/partiql/as
 	public fun <init> ()V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/DoReplaceAction$Excluded$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1652,8 +1652,8 @@ public final class org/partiql/ast/dml/DoUpdateAction$Excluded : org/partiql/ast
 	public fun <init> ()V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/DoUpdateAction$Excluded$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1670,8 +1670,8 @@ public final class org/partiql/ast/dml/Insert : org/partiql/ast/Statement {
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/dml/InsertSource;Lorg/partiql/ast/dml/OnConflict;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/Insert$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1692,8 +1692,8 @@ public final class org/partiql/ast/dml/InsertSource$FromDefault : org/partiql/as
 	public fun <init> ()V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/InsertSource$FromDefault$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1708,8 +1708,8 @@ public final class org/partiql/ast/dml/InsertSource$FromExpr : org/partiql/ast/d
 	public fun <init> (Ljava/util/List;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/InsertSource$FromExpr$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1726,8 +1726,8 @@ public final class org/partiql/ast/dml/OnConflict : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/dml/ConflictAction;Lorg/partiql/ast/dml/ConflictTarget;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/OnConflict$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1745,8 +1745,8 @@ public final class org/partiql/ast/dml/Replace : org/partiql/ast/Statement {
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/dml/InsertSource;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/Replace$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1764,8 +1764,8 @@ public final class org/partiql/ast/dml/SetClause : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/dml/UpdateTarget;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/SetClause$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1783,8 +1783,8 @@ public final class org/partiql/ast/dml/Update : org/partiql/ast/Statement {
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Ljava/util/List;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/Update$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1802,8 +1802,8 @@ public final class org/partiql/ast/dml/UpdateTarget : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/Identifier;Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/UpdateTarget$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1825,8 +1825,8 @@ public final class org/partiql/ast/dml/UpdateTargetStep$Element : org/partiql/as
 	public fun <init> (Lorg/partiql/ast/Literal;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/UpdateTargetStep$Element$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1841,8 +1841,8 @@ public final class org/partiql/ast/dml/UpdateTargetStep$Field : org/partiql/ast/
 	public fun <init> (Lorg/partiql/ast/Identifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/UpdateTargetStep$Field$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1859,8 +1859,8 @@ public final class org/partiql/ast/dml/Upsert : org/partiql/ast/Statement {
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/dml/InsertSource;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/Upsert$Builder;
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1883,8 +1883,8 @@ public class org/partiql/ast/expr/ExprAnd : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprAnd$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1901,8 +1901,8 @@ public class org/partiql/ast/expr/ExprArray : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprArray$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1918,8 +1918,8 @@ public class org/partiql/ast/expr/ExprBag : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprBag$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1938,8 +1938,8 @@ public class org/partiql/ast/expr/ExprBetween : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprBetween$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1960,8 +1960,8 @@ public class org/partiql/ast/expr/ExprCall : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprCall$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1981,8 +1981,8 @@ public class org/partiql/ast/expr/ExprCase : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprCase$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1993,8 +1993,8 @@ public class org/partiql/ast/expr/ExprCase$Branch : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprCase$Branch$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2020,8 +2020,8 @@ public class org/partiql/ast/expr/ExprCast : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprCast$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2038,8 +2038,8 @@ public class org/partiql/ast/expr/ExprCoalesce : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprCoalesce$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2056,8 +2056,8 @@ public class org/partiql/ast/expr/ExprExtract : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprExtract$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2076,8 +2076,8 @@ public class org/partiql/ast/expr/ExprInCollection : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprInCollection$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2097,8 +2097,8 @@ public class org/partiql/ast/expr/ExprIsType : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprIsType$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2119,8 +2119,8 @@ public class org/partiql/ast/expr/ExprLike : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprLike$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2138,8 +2138,8 @@ public class org/partiql/ast/expr/ExprLit : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/Literal;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2150,8 +2150,8 @@ public class org/partiql/ast/expr/ExprMatch : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprMatch$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2168,8 +2168,8 @@ public class org/partiql/ast/expr/ExprNot : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprNot$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2186,8 +2186,8 @@ public class org/partiql/ast/expr/ExprNullIf : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprNullIf$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2206,8 +2206,8 @@ public class org/partiql/ast/expr/ExprOperator : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprOperator$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2226,8 +2226,8 @@ public class org/partiql/ast/expr/ExprOr : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprOr$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2247,8 +2247,8 @@ public class org/partiql/ast/expr/ExprOverlay : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprOverlay$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2267,8 +2267,8 @@ public class org/partiql/ast/expr/ExprParameter : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprParameter$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2285,8 +2285,8 @@ public class org/partiql/ast/expr/ExprPath : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprPath$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2304,8 +2304,8 @@ public class org/partiql/ast/expr/ExprPosition : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprPosition$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2325,8 +2325,8 @@ public class org/partiql/ast/expr/ExprQuerySet : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprQuerySet$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2347,8 +2347,8 @@ public class org/partiql/ast/expr/ExprRowValue : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprRowValue$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2365,8 +2365,8 @@ public class org/partiql/ast/expr/ExprSessionAttribute : org/partiql/ast/expr/Ex
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprSessionAttribute$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2382,8 +2382,8 @@ public class org/partiql/ast/expr/ExprStruct : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprStruct$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2400,8 +2400,8 @@ public class org/partiql/ast/expr/ExprStruct$Field : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprStruct$Field$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2420,8 +2420,8 @@ public class org/partiql/ast/expr/ExprSubstring : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprSubstring$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2441,8 +2441,8 @@ public class org/partiql/ast/expr/ExprTrim : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprTrim$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2460,8 +2460,8 @@ public class org/partiql/ast/expr/ExprValues : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprValues$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2478,8 +2478,8 @@ public class org/partiql/ast/expr/ExprVarRef : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprVarRef$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2497,9 +2497,8 @@ public class org/partiql/ast/expr/ExprVariant : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprVariant$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public synthetic fun children ()Ljava/util/Collection;
-	public fun children ()Ljava/util/List;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2520,8 +2519,8 @@ public class org/partiql/ast/expr/ExprWindow : org/partiql/ast/expr/Expr {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprWindow$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2542,8 +2541,8 @@ public class org/partiql/ast/expr/ExprWindow$Over : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprWindow$Over$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2563,8 +2562,8 @@ public class org/partiql/ast/expr/PathStep$AllElements : org/partiql/ast/expr/Pa
 	public fun <init> (Lorg/partiql/ast/expr/PathStep;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2572,8 +2571,8 @@ public class org/partiql/ast/expr/PathStep$AllFields : org/partiql/ast/expr/Path
 	public fun <init> (Lorg/partiql/ast/expr/PathStep;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2582,8 +2581,8 @@ public class org/partiql/ast/expr/PathStep$Element : org/partiql/ast/expr/PathSt
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/PathStep;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2592,8 +2591,8 @@ public class org/partiql/ast/expr/PathStep$Field : org/partiql/ast/expr/PathStep
 	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/expr/PathStep;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2606,10 +2605,10 @@ public class org/partiql/ast/expr/Scope : org/partiql/ast/AstEnum {
 	public static fun UNKNOWN ()Lorg/partiql/ast/expr/Scope;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/expr/Scope;
@@ -2625,10 +2624,10 @@ public class org/partiql/ast/expr/SessionAttribute : org/partiql/ast/AstEnum {
 	public static fun UNKNOWN ()Lorg/partiql/ast/expr/SessionAttribute;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/expr/SessionAttribute;
@@ -2645,10 +2644,10 @@ public class org/partiql/ast/expr/TrimSpec : org/partiql/ast/AstEnum {
 	public static fun UNKNOWN ()Lorg/partiql/ast/expr/TrimSpec;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/expr/TrimSpec;
@@ -2664,10 +2663,10 @@ public class org/partiql/ast/expr/WindowFunction : org/partiql/ast/AstEnum {
 	public static fun UNKNOWN ()Lorg/partiql/ast/expr/WindowFunction;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/expr/WindowFunction;
@@ -2692,10 +2691,10 @@ public class org/partiql/ast/graph/GraphDirection : org/partiql/ast/AstEnum {
 	public static fun UNKNOWN ()Lorg/partiql/ast/graph/GraphDirection;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/graph/GraphDirection;
@@ -2712,8 +2711,8 @@ public class org/partiql/ast/graph/GraphLabel$Conj : org/partiql/ast/graph/Graph
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphLabel$Conj$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2731,8 +2730,8 @@ public class org/partiql/ast/graph/GraphLabel$Disj : org/partiql/ast/graph/Graph
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphLabel$Disj$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2749,8 +2748,8 @@ public class org/partiql/ast/graph/GraphLabel$Name : org/partiql/ast/graph/Graph
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphLabel$Name$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2766,8 +2765,8 @@ public class org/partiql/ast/graph/GraphLabel$Negation : org/partiql/ast/graph/G
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphLabel$Negation$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2782,8 +2781,8 @@ public class org/partiql/ast/graph/GraphLabel$Wildcard : org/partiql/ast/graph/G
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphLabel$Wildcard$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2799,8 +2798,8 @@ public class org/partiql/ast/graph/GraphMatch : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphMatch$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2825,8 +2824,8 @@ public class org/partiql/ast/graph/GraphPart$Edge : org/partiql/ast/graph/GraphP
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphPart$Edge$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2848,8 +2847,8 @@ public class org/partiql/ast/graph/GraphPart$Node : org/partiql/ast/graph/GraphP
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphPart$Node$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2867,8 +2866,8 @@ public class org/partiql/ast/graph/GraphPart$Pattern : org/partiql/ast/graph/Gra
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphPart$Pattern$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2888,8 +2887,8 @@ public class org/partiql/ast/graph/GraphPattern : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphPattern$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2910,8 +2909,8 @@ public class org/partiql/ast/graph/GraphQuantifier : org/partiql/ast/AstNode {
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphQuantifier$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2933,10 +2932,10 @@ public class org/partiql/ast/graph/GraphRestrictor : org/partiql/ast/AstEnum {
 	public static fun UNKNOWN ()Lorg/partiql/ast/graph/GraphRestrictor;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/graph/GraphRestrictor;
@@ -2951,8 +2950,8 @@ public class org/partiql/ast/graph/GraphSelector$AllShortest : org/partiql/ast/g
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphSelector$AllShortest$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2966,8 +2965,8 @@ public class org/partiql/ast/graph/GraphSelector$Any : org/partiql/ast/graph/Gra
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphSelector$Any$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2982,8 +2981,8 @@ public class org/partiql/ast/graph/GraphSelector$AnyK : org/partiql/ast/graph/Gr
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphSelector$AnyK$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2998,8 +2997,8 @@ public class org/partiql/ast/graph/GraphSelector$AnyShortest : org/partiql/ast/g
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphSelector$AnyShortest$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -3014,8 +3013,8 @@ public class org/partiql/ast/graph/GraphSelector$ShortestK : org/partiql/ast/gra
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphSelector$ShortestK$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -3031,8 +3030,8 @@ public class org/partiql/ast/graph/GraphSelector$ShortestKGroup : org/partiql/as
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphSelector$ShortestKGroup$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
-	public fun children ()Ljava/util/Collection;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/AstNode.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/AstNode.java
@@ -1,7 +1,5 @@
 package org.partiql.ast;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -10,10 +8,16 @@ import java.util.List;
  * TODO docs, equals, hashcode
  * TODO support source location -- https://github.com/partiql/partiql-lang-kotlin/issues/1608
  */
-@Setter
-@Getter
 public abstract class AstNode {
     private int tag = 0;
+
+    public int getTag() {
+        return tag;
+    }
+
+    public void setTag(int tag) {
+        this.tag = tag;
+    }
 
     @NotNull
     public abstract List<AstNode> getChildren();

--- a/partiql-ast/src/main/java/org/partiql/ast/AstNode.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/AstNode.java
@@ -2,7 +2,7 @@ package org.partiql.ast;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Random;
 
 /**
@@ -14,7 +14,7 @@ public abstract class AstNode {
     public String tag = "Ast-" + String.format("%06x", new Random().nextInt());
 
     @NotNull
-    public abstract Collection<AstNode> children();
+    public abstract List<AstNode> getChildren();
 
     public abstract <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx);
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/AstNode.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/AstNode.java
@@ -1,17 +1,19 @@
 package org.partiql.ast;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
-import java.util.Random;
 
 /**
  * TODO docs, equals, hashcode
  * TODO support source location -- https://github.com/partiql/partiql-lang-kotlin/issues/1608
  */
+@Setter
+@Getter
 public abstract class AstNode {
-    @NotNull
-    public String tag = "Ast-" + String.format("%06x", new Random().nextInt());
+    private int tag = 0;
 
     @NotNull
     public abstract List<AstNode> getChildren();

--- a/partiql-ast/src/main/java/org/partiql/ast/AstVisitor.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/AstVisitor.java
@@ -66,7 +66,7 @@ import org.partiql.ast.graph.GraphSelector;
 //  Also include docs on how a library user could create a new variant for sum types and which methods to override
 public abstract class AstVisitor<R, C> {
     public R defaultVisit(AstNode node, C ctx) {
-        for (AstNode child : node.children()) {
+        for (AstNode child : node.getChildren()) {
             child.accept(this, ctx);
         }
         return defaultReturn(node, ctx);

--- a/partiql-ast/src/main/java/org/partiql/ast/DataType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/DataType.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.ddl.AttributeConstraint;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
@@ -56,7 +55,7 @@ public class DataType extends AstEnum {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             ArrayList<AstNode> kids = new ArrayList<>();
             kids.add(name);
             kids.add(type);
@@ -722,7 +721,7 @@ public class DataType extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         if (name != null) {
             kids.add(name);

--- a/partiql-ast/src/main/java/org/partiql/ast/DatetimeField.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/DatetimeField.java
@@ -3,8 +3,8 @@ package org.partiql.ast;
 import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -118,7 +118,7 @@ public class DatetimeField extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Exclude.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Exclude.java
@@ -5,7 +5,6 @@ import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -23,7 +22,7 @@ public class Exclude extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>(excludePaths);
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/ExcludePath.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ExcludePath.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.expr.ExprVarRef;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -28,7 +27,7 @@ public class ExcludePath extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(root);
         kids.addAll(excludeSteps);

--- a/partiql-ast/src/main/java/org/partiql/ast/ExcludeStep.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ExcludeStep.java
@@ -5,7 +5,6 @@ import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -27,7 +26,7 @@ public abstract class ExcludeStep extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(symbol);
             return kids;
@@ -53,7 +52,7 @@ public abstract class ExcludeStep extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return new ArrayList<>();
         }
 
@@ -73,7 +72,7 @@ public abstract class ExcludeStep extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return new ArrayList<>();
         }
 
@@ -93,7 +92,7 @@ public abstract class ExcludeStep extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return new ArrayList<>();
         }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Explain.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Explain.java
@@ -5,7 +5,6 @@ import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -28,7 +27,7 @@ public class Explain extends Statement {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(statement);
         return kids;

--- a/partiql-ast/src/main/java/org/partiql/ast/From.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/From.java
@@ -5,7 +5,6 @@ import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -23,7 +22,7 @@ public class From extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>(tableRefs);
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/FromExpr.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/FromExpr.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -38,7 +37,7 @@ public class FromExpr extends FromTableRef {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(expr);
         if (asAlias != null) kids.add(asAlias);

--- a/partiql-ast/src/main/java/org/partiql/ast/FromJoin.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/FromJoin.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -37,7 +36,7 @@ public class FromJoin extends FromTableRef {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(lhs);
         kids.add(rhs);

--- a/partiql-ast/src/main/java/org/partiql/ast/FromType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/FromType.java
@@ -3,8 +3,8 @@ package org.partiql.ast;
 import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -70,7 +70,7 @@ public class FromType extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/GroupBy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/GroupBy.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -33,7 +32,7 @@ public class GroupBy extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>(keys);
         if (asAlias != null) {
             kids.add(asAlias);
@@ -64,7 +63,7 @@ public class GroupBy extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(expr);
             if (asAlias != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/GroupByStrategy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/GroupByStrategy.java
@@ -3,8 +3,8 @@ package org.partiql.ast;
 import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -70,7 +70,7 @@ public class GroupByStrategy extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Identifier.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Identifier.java
@@ -5,7 +5,7 @@ import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -25,7 +25,7 @@ public class Identifier extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/IdentifierChain.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/IdentifierChain.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -28,7 +27,7 @@ public class IdentifierChain extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(root);
         if (next != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/JoinType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/JoinType.java
@@ -3,8 +3,8 @@ package org.partiql.ast;
 import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -126,7 +126,7 @@ public class JoinType extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Let.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Let.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -24,7 +23,7 @@ public class Let extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>(bindings);
     }
 
@@ -51,7 +50,7 @@ public class Let extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(expr);
             kids.add(asAlias);

--- a/partiql-ast/src/main/java/org/partiql/ast/Literal.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Literal.java
@@ -5,8 +5,8 @@ import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -103,7 +103,7 @@ public class Literal extends AstEnum {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Nulls.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Nulls.java
@@ -3,8 +3,8 @@ package org.partiql.ast;
 import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -71,7 +71,7 @@ public class Nulls extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Order.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Order.java
@@ -3,8 +3,8 @@ package org.partiql.ast;
 import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
 public class Order extends AstEnum {
@@ -67,7 +67,7 @@ public class Order extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/OrderBy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/OrderBy.java
@@ -5,7 +5,6 @@ import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -23,7 +22,7 @@ public class OrderBy extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>(sorts);
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Query.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Query.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -24,7 +23,7 @@ public class Query extends Statement {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(expr);
         return kids;

--- a/partiql-ast/src/main/java/org/partiql/ast/QueryBody.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/QueryBody.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public abstract class QueryBody extends AstNode {
@@ -48,7 +47,7 @@ public abstract class QueryBody extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(select);
             if (exclude != null) kids.add(exclude);
@@ -89,7 +88,7 @@ public abstract class QueryBody extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(type);
             kids.add(lhs);

--- a/partiql-ast/src/main/java/org/partiql/ast/SelectItem.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SelectItem.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -28,7 +27,7 @@ public abstract class SelectItem extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(expr);
             return kids;
@@ -59,7 +58,7 @@ public abstract class SelectItem extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(expr);
             if (asAlias != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/SelectList.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SelectList.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -28,7 +27,7 @@ public class SelectList extends Select {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>(items);
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/SelectPivot.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SelectPivot.java
@@ -6,7 +6,6 @@ import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -28,7 +27,7 @@ public class SelectPivot extends Select {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(key);
         kids.add(value);

--- a/partiql-ast/src/main/java/org/partiql/ast/SelectStar.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SelectStar.java
@@ -5,8 +5,8 @@ import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -23,7 +23,7 @@ public class SelectStar extends Select {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/SelectValue.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SelectValue.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -29,10 +28,10 @@ public class SelectValue extends Select {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(constructor);
-            return kids;
+        return kids;
     }
 
     @Override

--- a/partiql-ast/src/main/java/org/partiql/ast/SetOp.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SetOp.java
@@ -5,8 +5,8 @@ import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -27,7 +27,7 @@ public class SetOp extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/SetOpType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SetOpType.java
@@ -3,8 +3,8 @@ package org.partiql.ast;
 import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -78,7 +78,7 @@ public class SetOpType extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/SetQuantifier.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SetQuantifier.java
@@ -3,8 +3,8 @@ package org.partiql.ast;
 import lombok.EqualsAndHashCode;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -70,7 +70,7 @@ public class SetQuantifier extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Sort.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Sort.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -33,7 +32,7 @@ public class Sort extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(expr);
         return kids;

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/AttributeConstraint.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/AttributeConstraint.java
@@ -9,7 +9,6 @@ import org.partiql.ast.IdentifierChain;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -26,7 +25,7 @@ public abstract class AttributeConstraint extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(name);
         return kids;
@@ -90,7 +89,7 @@ public abstract class AttributeConstraint extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(name);
             kids.add(searchCondition);

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/ColumnDefinition.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/ColumnDefinition.java
@@ -10,7 +10,6 @@ import org.partiql.ast.DataType;
 import org.partiql.ast.Identifier;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -49,7 +48,7 @@ public class ColumnDefinition extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(name);
         kids.add(dataType);

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/CreateTable.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/CreateTable.java
@@ -9,7 +9,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.IdentifierChain;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -49,7 +48,7 @@ public class CreateTable extends Ddl {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(name);
         kids.addAll(columns);

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/KeyValue.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/KeyValue.java
@@ -6,8 +6,8 @@ import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Any option that consists of a key value pair where the key is a string and value is a string.
@@ -29,7 +29,7 @@ public class KeyValue extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/PartitionBy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/PartitionBy.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.Identifier;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 @Builder(builderClassName = "Builder")
@@ -23,7 +22,7 @@ public class PartitionBy extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>(columns);
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/TableConstraint.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/TableConstraint.java
@@ -9,7 +9,6 @@ import org.partiql.ast.Identifier;
 import org.partiql.ast.IdentifierChain;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public abstract class TableConstraint extends AstNode {
@@ -35,7 +34,7 @@ public abstract class TableConstraint extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(name);
             kids.addAll(columns);

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/ConflictAction.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/ConflictAction.java
@@ -9,7 +9,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -36,7 +35,7 @@ public abstract class ConflictAction extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return new ArrayList<>();
         }
 
@@ -79,7 +78,7 @@ public abstract class ConflictAction extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> children = new ArrayList<>();
             children.add(action);
             if (condition != null) {
@@ -127,7 +126,7 @@ public abstract class ConflictAction extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> children = new ArrayList<>();
             children.add(action);
             if (condition != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/ConflictTarget.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/ConflictTarget.java
@@ -9,7 +9,6 @@ import org.partiql.ast.Identifier;
 import org.partiql.ast.IdentifierChain;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -44,7 +43,7 @@ public abstract class ConflictTarget extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return new ArrayList<>(indexes);
         }
 
@@ -78,7 +77,7 @@ public abstract class ConflictTarget extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> children = new ArrayList<>();
             children.add(name);
             return children;

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/Delete.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/Delete.java
@@ -11,7 +11,6 @@ import org.partiql.ast.Statement;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -44,7 +43,7 @@ public final class Delete extends Statement {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(tableName);
         if (condition != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/DoReplaceAction.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/DoReplaceAction.java
@@ -7,7 +7,7 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 
 /**
  * This represents the potential actions after the DO REPLACE clause. While there are more variants beyond EXCLUDED,
@@ -32,7 +32,7 @@ public abstract class DoReplaceAction extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return new ArrayList<>();
         }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/DoUpdateAction.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/DoUpdateAction.java
@@ -7,7 +7,7 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 
 /**
  * This represents the potential actions after the DO UPDATE clause. While there are more variants beyond EXCLUDED,
@@ -32,7 +32,7 @@ public abstract class DoUpdateAction extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return new ArrayList<>();
         }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/Insert.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/Insert.java
@@ -11,7 +11,6 @@ import org.partiql.ast.IdentifierChain;
 import org.partiql.ast.Statement;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -61,7 +60,7 @@ public final class Insert extends Statement {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(tableName);
         if (asAlias != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/InsertSource.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/InsertSource.java
@@ -10,7 +10,6 @@ import org.partiql.ast.Identifier;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -52,7 +51,7 @@ public abstract class InsertSource extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             if (columns != null) {
                 kids.addAll(columns);
@@ -83,7 +82,7 @@ public abstract class InsertSource extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return new ArrayList<>();
         }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/OnConflict.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/OnConflict.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -43,7 +42,7 @@ public final class OnConflict extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(action);
         if (target != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/Replace.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/Replace.java
@@ -11,7 +11,6 @@ import org.partiql.ast.IdentifierChain;
 import org.partiql.ast.Statement;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -53,7 +52,7 @@ public final class Replace extends Statement {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(tableName);
         if (asAlias != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/SetClause.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/SetClause.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -42,7 +41,7 @@ public final class SetClause extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(target);
         kids.add(expr);

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/Update.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/Update.java
@@ -11,7 +11,6 @@ import org.partiql.ast.Statement;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -53,7 +52,7 @@ public final class Update extends Statement {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(tableName);
         kids.addAll(setClauses);

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/UpdateTarget.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/UpdateTarget.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.Identifier;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -43,7 +42,7 @@ public final class UpdateTarget extends AstNode {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(root);
         kids.addAll(steps);

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/UpdateTargetStep.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/UpdateTargetStep.java
@@ -9,7 +9,6 @@ import org.partiql.ast.Identifier;
 import org.partiql.ast.Literal;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -62,7 +61,7 @@ public abstract class UpdateTargetStep extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(key);
             return kids;
@@ -98,7 +97,7 @@ public abstract class UpdateTargetStep extends AstNode {
 
         @NotNull
         @Override
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(key);
             return kids;

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/Upsert.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/Upsert.java
@@ -11,7 +11,6 @@ import org.partiql.ast.IdentifierChain;
 import org.partiql.ast.Statement;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -53,7 +52,7 @@ public final class Upsert extends Statement {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(tableName);
         if (asAlias != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprAnd.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprAnd.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -28,7 +27,7 @@ public class ExprAnd extends Expr {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(lhs);
         kids.add(rhs);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprArray.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprArray.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -25,7 +24,7 @@ public class ExprArray extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>(values);
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprBag.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprBag.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -25,7 +24,7 @@ public class ExprBag extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>(values);
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprBetween.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprBetween.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -36,7 +35,7 @@ public class ExprBetween extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(value);
         kids.add(from);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCall.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCall.java
@@ -10,7 +10,6 @@ import org.partiql.ast.IdentifierChain;
 import org.partiql.ast.SetQuantifier;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -36,7 +35,7 @@ public class ExprCall extends Expr {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(function);
         kids.addAll(args);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCase.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCase.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -34,7 +33,7 @@ public class ExprCase extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         if (expr != null) {
             kids.add(expr);
@@ -70,7 +69,7 @@ public class ExprCase extends Expr {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(condition);
             kids.add(expr);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCast.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCast.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.DataType;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -30,7 +29,7 @@ public class ExprCast extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(value);
         kids.add(asType);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCoalesce.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCoalesce.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -25,7 +24,7 @@ public class ExprCoalesce extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>(args);
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprExtract.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprExtract.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.DatetimeField;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -30,7 +29,7 @@ public class ExprExtract extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(source);
         return kids;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprInCollection.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprInCollection.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -32,7 +31,7 @@ public class ExprInCollection extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(lhs);
         kids.add(rhs);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprIsType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprIsType.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.DataType;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -34,7 +33,7 @@ public class ExprIsType extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(value);
         kids.add(type);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprLike.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprLike.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -37,7 +36,7 @@ public class ExprLike extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(value);
         kids.add(pattern);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprLit.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprLit.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.Literal;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -24,7 +23,7 @@ public class ExprLit extends Expr {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(lit);
         return kids;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprMatch.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprMatch.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.graph.GraphMatch;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -30,7 +29,7 @@ public class ExprMatch extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(expr);
         kids.add(pattern);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprNot.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprNot.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -25,7 +24,7 @@ public class ExprNot extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(value);
         return kids;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprNullIf.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprNullIf.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -29,7 +28,7 @@ public class ExprNullIf extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(v1);
         kids.add(v2);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprOperator.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprOperator.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -34,7 +33,7 @@ public class ExprOperator extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         if (lhs != null) {
             kids.add(lhs);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprOr.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprOr.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -29,7 +28,7 @@ public class ExprOr extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(lhs);
         kids.add(rhs);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprOverlay.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprOverlay.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -38,7 +37,7 @@ public class ExprOverlay extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(value);
         kids.add(placing);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprParameter.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprParameter.java
@@ -6,8 +6,8 @@ import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -23,7 +23,7 @@ public class ExprParameter extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprPath.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprPath.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -30,7 +29,7 @@ public class ExprPath extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(root);
         if (next != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprPosition.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprPosition.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -29,7 +28,7 @@ public class ExprPosition extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(lhs);
         kids.add(rhs);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprQuerySet.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprQuerySet.java
@@ -10,7 +10,6 @@ import org.partiql.ast.OrderBy;
 import org.partiql.ast.QueryBody;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -40,7 +39,7 @@ public class ExprQuerySet extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(body);
         if (orderBy != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprRowValue.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprRowValue.java
@@ -6,7 +6,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -52,7 +51,7 @@ public class ExprRowValue extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>(values);
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprSessionAttribute.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprSessionAttribute.java
@@ -6,8 +6,8 @@ import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -24,7 +24,7 @@ public class ExprSessionAttribute extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprStruct.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprStruct.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -25,7 +24,7 @@ public class ExprStruct extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>(fields);
     }
 
@@ -53,7 +52,7 @@ public class ExprStruct extends Expr {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(name);
             kids.add(value);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprSubstring.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprSubstring.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -34,7 +33,7 @@ public class ExprSubstring extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(value);
         if (start != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprTrim.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprTrim.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -34,7 +33,7 @@ public class ExprTrim extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(value);
         if (chars != null) {

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprValues.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprValues.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -38,7 +37,7 @@ public class ExprValues extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return new ArrayList<>(rows);
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprVarRef.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprVarRef.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.IdentifierChain;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -30,7 +29,7 @@ public class ExprVarRef extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(identifierChain);
         return kids;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprVariant.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprVariant.java
@@ -24,7 +24,7 @@ public class ExprVariant extends Expr {
 
     @NotNull
     @Override
-    public List<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprWindow.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprWindow.java
@@ -9,7 +9,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.Sort;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -43,7 +42,7 @@ public class ExprWindow extends Expr {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         kids.add(expression);
         if (offset != null) {
@@ -80,7 +79,7 @@ public class ExprWindow extends Expr {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             if (partitions != null) {
                 kids.addAll(partitions);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/PathStep.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/PathStep.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.Identifier;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -37,7 +36,7 @@ public abstract class PathStep extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             if (next != null) {
                 kids.add(next);
@@ -66,7 +65,7 @@ public abstract class PathStep extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(element);
             if (next != null) {
@@ -92,7 +91,7 @@ public abstract class PathStep extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             if (next != null) {
                 kids.add(next);
@@ -117,7 +116,7 @@ public abstract class PathStep extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             if (next != null) {
                 kids.add(next);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/Scope.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/Scope.java
@@ -6,8 +6,8 @@ import org.partiql.ast.AstEnum;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -74,7 +74,7 @@ public class Scope extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/SessionAttribute.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/SessionAttribute.java
@@ -6,8 +6,8 @@ import org.partiql.ast.AstEnum;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -73,7 +73,7 @@ public class SessionAttribute extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/TrimSpec.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/TrimSpec.java
@@ -6,8 +6,8 @@ import org.partiql.ast.AstEnum;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
 public class TrimSpec extends AstEnum {
@@ -78,7 +78,7 @@ public class TrimSpec extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/WindowFunction.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/WindowFunction.java
@@ -6,8 +6,8 @@ import org.partiql.ast.AstEnum;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -73,7 +73,7 @@ public class WindowFunction extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphDirection.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphDirection.java
@@ -6,8 +6,8 @@ import org.partiql.ast.AstEnum;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -113,7 +113,7 @@ public class GraphDirection extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphLabel.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphLabel.java
@@ -7,7 +7,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -29,7 +28,7 @@ public abstract class GraphLabel extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return new ArrayList<>();
         }
 
@@ -49,7 +48,7 @@ public abstract class GraphLabel extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return new ArrayList<>();
         }
 
@@ -74,7 +73,7 @@ public abstract class GraphLabel extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(arg);
             return kids;
@@ -105,7 +104,7 @@ public abstract class GraphLabel extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(lhs);
             kids.add(rhs);
@@ -137,7 +136,7 @@ public abstract class GraphLabel extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(lhs);
             kids.add(rhs);

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphMatch.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphMatch.java
@@ -8,7 +8,6 @@ import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -30,7 +29,7 @@ public class GraphMatch extends AstNode {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>(patterns);
         if (selector != null) {
             kids.add(selector);

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphPart.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphPart.java
@@ -9,7 +9,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -39,7 +38,7 @@ public abstract class GraphPart extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             if (prefilter != null) {
                 kids.add(prefilter);
@@ -88,7 +87,7 @@ public abstract class GraphPart extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             if (quantifier != null) {
                 kids.add(quantifier);
@@ -123,7 +122,7 @@ public abstract class GraphPart extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(pattern);
             return kids;

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphPattern.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphPattern.java
@@ -9,7 +9,6 @@ import org.partiql.ast.AstVisitor;
 import org.partiql.ast.expr.Expr;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -45,7 +44,7 @@ public class GraphPattern extends AstNode {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         List<AstNode> kids = new ArrayList<>();
         if (prefilter != null) {
             kids.add(prefilter);

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphQuantifier.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphQuantifier.java
@@ -7,8 +7,8 @@ import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -28,7 +28,7 @@ public class GraphQuantifier extends AstNode {
 
     @Override
     @NotNull
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphRestrictor.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphRestrictor.java
@@ -6,8 +6,8 @@ import org.partiql.ast.AstEnum;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -81,7 +81,7 @@ public class GraphRestrictor extends AstEnum {
 
     @NotNull
     @Override
-    public Collection<AstNode> children() {
+    public List<AstNode> getChildren() {
         return Collections.emptyList();
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphSelector.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphSelector.java
@@ -6,8 +6,8 @@ import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * TODO docs, equals, hashcode
@@ -23,7 +23,7 @@ public abstract class GraphSelector extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return Collections.emptyList();
         }
 
@@ -43,7 +43,7 @@ public abstract class GraphSelector extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return Collections.emptyList();
         }
 
@@ -63,7 +63,7 @@ public abstract class GraphSelector extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return Collections.emptyList();
         }
 
@@ -87,7 +87,7 @@ public abstract class GraphSelector extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return Collections.emptyList();
         }
 
@@ -111,7 +111,7 @@ public abstract class GraphSelector extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return Collections.emptyList();
         }
 
@@ -135,7 +135,7 @@ public abstract class GraphSelector extends AstNode {
 
         @Override
         @NotNull
-        public Collection<AstNode> children() {
+        public List<AstNode> getChildren() {
             return Collections.emptyList();
         }
 

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -376,9 +376,11 @@ internal class PartiQLParserDefault : PartiQLParser {
      */
     private class Visitor(
         private val tokens: CommonTokenStream,
-        private val locations: MutableMap<String, SourceLocation>,
+        private val locations: MutableMap<Int, SourceLocation>,
         private val parameters: Map<Int, Int> = mapOf(),
     ) : PartiQLParserBaseVisitor<AstNode>() {
+        // Counter to store unique AstNode tags
+        private var counter = 0
 
         companion object {
 
@@ -391,7 +393,7 @@ internal class PartiQLParserDefault : PartiQLParser {
                 tokens: CountingTokenStream,
                 tree: GeneratedParser.StatementsContext,
             ): PartiQLParser.Result {
-                val locations = mutableMapOf<String, SourceLocation>()
+                val locations = mutableMapOf<Int, SourceLocation>()
                 val visitor = Visitor(tokens, locations, tokens.parameterIndexes)
                 val statements = tree.statement().map { statementCtx ->
                     visitor.visit(statementCtx) as Statement
@@ -447,6 +449,7 @@ internal class PartiQLParserDefault : PartiQLParser {
          */
         private inline fun <T : AstNode> translate(ctx: ParserRuleContext, block: () -> T): T {
             val node = block()
+            node.tag = counter++
             if (ctx.start != null) {
                 locations[node.tag] = SourceLocation(
                     ctx.start.line,

--- a/partiql-spi/api/partiql-spi.api
+++ b/partiql-spi/api/partiql-spi.api
@@ -58,8 +58,8 @@ public class org/partiql/spi/SourceLocations : java/util/Map {
 	public fun get (Ljava/lang/Object;)Lorg/partiql/spi/SourceLocation;
 	public fun isEmpty ()Z
 	public fun keySet ()Ljava/util/Set;
+	public fun put (Ljava/lang/Integer;Lorg/partiql/spi/SourceLocation;)Lorg/partiql/spi/SourceLocation;
 	public synthetic fun put (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun put (Ljava/lang/String;Lorg/partiql/spi/SourceLocation;)Lorg/partiql/spi/SourceLocation;
 	public fun putAll (Ljava/util/Map;)V
 	public synthetic fun remove (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun remove (Ljava/lang/Object;)Lorg/partiql/spi/SourceLocation;

--- a/partiql-spi/src/main/java/org/partiql/spi/SourceLocations.java
+++ b/partiql-spi/src/main/java/org/partiql/spi/SourceLocations.java
@@ -13,9 +13,9 @@ import java.util.Set;
  * <b>Note!</b>: This class is immutable and does not support {@link Map#put(Object, Object)}, amongst others. Please
  * handle the runtime exceptions indicated by {@link Map}'s Javadocs.
  */
-public class SourceLocations implements Map<String, SourceLocation> {
+public class SourceLocations implements Map<Integer, SourceLocation> {
 
-    private final Map<String, SourceLocation> delegate;
+    private final Map<Integer, SourceLocation> delegate;
 
     /**
      * Creates an empty instance.
@@ -29,20 +29,20 @@ public class SourceLocations implements Map<String, SourceLocation> {
      * to an internal structure.
      * @param delegate the delegate holding the locations.
      */
-    public SourceLocations(Map<String, SourceLocation> delegate) {
+    public SourceLocations(Map<Integer, SourceLocation> delegate) {
         this.delegate = new java.util.HashMap<>();
         this.delegate.putAll(delegate);
     }
 
     @NotNull
     @Override
-    public Set<Map.Entry<String, SourceLocation>> entrySet() {
+    public Set<Map.Entry<Integer, SourceLocation>> entrySet() {
         return delegate.entrySet();
     }
 
     @NotNull
     @Override
-    public Set<String> keySet() {
+    public Set<Integer> keySet() {
         return delegate.keySet();
     }
 
@@ -74,7 +74,7 @@ public class SourceLocations implements Map<String, SourceLocation> {
 
     @Nullable
     @Override
-    public SourceLocation put(String key, SourceLocation value) {
+    public SourceLocation put(Integer key, SourceLocation value) {
         throw new UnsupportedOperationException();
     }
 
@@ -84,7 +84,7 @@ public class SourceLocations implements Map<String, SourceLocation> {
     }
 
     @Override
-    public void putAll(@NotNull Map<? extends String, ? extends SourceLocation> m) {
+    public void putAll(@NotNull Map<? extends Integer, ? extends SourceLocation> m) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
## Relevant Issues
- https://github.com/partiql/partiql-lang-kotlin/issues/1610
- https://github.com/partiql/partiql-lang-kotlin/issues/1642

## Description
- From recent PR comment https://github.com/partiql/partiql-lang-kotlin/pull/1650#discussion_r1873771424, changing AstNode's `children` method in a couple ways
1. use `List` in signature to retain order property
2. rename to `getChildren()` to allow for Kotlin accessor syntax sugar:
```Kotlin
// Previous modeling w/ `children()`
node.children().filter { it is Expr }
// New modeling w/ `getChildren()` allows for slight syntax improvements from Kotlin
node.children.filter { it is Expr }
```
- Also changes the `AstNode` tag to be a mutable int

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - No, `v1` not yet released.

- Any backward-incompatible changes? **[YES]**
  - Yes, but `v1` not yet released.

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.