### PR TITLE
[v1] Make `AstNode` equals and hashcode abstract; add missing impls

### DIFF
--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -124,8 +124,10 @@ public abstract class org/partiql/ast/AstEnum : org/partiql/ast/AstNode {
 public abstract class org/partiql/ast/AstNode {
 	public fun <init> ()V
 	public abstract fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun equals (Ljava/lang/Object;)Z
 	public abstract fun getChildren ()Ljava/util/List;
 	public fun getTag ()I
+	public abstract fun hashCode ()I
 	public fun setTag (I)V
 }
 
@@ -886,7 +888,10 @@ public class org/partiql/ast/GroupBy$Key : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/Identifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/GroupBy$Key$Builder;
+	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
 }
 
 public class org/partiql/ast/GroupBy$Key$Builder {
@@ -1001,7 +1006,10 @@ public class org/partiql/ast/Let$Binding : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/Identifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Let$Binding$Builder;
+	protected fun canEqual (Ljava/lang/Object;)Z
+	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun hashCode ()I
 }
 
 public class org/partiql/ast/Let$Binding$Builder {

--- a/partiql-ast/src/main/java/org/partiql/ast/AstNode.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/AstNode.java
@@ -23,4 +23,10 @@ public abstract class AstNode {
     public abstract List<AstNode> getChildren();
 
     public abstract <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx);
+
+    @Override
+    public abstract int hashCode();
+
+    @Override
+    public abstract boolean equals(Object obj);
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/GroupBy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/GroupBy.java
@@ -49,6 +49,7 @@ public class GroupBy extends AstNode {
      * TODO docs, equals, hashcode
      */
     @lombok.Builder(builderClassName = "Builder")
+    @EqualsAndHashCode(callSuper = false)
     public static class Key extends AstNode {
         @NotNull
         public final Expr expr;

--- a/partiql-ast/src/main/java/org/partiql/ast/Let.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Let.java
@@ -36,6 +36,7 @@ public class Let extends AstNode {
      * TODO docs, equals, hashcode
      */
     @lombok.Builder(builderClassName = "Builder")
+    @EqualsAndHashCode(callSuper = false)
     public static class Binding extends AstNode {
         @NotNull
         public final Expr expr;


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Make `AstNode`'s `equals` and `hashCode` functions abstract such that the extending classes need to implement. This ensures an `AstNode` does NOT rely on the implicit equals function of `AstNode` which includes the tag
  - See a similar pattern in Trino's AST -- https://github.com/prestodb/presto/blob/cd9f2dd43470b5298a9f9fb0572be7d2aa9bf74c/presto-parser/src/main/java/com/facebook/presto/sql/tree/Node.java#L45-L50
- Making the two functions abstract uncovered a couple classes that were missing `equals` and `hashcode` implementations

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - No, on `v1` branch.

- Any backward-incompatible changes? **[YES]**
  - Yes but not yet released.

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.