### PR TITLE
[v1] Change public fields to Lombok getters; make concrete classes final

### DIFF
--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -257,8 +257,8 @@ public abstract class org/partiql/ast/AstRewriter : org/partiql/ast/AstVisitor {
 	public fun visitConflictTargetConstraint (Lorg/partiql/ast/dml/ConflictTarget$Constraint;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitConflictTargetIndex (Lorg/partiql/ast/dml/ConflictTarget$Index;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitConflictTargetIndex (Lorg/partiql/ast/dml/ConflictTarget$Index;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
-	public synthetic fun visitDdl (Lorg/partiql/ast/ddl/Ddl;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun visitDdl (Lorg/partiql/ast/ddl/Ddl;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
+	public synthetic fun visitCreateTable (Lorg/partiql/ast/ddl/CreateTable;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitCreateTable (Lorg/partiql/ast/ddl/CreateTable;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitDelete (Lorg/partiql/ast/dml/Delete;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDelete (Lorg/partiql/ast/dml/Delete;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitDoReplaceActionExcluded (Lorg/partiql/ast/dml/DoReplaceAction$Excluded;Ljava/lang/Object;)Ljava/lang/Object;
@@ -461,7 +461,6 @@ public abstract class org/partiql/ast/AstVisitor {
 	public fun visitConflictTargetIndex (Lorg/partiql/ast/dml/ConflictTarget$Index;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitCreateTable (Lorg/partiql/ast/ddl/CreateTable;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDataType (Lorg/partiql/ast/DataType;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun visitDdl (Lorg/partiql/ast/ddl/Ddl;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDelete (Lorg/partiql/ast/dml/Delete;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDoReplaceAction (Lorg/partiql/ast/dml/DoReplaceAction;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDoReplaceActionExcluded (Lorg/partiql/ast/dml/DoReplaceAction$Excluded;Ljava/lang/Object;)Ljava/lang/Object;
@@ -1514,7 +1513,7 @@ public class org/partiql/ast/ddl/ColumnDefinition$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class org/partiql/ast/ddl/CreateTable : org/partiql/ast/ddl/Ddl {
+public final class org/partiql/ast/ddl/CreateTable : org/partiql/ast/Statement {
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Ljava/util/List;Ljava/util/List;Lorg/partiql/ast/ddl/PartitionBy;Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ddl/CreateTable$Builder;
@@ -1536,10 +1535,6 @@ public class org/partiql/ast/ddl/CreateTable$Builder {
 	public fun partitionBy (Lorg/partiql/ast/ddl/PartitionBy;)Lorg/partiql/ast/ddl/CreateTable$Builder;
 	public fun tableProperties (Ljava/util/List;)Lorg/partiql/ast/ddl/CreateTable$Builder;
 	public fun toString ()Ljava/lang/String;
-}
-
-public abstract class org/partiql/ast/ddl/Ddl : org/partiql/ast/Statement {
-	public fun <init> ()V
 }
 
 public final class org/partiql/ast/ddl/KeyValue : org/partiql/ast/AstNode {
@@ -3176,10 +3171,10 @@ public abstract class org/partiql/ast/sql/SqlDialect : org/partiql/ast/AstVisito
 	public fun defaultReturn (Lorg/partiql/ast/AstNode;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public static final fun getSTANDARD ()Lorg/partiql/ast/sql/SqlDialect;
 	public final fun transform (Lorg/partiql/ast/AstNode;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitCreateTable (Lorg/partiql/ast/ddl/CreateTable;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitCreateTable (Lorg/partiql/ast/ddl/CreateTable;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitDataType (Lorg/partiql/ast/DataType;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDataType (Lorg/partiql/ast/DataType;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
-	public synthetic fun visitDdl (Lorg/partiql/ast/ddl/Ddl;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun visitDdl (Lorg/partiql/ast/ddl/Ddl;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitDelete (Lorg/partiql/ast/dml/Delete;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDelete (Lorg/partiql/ast/dml/Delete;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExclude (Lorg/partiql/ast/Exclude;Ljava/lang/Object;)Ljava/lang/Object;

--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -730,9 +730,9 @@ public class org/partiql/ast/DataType$StructField : org/partiql/ast/AstNode {
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun getName ()Lorg/partiql/ast/Identifier;
-	public fun getOptional ()Z
 	public fun getType ()Lorg/partiql/ast/DataType;
 	public fun hashCode ()I
+	public fun isOptional ()Z
 }
 
 public final class org/partiql/ast/DatetimeField : org/partiql/ast/AstEnum {
@@ -1021,9 +1021,9 @@ public final class org/partiql/ast/Identifier : org/partiql/ast/AstNode {
 	public static fun builder ()Lorg/partiql/ast/Identifier$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
-	public fun getDelimited ()Z
 	public fun getSymbol ()Ljava/lang/String;
 	public fun hashCode ()I
+	public fun isDelimited ()Z
 }
 
 public class org/partiql/ast/Identifier$Builder {
@@ -1253,9 +1253,9 @@ public class org/partiql/ast/QueryBody$SetOp : org/partiql/ast/QueryBody {
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
-	public fun getOuter ()Z
 	public fun getType ()Lorg/partiql/ast/SetOp;
 	public fun hashCode ()I
+	public fun isOuter ()Z
 }
 
 public class org/partiql/ast/QueryBody$SetOp$Builder {
@@ -1477,8 +1477,8 @@ public class org/partiql/ast/ddl/AttributeConstraint$Null : org/partiql/ast/ddl/
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getNullable ()Z
 	public fun hashCode ()I
+	public fun isNullable ()Z
 }
 
 public class org/partiql/ast/ddl/AttributeConstraint$Unique : org/partiql/ast/ddl/AttributeConstraint {
@@ -1486,8 +1486,8 @@ public class org/partiql/ast/ddl/AttributeConstraint$Unique : org/partiql/ast/dd
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getPrimaryKey ()Z
 	public fun hashCode ()I
+	public fun isPrimaryKey ()Z
 }
 
 public final class org/partiql/ast/ddl/ColumnDefinition : org/partiql/ast/AstNode {
@@ -1500,8 +1500,8 @@ public final class org/partiql/ast/ddl/ColumnDefinition : org/partiql/ast/AstNod
 	public fun getConstraints ()Ljava/util/List;
 	public fun getDataType ()Lorg/partiql/ast/DataType;
 	public fun getName ()Lorg/partiql/ast/Identifier;
-	public fun getOptional ()Z
 	public fun hashCode ()I
+	public fun isOptional ()Z
 }
 
 public class org/partiql/ast/ddl/ColumnDefinition$Builder {
@@ -1589,8 +1589,8 @@ public class org/partiql/ast/ddl/TableConstraint$Unique : org/partiql/ast/ddl/Ta
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun getColumns ()Ljava/util/List;
-	public fun getPrimaryKey ()Z
 	public fun hashCode ()I
+	public fun isPrimaryKey ()Z
 }
 
 public abstract class org/partiql/ast/dml/ConflictAction : org/partiql/ast/AstNode {
@@ -2008,10 +2008,10 @@ public final class org/partiql/ast/expr/ExprBetween : org/partiql/ast/expr/Expr 
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun getFrom ()Lorg/partiql/ast/expr/Expr;
-	public fun getNot ()Z
 	public fun getTo ()Lorg/partiql/ast/expr/Expr;
 	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
+	public fun isNot ()Z
 }
 
 public class org/partiql/ast/expr/ExprBetween$Builder {
@@ -2029,10 +2029,10 @@ public final class org/partiql/ast/expr/ExprBoolTest : org/partiql/ast/expr/Expr
 	public static fun builder ()Lorg/partiql/ast/expr/ExprBoolTest$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
-	public fun getNot ()Z
 	public fun getTruthValue ()Lorg/partiql/ast/expr/TruthValue;
 	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
+	public fun isNot ()Z
 }
 
 public class org/partiql/ast/expr/ExprBoolTest$Builder {
@@ -2161,9 +2161,9 @@ public final class org/partiql/ast/expr/ExprInCollection : org/partiql/ast/expr/
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun getLhs ()Lorg/partiql/ast/expr/Expr;
-	public fun getNot ()Z
 	public fun getRhs ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
+	public fun isNot ()Z
 }
 
 public class org/partiql/ast/expr/ExprInCollection$Builder {
@@ -2180,10 +2180,10 @@ public final class org/partiql/ast/expr/ExprIsType : org/partiql/ast/expr/Expr {
 	public static fun builder ()Lorg/partiql/ast/expr/ExprIsType$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
-	public fun getNot ()Z
 	public fun getType ()Lorg/partiql/ast/DataType;
 	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
+	public fun isNot ()Z
 }
 
 public class org/partiql/ast/expr/ExprIsType$Builder {
@@ -2201,10 +2201,10 @@ public final class org/partiql/ast/expr/ExprLike : org/partiql/ast/expr/Expr {
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun getEscape ()Lorg/partiql/ast/expr/Expr;
-	public fun getNot ()Z
 	public fun getPattern ()Lorg/partiql/ast/expr/Expr;
 	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
+	public fun isNot ()Z
 }
 
 public class org/partiql/ast/expr/ExprLike$Builder {
@@ -2249,9 +2249,9 @@ public final class org/partiql/ast/expr/ExprMissingPredicate : org/partiql/ast/e
 	public static fun builder ()Lorg/partiql/ast/expr/ExprMissingPredicate$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
-	public fun getNot ()Z
 	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
+	public fun isNot ()Z
 }
 
 public class org/partiql/ast/expr/ExprMissingPredicate$Builder {
@@ -2301,9 +2301,9 @@ public final class org/partiql/ast/expr/ExprNullPredicate : org/partiql/ast/expr
 	public static fun builder ()Lorg/partiql/ast/expr/ExprNullPredicate$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
-	public fun getNot ()Z
 	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
+	public fun isNot ()Z
 }
 
 public class org/partiql/ast/expr/ExprNullPredicate$Builder {
@@ -2454,7 +2454,6 @@ public final class org/partiql/ast/expr/ExprRowValue : org/partiql/ast/expr/Expr
 	public static fun builder ()Lorg/partiql/ast/expr/ExprRowValue$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
-	public fun getExplicit ()Z
 	public fun getValues ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun isExplicit ()Z

--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -587,7 +587,7 @@ public abstract class org/partiql/ast/AstVisitor {
 	public fun visitUpsert (Lorg/partiql/ast/dml/Upsert;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
-public class org/partiql/ast/DataType : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/DataType : org/partiql/ast/AstEnum {
 	public static final field ARRAY I
 	public static final field BAG I
 	public static final field BIGINT I
@@ -708,7 +708,6 @@ public class org/partiql/ast/DataType : org/partiql/ast/AstEnum {
 	public static fun VARCHAR ()Lorg/partiql/ast/DataType;
 	public static fun VARCHAR (I)Lorg/partiql/ast/DataType;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -725,20 +724,18 @@ public class org/partiql/ast/DataType : org/partiql/ast/AstEnum {
 }
 
 public class org/partiql/ast/DataType$StructField : org/partiql/ast/AstNode {
-	public final field comment Ljava/lang/String;
-	public final field constraints Ljava/util/List;
-	public final field isOptional Z
-	public final field name Lorg/partiql/ast/Identifier;
-	public final field type Lorg/partiql/ast/DataType;
 	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/DataType;ZLjava/util/List;Ljava/lang/String;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getName ()Lorg/partiql/ast/Identifier;
+	public fun getOptional ()Z
+	public fun getType ()Lorg/partiql/ast/DataType;
 	public fun hashCode ()I
 }
 
-public class org/partiql/ast/DatetimeField : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/DatetimeField : org/partiql/ast/AstEnum {
 	public static final field DAY I
 	public static final field HOUR I
 	public static final field MINUTE I
@@ -756,7 +753,6 @@ public class org/partiql/ast/DatetimeField : org/partiql/ast/AstEnum {
 	public static fun TIMEZONE_MINUTE ()Lorg/partiql/ast/DatetimeField;
 	public static fun YEAR ()Lorg/partiql/ast/DatetimeField;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -766,14 +762,13 @@ public class org/partiql/ast/DatetimeField : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/DatetimeField;
 }
 
-public class org/partiql/ast/Exclude : org/partiql/ast/AstNode {
-	public final field excludePaths Ljava/util/List;
+public final class org/partiql/ast/Exclude : org/partiql/ast/AstNode {
 	public fun <init> (Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Exclude$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getExcludePaths ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -783,15 +778,14 @@ public class org/partiql/ast/Exclude$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/ExcludePath : org/partiql/ast/AstNode {
-	public final field excludeSteps Ljava/util/List;
-	public final field root Lorg/partiql/ast/expr/ExprVarRef;
+public final class org/partiql/ast/ExcludePath : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/expr/ExprVarRef;Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ExcludePath$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getExcludeSteps ()Ljava/util/List;
+	public fun getRoot ()Lorg/partiql/ast/expr/ExprVarRef;
 	public fun hashCode ()I
 }
 
@@ -807,13 +801,13 @@ public abstract class org/partiql/ast/ExcludeStep : org/partiql/ast/AstNode {
 }
 
 public class org/partiql/ast/ExcludeStep$CollIndex : org/partiql/ast/ExcludeStep {
-	public final field index I
 	public fun <init> (I)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ExcludeStep$CollIndex$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getIndex ()I
 	public fun hashCode ()I
 }
 
@@ -839,13 +833,13 @@ public class org/partiql/ast/ExcludeStep$CollWildcard$Builder {
 }
 
 public class org/partiql/ast/ExcludeStep$StructField : org/partiql/ast/ExcludeStep {
-	public final field symbol Lorg/partiql/ast/Identifier;
 	public fun <init> (Lorg/partiql/ast/Identifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ExcludeStep$StructField$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getSymbol ()Lorg/partiql/ast/Identifier;
 	public fun hashCode ()I
 }
 
@@ -870,15 +864,14 @@ public class org/partiql/ast/ExcludeStep$StructWildcard$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/Explain : org/partiql/ast/Statement {
-	public final field options Ljava/util/Map;
-	public final field statement Lorg/partiql/ast/Statement;
+public final class org/partiql/ast/Explain : org/partiql/ast/Statement {
 	public fun <init> (Ljava/util/Map;Lorg/partiql/ast/Statement;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Explain$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getOptions ()Ljava/util/Map;
+	public fun getStatement ()Lorg/partiql/ast/Statement;
 	public fun hashCode ()I
 }
 
@@ -889,14 +882,13 @@ public class org/partiql/ast/Explain$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/From : org/partiql/ast/AstNode {
-	public final field tableRefs Ljava/util/List;
+public final class org/partiql/ast/From : org/partiql/ast/AstNode {
 	public fun <init> (Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/From$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getTableRefs ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -906,17 +898,16 @@ public class org/partiql/ast/From$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/FromExpr : org/partiql/ast/FromTableRef {
-	public final field asAlias Lorg/partiql/ast/Identifier;
-	public final field atAlias Lorg/partiql/ast/Identifier;
-	public final field expr Lorg/partiql/ast/expr/Expr;
-	public final field fromType Lorg/partiql/ast/FromType;
+public final class org/partiql/ast/FromExpr : org/partiql/ast/FromTableRef {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/FromType;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/Identifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/FromExpr$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAsAlias ()Lorg/partiql/ast/Identifier;
+	public fun getAtAlias ()Lorg/partiql/ast/Identifier;
 	public fun getChildren ()Ljava/util/List;
+	public fun getExpr ()Lorg/partiql/ast/expr/Expr;
+	public fun getFromType ()Lorg/partiql/ast/FromType;
 	public fun hashCode ()I
 }
 
@@ -929,17 +920,16 @@ public class org/partiql/ast/FromExpr$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/FromJoin : org/partiql/ast/FromTableRef {
-	public final field condition Lorg/partiql/ast/expr/Expr;
-	public final field joinType Lorg/partiql/ast/JoinType;
-	public final field lhs Lorg/partiql/ast/FromTableRef;
-	public final field rhs Lorg/partiql/ast/FromTableRef;
+public final class org/partiql/ast/FromJoin : org/partiql/ast/FromTableRef {
 	public fun <init> (Lorg/partiql/ast/FromTableRef;Lorg/partiql/ast/FromTableRef;Lorg/partiql/ast/JoinType;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/FromJoin$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getCondition ()Lorg/partiql/ast/expr/Expr;
+	public fun getJoinType ()Lorg/partiql/ast/JoinType;
+	public fun getLhs ()Lorg/partiql/ast/FromTableRef;
+	public fun getRhs ()Lorg/partiql/ast/FromTableRef;
 	public fun hashCode ()I
 }
 
@@ -956,13 +946,12 @@ public abstract class org/partiql/ast/FromTableRef : org/partiql/ast/AstNode {
 	public fun <init> ()V
 }
 
-public class org/partiql/ast/FromType : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/FromType : org/partiql/ast/AstEnum {
 	public static final field SCAN I
 	public static final field UNPIVOT I
 	public static fun SCAN ()Lorg/partiql/ast/FromType;
 	public static fun UNPIVOT ()Lorg/partiql/ast/FromType;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -972,16 +961,15 @@ public class org/partiql/ast/FromType : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/FromType;
 }
 
-public class org/partiql/ast/GroupBy : org/partiql/ast/AstNode {
-	public final field asAlias Lorg/partiql/ast/Identifier;
-	public final field keys Ljava/util/List;
-	public final field strategy Lorg/partiql/ast/GroupByStrategy;
+public final class org/partiql/ast/GroupBy : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/GroupByStrategy;Ljava/util/List;Lorg/partiql/ast/Identifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/GroupBy$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAsAlias ()Lorg/partiql/ast/Identifier;
 	public fun getChildren ()Ljava/util/List;
+	public fun getKeys ()Ljava/util/List;
+	public fun getStrategy ()Lorg/partiql/ast/GroupByStrategy;
 	public fun hashCode ()I
 }
 
@@ -994,14 +982,14 @@ public class org/partiql/ast/GroupBy$Builder {
 }
 
 public class org/partiql/ast/GroupBy$Key : org/partiql/ast/AstNode {
-	public final field asAlias Lorg/partiql/ast/Identifier;
-	public final field expr Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/Identifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/GroupBy$Key$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAsAlias ()Lorg/partiql/ast/Identifier;
 	public fun getChildren ()Ljava/util/List;
+	public fun getExpr ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -1012,13 +1000,12 @@ public class org/partiql/ast/GroupBy$Key$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/GroupByStrategy : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/GroupByStrategy : org/partiql/ast/AstEnum {
 	public static final field FULL I
 	public static final field PARTIAL I
 	public static fun FULL ()Lorg/partiql/ast/GroupByStrategy;
 	public static fun PARTIAL ()Lorg/partiql/ast/GroupByStrategy;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -1028,34 +1015,32 @@ public class org/partiql/ast/GroupByStrategy : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/GroupByStrategy;
 }
 
-public class org/partiql/ast/Identifier : org/partiql/ast/AstNode {
-	public final field isDelimited Z
-	public final field symbol Ljava/lang/String;
+public final class org/partiql/ast/Identifier : org/partiql/ast/AstNode {
 	public fun <init> (Ljava/lang/String;Z)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Identifier$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getDelimited ()Z
+	public fun getSymbol ()Ljava/lang/String;
 	public fun hashCode ()I
 }
 
 public class org/partiql/ast/Identifier$Builder {
 	public fun build ()Lorg/partiql/ast/Identifier;
-	public fun isDelimited (Z)Lorg/partiql/ast/Identifier$Builder;
+	public fun delimited (Z)Lorg/partiql/ast/Identifier$Builder;
 	public fun symbol (Ljava/lang/String;)Lorg/partiql/ast/Identifier$Builder;
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/IdentifierChain : org/partiql/ast/AstNode {
-	public final field next Lorg/partiql/ast/IdentifierChain;
-	public final field root Lorg/partiql/ast/Identifier;
+public final class org/partiql/ast/IdentifierChain : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/IdentifierChain;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/IdentifierChain$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getNext ()Lorg/partiql/ast/IdentifierChain;
+	public fun getRoot ()Lorg/partiql/ast/Identifier;
 	public fun hashCode ()I
 }
 
@@ -1066,7 +1051,7 @@ public class org/partiql/ast/IdentifierChain$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/JoinType : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/JoinType : org/partiql/ast/AstEnum {
 	public static final field CROSS I
 	public static final field FULL I
 	public static final field FULL_OUTER I
@@ -1086,7 +1071,6 @@ public class org/partiql/ast/JoinType : org/partiql/ast/AstEnum {
 	public static fun RIGHT ()Lorg/partiql/ast/JoinType;
 	public static fun RIGHT_OUTER ()Lorg/partiql/ast/JoinType;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -1096,26 +1080,25 @@ public class org/partiql/ast/JoinType : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/JoinType;
 }
 
-public class org/partiql/ast/Let : org/partiql/ast/AstNode {
-	public final field bindings Ljava/util/List;
+public final class org/partiql/ast/Let : org/partiql/ast/AstNode {
 	public fun <init> (Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Let$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getBindings ()Ljava/util/List;
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
 public class org/partiql/ast/Let$Binding : org/partiql/ast/AstNode {
-	public final field asAlias Lorg/partiql/ast/Identifier;
-	public final field expr Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/Identifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Let$Binding$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAsAlias ()Lorg/partiql/ast/Identifier;
 	public fun getChildren ()Ljava/util/List;
+	public fun getExpr ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -1132,7 +1115,7 @@ public class org/partiql/ast/Let$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/Literal : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/Literal : org/partiql/ast/AstEnum {
 	public static final field APPROX_NUM I
 	public static final field BOOL I
 	public static final field EXACT_NUM I
@@ -1146,7 +1129,6 @@ public class org/partiql/ast/Literal : org/partiql/ast/AstEnum {
 	public fun bigDecimalValue ()Ljava/math/BigDecimal;
 	public static fun bool (Z)Lorg/partiql/ast/Literal;
 	public fun booleanValue ()Z
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public fun dataType ()Lorg/partiql/ast/DataType;
 	public fun equals (Ljava/lang/Object;)Z
@@ -1167,13 +1149,12 @@ public class org/partiql/ast/Literal : org/partiql/ast/AstEnum {
 	public static fun typedString (Lorg/partiql/ast/DataType;Ljava/lang/String;)Lorg/partiql/ast/Literal;
 }
 
-public class org/partiql/ast/Nulls : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/Nulls : org/partiql/ast/AstEnum {
 	public static final field FIRST I
 	public static final field LAST I
 	public static fun FIRST ()Lorg/partiql/ast/Nulls;
 	public static fun LAST ()Lorg/partiql/ast/Nulls;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -1183,13 +1164,12 @@ public class org/partiql/ast/Nulls : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/Nulls;
 }
 
-public class org/partiql/ast/Order : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/Order : org/partiql/ast/AstEnum {
 	public static final field ASC I
 	public static final field DESC I
 	public static fun ASC ()Lorg/partiql/ast/Order;
 	public static fun DESC ()Lorg/partiql/ast/Order;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -1199,14 +1179,13 @@ public class org/partiql/ast/Order : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/Order;
 }
 
-public class org/partiql/ast/OrderBy : org/partiql/ast/AstNode {
-	public final field sorts Ljava/util/List;
+public final class org/partiql/ast/OrderBy : org/partiql/ast/AstNode {
 	public fun <init> (Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/OrderBy$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getSorts ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1216,14 +1195,13 @@ public class org/partiql/ast/OrderBy$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/Query : org/partiql/ast/Statement {
-	public final field expr Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/Query : org/partiql/ast/Statement {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Query$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getExpr ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -1238,19 +1216,19 @@ public abstract class org/partiql/ast/QueryBody : org/partiql/ast/AstNode {
 }
 
 public class org/partiql/ast/QueryBody$SFW : org/partiql/ast/QueryBody {
-	public final field exclude Lorg/partiql/ast/Exclude;
-	public final field from Lorg/partiql/ast/From;
-	public final field groupBy Lorg/partiql/ast/GroupBy;
-	public final field having Lorg/partiql/ast/expr/Expr;
-	public final field let Lorg/partiql/ast/Let;
-	public final field select Lorg/partiql/ast/Select;
-	public final field where Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Lorg/partiql/ast/Select;Lorg/partiql/ast/Exclude;Lorg/partiql/ast/From;Lorg/partiql/ast/Let;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/GroupBy;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/QueryBody$SFW$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getExclude ()Lorg/partiql/ast/Exclude;
+	public fun getFrom ()Lorg/partiql/ast/From;
+	public fun getGroupBy ()Lorg/partiql/ast/GroupBy;
+	public fun getHaving ()Lorg/partiql/ast/expr/Expr;
+	public fun getLet ()Lorg/partiql/ast/Let;
+	public fun getSelect ()Lorg/partiql/ast/Select;
+	public fun getWhere ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -1267,23 +1245,23 @@ public class org/partiql/ast/QueryBody$SFW$Builder {
 }
 
 public class org/partiql/ast/QueryBody$SetOp : org/partiql/ast/QueryBody {
-	public final field isOuter Z
 	public field lhs Lorg/partiql/ast/expr/Expr;
 	public field rhs Lorg/partiql/ast/expr/Expr;
-	public final field type Lorg/partiql/ast/SetOp;
 	public fun <init> (Lorg/partiql/ast/SetOp;ZLorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/QueryBody$SetOp$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getOuter ()Z
+	public fun getType ()Lorg/partiql/ast/SetOp;
 	public fun hashCode ()I
 }
 
 public class org/partiql/ast/QueryBody$SetOp$Builder {
 	public fun build ()Lorg/partiql/ast/QueryBody$SetOp;
-	public fun isOuter (Z)Lorg/partiql/ast/QueryBody$SetOp$Builder;
 	public fun lhs (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/QueryBody$SetOp$Builder;
+	public fun outer (Z)Lorg/partiql/ast/QueryBody$SetOp$Builder;
 	public fun rhs (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/QueryBody$SetOp$Builder;
 	public fun toString ()Ljava/lang/String;
 	public fun type (Lorg/partiql/ast/SetOp;)Lorg/partiql/ast/QueryBody$SetOp$Builder;
@@ -1298,14 +1276,14 @@ public abstract class org/partiql/ast/SelectItem : org/partiql/ast/AstNode {
 }
 
 public class org/partiql/ast/SelectItem$Expr : org/partiql/ast/SelectItem {
-	public final field asAlias Lorg/partiql/ast/Identifier;
-	public final field expr Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/Identifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SelectItem$Expr$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAsAlias ()Lorg/partiql/ast/Identifier;
 	public fun getChildren ()Ljava/util/List;
+	public fun getExpr ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -1317,13 +1295,13 @@ public class org/partiql/ast/SelectItem$Expr$Builder {
 }
 
 public class org/partiql/ast/SelectItem$Star : org/partiql/ast/SelectItem {
-	public final field expr Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SelectItem$Star$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getExpr ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -1333,15 +1311,14 @@ public class org/partiql/ast/SelectItem$Star$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/SelectList : org/partiql/ast/Select {
-	public final field items Ljava/util/List;
-	public final field setq Lorg/partiql/ast/SetQuantifier;
+public final class org/partiql/ast/SelectList : org/partiql/ast/Select {
 	public fun <init> (Ljava/util/List;Lorg/partiql/ast/SetQuantifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SelectList$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getItems ()Ljava/util/List;
+	public fun getSetq ()Lorg/partiql/ast/SetQuantifier;
 	public fun hashCode ()I
 }
 
@@ -1352,15 +1329,14 @@ public class org/partiql/ast/SelectList$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/SelectPivot : org/partiql/ast/Select {
-	public final field key Lorg/partiql/ast/expr/Expr;
-	public final field value Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/SelectPivot : org/partiql/ast/Select {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SelectPivot$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getKey ()Lorg/partiql/ast/expr/Expr;
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -1371,14 +1347,13 @@ public class org/partiql/ast/SelectPivot$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/SelectPivot$Builder;
 }
 
-public class org/partiql/ast/SelectStar : org/partiql/ast/Select {
-	public final field setq Lorg/partiql/ast/SetQuantifier;
+public final class org/partiql/ast/SelectStar : org/partiql/ast/Select {
 	public fun <init> (Lorg/partiql/ast/SetQuantifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SelectStar$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getSetq ()Lorg/partiql/ast/SetQuantifier;
 	public fun hashCode ()I
 }
 
@@ -1388,15 +1363,14 @@ public class org/partiql/ast/SelectStar$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/SelectValue : org/partiql/ast/Select {
-	public final field constructor Lorg/partiql/ast/expr/Expr;
-	public final field setq Lorg/partiql/ast/SetQuantifier;
+public final class org/partiql/ast/SelectValue : org/partiql/ast/Select {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/SetQuantifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SelectValue$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getConstructor ()Lorg/partiql/ast/expr/Expr;
+	public fun getSetq ()Lorg/partiql/ast/SetQuantifier;
 	public fun hashCode ()I
 }
 
@@ -1407,15 +1381,14 @@ public class org/partiql/ast/SelectValue$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/SetOp : org/partiql/ast/AstNode {
-	public final field setOpType Lorg/partiql/ast/SetOpType;
-	public final field setq Lorg/partiql/ast/SetQuantifier;
+public final class org/partiql/ast/SetOp : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/SetOpType;Lorg/partiql/ast/SetQuantifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/SetOp$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getSetOpType ()Lorg/partiql/ast/SetOpType;
+	public fun getSetq ()Lorg/partiql/ast/SetQuantifier;
 	public fun hashCode ()I
 }
 
@@ -1426,7 +1399,7 @@ public class org/partiql/ast/SetOp$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/SetOpType : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/SetOpType : org/partiql/ast/AstEnum {
 	public static final field EXCEPT I
 	public static final field INTERSECT I
 	public static final field UNION I
@@ -1434,7 +1407,6 @@ public class org/partiql/ast/SetOpType : org/partiql/ast/AstEnum {
 	public static fun INTERSECT ()Lorg/partiql/ast/SetOpType;
 	public static fun UNION ()Lorg/partiql/ast/SetOpType;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -1444,13 +1416,12 @@ public class org/partiql/ast/SetOpType : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/SetOpType;
 }
 
-public class org/partiql/ast/SetQuantifier : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/SetQuantifier : org/partiql/ast/AstEnum {
 	public static final field ALL I
 	public static final field DISTINCT I
 	public static fun ALL ()Lorg/partiql/ast/SetQuantifier;
 	public static fun DISTINCT ()Lorg/partiql/ast/SetQuantifier;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -1460,16 +1431,15 @@ public class org/partiql/ast/SetQuantifier : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/SetQuantifier;
 }
 
-public class org/partiql/ast/Sort : org/partiql/ast/AstNode {
-	public final field expr Lorg/partiql/ast/expr/Expr;
-	public final field nulls Lorg/partiql/ast/Nulls;
-	public final field order Lorg/partiql/ast/Order;
+public final class org/partiql/ast/Sort : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/Order;Lorg/partiql/ast/Nulls;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/Sort$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getExpr ()Lorg/partiql/ast/expr/Expr;
+	public fun getNulls ()Lorg/partiql/ast/Nulls;
+	public fun getOrder ()Lorg/partiql/ast/Order;
 	public fun hashCode ()I
 }
 
@@ -1486,51 +1456,51 @@ public abstract class org/partiql/ast/Statement : org/partiql/ast/AstNode {
 }
 
 public abstract class org/partiql/ast/ddl/AttributeConstraint : org/partiql/ast/AstNode {
-	public final field name Lorg/partiql/ast/IdentifierChain;
+	protected final field name Lorg/partiql/ast/IdentifierChain;
 	protected fun <init> (Lorg/partiql/ast/IdentifierChain;)V
 	public fun getChildren ()Ljava/util/List;
+	public fun getName ()Lorg/partiql/ast/IdentifierChain;
 }
 
 public class org/partiql/ast/ddl/AttributeConstraint$Check : org/partiql/ast/ddl/AttributeConstraint {
-	public final field searchCondition Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getSearchCondition ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
 public class org/partiql/ast/ddl/AttributeConstraint$Null : org/partiql/ast/ddl/AttributeConstraint {
-	public final field isNullable Z
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Z)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getNullable ()Z
 	public fun hashCode ()I
 }
 
 public class org/partiql/ast/ddl/AttributeConstraint$Unique : org/partiql/ast/ddl/AttributeConstraint {
-	public final field isPrimaryKey Z
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Z)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getPrimaryKey ()Z
 	public fun hashCode ()I
 }
 
-public class org/partiql/ast/ddl/ColumnDefinition : org/partiql/ast/AstNode {
-	public final field comment Ljava/lang/String;
-	public final field constraints Ljava/util/List;
-	public final field dataType Lorg/partiql/ast/DataType;
-	public final field isOptional Z
-	public final field name Lorg/partiql/ast/Identifier;
+public final class org/partiql/ast/ddl/ColumnDefinition : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/DataType;ZLjava/util/List;Ljava/lang/String;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ddl/ColumnDefinition$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getComment ()Ljava/lang/String;
+	public fun getConstraints ()Ljava/util/List;
+	public fun getDataType ()Lorg/partiql/ast/DataType;
+	public fun getName ()Lorg/partiql/ast/Identifier;
+	public fun getOptional ()Z
 	public fun hashCode ()I
 }
 
@@ -1539,23 +1509,22 @@ public class org/partiql/ast/ddl/ColumnDefinition$Builder {
 	public fun comment (Ljava/lang/String;)Lorg/partiql/ast/ddl/ColumnDefinition$Builder;
 	public fun constraints (Ljava/util/List;)Lorg/partiql/ast/ddl/ColumnDefinition$Builder;
 	public fun dataType (Lorg/partiql/ast/DataType;)Lorg/partiql/ast/ddl/ColumnDefinition$Builder;
-	public fun isOptional (Z)Lorg/partiql/ast/ddl/ColumnDefinition$Builder;
 	public fun name (Lorg/partiql/ast/Identifier;)Lorg/partiql/ast/ddl/ColumnDefinition$Builder;
+	public fun optional (Z)Lorg/partiql/ast/ddl/ColumnDefinition$Builder;
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/ddl/CreateTable : org/partiql/ast/ddl/Ddl {
-	public final field columns Ljava/util/List;
-	public final field constraints Ljava/util/List;
-	public final field name Lorg/partiql/ast/IdentifierChain;
-	public final field partitionBy Lorg/partiql/ast/ddl/PartitionBy;
-	public final field tableProperties Ljava/util/List;
+public final class org/partiql/ast/ddl/CreateTable : org/partiql/ast/ddl/Ddl {
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Ljava/util/List;Ljava/util/List;Lorg/partiql/ast/ddl/PartitionBy;Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ddl/CreateTable$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getColumns ()Ljava/util/List;
+	public fun getConstraints ()Ljava/util/List;
+	public fun getName ()Lorg/partiql/ast/IdentifierChain;
+	public fun getPartitionBy ()Lorg/partiql/ast/ddl/PartitionBy;
+	public fun getTableProperties ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1573,15 +1542,14 @@ public abstract class org/partiql/ast/ddl/Ddl : org/partiql/ast/Statement {
 	public fun <init> ()V
 }
 
-public class org/partiql/ast/ddl/KeyValue : org/partiql/ast/AstNode {
-	public final field key Ljava/lang/String;
-	public final field value Ljava/lang/String;
+public final class org/partiql/ast/ddl/KeyValue : org/partiql/ast/AstNode {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ddl/KeyValue$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getKey ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 }
 
@@ -1592,14 +1560,13 @@ public class org/partiql/ast/ddl/KeyValue$Builder {
 	public fun value (Ljava/lang/String;)Lorg/partiql/ast/ddl/KeyValue$Builder;
 }
 
-public class org/partiql/ast/ddl/PartitionBy : org/partiql/ast/AstNode {
-	public final field columns Ljava/util/List;
+public final class org/partiql/ast/ddl/PartitionBy : org/partiql/ast/AstNode {
 	public fun <init> (Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ddl/PartitionBy$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getColumns ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1610,18 +1577,19 @@ public class org/partiql/ast/ddl/PartitionBy$Builder {
 }
 
 public abstract class org/partiql/ast/ddl/TableConstraint : org/partiql/ast/AstNode {
-	public final field name Lorg/partiql/ast/IdentifierChain;
+	protected final field name Lorg/partiql/ast/IdentifierChain;
 	protected fun <init> (Lorg/partiql/ast/IdentifierChain;)V
+	public fun getName ()Lorg/partiql/ast/IdentifierChain;
 }
 
 public class org/partiql/ast/ddl/TableConstraint$Unique : org/partiql/ast/ddl/TableConstraint {
-	public final field columns Ljava/util/List;
-	public final field isPrimaryKey Z
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Ljava/util/List;Z)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getColumns ()Ljava/util/List;
+	public fun getPrimaryKey ()Z
 	public fun hashCode ()I
 }
 
@@ -1644,13 +1612,13 @@ public class org/partiql/ast/dml/ConflictAction$DoNothing$Builder {
 }
 
 public final class org/partiql/ast/dml/ConflictAction$DoReplace : org/partiql/ast/dml/ConflictAction {
-	public final field action Lorg/partiql/ast/dml/DoReplaceAction;
-	public final field condition Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Lorg/partiql/ast/dml/DoReplaceAction;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/ConflictAction$DoReplace$Builder;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAction ()Lorg/partiql/ast/dml/DoReplaceAction;
 	public fun getChildren ()Ljava/util/List;
+	public fun getCondition ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -1662,13 +1630,13 @@ public class org/partiql/ast/dml/ConflictAction$DoReplace$Builder {
 }
 
 public final class org/partiql/ast/dml/ConflictAction$DoUpdate : org/partiql/ast/dml/ConflictAction {
-	public final field action Lorg/partiql/ast/dml/DoUpdateAction;
-	public final field condition Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Lorg/partiql/ast/dml/DoUpdateAction;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/ConflictAction$DoUpdate$Builder;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAction ()Lorg/partiql/ast/dml/DoUpdateAction;
 	public fun getChildren ()Ljava/util/List;
+	public fun getCondition ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -1684,12 +1652,12 @@ public abstract class org/partiql/ast/dml/ConflictTarget : org/partiql/ast/AstNo
 }
 
 public final class org/partiql/ast/dml/ConflictTarget$Constraint : org/partiql/ast/dml/ConflictTarget {
-	public final field name Lorg/partiql/ast/IdentifierChain;
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/ConflictTarget$Constraint$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getName ()Lorg/partiql/ast/IdentifierChain;
 	public fun hashCode ()I
 }
 
@@ -1700,12 +1668,12 @@ public class org/partiql/ast/dml/ConflictTarget$Constraint$Builder {
 }
 
 public final class org/partiql/ast/dml/ConflictTarget$Index : org/partiql/ast/dml/ConflictTarget {
-	public final field indexes Ljava/util/List;
 	public fun <init> (Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/ConflictTarget$Index$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getIndexes ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1716,13 +1684,13 @@ public class org/partiql/ast/dml/ConflictTarget$Index$Builder {
 }
 
 public final class org/partiql/ast/dml/Delete : org/partiql/ast/Statement {
-	public final field condition Lorg/partiql/ast/expr/Expr;
-	public final field tableName Lorg/partiql/ast/IdentifierChain;
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/Delete$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getCondition ()Lorg/partiql/ast/expr/Expr;
+	public fun getTableName ()Lorg/partiql/ast/IdentifierChain;
 	public fun hashCode ()I
 }
 
@@ -1770,15 +1738,15 @@ public class org/partiql/ast/dml/DoUpdateAction$Excluded$Builder {
 }
 
 public final class org/partiql/ast/dml/Insert : org/partiql/ast/Statement {
-	public final field asAlias Lorg/partiql/ast/Identifier;
-	public final field onConflict Lorg/partiql/ast/dml/OnConflict;
-	public final field source Lorg/partiql/ast/dml/InsertSource;
-	public final field tableName Lorg/partiql/ast/IdentifierChain;
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/dml/InsertSource;Lorg/partiql/ast/dml/OnConflict;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/Insert$Builder;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAsAlias ()Lorg/partiql/ast/Identifier;
 	public fun getChildren ()Ljava/util/List;
+	public fun getOnConflict ()Lorg/partiql/ast/dml/OnConflict;
+	public fun getSource ()Lorg/partiql/ast/dml/InsertSource;
+	public fun getTableName ()Lorg/partiql/ast/IdentifierChain;
 	public fun hashCode ()I
 }
 
@@ -1810,13 +1778,13 @@ public class org/partiql/ast/dml/InsertSource$FromDefault$Builder {
 }
 
 public final class org/partiql/ast/dml/InsertSource$FromExpr : org/partiql/ast/dml/InsertSource {
-	public final field columns Ljava/util/List;
-	public final field expr Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Ljava/util/List;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/InsertSource$FromExpr$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getColumns ()Ljava/util/List;
+	public fun getExpr ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -1828,13 +1796,13 @@ public class org/partiql/ast/dml/InsertSource$FromExpr$Builder {
 }
 
 public final class org/partiql/ast/dml/OnConflict : org/partiql/ast/AstNode {
-	public final field action Lorg/partiql/ast/dml/ConflictAction;
-	public final field target Lorg/partiql/ast/dml/ConflictTarget;
 	public fun <init> (Lorg/partiql/ast/dml/ConflictAction;Lorg/partiql/ast/dml/ConflictTarget;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/OnConflict$Builder;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAction ()Lorg/partiql/ast/dml/ConflictAction;
 	public fun getChildren ()Ljava/util/List;
+	public fun getTarget ()Lorg/partiql/ast/dml/ConflictTarget;
 	public fun hashCode ()I
 }
 
@@ -1846,14 +1814,14 @@ public class org/partiql/ast/dml/OnConflict$Builder {
 }
 
 public final class org/partiql/ast/dml/Replace : org/partiql/ast/Statement {
-	public final field asAlias Lorg/partiql/ast/Identifier;
-	public final field source Lorg/partiql/ast/dml/InsertSource;
-	public final field tableName Lorg/partiql/ast/IdentifierChain;
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/dml/InsertSource;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/Replace$Builder;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAsAlias ()Lorg/partiql/ast/Identifier;
 	public fun getChildren ()Ljava/util/List;
+	public fun getSource ()Lorg/partiql/ast/dml/InsertSource;
+	public fun getTableName ()Lorg/partiql/ast/IdentifierChain;
 	public fun hashCode ()I
 }
 
@@ -1866,13 +1834,13 @@ public class org/partiql/ast/dml/Replace$Builder {
 }
 
 public final class org/partiql/ast/dml/SetClause : org/partiql/ast/AstNode {
-	public final field expr Lorg/partiql/ast/expr/Expr;
-	public final field target Lorg/partiql/ast/dml/UpdateTarget;
 	public fun <init> (Lorg/partiql/ast/dml/UpdateTarget;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/SetClause$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getExpr ()Lorg/partiql/ast/expr/Expr;
+	public fun getTarget ()Lorg/partiql/ast/dml/UpdateTarget;
 	public fun hashCode ()I
 }
 
@@ -1884,14 +1852,14 @@ public class org/partiql/ast/dml/SetClause$Builder {
 }
 
 public final class org/partiql/ast/dml/Update : org/partiql/ast/Statement {
-	public final field condition Lorg/partiql/ast/expr/Expr;
-	public final field setClauses Ljava/util/List;
-	public final field tableName Lorg/partiql/ast/IdentifierChain;
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Ljava/util/List;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/Update$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getCondition ()Lorg/partiql/ast/expr/Expr;
+	public fun getSetClauses ()Ljava/util/List;
+	public fun getTableName ()Lorg/partiql/ast/IdentifierChain;
 	public fun hashCode ()I
 }
 
@@ -1904,13 +1872,13 @@ public class org/partiql/ast/dml/Update$Builder {
 }
 
 public final class org/partiql/ast/dml/UpdateTarget : org/partiql/ast/AstNode {
-	public final field root Lorg/partiql/ast/Identifier;
-	public final field steps Ljava/util/List;
 	public fun <init> (Lorg/partiql/ast/Identifier;Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/UpdateTarget$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getRoot ()Lorg/partiql/ast/Identifier;
+	public fun getSteps ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -1926,7 +1894,6 @@ public abstract class org/partiql/ast/dml/UpdateTargetStep : org/partiql/ast/Ast
 }
 
 public final class org/partiql/ast/dml/UpdateTargetStep$Element : org/partiql/ast/dml/UpdateTargetStep {
-	public final field key Lorg/partiql/ast/Literal;
 	public fun <init> (I)V
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Lorg/partiql/ast/Literal;)V
@@ -1934,6 +1901,7 @@ public final class org/partiql/ast/dml/UpdateTargetStep$Element : org/partiql/as
 	public static fun builder ()Lorg/partiql/ast/dml/UpdateTargetStep$Element$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getKey ()Lorg/partiql/ast/Literal;
 	public fun hashCode ()I
 }
 
@@ -1944,12 +1912,12 @@ public class org/partiql/ast/dml/UpdateTargetStep$Element$Builder {
 }
 
 public final class org/partiql/ast/dml/UpdateTargetStep$Field : org/partiql/ast/dml/UpdateTargetStep {
-	public final field key Lorg/partiql/ast/Identifier;
 	public fun <init> (Lorg/partiql/ast/Identifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/UpdateTargetStep$Field$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getKey ()Lorg/partiql/ast/Identifier;
 	public fun hashCode ()I
 }
 
@@ -1960,14 +1928,14 @@ public class org/partiql/ast/dml/UpdateTargetStep$Field$Builder {
 }
 
 public final class org/partiql/ast/dml/Upsert : org/partiql/ast/Statement {
-	public final field asAlias Lorg/partiql/ast/Identifier;
-	public final field source Lorg/partiql/ast/dml/InsertSource;
-	public final field tableName Lorg/partiql/ast/IdentifierChain;
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Lorg/partiql/ast/Identifier;Lorg/partiql/ast/dml/InsertSource;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/dml/Upsert$Builder;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAsAlias ()Lorg/partiql/ast/Identifier;
 	public fun getChildren ()Ljava/util/List;
+	public fun getSource ()Lorg/partiql/ast/dml/InsertSource;
+	public fun getTableName ()Lorg/partiql/ast/IdentifierChain;
 	public fun hashCode ()I
 }
 
@@ -1983,15 +1951,14 @@ public abstract class org/partiql/ast/expr/Expr : org/partiql/ast/AstNode {
 	public fun <init> ()V
 }
 
-public class org/partiql/ast/expr/ExprAnd : org/partiql/ast/expr/Expr {
-	public final field lhs Lorg/partiql/ast/expr/Expr;
-	public final field rhs Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprAnd : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprAnd$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getLhs ()Lorg/partiql/ast/expr/Expr;
+	public fun getRhs ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2002,14 +1969,13 @@ public class org/partiql/ast/expr/ExprAnd$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprArray : org/partiql/ast/expr/Expr {
-	public final field values Ljava/util/List;
+public final class org/partiql/ast/expr/ExprArray : org/partiql/ast/expr/Expr {
 	public fun <init> (Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprArray$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getValues ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2019,14 +1985,13 @@ public class org/partiql/ast/expr/ExprArray$Builder {
 	public fun values (Ljava/util/List;)Lorg/partiql/ast/expr/ExprArray$Builder;
 }
 
-public class org/partiql/ast/expr/ExprBag : org/partiql/ast/expr/Expr {
-	public final field values Ljava/util/List;
+public final class org/partiql/ast/expr/ExprBag : org/partiql/ast/expr/Expr {
 	public fun <init> (Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprBag$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getValues ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2036,17 +2001,16 @@ public class org/partiql/ast/expr/ExprBag$Builder {
 	public fun values (Ljava/util/List;)Lorg/partiql/ast/expr/ExprBag$Builder;
 }
 
-public class org/partiql/ast/expr/ExprBetween : org/partiql/ast/expr/Expr {
-	public final field from Lorg/partiql/ast/expr/Expr;
-	public final field not Z
-	public final field to Lorg/partiql/ast/expr/Expr;
-	public final field value Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprBetween : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Z)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprBetween$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getFrom ()Lorg/partiql/ast/expr/Expr;
+	public fun getNot ()Z
+	public fun getTo ()Lorg/partiql/ast/expr/Expr;
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2059,16 +2023,15 @@ public class org/partiql/ast/expr/ExprBetween$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprBetween$Builder;
 }
 
-public class org/partiql/ast/expr/ExprBoolTest : org/partiql/ast/expr/Expr {
-	public final field not Z
-	public final field truthValue Lorg/partiql/ast/expr/TruthValue;
-	public final field value Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprBoolTest : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;ZLorg/partiql/ast/expr/TruthValue;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprBoolTest$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getNot ()Z
+	public fun getTruthValue ()Lorg/partiql/ast/expr/TruthValue;
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2080,16 +2043,15 @@ public class org/partiql/ast/expr/ExprBoolTest$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprBoolTest$Builder;
 }
 
-public class org/partiql/ast/expr/ExprCall : org/partiql/ast/expr/Expr {
-	public final field args Ljava/util/List;
-	public final field function Lorg/partiql/ast/IdentifierChain;
-	public final field setq Lorg/partiql/ast/SetQuantifier;
+public final class org/partiql/ast/expr/ExprCall : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Ljava/util/List;Lorg/partiql/ast/SetQuantifier;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprCall$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getArgs ()Ljava/util/List;
 	public fun getChildren ()Ljava/util/List;
+	public fun getFunction ()Lorg/partiql/ast/IdentifierChain;
+	public fun getSetq ()Lorg/partiql/ast/SetQuantifier;
 	public fun hashCode ()I
 }
 
@@ -2101,28 +2063,27 @@ public class org/partiql/ast/expr/ExprCall$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprCase : org/partiql/ast/expr/Expr {
-	public final field branches Ljava/util/List;
-	public final field defaultExpr Lorg/partiql/ast/expr/Expr;
-	public final field expr Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprCase : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Ljava/util/List;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprCase$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getBranches ()Ljava/util/List;
 	public fun getChildren ()Ljava/util/List;
+	public fun getDefaultExpr ()Lorg/partiql/ast/expr/Expr;
+	public fun getExpr ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
 public class org/partiql/ast/expr/ExprCase$Branch : org/partiql/ast/AstNode {
-	public final field condition Lorg/partiql/ast/expr/Expr;
-	public final field expr Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprCase$Branch$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getCondition ()Lorg/partiql/ast/expr/Expr;
+	public fun getExpr ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2141,15 +2102,14 @@ public class org/partiql/ast/expr/ExprCase$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprCast : org/partiql/ast/expr/Expr {
-	public final field asType Lorg/partiql/ast/DataType;
-	public final field value Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprCast : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/DataType;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprCast$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAsType ()Lorg/partiql/ast/DataType;
 	public fun getChildren ()Ljava/util/List;
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2160,13 +2120,12 @@ public class org/partiql/ast/expr/ExprCast$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprCast$Builder;
 }
 
-public class org/partiql/ast/expr/ExprCoalesce : org/partiql/ast/expr/Expr {
-	public final field args Ljava/util/List;
+public final class org/partiql/ast/expr/ExprCoalesce : org/partiql/ast/expr/Expr {
 	public fun <init> (Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprCoalesce$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getArgs ()Ljava/util/List;
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
@@ -2177,15 +2136,14 @@ public class org/partiql/ast/expr/ExprCoalesce$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprExtract : org/partiql/ast/expr/Expr {
-	public final field field Lorg/partiql/ast/DatetimeField;
-	public final field source Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprExtract : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/DatetimeField;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprExtract$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getField ()Lorg/partiql/ast/DatetimeField;
+	public fun getSource ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2196,16 +2154,15 @@ public class org/partiql/ast/expr/ExprExtract$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprInCollection : org/partiql/ast/expr/Expr {
-	public final field lhs Lorg/partiql/ast/expr/Expr;
-	public final field not Z
-	public final field rhs Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprInCollection : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Z)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprInCollection$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getLhs ()Lorg/partiql/ast/expr/Expr;
+	public fun getNot ()Z
+	public fun getRhs ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2217,16 +2174,15 @@ public class org/partiql/ast/expr/ExprInCollection$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprIsType : org/partiql/ast/expr/Expr {
-	public final field not Z
-	public final field type Lorg/partiql/ast/DataType;
-	public final field value Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprIsType : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/DataType;Z)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprIsType$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getNot ()Z
+	public fun getType ()Lorg/partiql/ast/DataType;
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2238,17 +2194,16 @@ public class org/partiql/ast/expr/ExprIsType$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprIsType$Builder;
 }
 
-public class org/partiql/ast/expr/ExprLike : org/partiql/ast/expr/Expr {
-	public final field escape Lorg/partiql/ast/expr/Expr;
-	public final field not Z
-	public final field pattern Lorg/partiql/ast/expr/Expr;
-	public final field value Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprLike : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Z)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprLike$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getEscape ()Lorg/partiql/ast/expr/Expr;
+	public fun getNot ()Z
+	public fun getPattern ()Lorg/partiql/ast/expr/Expr;
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2261,25 +2216,23 @@ public class org/partiql/ast/expr/ExprLike$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprLike$Builder;
 }
 
-public class org/partiql/ast/expr/ExprLit : org/partiql/ast/expr/Expr {
-	public field lit Lorg/partiql/ast/Literal;
+public final class org/partiql/ast/expr/ExprLit : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/Literal;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getLit ()Lorg/partiql/ast/Literal;
 	public fun hashCode ()I
 }
 
-public class org/partiql/ast/expr/ExprMatch : org/partiql/ast/expr/Expr {
-	public final field expr Lorg/partiql/ast/expr/Expr;
-	public final field pattern Lorg/partiql/ast/graph/GraphMatch;
+public final class org/partiql/ast/expr/ExprMatch : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/graph/GraphMatch;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprMatch$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getExpr ()Lorg/partiql/ast/expr/Expr;
+	public fun getPattern ()Lorg/partiql/ast/graph/GraphMatch;
 	public fun hashCode ()I
 }
 
@@ -2290,15 +2243,14 @@ public class org/partiql/ast/expr/ExprMatch$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprMissingPredicate : org/partiql/ast/expr/Expr {
-	public final field not Z
-	public final field value Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprMissingPredicate : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Z)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprMissingPredicate$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getNot ()Z
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2309,14 +2261,13 @@ public class org/partiql/ast/expr/ExprMissingPredicate$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprMissingPredicate$Builder;
 }
 
-public class org/partiql/ast/expr/ExprNot : org/partiql/ast/expr/Expr {
-	public final field value Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprNot : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprNot$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2326,15 +2277,14 @@ public class org/partiql/ast/expr/ExprNot$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprNot$Builder;
 }
 
-public class org/partiql/ast/expr/ExprNullIf : org/partiql/ast/expr/Expr {
-	public final field v1 Lorg/partiql/ast/expr/Expr;
-	public final field v2 Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprNullIf : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprNullIf$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getV1 ()Lorg/partiql/ast/expr/Expr;
+	public fun getV2 ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2345,15 +2295,14 @@ public class org/partiql/ast/expr/ExprNullIf$Builder {
 	public fun v2 (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprNullIf$Builder;
 }
 
-public class org/partiql/ast/expr/ExprNullPredicate : org/partiql/ast/expr/Expr {
-	public final field not Z
-	public final field value Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprNullPredicate : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Z)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprNullPredicate$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getNot ()Z
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2364,16 +2313,15 @@ public class org/partiql/ast/expr/ExprNullPredicate$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprNullPredicate$Builder;
 }
 
-public class org/partiql/ast/expr/ExprOperator : org/partiql/ast/expr/Expr {
-	public final field lhs Lorg/partiql/ast/expr/Expr;
-	public final field rhs Lorg/partiql/ast/expr/Expr;
-	public final field symbol Ljava/lang/String;
+public final class org/partiql/ast/expr/ExprOperator : org/partiql/ast/expr/Expr {
 	public fun <init> (Ljava/lang/String;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprOperator$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getLhs ()Lorg/partiql/ast/expr/Expr;
+	public fun getRhs ()Lorg/partiql/ast/expr/Expr;
+	public fun getSymbol ()Ljava/lang/String;
 	public fun hashCode ()I
 }
 
@@ -2385,15 +2333,14 @@ public class org/partiql/ast/expr/ExprOperator$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprOr : org/partiql/ast/expr/Expr {
-	public final field lhs Lorg/partiql/ast/expr/Expr;
-	public final field rhs Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprOr : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprOr$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getLhs ()Lorg/partiql/ast/expr/Expr;
+	public fun getRhs ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2404,17 +2351,16 @@ public class org/partiql/ast/expr/ExprOr$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprOverlay : org/partiql/ast/expr/Expr {
-	public final field forLength Lorg/partiql/ast/expr/Expr;
-	public final field from Lorg/partiql/ast/expr/Expr;
-	public final field placing Lorg/partiql/ast/expr/Expr;
-	public final field value Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprOverlay : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprOverlay$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getForLength ()Lorg/partiql/ast/expr/Expr;
+	public fun getFrom ()Lorg/partiql/ast/expr/Expr;
+	public fun getPlacing ()Lorg/partiql/ast/expr/Expr;
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2427,14 +2373,13 @@ public class org/partiql/ast/expr/ExprOverlay$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprOverlay$Builder;
 }
 
-public class org/partiql/ast/expr/ExprParameter : org/partiql/ast/expr/Expr {
-	public final field index I
+public final class org/partiql/ast/expr/ExprParameter : org/partiql/ast/expr/Expr {
 	public fun <init> (I)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprParameter$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getIndex ()I
 	public fun hashCode ()I
 }
 
@@ -2444,15 +2389,14 @@ public class org/partiql/ast/expr/ExprParameter$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprPath : org/partiql/ast/expr/Expr {
-	public final field next Lorg/partiql/ast/expr/PathStep;
-	public final field root Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprPath : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/PathStep;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprPath$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getNext ()Lorg/partiql/ast/expr/PathStep;
+	public fun getRoot ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2463,15 +2407,14 @@ public class org/partiql/ast/expr/ExprPath$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprPosition : org/partiql/ast/expr/Expr {
-	public final field lhs Lorg/partiql/ast/expr/Expr;
-	public final field rhs Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprPosition : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprPosition$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getLhs ()Lorg/partiql/ast/expr/Expr;
+	public fun getRhs ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2482,17 +2425,16 @@ public class org/partiql/ast/expr/ExprPosition$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprQuerySet : org/partiql/ast/expr/Expr {
-	public final field body Lorg/partiql/ast/QueryBody;
-	public final field limit Lorg/partiql/ast/expr/Expr;
-	public final field offset Lorg/partiql/ast/expr/Expr;
-	public final field orderBy Lorg/partiql/ast/OrderBy;
+public final class org/partiql/ast/expr/ExprQuerySet : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/QueryBody;Lorg/partiql/ast/OrderBy;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprQuerySet$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getBody ()Lorg/partiql/ast/QueryBody;
 	public fun getChildren ()Ljava/util/List;
+	public fun getLimit ()Lorg/partiql/ast/expr/Expr;
+	public fun getOffset ()Lorg/partiql/ast/expr/Expr;
+	public fun getOrderBy ()Lorg/partiql/ast/OrderBy;
 	public fun hashCode ()I
 }
 
@@ -2505,34 +2447,33 @@ public class org/partiql/ast/expr/ExprQuerySet$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprRowValue : org/partiql/ast/expr/Expr {
-	public field isExplicit Z
-	public final field values Ljava/util/List;
+public final class org/partiql/ast/expr/ExprRowValue : org/partiql/ast/expr/Expr {
 	public fun <init> (Ljava/util/List;)V
 	public fun <init> (ZLjava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprRowValue$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getExplicit ()Z
+	public fun getValues ()Ljava/util/List;
 	public fun hashCode ()I
+	public fun isExplicit ()Z
 }
 
 public class org/partiql/ast/expr/ExprRowValue$Builder {
 	public fun build ()Lorg/partiql/ast/expr/ExprRowValue;
-	public fun isExplicit (Z)Lorg/partiql/ast/expr/ExprRowValue$Builder;
+	public fun explicit (Z)Lorg/partiql/ast/expr/ExprRowValue$Builder;
 	public fun toString ()Ljava/lang/String;
 	public fun values (Ljava/util/List;)Lorg/partiql/ast/expr/ExprRowValue$Builder;
 }
 
-public class org/partiql/ast/expr/ExprSessionAttribute : org/partiql/ast/expr/Expr {
-	public final field sessionAttribute Lorg/partiql/ast/expr/SessionAttribute;
+public final class org/partiql/ast/expr/ExprSessionAttribute : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/SessionAttribute;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprSessionAttribute$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getSessionAttribute ()Lorg/partiql/ast/expr/SessionAttribute;
 	public fun hashCode ()I
 }
 
@@ -2542,14 +2483,13 @@ public class org/partiql/ast/expr/ExprSessionAttribute$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprStruct : org/partiql/ast/expr/Expr {
-	public final field fields Ljava/util/List;
+public final class org/partiql/ast/expr/ExprStruct : org/partiql/ast/expr/Expr {
 	public fun <init> (Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprStruct$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getFields ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2560,14 +2500,14 @@ public class org/partiql/ast/expr/ExprStruct$Builder {
 }
 
 public class org/partiql/ast/expr/ExprStruct$Field : org/partiql/ast/AstNode {
-	public final field name Lorg/partiql/ast/expr/Expr;
-	public final field value Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprStruct$Field$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getName ()Lorg/partiql/ast/expr/Expr;
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2578,16 +2518,15 @@ public class org/partiql/ast/expr/ExprStruct$Field$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprStruct$Field$Builder;
 }
 
-public class org/partiql/ast/expr/ExprSubstring : org/partiql/ast/expr/Expr {
-	public final field length Lorg/partiql/ast/expr/Expr;
-	public final field start Lorg/partiql/ast/expr/Expr;
-	public final field value Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprSubstring : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprSubstring$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getLength ()Lorg/partiql/ast/expr/Expr;
+	public fun getStart ()Lorg/partiql/ast/expr/Expr;
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2599,16 +2538,15 @@ public class org/partiql/ast/expr/ExprSubstring$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprSubstring$Builder;
 }
 
-public class org/partiql/ast/expr/ExprTrim : org/partiql/ast/expr/Expr {
-	public final field chars Lorg/partiql/ast/expr/Expr;
-	public final field trimSpec Lorg/partiql/ast/expr/TrimSpec;
-	public final field value Lorg/partiql/ast/expr/Expr;
+public final class org/partiql/ast/expr/ExprTrim : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/TrimSpec;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprTrim$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChars ()Lorg/partiql/ast/expr/Expr;
 	public fun getChildren ()Ljava/util/List;
+	public fun getTrimSpec ()Lorg/partiql/ast/expr/TrimSpec;
+	public fun getValue ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
@@ -2620,14 +2558,13 @@ public class org/partiql/ast/expr/ExprTrim$Builder {
 	public fun value (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprTrim$Builder;
 }
 
-public class org/partiql/ast/expr/ExprValues : org/partiql/ast/expr/Expr {
-	public final field rows Ljava/util/List;
+public final class org/partiql/ast/expr/ExprValues : org/partiql/ast/expr/Expr {
 	public fun <init> (Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprValues$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getRows ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2637,15 +2574,14 @@ public class org/partiql/ast/expr/ExprValues$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprVarRef : org/partiql/ast/expr/Expr {
-	public final field identifierChain Lorg/partiql/ast/IdentifierChain;
-	public final field scope Lorg/partiql/ast/expr/Scope;
+public final class org/partiql/ast/expr/ExprVarRef : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Lorg/partiql/ast/expr/Scope;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprVarRef$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getIdentifierChain ()Lorg/partiql/ast/IdentifierChain;
+	public fun getScope ()Lorg/partiql/ast/expr/Scope;
 	public fun hashCode ()I
 }
 
@@ -2656,15 +2592,14 @@ public class org/partiql/ast/expr/ExprVarRef$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/expr/ExprVariant : org/partiql/ast/expr/Expr {
-	public final field encoding Ljava/lang/String;
-	public final field value Ljava/lang/String;
+public final class org/partiql/ast/expr/ExprVariant : org/partiql/ast/expr/Expr {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprVariant$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getEncoding ()Ljava/lang/String;
+	public fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 }
 
@@ -2675,18 +2610,17 @@ public class org/partiql/ast/expr/ExprVariant$Builder {
 	public fun value (Ljava/lang/String;)Lorg/partiql/ast/expr/ExprVariant$Builder;
 }
 
-public class org/partiql/ast/expr/ExprWindow : org/partiql/ast/expr/Expr {
-	public final field defaultValue Lorg/partiql/ast/expr/Expr;
-	public final field expression Lorg/partiql/ast/expr/Expr;
-	public final field offset Lorg/partiql/ast/expr/Expr;
-	public final field over Lorg/partiql/ast/expr/ExprWindow$Over;
-	public final field windowFunction Lorg/partiql/ast/expr/WindowFunction;
+public final class org/partiql/ast/expr/ExprWindow : org/partiql/ast/expr/Expr {
 	public fun <init> (Lorg/partiql/ast/expr/WindowFunction;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/ExprWindow$Over;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprWindow$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getDefaultValue ()Lorg/partiql/ast/expr/Expr;
+	public fun getExpression ()Lorg/partiql/ast/expr/Expr;
+	public fun getOffset ()Lorg/partiql/ast/expr/Expr;
+	public fun getOver ()Lorg/partiql/ast/expr/ExprWindow$Over;
+	public fun getWindowFunction ()Lorg/partiql/ast/expr/WindowFunction;
 	public fun hashCode ()I
 }
 
@@ -2701,14 +2635,14 @@ public class org/partiql/ast/expr/ExprWindow$Builder {
 }
 
 public class org/partiql/ast/expr/ExprWindow$Over : org/partiql/ast/AstNode {
-	public final field partitions Ljava/util/List;
-	public final field sorts Ljava/util/List;
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/expr/ExprWindow$Over$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getPartitions ()Ljava/util/List;
+	public fun getSorts ()Ljava/util/List;
 	public fun hashCode ()I
 }
 
@@ -2720,8 +2654,9 @@ public class org/partiql/ast/expr/ExprWindow$Over$Builder {
 }
 
 public abstract class org/partiql/ast/expr/PathStep : org/partiql/ast/AstNode {
-	public final field next Lorg/partiql/ast/expr/PathStep;
+	protected final field next Lorg/partiql/ast/expr/PathStep;
 	protected fun <init> (Lorg/partiql/ast/expr/PathStep;)V
+	public fun getNext ()Lorg/partiql/ast/expr/PathStep;
 }
 
 public class org/partiql/ast/expr/PathStep$AllElements : org/partiql/ast/expr/PathStep {
@@ -2743,32 +2678,31 @@ public class org/partiql/ast/expr/PathStep$AllFields : org/partiql/ast/expr/Path
 }
 
 public class org/partiql/ast/expr/PathStep$Element : org/partiql/ast/expr/PathStep {
-	public final field element Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/PathStep;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getElement ()Lorg/partiql/ast/expr/Expr;
 	public fun hashCode ()I
 }
 
 public class org/partiql/ast/expr/PathStep$Field : org/partiql/ast/expr/PathStep {
-	public final field field Lorg/partiql/ast/Identifier;
 	public fun <init> (Lorg/partiql/ast/Identifier;Lorg/partiql/ast/expr/PathStep;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getField ()Lorg/partiql/ast/Identifier;
 	public fun hashCode ()I
 }
 
-public class org/partiql/ast/expr/Scope : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/expr/Scope : org/partiql/ast/AstEnum {
 	public static final field DEFAULT I
 	public static final field LOCAL I
 	public static fun DEFAULT ()Lorg/partiql/ast/expr/Scope;
 	public static fun LOCAL ()Lorg/partiql/ast/expr/Scope;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -2778,14 +2712,13 @@ public class org/partiql/ast/expr/Scope : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/expr/Scope;
 }
 
-public class org/partiql/ast/expr/SessionAttribute : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/expr/SessionAttribute : org/partiql/ast/AstEnum {
 	public static final field CURRENT_DATE I
 	public static final field CURRENT_USER I
 	public fun <init> (I)V
 	public static fun CURRENT_DATE ()Lorg/partiql/ast/expr/SessionAttribute;
 	public static fun CURRENT_USER ()Lorg/partiql/ast/expr/SessionAttribute;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -2795,7 +2728,7 @@ public class org/partiql/ast/expr/SessionAttribute : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/expr/SessionAttribute;
 }
 
-public class org/partiql/ast/expr/TrimSpec : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/expr/TrimSpec : org/partiql/ast/AstEnum {
 	public static final field BOTH I
 	public static final field LEADING I
 	public static final field TRAILING I
@@ -2803,7 +2736,6 @@ public class org/partiql/ast/expr/TrimSpec : org/partiql/ast/AstEnum {
 	public static fun LEADING ()Lorg/partiql/ast/expr/TrimSpec;
 	public static fun TRAILING ()Lorg/partiql/ast/expr/TrimSpec;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -2813,7 +2745,7 @@ public class org/partiql/ast/expr/TrimSpec : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/expr/TrimSpec;
 }
 
-public class org/partiql/ast/expr/TruthValue : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/expr/TruthValue : org/partiql/ast/AstEnum {
 	public static final field FALSE I
 	public static final field TRUE I
 	public static final field UNKNOWN I
@@ -2822,7 +2754,6 @@ public class org/partiql/ast/expr/TruthValue : org/partiql/ast/AstEnum {
 	public static fun TRUE ()Lorg/partiql/ast/expr/TruthValue;
 	public static fun UNKNOWN ()Lorg/partiql/ast/expr/TruthValue;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
@@ -2831,14 +2762,13 @@ public class org/partiql/ast/expr/TruthValue : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/expr/TruthValue;
 }
 
-public class org/partiql/ast/expr/WindowFunction : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/expr/WindowFunction : org/partiql/ast/AstEnum {
 	public static final field LAG I
 	public static final field LEAD I
 	public fun <init> (I)V
 	public static fun LAG ()Lorg/partiql/ast/expr/WindowFunction;
 	public static fun LEAD ()Lorg/partiql/ast/expr/WindowFunction;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -2848,7 +2778,7 @@ public class org/partiql/ast/expr/WindowFunction : org/partiql/ast/AstEnum {
 	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/expr/WindowFunction;
 }
 
-public class org/partiql/ast/graph/GraphDirection : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/graph/GraphDirection : org/partiql/ast/AstEnum {
 	public static final field LEFT I
 	public static final field LEFT_OR_RIGHT I
 	public static final field LEFT_OR_UNDIRECTED I
@@ -2864,7 +2794,6 @@ public class org/partiql/ast/graph/GraphDirection : org/partiql/ast/AstEnum {
 	public static fun UNDIRECTED ()Lorg/partiql/ast/graph/GraphDirection;
 	public static fun UNDIRECTED_OR_RIGHT ()Lorg/partiql/ast/graph/GraphDirection;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -2887,6 +2816,8 @@ public class org/partiql/ast/graph/GraphLabel$Conj : org/partiql/ast/graph/Graph
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getLhs ()Lorg/partiql/ast/graph/GraphLabel;
+	public fun getRhs ()Lorg/partiql/ast/graph/GraphLabel;
 	public fun hashCode ()I
 }
 
@@ -2906,6 +2837,8 @@ public class org/partiql/ast/graph/GraphLabel$Disj : org/partiql/ast/graph/Graph
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getLhs ()Lorg/partiql/ast/graph/GraphLabel;
+	public fun getRhs ()Lorg/partiql/ast/graph/GraphLabel;
 	public fun hashCode ()I
 }
 
@@ -2917,13 +2850,13 @@ public class org/partiql/ast/graph/GraphLabel$Disj$Builder {
 }
 
 public class org/partiql/ast/graph/GraphLabel$Name : org/partiql/ast/graph/GraphLabel {
-	public final field name Ljava/lang/String;
 	public fun <init> (Ljava/lang/String;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphLabel$Name$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 }
 
@@ -2934,12 +2867,12 @@ public class org/partiql/ast/graph/GraphLabel$Name$Builder {
 }
 
 public class org/partiql/ast/graph/GraphLabel$Negation : org/partiql/ast/graph/GraphLabel {
-	public final field arg Lorg/partiql/ast/graph/GraphLabel;
 	public fun <init> (Lorg/partiql/ast/graph/GraphLabel;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphLabel$Negation$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getArg ()Lorg/partiql/ast/graph/GraphLabel;
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 }
@@ -2965,15 +2898,14 @@ public class org/partiql/ast/graph/GraphLabel$Wildcard$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/graph/GraphMatch : org/partiql/ast/AstNode {
-	public final field patterns Ljava/util/List;
-	public final field selector Lorg/partiql/ast/graph/GraphSelector;
+public final class org/partiql/ast/graph/GraphMatch : org/partiql/ast/AstNode {
 	public fun <init> (Ljava/util/List;Lorg/partiql/ast/graph/GraphSelector;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphMatch$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getPatterns ()Ljava/util/List;
+	public fun getSelector ()Lorg/partiql/ast/graph/GraphSelector;
 	public fun hashCode ()I
 }
 
@@ -2989,17 +2921,17 @@ public abstract class org/partiql/ast/graph/GraphPart : org/partiql/ast/AstNode 
 }
 
 public class org/partiql/ast/graph/GraphPart$Edge : org/partiql/ast/graph/GraphPart {
-	public final field direction Lorg/partiql/ast/graph/GraphDirection;
-	public final field label Lorg/partiql/ast/graph/GraphLabel;
-	public final field prefilter Lorg/partiql/ast/expr/Expr;
-	public final field quantifier Lorg/partiql/ast/graph/GraphQuantifier;
-	public final field variable Ljava/lang/String;
 	public fun <init> (Lorg/partiql/ast/graph/GraphDirection;Lorg/partiql/ast/graph/GraphQuantifier;Lorg/partiql/ast/expr/Expr;Ljava/lang/String;Lorg/partiql/ast/graph/GraphLabel;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphPart$Edge$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getDirection ()Lorg/partiql/ast/graph/GraphDirection;
+	public fun getLabel ()Lorg/partiql/ast/graph/GraphLabel;
+	public fun getPrefilter ()Lorg/partiql/ast/expr/Expr;
+	public fun getQuantifier ()Lorg/partiql/ast/graph/GraphQuantifier;
+	public fun getVariable ()Ljava/lang/String;
 	public fun hashCode ()I
 }
 
@@ -3014,15 +2946,15 @@ public class org/partiql/ast/graph/GraphPart$Edge$Builder {
 }
 
 public class org/partiql/ast/graph/GraphPart$Node : org/partiql/ast/graph/GraphPart {
-	public final field label Lorg/partiql/ast/graph/GraphLabel;
-	public final field prefilter Lorg/partiql/ast/expr/Expr;
-	public final field variable Ljava/lang/String;
 	public fun <init> (Lorg/partiql/ast/expr/Expr;Ljava/lang/String;Lorg/partiql/ast/graph/GraphLabel;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphPart$Node$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getLabel ()Lorg/partiql/ast/graph/GraphLabel;
+	public fun getPrefilter ()Lorg/partiql/ast/expr/Expr;
+	public fun getVariable ()Ljava/lang/String;
 	public fun hashCode ()I
 }
 
@@ -3035,13 +2967,13 @@ public class org/partiql/ast/graph/GraphPart$Node$Builder {
 }
 
 public class org/partiql/ast/graph/GraphPart$Pattern : org/partiql/ast/graph/GraphPart {
-	public final field pattern Lorg/partiql/ast/graph/GraphPattern;
 	public fun <init> (Lorg/partiql/ast/graph/GraphPattern;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphPart$Pattern$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getPattern ()Lorg/partiql/ast/graph/GraphPattern;
 	public fun hashCode ()I
 }
 
@@ -3051,7 +2983,7 @@ public class org/partiql/ast/graph/GraphPart$Pattern$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public class org/partiql/ast/graph/GraphPattern : org/partiql/ast/AstNode {
+public final class org/partiql/ast/graph/GraphPattern : org/partiql/ast/AstNode {
 	public final field parts Ljava/util/List;
 	public final field prefilter Lorg/partiql/ast/expr/Expr;
 	public final field quantifier Lorg/partiql/ast/graph/GraphQuantifier;
@@ -3060,7 +2992,6 @@ public class org/partiql/ast/graph/GraphPattern : org/partiql/ast/AstNode {
 	public fun <init> (Lorg/partiql/ast/graph/GraphRestrictor;Lorg/partiql/ast/expr/Expr;Ljava/lang/String;Lorg/partiql/ast/graph/GraphQuantifier;Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphPattern$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -3076,15 +3007,14 @@ public class org/partiql/ast/graph/GraphPattern$Builder {
 	public fun variable (Ljava/lang/String;)Lorg/partiql/ast/graph/GraphPattern$Builder;
 }
 
-public class org/partiql/ast/graph/GraphQuantifier : org/partiql/ast/AstNode {
-	public final field lower J
-	public final field upper Ljava/lang/Long;
+public final class org/partiql/ast/graph/GraphQuantifier : org/partiql/ast/AstNode {
 	public fun <init> (JLjava/lang/Long;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphQuantifier$Builder;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getLower ()J
+	public fun getUpper ()Ljava/lang/Long;
 	public fun hashCode ()I
 }
 
@@ -3095,7 +3025,7 @@ public class org/partiql/ast/graph/GraphQuantifier$Builder {
 	public fun upper (Ljava/lang/Long;)Lorg/partiql/ast/graph/GraphQuantifier$Builder;
 }
 
-public class org/partiql/ast/graph/GraphRestrictor : org/partiql/ast/AstEnum {
+public final class org/partiql/ast/graph/GraphRestrictor : org/partiql/ast/AstEnum {
 	public static final field ACYCLIC I
 	public static final field SIMPLE I
 	public static final field TRAIL I
@@ -3103,7 +3033,6 @@ public class org/partiql/ast/graph/GraphRestrictor : org/partiql/ast/AstEnum {
 	public static fun SIMPLE ()Lorg/partiql/ast/graph/GraphRestrictor;
 	public static fun TRAIL ()Lorg/partiql/ast/graph/GraphRestrictor;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
-	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
 	public static fun codes ()[I
 	public fun equals (Ljava/lang/Object;)Z
@@ -3148,13 +3077,13 @@ public class org/partiql/ast/graph/GraphSelector$Any$Builder {
 }
 
 public class org/partiql/ast/graph/GraphSelector$AnyK : org/partiql/ast/graph/GraphSelector {
-	public final field k J
 	public fun <init> (J)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphSelector$AnyK$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getK ()J
 	public fun hashCode ()I
 }
 

--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -728,6 +728,8 @@ public class org/partiql/ast/DataType$StructField : org/partiql/ast/AstNode {
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getComment ()Ljava/lang/String;
+	public fun getConstraints ()Ljava/util/List;
 	public fun getName ()Lorg/partiql/ast/Identifier;
 	public fun getType ()Lorg/partiql/ast/DataType;
 	public fun hashCode ()I
@@ -1244,14 +1246,14 @@ public class org/partiql/ast/QueryBody$SFW$Builder {
 }
 
 public class org/partiql/ast/QueryBody$SetOp : org/partiql/ast/QueryBody {
-	public field lhs Lorg/partiql/ast/expr/Expr;
-	public field rhs Lorg/partiql/ast/expr/Expr;
 	public fun <init> (Lorg/partiql/ast/SetOp;ZLorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/QueryBody$SetOp$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getLhs ()Lorg/partiql/ast/expr/Expr;
+	public fun getRhs ()Lorg/partiql/ast/expr/Expr;
 	public fun getType ()Lorg/partiql/ast/SetOp;
 	public fun hashCode ()I
 	public fun isOuter ()Z
@@ -1572,7 +1574,6 @@ public class org/partiql/ast/ddl/PartitionBy$Builder {
 }
 
 public abstract class org/partiql/ast/ddl/TableConstraint : org/partiql/ast/AstNode {
-	protected final field name Lorg/partiql/ast/IdentifierChain;
 	protected fun <init> (Lorg/partiql/ast/IdentifierChain;)V
 	public fun getName ()Lorg/partiql/ast/IdentifierChain;
 }
@@ -2648,7 +2649,6 @@ public class org/partiql/ast/expr/ExprWindow$Over$Builder {
 }
 
 public abstract class org/partiql/ast/expr/PathStep : org/partiql/ast/AstNode {
-	protected final field next Lorg/partiql/ast/expr/PathStep;
 	protected fun <init> (Lorg/partiql/ast/expr/PathStep;)V
 	public fun getNext ()Lorg/partiql/ast/expr/PathStep;
 }

--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -2807,8 +2807,6 @@ public abstract class org/partiql/ast/graph/GraphLabel : org/partiql/ast/AstNode
 }
 
 public class org/partiql/ast/graph/GraphLabel$Conj : org/partiql/ast/graph/GraphLabel {
-	public final field lhs Lorg/partiql/ast/graph/GraphLabel;
-	public final field rhs Lorg/partiql/ast/graph/GraphLabel;
 	public fun <init> (Lorg/partiql/ast/graph/GraphLabel;Lorg/partiql/ast/graph/GraphLabel;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphLabel$Conj$Builder;
@@ -2828,8 +2826,6 @@ public class org/partiql/ast/graph/GraphLabel$Conj$Builder {
 }
 
 public class org/partiql/ast/graph/GraphLabel$Disj : org/partiql/ast/graph/GraphLabel {
-	public final field lhs Lorg/partiql/ast/graph/GraphLabel;
-	public final field rhs Lorg/partiql/ast/graph/GraphLabel;
 	public fun <init> (Lorg/partiql/ast/graph/GraphLabel;Lorg/partiql/ast/graph/GraphLabel;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphLabel$Disj$Builder;
@@ -2983,16 +2979,16 @@ public class org/partiql/ast/graph/GraphPart$Pattern$Builder {
 }
 
 public final class org/partiql/ast/graph/GraphPattern : org/partiql/ast/AstNode {
-	public final field parts Ljava/util/List;
-	public final field prefilter Lorg/partiql/ast/expr/Expr;
-	public final field quantifier Lorg/partiql/ast/graph/GraphQuantifier;
-	public final field restrictor Lorg/partiql/ast/graph/GraphRestrictor;
-	public final field variable Ljava/lang/String;
 	public fun <init> (Lorg/partiql/ast/graph/GraphRestrictor;Lorg/partiql/ast/expr/Expr;Ljava/lang/String;Lorg/partiql/ast/graph/GraphQuantifier;Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphPattern$Builder;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getParts ()Ljava/util/List;
+	public fun getPrefilter ()Lorg/partiql/ast/expr/Expr;
+	public fun getQuantifier ()Lorg/partiql/ast/graph/GraphQuantifier;
+	public fun getRestrictor ()Lorg/partiql/ast/graph/GraphRestrictor;
+	public fun getVariable ()Ljava/lang/String;
 	public fun hashCode ()I
 }
 
@@ -3108,13 +3104,13 @@ public class org/partiql/ast/graph/GraphSelector$AnyShortest$Builder {
 }
 
 public class org/partiql/ast/graph/GraphSelector$ShortestK : org/partiql/ast/graph/GraphSelector {
-	public final field k J
 	public fun <init> (J)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphSelector$ShortestK$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getK ()J
 	public fun hashCode ()I
 }
 
@@ -3125,13 +3121,13 @@ public class org/partiql/ast/graph/GraphSelector$ShortestK$Builder {
 }
 
 public class org/partiql/ast/graph/GraphSelector$ShortestKGroup : org/partiql/ast/graph/GraphSelector {
-	public final field k J
 	public fun <init> (J)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/graph/GraphSelector$ShortestKGroup$Builder;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
+	public fun getK ()J
 	public fun hashCode ()I
 }
 

--- a/partiql-ast/build.gradle.kts
+++ b/partiql-ast/build.gradle.kts
@@ -21,10 +21,6 @@ plugins {
     kotlin("plugin.lombok") version "2.1.0"
 }
 
-kotlinLombok {
-    lombokConfigurationFile(file("lombok.config"))
-}
-
 dependencies {
     api(Deps.ionElement)
     compileOnly(Deps.lombok)

--- a/partiql-ast/build.gradle.kts
+++ b/partiql-ast/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id(Plugins.publish)
     // To allow for Kotlin code in partiql-ast to understand Java Lombok annotations, need the following plugin.
     // https://kotlinlang.org/docs/lombok.html
-    kotlin("plugin.lombok") version "2.1.0"
+    id(Plugins.kotlinLombok) version Versions.kotlinLombok
 }
 
 dependencies {

--- a/partiql-ast/build.gradle.kts
+++ b/partiql-ast/build.gradle.kts
@@ -16,7 +16,7 @@
 plugins {
     id(Plugins.conventions)
     id(Plugins.publish)
-    // To allow for Kotlin code in partiql-ast to understand Java Lombok annotations, need the following plugin.
+    // Need the Kotlin lombok plugin to allow for Kotlin code in partiql-ast to understand Java Lombok annotations.
     // https://kotlinlang.org/docs/lombok.html
     id(Plugins.kotlinLombok) version Versions.kotlinLombok
 }

--- a/partiql-ast/build.gradle.kts
+++ b/partiql-ast/build.gradle.kts
@@ -16,6 +16,13 @@
 plugins {
     id(Plugins.conventions)
     id(Plugins.publish)
+    // To allow for Kotlin code in partiql-ast to understand Java Lombok annotations, need the following plugin.
+    // https://kotlinlang.org/docs/lombok.html
+    kotlin("plugin.lombok") version "2.1.0"
+}
+
+kotlinLombok {
+    lombokConfigurationFile(file("lombok.config"))
 }
 
 dependencies {

--- a/partiql-ast/lombok.config
+++ b/partiql-ast/lombok.config
@@ -1,3 +1,0 @@
-# Make getters generated for `boolean` fields to use `get` prefix rather than default `is` prefix
-# Also, 
-lombok.getter.noIsPrefix = true

--- a/partiql-ast/lombok.config
+++ b/partiql-ast/lombok.config
@@ -1,0 +1,3 @@
+# Make getters generated for `boolean` fields to use `get` prefix rather than default `is` prefix
+# Also, 
+lombok.getter.noIsPrefix = true

--- a/partiql-ast/src/main/java/org/partiql/ast/AstVisitor.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/AstVisitor.java
@@ -3,7 +3,6 @@ package org.partiql.ast;
 import org.partiql.ast.ddl.AttributeConstraint;
 import org.partiql.ast.ddl.ColumnDefinition;
 import org.partiql.ast.ddl.CreateTable;
-import org.partiql.ast.ddl.Ddl;
 import org.partiql.ast.ddl.KeyValue;
 import org.partiql.ast.ddl.PartitionBy;
 import org.partiql.ast.ddl.TableConstraint;
@@ -88,10 +87,6 @@ public abstract class AstVisitor<R, C> {
     //
     // DDL
     //
-    public R visitDdl(Ddl node, C ctx) {
-        return defaultVisit(node, ctx);
-    }
-
     public R visitCreateTable(CreateTable node, C ctx) {
         return defaultVisit(node, ctx);
     }

--- a/partiql-ast/src/main/java/org/partiql/ast/DataType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/DataType.java
@@ -40,8 +40,11 @@ public final class DataType extends AstEnum {
         private final boolean optional;
 
         @Nullable
+        @Getter
         private final List<AttributeConstraint> constraints;
+
         @Nullable
+        @Getter
         private final String comment;
 
         public StructField(

--- a/partiql-ast/src/main/java/org/partiql/ast/DataType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/DataType.java
@@ -1,6 +1,7 @@
 package org.partiql.ast;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.ddl.AttributeConstraint;
@@ -9,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
-public class DataType extends AstEnum {
+public final class DataType extends AstEnum {
     /**
      * A field definition with in a Struct Type Definition
      */
@@ -28,26 +29,30 @@ public class DataType extends AstEnum {
     @EqualsAndHashCode(callSuper = false)
     public static class StructField extends AstNode {
         @NotNull
-        public final Identifier name;
+        @Getter
+        private final Identifier name;
+
         @NotNull
-        public final DataType type;
+        @Getter
+        private final DataType type;
 
-        public final boolean isOptional;
+        @Getter
+        private final boolean optional;
 
         @Nullable
-        public final List<AttributeConstraint> constraints;
+        private final List<AttributeConstraint> constraints;
         @Nullable
-        public final String comment;
+        private final String comment;
 
         public StructField(
                 @NotNull Identifier name,
                 @NotNull DataType type,
-                boolean isOptional,
+                boolean optional,
                 @Nullable List<AttributeConstraint> constraints,
                 @Nullable String comment) {
             this.name = name;
             this.type = type;
-            this.isOptional = isOptional;
+            this.optional = optional;
             this.constraints = constraints;
             this.comment = comment;
         }

--- a/partiql-ast/src/main/java/org/partiql/ast/DatetimeField.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/DatetimeField.java
@@ -10,7 +10,7 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class DatetimeField extends AstEnum {
+public final class DatetimeField extends AstEnum {
     public static final int YEAR = 0;
     public static final int MONTH = 1;
     public static final int DAY = 2;

--- a/partiql-ast/src/main/java/org/partiql/ast/Exclude.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Exclude.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -12,9 +13,10 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class Exclude extends AstNode {
+public final class Exclude extends AstNode {
     @NotNull
-    public final List<ExcludePath> excludePaths;
+    @Getter
+    private final List<ExcludePath> excludePaths;
 
     public Exclude(@NotNull List<ExcludePath> excludePaths) {
         this.excludePaths = excludePaths;

--- a/partiql-ast/src/main/java/org/partiql/ast/ExcludePath.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ExcludePath.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.expr.ExprVarRef;
 
@@ -13,12 +14,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExcludePath extends AstNode {
+public final class ExcludePath extends AstNode {
     @NotNull
-    public final ExprVarRef root;
+    @Getter
+    private final ExprVarRef root;
 
     @NotNull
-    public final List<ExcludeStep> excludeSteps;
+    @Getter
+    private final List<ExcludeStep> excludeSteps;
 
     public ExcludePath(@NotNull ExprVarRef root, @NotNull List<ExcludeStep> excludeSteps) {
         this.root = root;

--- a/partiql-ast/src/main/java/org/partiql/ast/ExcludeStep.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ExcludeStep.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -18,7 +19,8 @@ public abstract class ExcludeStep extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class StructField extends ExcludeStep {
         @NotNull
-        public final Identifier symbol;
+        @Getter
+        private final Identifier symbol;
 
         public StructField(@NotNull Identifier symbol) {
             this.symbol = symbol;
@@ -44,7 +46,8 @@ public abstract class ExcludeStep extends AstNode {
     @Builder(builderClassName = "Builder")
     @EqualsAndHashCode(callSuper = false)
     public static class CollIndex extends ExcludeStep {
-        public final int index;
+        @Getter
+        private final int index;
 
         public CollIndex(int index) {
             this.index = index;

--- a/partiql-ast/src/main/java/org/partiql/ast/Explain.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Explain.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -13,12 +14,14 @@ import java.util.Map;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class Explain extends Statement {
+public final class Explain extends Statement {
     @NotNull
-    public final Map<String, Literal> options;
+    @Getter
+    private final Map<String, Literal> options;
 
     @NotNull
-    public final Statement statement;
+    @Getter
+    private final Statement statement;
 
     public Explain(@NotNull Map<String, Literal> options, @NotNull Statement statement) {
         this.options = options;

--- a/partiql-ast/src/main/java/org/partiql/ast/From.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/From.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -12,9 +13,10 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class From extends AstNode {
+public final class From extends AstNode {
     @NotNull
-    public final List<FromTableRef> tableRefs;
+    @Getter
+    private final List<FromTableRef> tableRefs;
 
     public From(@NotNull List<FromTableRef> tableRefs) {
         this.tableRefs = tableRefs;

--- a/partiql-ast/src/main/java/org/partiql/ast/FromExpr.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/FromExpr.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.expr.Expr;
@@ -14,18 +15,22 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class FromExpr extends FromTableRef {
+public final class FromExpr extends FromTableRef {
     @NotNull
-    public final Expr expr;
+    @Getter
+    private final Expr expr;
 
     @NotNull
-    public final FromType fromType;
+    @Getter
+    private final FromType fromType;
 
     @Nullable
-    public final Identifier asAlias;
+    @Getter
+    private final Identifier asAlias;
 
     @Nullable
-    public final Identifier atAlias;
+    @Getter
+    private final Identifier atAlias;
 
     public FromExpr(@NotNull Expr expr, @NotNull FromType fromType, @Nullable Identifier asAlias,
                     @Nullable Identifier atAlias) {

--- a/partiql-ast/src/main/java/org/partiql/ast/FromJoin.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/FromJoin.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.expr.Expr;
@@ -14,18 +15,22 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class FromJoin extends FromTableRef {
+public final class FromJoin extends FromTableRef {
     @NotNull
-    public final FromTableRef lhs;
+    @Getter
+    private final FromTableRef lhs;
 
     @NotNull
-    public final FromTableRef rhs;
+    @Getter
+    private final FromTableRef rhs;
 
     @Nullable
-    public final JoinType joinType;
+    @Getter
+    private final JoinType joinType;
 
     @Nullable
-    public final Expr condition;
+    @Getter
+    private final Expr condition;
 
     public FromJoin(@NotNull FromTableRef lhs, @NotNull FromTableRef rhs, @Nullable JoinType joinType, @Nullable Expr condition) {
         this.lhs = lhs;

--- a/partiql-ast/src/main/java/org/partiql/ast/FromType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/FromType.java
@@ -10,7 +10,7 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class FromType extends AstEnum {
+public final class FromType extends AstEnum {
     public static final int SCAN = 0;
     public static final int UNPIVOT = 1;
 

--- a/partiql-ast/src/main/java/org/partiql/ast/GroupBy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/GroupBy.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.expr.Expr;
@@ -14,15 +15,18 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class GroupBy extends AstNode {
+public final class GroupBy extends AstNode {
     @NotNull
-    public final GroupByStrategy strategy;
+    @Getter
+    private final GroupByStrategy strategy;
 
     @NotNull
-    public final List<Key> keys;
+    @Getter
+    private final List<Key> keys;
 
     @Nullable
-    public final Identifier asAlias;
+    @Getter
+    private final Identifier asAlias;
 
     public GroupBy(@NotNull GroupByStrategy strategy, @NotNull List<Key> keys, @Nullable Identifier asAlias) {
         this.strategy = strategy;
@@ -52,10 +56,12 @@ public class GroupBy extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Key extends AstNode {
         @NotNull
-        public final Expr expr;
+        @Getter
+        private final Expr expr;
 
         @Nullable
-        public final Identifier asAlias;
+        @Getter
+        private final Identifier asAlias;
 
         public Key(@NotNull Expr expr, @Nullable Identifier asAlias) {
         this.expr = expr;

--- a/partiql-ast/src/main/java/org/partiql/ast/GroupByStrategy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/GroupByStrategy.java
@@ -10,7 +10,7 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class GroupByStrategy extends AstEnum {
+public final class GroupByStrategy extends AstEnum {
     public static final int FULL = 0;
     public static final int PARTIAL = 1;
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Identifier.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Identifier.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -12,15 +13,17 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class Identifier extends AstNode {
+public final class Identifier extends AstNode {
     @NotNull
-    public final String symbol;
+    @Getter
+    private final String symbol;
 
-    public final boolean isDelimited;
+    @Getter
+    private final boolean delimited;
 
-    public Identifier(@NotNull String symbol, boolean isDelimited) {
+    public Identifier(@NotNull String symbol, boolean delimited) {
         this.symbol = symbol;
-        this.isDelimited = isDelimited;
+        this.delimited = delimited;
     }
 
     @NotNull

--- a/partiql-ast/src/main/java/org/partiql/ast/IdentifierChain.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/IdentifierChain.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,12 +14,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class IdentifierChain extends AstNode {
+public final class IdentifierChain extends AstNode {
     @NotNull
-    public final Identifier root;
+    @Getter
+    private final Identifier root;
 
     @Nullable
-    public final IdentifierChain next;
+    @Getter
+    private final IdentifierChain next;
 
     public IdentifierChain(@NotNull Identifier root, @Nullable IdentifierChain next) {
         this.root = root;

--- a/partiql-ast/src/main/java/org/partiql/ast/JoinType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/JoinType.java
@@ -10,7 +10,7 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class JoinType extends AstEnum {
+public final class JoinType extends AstEnum {
     public static final int INNER = 0;
     public static final int LEFT = 1;
     public static final int LEFT_OUTER = 2;

--- a/partiql-ast/src/main/java/org/partiql/ast/Let.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Let.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.expr.Expr;
 
@@ -13,9 +14,10 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class Let extends AstNode {
+public final class Let extends AstNode {
     @NotNull
-    public final List<Binding> bindings;
+    @Getter
+    private final List<Binding> bindings;
 
     public Let(@NotNull List<Binding> bindings) {
         this.bindings = bindings;
@@ -39,10 +41,12 @@ public class Let extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Binding extends AstNode {
         @NotNull
-        public final Expr expr;
+        @Getter
+        private final Expr expr;
 
         @NotNull
-        public final Identifier asAlias;
+        @Getter
+        private final Identifier asAlias;
 
         public Binding(@NotNull Expr expr, @NotNull Identifier asAlias) {
             this.expr = expr;

--- a/partiql-ast/src/main/java/org/partiql/ast/Literal.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Literal.java
@@ -14,7 +14,7 @@ import static java.util.Objects.requireNonNull;
  * TODO docs
  */
 @EqualsAndHashCode(callSuper = false)
-public class Literal extends AstEnum {
+public final class Literal extends AstEnum {
     // absent literals
     public static final int NULL = 0;
     public static final int MISSING = 1;

--- a/partiql-ast/src/main/java/org/partiql/ast/Nulls.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Nulls.java
@@ -10,7 +10,7 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class Nulls extends AstEnum {
+public final class Nulls extends AstEnum {
     public static final int FIRST = 0;
     public static final int LAST = 1;
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Order.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Order.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
-public class Order extends AstEnum {
+public final class Order extends AstEnum {
     public static final int ASC = 0;
     public static final int DESC = 1;
 

--- a/partiql-ast/src/main/java/org/partiql/ast/OrderBy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/OrderBy.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -12,9 +13,10 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class OrderBy extends AstNode {
+public final class OrderBy extends AstNode {
     @NotNull
-    public final List<Sort> sorts;
+    @Getter
+    private final List<Sort> sorts;
 
     public OrderBy(@NotNull List<Sort> sorts) {
         this.sorts = sorts;

--- a/partiql-ast/src/main/java/org/partiql/ast/Query.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Query.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.expr.Expr;
 
@@ -13,9 +14,10 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class Query extends Statement {
+public final class Query extends Statement {
     @NotNull
-    public final Expr expr;
+    @Getter
+    private final Expr expr;
 
     public Query(@NotNull Expr expr) {
         this.expr = expr;

--- a/partiql-ast/src/main/java/org/partiql/ast/QueryBody.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/QueryBody.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.expr.Expr;
@@ -14,25 +15,32 @@ public abstract class QueryBody extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class SFW extends QueryBody {
         @NotNull
-        public final Select select;
+        @Getter
+        private final Select select;
 
         @Nullable
-        public final Exclude exclude;
+        @Getter
+        private final Exclude exclude;
 
         @NotNull
-        public final From from;
+        @Getter
+        private final From from;
 
         @Nullable
-        public final Let let;
+        @Getter
+        private final Let let;
 
         @Nullable
-        public final Expr where;
+        @Getter
+        private final Expr where;
 
         @Nullable
-        public final GroupBy groupBy;
+        @Getter
+        private final GroupBy groupBy;
 
         @Nullable
-        public final Expr having;
+        @Getter
+        private final Expr having;
 
         public SFW(@NotNull Select select, @Nullable Exclude exclude, @NotNull From from,
         @Nullable Let let, @Nullable Expr where, @Nullable GroupBy groupBy, @Nullable Expr having) {
@@ -69,9 +77,11 @@ public abstract class QueryBody extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class SetOp extends QueryBody {
         @NotNull
-        public final org.partiql.ast.SetOp type;
+        @Getter
+        private final org.partiql.ast.SetOp type;
 
-        public final boolean isOuter;
+        @Getter
+        private final boolean outer;
 
         @NotNull
         public Expr lhs;
@@ -79,9 +89,9 @@ public abstract class QueryBody extends AstNode {
         @NotNull
         public Expr rhs;
 
-        public SetOp(@NotNull org.partiql.ast.SetOp type, boolean isOuter, @NotNull Expr lhs, @NotNull Expr rhs) {
+        public SetOp(@NotNull org.partiql.ast.SetOp type, boolean outer, @NotNull Expr lhs, @NotNull Expr rhs) {
             this.type = type;
-            this.isOuter = isOuter;
+            this.outer = outer;
             this.lhs = lhs;
             this.rhs = rhs;
         }

--- a/partiql-ast/src/main/java/org/partiql/ast/QueryBody.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/QueryBody.java
@@ -84,10 +84,12 @@ public abstract class QueryBody extends AstNode {
         private final boolean outer;
 
         @NotNull
-        public Expr lhs;
+        @Getter
+        private final Expr lhs;
 
         @NotNull
-        public Expr rhs;
+        @Getter
+        private final Expr rhs;
 
         public SetOp(@NotNull org.partiql.ast.SetOp type, boolean outer, @NotNull Expr lhs, @NotNull Expr rhs) {
             this.type = type;

--- a/partiql-ast/src/main/java/org/partiql/ast/SelectItem.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SelectItem.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,7 +20,8 @@ public abstract class SelectItem extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Star extends SelectItem {
         @NotNull
-        public final org.partiql.ast.expr.Expr expr;
+        @Getter
+        private final org.partiql.ast.expr.Expr expr;
 
         public Star(@NotNull org.partiql.ast.expr.Expr expr) {
             this.expr = expr;
@@ -46,10 +48,10 @@ public abstract class SelectItem extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Expr extends SelectItem {
         @NotNull
-        public final org.partiql.ast.expr.Expr expr;
+        private final org.partiql.ast.expr.Expr expr;
 
         @Nullable
-        public final Identifier asAlias;
+        private final Identifier asAlias;
 
         public Expr(@NotNull org.partiql.ast.expr.Expr expr, @Nullable Identifier asAlias) {
             this.expr = expr;
@@ -70,6 +72,16 @@ public abstract class SelectItem extends AstNode {
         @Override
         public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
             return visitor.visitSelectItemExpr(this, ctx);
+        }
+
+        @NotNull
+        public org.partiql.ast.expr.Expr getExpr() {
+            return this.expr;
+        }
+
+        @Nullable
+        public Identifier getAsAlias() {
+            return this.asAlias;
         }
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/SelectItem.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SelectItem.java
@@ -48,9 +48,11 @@ public abstract class SelectItem extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Expr extends SelectItem {
         @NotNull
+        @Getter
         private final org.partiql.ast.expr.Expr expr;
 
         @Nullable
+        @Getter
         private final Identifier asAlias;
 
         public Expr(@NotNull org.partiql.ast.expr.Expr expr, @Nullable Identifier asAlias) {
@@ -72,16 +74,6 @@ public abstract class SelectItem extends AstNode {
         @Override
         public <R, C> R accept(@NotNull AstVisitor<R, C> visitor, C ctx) {
             return visitor.visitSelectItemExpr(this, ctx);
-        }
-
-        @NotNull
-        public org.partiql.ast.expr.Expr getExpr() {
-            return this.expr;
-        }
-
-        @Nullable
-        public Identifier getAsAlias() {
-            return this.asAlias;
         }
     }
 }

--- a/partiql-ast/src/main/java/org/partiql/ast/SelectList.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SelectList.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,12 +14,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class SelectList extends Select {
+public final class SelectList extends Select {
     @NotNull
-    public final List<SelectItem> items;
+    @Getter
+    private final List<SelectItem> items;
 
     @Nullable
-    public final SetQuantifier setq;
+    @Getter
+    private final SetQuantifier setq;
 
     public SelectList(@NotNull List<SelectItem> items, @Nullable SetQuantifier setq) {
         this.items = items;

--- a/partiql-ast/src/main/java/org/partiql/ast/SelectPivot.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SelectPivot.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.expr.Expr;
 
@@ -13,12 +14,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class SelectPivot extends Select {
+public final class SelectPivot extends Select {
     @NotNull
-    public final Expr key;
+    @Getter
+    private final Expr key;
 
     @NotNull
-    public final Expr value;
+    @Getter
+    private final Expr value;
 
     public SelectPivot(@NotNull Expr key, @NotNull Expr value) {
         this.key = key;

--- a/partiql-ast/src/main/java/org/partiql/ast/SelectStar.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SelectStar.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,9 +14,10 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class SelectStar extends Select {
+public final class SelectStar extends Select {
     @Nullable
-    public final SetQuantifier setq;
+    @Getter
+    private final SetQuantifier setq;
 
     public SelectStar(@Nullable SetQuantifier setq) {
         this.setq = setq;

--- a/partiql-ast/src/main/java/org/partiql/ast/SelectValue.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SelectValue.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.expr.Expr;
@@ -14,12 +15,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class SelectValue extends Select {
+public final class SelectValue extends Select {
     @NotNull
-    public final Expr constructor;
+    @Getter
+    private final Expr constructor;
 
     @Nullable
-    public final SetQuantifier setq;
+    @Getter
+    private final SetQuantifier setq;
 
     public SelectValue(@NotNull Expr constructor, @Nullable SetQuantifier setq) {
         this.constructor = constructor;

--- a/partiql-ast/src/main/java/org/partiql/ast/SetOp.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SetOp.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,12 +14,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class SetOp extends AstNode {
+public final class SetOp extends AstNode {
     @NotNull
-    public final SetOpType setOpType;
+    @Getter
+    private final SetOpType setOpType;
 
     @Nullable
-    public final SetQuantifier setq;
+    @Getter
+    private final SetQuantifier setq;
 
     public SetOp(@NotNull SetOpType setOpType, @Nullable SetQuantifier setq) {
         this.setOpType = setOpType;

--- a/partiql-ast/src/main/java/org/partiql/ast/SetOpType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SetOpType.java
@@ -10,7 +10,7 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class SetOpType extends AstEnum {
+public final class SetOpType extends AstEnum {
     public static final int UNION = 0;
     public static final int INTERSECT = 1;
     public static final int EXCEPT = 2;

--- a/partiql-ast/src/main/java/org/partiql/ast/SetQuantifier.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SetQuantifier.java
@@ -10,7 +10,7 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class SetQuantifier extends AstEnum {
+public final class SetQuantifier extends AstEnum {
     public static final int ALL = 0;
     public static final int DISTINCT = 1;
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Sort.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Sort.java
@@ -2,6 +2,7 @@ package org.partiql.ast;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.expr.Expr;
@@ -14,15 +15,18 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class Sort extends AstNode {
+public final class Sort extends AstNode {
     @NotNull
-    public final Expr expr;
+    @Getter
+    private final Expr expr;
 
     @Nullable
-    public final Order order;
+    @Getter
+    private final Order order;
 
     @Nullable
-    public final Nulls nulls;
+    @Getter
+    private final Nulls nulls;
 
     public Sort(@NotNull Expr expr, @Nullable Order order, @Nullable Nulls nulls) {
         this.expr = expr;

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/AttributeConstraint.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/AttributeConstraint.java
@@ -1,6 +1,7 @@
 package org.partiql.ast.ddl;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -17,7 +18,8 @@ import java.util.List;
 public abstract class AttributeConstraint extends AstNode {
 
     @Nullable
-    public final IdentifierChain name;
+    @Getter
+    protected final IdentifierChain name;
 
     protected AttributeConstraint(@Nullable IdentifierChain name) {
         this.name = name;
@@ -38,12 +40,12 @@ public abstract class AttributeConstraint extends AstNode {
      */
     @EqualsAndHashCode(callSuper = false)
     public static class Null extends AttributeConstraint {
+        @Getter
+        private final boolean nullable;
 
-        public final boolean isNullable;
-
-        public Null(@Nullable IdentifierChain name, boolean isNullable) {
+        public Null(@Nullable IdentifierChain name, boolean nullable) {
             super(name);
-            this.isNullable = isNullable;
+            this.nullable = nullable;
         }
 
         @Override
@@ -59,12 +61,12 @@ public abstract class AttributeConstraint extends AstNode {
      */
     @EqualsAndHashCode(callSuper = false)
     public static class Unique extends AttributeConstraint {
+        @Getter
+        private final boolean primaryKey;
 
-        public final boolean isPrimaryKey;
-
-        public Unique(@Nullable IdentifierChain name, boolean isPrimary) {
+        public Unique(@Nullable IdentifierChain name, boolean primaryKey) {
             super(name);
-            this.isPrimaryKey = isPrimary;
+            this.primaryKey = primaryKey;
         }
 
         @Override
@@ -78,9 +80,9 @@ public abstract class AttributeConstraint extends AstNode {
      */
     @EqualsAndHashCode(callSuper = false)
     public static class Check extends AttributeConstraint {
-
         @NotNull
-        public final Expr searchCondition;
+        @Getter
+        private final Expr searchCondition;
 
         public Check(@Nullable IdentifierChain name, @NotNull Expr searchCondition) {
             super(name);

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/ColumnDefinition.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/ColumnDefinition.java
@@ -2,6 +2,7 @@ package org.partiql.ast.ddl;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -17,31 +18,35 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ColumnDefinition extends AstNode {
+public final class ColumnDefinition extends AstNode {
+    @NotNull
+    @Getter
+    private final Identifier name;
 
     @NotNull
-    public final Identifier name;
+    @Getter
+    private final DataType dataType;
+
+    @Getter
+    private final boolean optional;
 
     @NotNull
-    public final DataType dataType;
-
-    public final boolean isOptional;
-
-    @NotNull
-    public final List<AttributeConstraint> constraints;
+    @Getter
+    private final List<AttributeConstraint> constraints;
 
     @Nullable
-    public final String comment;
+    @Getter
+    private final String comment;
 
     public ColumnDefinition(
             @NotNull Identifier name,
             @NotNull DataType dataType,
-            boolean isOptional,
+            boolean optional,
             @NotNull List<AttributeConstraint> constraints,
             @Nullable String comment) {
         this.name = name;
         this.dataType = dataType;
-        this.isOptional = isOptional;
+        this.optional = optional;
         this.constraints = constraints;
         this.comment = comment;
     }

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/CreateTable.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/CreateTable.java
@@ -2,6 +2,7 @@ package org.partiql.ast.ddl;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -16,22 +17,27 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class CreateTable extends Ddl {
+public final class CreateTable extends Ddl {
 
     @NotNull
-    public final IdentifierChain name;
+    @Getter
+    private final IdentifierChain name;
 
     @NotNull
-    public final List<ColumnDefinition> columns;
+    @Getter
+    private final List<ColumnDefinition> columns;
 
     @NotNull
-    public final List<TableConstraint> constraints;
+    @Getter
+    private final List<TableConstraint> constraints;
 
     @Nullable
-    public final PartitionBy partitionBy;
+    @Getter
+    private final PartitionBy partitionBy;
 
     @NotNull
-    public final List<KeyValue> tableProperties;
+    @Getter
+    private final List<KeyValue> tableProperties;
 
     public CreateTable(
             @NotNull IdentifierChain name,

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/CreateTable.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/CreateTable.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 import org.partiql.ast.IdentifierChain;
+import org.partiql.ast.Statement;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public final class CreateTable extends Ddl {
+public final class CreateTable extends Statement {
 
     @NotNull
     @Getter

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/Ddl.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/Ddl.java
@@ -1,9 +1,0 @@
-package org.partiql.ast.ddl;
-
-import org.partiql.ast.Statement;
-
-/**
- * TODO docs, equals, hashcode
- */
-public abstract class Ddl extends Statement {
-}

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/KeyValue.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/KeyValue.java
@@ -2,6 +2,7 @@ package org.partiql.ast.ddl;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -16,11 +17,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class KeyValue extends AstNode {
+public final class KeyValue extends AstNode {
     @NotNull
-    public final String key;
+    @Getter
+    private final String key;
+
     @NotNull
-    public final String value;
+    @Getter
+    private final String value;
 
     public KeyValue(@NotNull String key, @NotNull String value) {
         this.key = key;

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/PartitionBy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/PartitionBy.java
@@ -2,6 +2,7 @@ package org.partiql.ast.ddl;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -12,9 +13,10 @@ import java.util.List;
 
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class PartitionBy extends AstNode {
+public final class PartitionBy extends AstNode {
     @NotNull
-    public final List<Identifier> columns;
+    @Getter
+    private final List<Identifier> columns;
 
     public PartitionBy(@NotNull List<Identifier> columns) {
         this.columns = columns;

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/TableConstraint.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/TableConstraint.java
@@ -15,7 +15,7 @@ import java.util.List;
 public abstract class TableConstraint extends AstNode {
     @Nullable
     @Getter
-    protected final IdentifierChain name;
+    private final IdentifierChain name;
 
     protected TableConstraint(@Nullable IdentifierChain name) {
         this.name = name;
@@ -40,7 +40,7 @@ public abstract class TableConstraint extends AstNode {
         @Override
         public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
-            kids.add(name);
+            kids.add(getName());
             kids.addAll(columns);
             return kids;
         }

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/TableConstraint.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/TableConstraint.java
@@ -1,6 +1,7 @@
 package org.partiql.ast.ddl;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -13,7 +14,8 @@ import java.util.List;
 
 public abstract class TableConstraint extends AstNode {
     @Nullable
-    public final IdentifierChain name;
+    @Getter
+    protected final IdentifierChain name;
 
     protected TableConstraint(@Nullable IdentifierChain name) {
         this.name = name;
@@ -22,14 +24,16 @@ public abstract class TableConstraint extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Unique extends TableConstraint {
         @NotNull
-        public final List<Identifier> columns;
+        @Getter
+        private final List<Identifier> columns;
 
-        public final boolean isPrimaryKey;
+        @Getter
+        private final boolean primaryKey;
 
-        public Unique(@Nullable IdentifierChain name, @NotNull List<Identifier> column, boolean isPrimaryKey) {
+        public Unique(@Nullable IdentifierChain name, @NotNull List<Identifier> column, boolean primaryKey) {
             super(name);
             this.columns = column;
-            this.isPrimaryKey = isPrimaryKey;
+            this.primaryKey = primaryKey;
         }
 
         @NotNull

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/ConflictAction.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/ConflictAction.java
@@ -2,6 +2,7 @@ package org.partiql.ast.dml;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -58,13 +59,15 @@ public abstract class ConflictAction extends AstNode {
          * TODO
          */
         @NotNull
-        public final DoReplaceAction action;
+        @Getter
+        private final DoReplaceAction action;
 
         /**
          * TODO
          */
         @Nullable
-        public final Expr condition;
+        @Getter
+        private final Expr condition;
 
         /**
          * TODO
@@ -106,13 +109,15 @@ public abstract class ConflictAction extends AstNode {
          * TODO
          */
         @NotNull
-        public final DoUpdateAction action;
+        @Getter
+        private final DoUpdateAction action;
 
         /**
          * TODO
          */
         @Nullable
-        public final Expr condition;
+        @Getter
+        private final Expr condition;
 
         /**
          * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/ConflictTarget.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/ConflictTarget.java
@@ -2,6 +2,7 @@ package org.partiql.ast.dml;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -31,7 +32,8 @@ public abstract class ConflictTarget extends AstNode {
          */
         // TODO: Should this be a list of identifiers? Or paths? Expressions?
         @NotNull
-        public final List<Identifier> indexes;
+        @Getter
+        private final List<Identifier> indexes;
 
         /**
          * TODO
@@ -65,7 +67,8 @@ public abstract class ConflictTarget extends AstNode {
          * TODO
          */
         @NotNull
-        public final IdentifierChain name;
+        @Getter
+        private final IdentifierChain name;
 
         /**
          * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/Delete.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/Delete.java
@@ -2,6 +2,7 @@ package org.partiql.ast.dml;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -23,13 +24,15 @@ public final class Delete extends Statement {
      * TODO
      */
     @NotNull
-    public final IdentifierChain tableName;
+    @Getter
+    private final IdentifierChain tableName;
 
     /**
      * TODO
      */
     @Nullable
-    public final Expr condition;
+    @Getter
+    private final Expr condition;
 
     /**
      * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/Insert.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/Insert.java
@@ -2,6 +2,7 @@ package org.partiql.ast.dml;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -24,25 +25,29 @@ public final class Insert extends Statement {
      * TODO
      */
     @NotNull
-    public final IdentifierChain tableName;
+    @Getter
+    private final IdentifierChain tableName;
 
     /**
      * TODO
      */
     @Nullable
-    public final Identifier asAlias;
+    @Getter
+    private final Identifier asAlias;
 
     /**
      * TODO
      */
     @NotNull
-    public final InsertSource source;
+    @Getter
+    private final InsertSource source;
 
     /**
      * TODO
      */
     @Nullable
-    public final OnConflict onConflict;
+    @Getter
+    private final OnConflict onConflict;
 
     /**
      * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/InsertSource.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/InsertSource.java
@@ -2,6 +2,7 @@ package org.partiql.ast.dml;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -31,13 +32,15 @@ public abstract class InsertSource extends AstNode {
          * TODO
          */
         @Nullable
-        public final List<Identifier> columns;
+        @Getter
+        private final List<Identifier> columns;
 
         /**
          * TODO
          */
         @NotNull
-        public final Expr expr;
+        @Getter
+        private final Expr expr;
 
         /**
          * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/OnConflict.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/OnConflict.java
@@ -2,6 +2,7 @@ package org.partiql.ast.dml;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -22,13 +23,15 @@ public final class OnConflict extends AstNode {
      * TODO
      */
     @NotNull
-    public final ConflictAction action;
+    @Getter
+    private final ConflictAction action;
 
     /**
      * TODO
      */
     @Nullable
-    public final ConflictTarget target;
+    @Getter
+    private final ConflictTarget target;
 
     /**
      * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/Replace.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/Replace.java
@@ -2,6 +2,7 @@ package org.partiql.ast.dml;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -24,19 +25,22 @@ public final class Replace extends Statement {
      * TODO
      */
     @NotNull
-    public final IdentifierChain tableName;
+    @Getter
+    private final IdentifierChain tableName;
 
     /**
      * TODO
      */
     @Nullable
-    public final Identifier asAlias;
+    @Getter
+    private final Identifier asAlias;
 
     /**
      * TODO
      */
     @NotNull
-    public final InsertSource source;
+    @Getter
+    private final InsertSource source;
 
     /**
      * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/SetClause.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/SetClause.java
@@ -2,6 +2,7 @@ package org.partiql.ast.dml;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -21,13 +22,15 @@ public final class SetClause extends AstNode {
      * TODO
      */
     @NotNull
-    public final UpdateTarget target;
+    @Getter
+    private final UpdateTarget target;
 
     /**
      * TODO
      */
     @NotNull
-    public final Expr expr;
+    @Getter
+    private final Expr expr;
 
     /**
      * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/Update.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/Update.java
@@ -2,6 +2,7 @@ package org.partiql.ast.dml;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -24,19 +25,22 @@ public final class Update extends Statement {
      * TODO
      */
     @NotNull
-    public final IdentifierChain tableName;
+    @Getter
+    private final IdentifierChain tableName;
 
     /**
      * TODO
      */
     @NotNull
-    public final List<SetClause> setClauses;
+    @Getter
+    private final List<SetClause> setClauses;
 
     /**
      * TODO
      */
     @Nullable
-    public final Expr condition;
+    @Getter
+    private final Expr condition;
 
     /**
      * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/UpdateTarget.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/UpdateTarget.java
@@ -2,6 +2,7 @@ package org.partiql.ast.dml;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -22,13 +23,15 @@ public final class UpdateTarget extends AstNode {
      * TODO
      */
     @NotNull
-    public final Identifier root;
+    @Getter
+    private final Identifier root;
 
     /**
      * TODO
      */
     @NotNull
-    public final List<UpdateTargetStep> steps;
+    @Getter
+    private final List<UpdateTargetStep> steps;
 
     /**
      * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/UpdateTargetStep.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/UpdateTargetStep.java
@@ -2,6 +2,7 @@ package org.partiql.ast.dml;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -33,7 +34,8 @@ public abstract class UpdateTargetStep extends AstNode {
          * TODO
          */
         @NotNull
-        public final Literal key;
+        @Getter
+        private final Literal key;
 
         /**
          * TODO
@@ -85,7 +87,8 @@ public abstract class UpdateTargetStep extends AstNode {
          * TODO
          */
         @NotNull
-        public final Identifier key;
+        @Getter
+        private final Identifier key;
 
         /**
          * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/dml/Upsert.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/dml/Upsert.java
@@ -2,6 +2,7 @@ package org.partiql.ast.dml;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -24,19 +25,22 @@ public final class Upsert extends Statement {
      * TODO
      */
     @NotNull
-    public final IdentifierChain tableName;
+    @Getter
+    private final IdentifierChain tableName;
 
     /**
      * TODO
      */
     @Nullable
-    public final Identifier asAlias;
+    @Getter
+    private final Identifier asAlias;
 
     /**
      * TODO
      */
     @NotNull
-    public final InsertSource source;
+    @Getter
+    private final InsertSource source;
 
     /**
      * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprAnd.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprAnd.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,11 +15,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprAnd extends Expr {
+public final class ExprAnd extends Expr {
     @NotNull
-    public final Expr lhs;
+    @Getter
+    private final Expr lhs;
+
     @NotNull
-    public final Expr rhs;
+    @Getter
+    private final Expr rhs;
 
     public ExprAnd(@NotNull Expr lhs, @NotNull Expr rhs) {
         this.lhs = lhs;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprArray.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprArray.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,9 +15,10 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprArray extends Expr {
+public final class ExprArray extends Expr {
     @NotNull
-    public final List<Expr> values;
+    @Getter
+    private final List<Expr> values;
 
     public ExprArray(@NotNull List<Expr> values) {
         this.values = values;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprBag.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprBag.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,9 +15,10 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprBag extends Expr {
+public final class ExprBag extends Expr {
     @NotNull
-    public final List<Expr> values;
+    @Getter
+    private final List<Expr> values;
 
     public ExprBag(@NotNull List<Expr> values) {
         this.values = values;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprBetween.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprBetween.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,17 +15,21 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprBetween extends Expr {
+public final class ExprBetween extends Expr {
     @NotNull
-    public final Expr value;
+    @Getter
+    private final Expr value;
 
     @NotNull
-    public final Expr from;
+    @Getter
+    private final Expr from;
 
     @NotNull
-    public final Expr to;
+    @Getter
+    private final Expr to;
 
-    public final boolean not;
+    @Getter
+    private final boolean not;
 
     public ExprBetween(@NotNull Expr value, @NotNull Expr from, @NotNull Expr to, boolean not) {
         this.value = value;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprBoolTest.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprBoolTest.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -15,14 +16,17 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprBoolTest extends Expr {
+public final class ExprBoolTest extends Expr {
     @NotNull
-    public final Expr value;
+    @Getter
+    private final Expr value;
 
-    public final boolean not;
+    @Getter
+    private final boolean not;
 
     @NotNull
-    public final TruthValue truthValue;
+    @Getter
+    private final TruthValue truthValue;
 
     public ExprBoolTest(@NotNull Expr value, boolean not, @NotNull TruthValue truthValue) {
         this.value = value;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCall.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCall.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -17,15 +18,18 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprCall extends Expr {
+public final class ExprCall extends Expr {
     @NotNull
-    public final IdentifierChain function;
+    @Getter
+    private final IdentifierChain function;
 
     @NotNull
-    public final List<Expr> args;
+    @Getter
+    private final List<Expr> args;
 
     @Nullable
-    public final SetQuantifier setq;
+    @Getter
+    private final SetQuantifier setq;
 
     public ExprCall(@NotNull IdentifierChain function, @NotNull List<Expr> args, @Nullable SetQuantifier setq) {
         this.function = function;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCase.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCase.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -15,15 +16,18 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprCase extends Expr {
+public final class ExprCase extends Expr {
     @Nullable
-    public final Expr expr;
+    @Getter
+    private final Expr expr;
 
     @NotNull
-    public final List<Branch> branches;
+    @Getter
+    private final List<Branch> branches;
 
     @Nullable
-    public final Expr defaultExpr;
+    @Getter
+    private final Expr defaultExpr;
 
     public ExprCase(@Nullable Expr expr, @NotNull List<Branch> branches, @Nullable Expr defaultExpr) {
         this.expr = expr;
@@ -57,10 +61,12 @@ public class ExprCase extends Expr {
     @EqualsAndHashCode(callSuper = false)
     public static class Branch extends AstNode {
         @NotNull
-        public final Expr condition;
+        @Getter
+        private final Expr condition;
 
         @NotNull
-        public final Expr expr;
+        @Getter
+        private final Expr expr;
 
         public Branch(@NotNull Expr condition, @NotNull Expr expr) {
         this.condition = condition;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCast.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCast.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -15,12 +16,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprCast extends Expr {
+public final class ExprCast extends Expr {
     @NotNull
-    public final Expr value;
+    @Getter
+    private final Expr value;
 
     @NotNull
-    public final DataType asType;
+    @Getter
+    private final DataType asType;
 
     public ExprCast(@NotNull Expr value, @NotNull DataType asType) {
         this.value = value;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCoalesce.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprCoalesce.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,9 +15,10 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprCoalesce extends Expr {
+public final class ExprCoalesce extends Expr {
     @NotNull
-    public final List<Expr> args;
+    @Getter
+    private final List<Expr> args;
 
     public ExprCoalesce(@NotNull List<Expr> args) {
         this.args = args;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprExtract.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprExtract.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -15,12 +16,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprExtract extends Expr {
+public final class ExprExtract extends Expr {
     @NotNull
-    public final DatetimeField field;
+    @Getter
+    private final DatetimeField field;
 
     @NotNull
-    public final Expr source;
+    @Getter
+    private final Expr source;
 
     public ExprExtract(@NotNull DatetimeField field, @NotNull Expr source) {
         this.field = field;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprInCollection.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprInCollection.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,14 +15,17 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprInCollection extends Expr {
+public final class ExprInCollection extends Expr {
     @NotNull
-    public final Expr lhs;
+    @Getter
+    private final Expr lhs;
 
     @NotNull
-    public final Expr rhs;
+    @Getter
+    private final Expr rhs;
 
-    public final boolean not;
+    @Getter
+    private final boolean not;
 
     public ExprInCollection(@NotNull Expr lhs, @NotNull Expr rhs, boolean not) {
         this.lhs = lhs;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprIsType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprIsType.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -16,14 +17,17 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprIsType extends Expr {
+public final class ExprIsType extends Expr {
     @NotNull
-    public final Expr value;
+    @Getter
+    private final Expr value;
 
     @NotNull
-    public final DataType type;
+    @Getter
+    private final DataType type;
 
-    public final boolean not;
+    @Getter
+    private final boolean not;
 
     public ExprIsType(@NotNull Expr value, @NotNull DataType type, boolean not) {
         this.value = value;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprLike.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprLike.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -15,17 +16,21 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprLike extends Expr {
+public final class ExprLike extends Expr {
     @NotNull
-    public final Expr value;
+    @Getter
+    private final Expr value;
 
     @NotNull
-    public final Expr pattern;
+    @Getter
+    private final Expr pattern;
 
     @Nullable
-    public final Expr escape;
+    @Getter
+    private final Expr escape;
 
-    public final boolean not;
+    @Getter
+    private final boolean not;
 
     public ExprLike(@NotNull Expr value, @NotNull Expr pattern, @Nullable Expr escape, boolean not) {
         this.value = value;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprLit.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprLit.java
@@ -1,6 +1,7 @@
 package org.partiql.ast.expr;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -13,9 +14,10 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class ExprLit extends Expr {
+public final class ExprLit extends Expr {
     @NotNull
-    public Literal lit;
+    @Getter
+    private final Literal lit;
 
     public ExprLit(@NotNull Literal lit) {
         this.lit = lit;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprMatch.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprMatch.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -15,12 +16,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprMatch extends Expr {
+public final class ExprMatch extends Expr {
     @NotNull
-    public final Expr expr;
+    @Getter
+    private final Expr expr;
 
     @NotNull
-    public final GraphMatch pattern;
+    @Getter
+    private final GraphMatch pattern;
 
     public ExprMatch(@NotNull Expr expr, @NotNull GraphMatch pattern) {
         this.expr = expr;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprMissingPredicate.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprMissingPredicate.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -15,11 +16,13 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprMissingPredicate extends Expr {
+public final class ExprMissingPredicate extends Expr {
     @NotNull
-    public final Expr value;
+    @Getter
+    private final Expr value;
 
-    public final boolean not;
+    @Getter
+    private final boolean not;
 
     public ExprMissingPredicate(@NotNull Expr value, boolean not) {
         this.value = value;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprNot.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprNot.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,9 +15,10 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprNot extends Expr {
+public final class ExprNot extends Expr {
     @NotNull
-    public final Expr value;
+    @Getter
+    private final Expr value;
 
     public ExprNot(@NotNull Expr value) {
         this.value = value;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprNullIf.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprNullIf.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,12 +15,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprNullIf extends Expr {
+public final class ExprNullIf extends Expr {
     @NotNull
-    public final Expr v1;
+    @Getter
+    private final Expr v1;
 
     @NotNull
-    public final Expr v2;
+    @Getter
+    private final Expr v2;
 
     public ExprNullIf(@NotNull Expr v1, @NotNull Expr v2) {
         this.v1 = v1;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprNullPredicate.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprNullPredicate.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -15,11 +16,13 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprNullPredicate extends Expr {
+public final class ExprNullPredicate extends Expr {
     @NotNull
-    public final Expr value;
+    @Getter
+    private final Expr value;
 
-    public final boolean not;
+    @Getter
+    private final boolean not;
 
     public ExprNullPredicate(@NotNull Expr value, boolean not) {
         this.value = value;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprOperator.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprOperator.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -15,15 +16,18 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprOperator extends Expr {
+public final class ExprOperator extends Expr {
     @NotNull
-    public final String symbol;
+    @Getter
+    private final String symbol;
 
     @Nullable
-    public final Expr lhs;
+    @Getter
+    private final Expr lhs;
 
     @NotNull
-    public final Expr rhs;
+    @Getter
+    private final Expr rhs;
 
     public ExprOperator(@NotNull String symbol, @Nullable Expr lhs, @NotNull Expr rhs) {
         this.symbol = symbol;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprOr.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprOr.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,12 +15,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprOr extends Expr {
+public final class ExprOr extends Expr {
     @NotNull
-    public final Expr lhs;
+    @Getter
+    private final Expr lhs;
 
     @NotNull
-    public final Expr rhs;
+    @Getter
+    private final Expr rhs;
 
     public ExprOr(@NotNull Expr lhs, @NotNull Expr rhs) {
         this.lhs = lhs;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprOverlay.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprOverlay.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -15,18 +16,22 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprOverlay extends Expr {
+public final class ExprOverlay extends Expr {
     @NotNull
-    public final Expr value;
+    @Getter
+    private final Expr value;
 
     @NotNull
-    public final Expr placing;
+    @Getter
+    private final Expr placing;
 
     @NotNull
-    public final Expr from;
+    @Getter
+    private final Expr from;
 
     @Nullable
-    public final Expr forLength;
+    @Getter
+    private final Expr forLength;
 
     public ExprOverlay(@NotNull Expr value, @NotNull Expr placing, @NotNull Expr from, @Nullable Expr forLength) {
         this.value = value;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprParameter.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprParameter.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,8 +15,9 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprParameter extends Expr {
-    public final int index;
+public final class ExprParameter extends Expr {
+    @Getter
+    private final int index;
 
     public ExprParameter(int index) {
         this.index = index;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprPath.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprPath.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -15,12 +16,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprPath extends Expr {
+public final class ExprPath extends Expr {
     @NotNull
-    public final Expr root;
+    @Getter
+    private final Expr root;
 
     @Nullable
-    public final PathStep next;
+    @Getter
+    private final PathStep next;
 
     public ExprPath(@NotNull Expr root, @Nullable PathStep next) {
         this.root = root;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprPosition.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprPosition.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,12 +15,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprPosition extends Expr {
+public final class ExprPosition extends Expr {
     @NotNull
-    public final Expr lhs;
+    @Getter
+    private final Expr lhs;
 
     @NotNull
-    public final Expr rhs;
+    @Getter
+    private final Expr rhs;
 
     public ExprPosition(@NotNull Expr lhs, @NotNull Expr rhs) {
         this.lhs = lhs;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprQuerySet.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprQuerySet.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -17,18 +18,22 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprQuerySet extends Expr {
+public final class ExprQuerySet extends Expr {
     @NotNull
-    public final QueryBody body;
+    @Getter
+    private final QueryBody body;
 
     @Nullable
-    public final OrderBy orderBy;
+    @Getter
+    private final OrderBy orderBy;
 
     @Nullable
-    public final Expr limit;
+    @Getter
+    private final Expr limit;
 
     @Nullable
-    public final Expr offset;
+    @Getter
+    private final Expr offset;
 
     public ExprQuerySet(@NotNull QueryBody body, @Nullable OrderBy orderBy, @Nullable Expr limit, @Nullable Expr offset) {
         this.body = body;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprRowValue.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprRowValue.java
@@ -22,10 +22,6 @@ import java.util.List;
 @lombok.Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
 public final class ExprRowValue extends Expr {
-    public boolean isExplicit() {
-        return explicit;
-    }
-
     /**
      * Specifies whether the ROW keyword explicitly precedes the elements in the textual representation. For example,
      * {@code ROW (1, 2, 3)} versus {@code (1, 2, 3)}. In the first example, {@code isExplicit} is true.

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprRowValue.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprRowValue.java
@@ -1,6 +1,7 @@
 package org.partiql.ast.expr;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -20,32 +21,38 @@ import java.util.List;
  */
 @lombok.Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprRowValue extends Expr {
+public final class ExprRowValue extends Expr {
+    public boolean isExplicit() {
+        return explicit;
+    }
+
     /**
      * Specifies whether the ROW keyword explicitly precedes the elements in the textual representation. For example,
      * {@code ROW (1, 2, 3)} versus {@code (1, 2, 3)}. In the first example, {@code isExplicit} is true.
      */
-    public boolean isExplicit;
+    @Getter
+    private final boolean explicit;
 
     @NotNull
-    public final List<Expr> values;
+    @Getter
+    private final List<Expr> values;
 
     /**
-     * By default, {@link ExprRowValue#isExplicit} is false.
+     * By default, {@link ExprRowValue#explicit} is false.
      * @param values TODO
      */
     public ExprRowValue(@NotNull List<Expr> values) {
-        this.isExplicit = false;
+        this.explicit = false;
         this.values = values;
     }
 
     /**
      * TODO
-     * @param isExplicit TODO
+     * @param explicit TODO
      * @param values TODO
      */
-    public ExprRowValue(boolean isExplicit, @NotNull List<Expr> values) {
-        this.isExplicit = isExplicit;
+    public ExprRowValue(boolean explicit, @NotNull List<Expr> values) {
+        this.explicit = explicit;
         this.values = values;
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprSessionAttribute.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprSessionAttribute.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,9 +15,10 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprSessionAttribute extends Expr {
+public final class ExprSessionAttribute extends Expr {
     @NotNull
-    public final SessionAttribute sessionAttribute;
+    @Getter
+    private final SessionAttribute sessionAttribute;
 
     public ExprSessionAttribute(@NotNull SessionAttribute sessionAttribute) {
         this.sessionAttribute = sessionAttribute;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprStruct.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprStruct.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -14,9 +15,10 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprStruct extends Expr {
+public final class ExprStruct extends Expr {
     @NotNull
-    public final List<Field> fields;
+    @Getter
+    private final List<Field> fields;
 
     public ExprStruct(@NotNull List<Field> fields) {
         this.fields = fields;
@@ -40,10 +42,12 @@ public class ExprStruct extends Expr {
     @EqualsAndHashCode(callSuper = false)
     public static class Field extends AstNode {
         @NotNull
-        public final Expr name;
+        @Getter
+        private final Expr name;
 
         @NotNull
-        public final Expr value;
+        @Getter
+        private final Expr value;
 
         public Field(@NotNull Expr name, @NotNull Expr value) {
             this.name = name;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprSubstring.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprSubstring.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -15,15 +16,18 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprSubstring extends Expr {
+public final class ExprSubstring extends Expr {
     @NotNull
-    public final Expr value;
+    @Getter
+    private final Expr value;
 
     @Nullable
-    public final Expr start;
+    @Getter
+    private final Expr start;
 
     @Nullable
-    public final Expr length;
+    @Getter
+    private final Expr length;
 
     public ExprSubstring(@NotNull Expr value, @Nullable Expr start, @Nullable Expr length) {
         this.value = value;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprTrim.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprTrim.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -15,15 +16,18 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprTrim extends Expr {
+public final class ExprTrim extends Expr {
     @NotNull
-    public final Expr value;
+    @Getter
+    private final Expr value;
 
     @Nullable
-    public final Expr chars;
+    @Getter
+    private final Expr chars;
 
     @Nullable
-    public final TrimSpec trimSpec;
+    @Getter
+    private final TrimSpec trimSpec;
 
     public ExprTrim(@NotNull Expr value, @Nullable Expr chars, @Nullable TrimSpec trimSpec) {
         this.value = value;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprValues.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprValues.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -17,7 +18,7 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprValues extends Expr {
+public final class ExprValues extends Expr {
     // TODO: May not be an expr?
     // TODO: Tracking issue for VALUES and subqueries -- https://github.com/partiql/partiql-lang-kotlin/issues/1641.
 
@@ -25,7 +26,8 @@ public class ExprValues extends Expr {
      * TODO
      */
     @NotNull
-    public final List<Expr> rows;
+    @Getter
+    private final List<Expr> rows;
 
     /**
      * TODO

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprVarRef.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprVarRef.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -15,12 +16,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprVarRef extends Expr {
+public final class ExprVarRef extends Expr {
     @NotNull
-    public final IdentifierChain identifierChain;
+    @Getter
+    private final IdentifierChain identifierChain;
 
     @NotNull
-    public final Scope scope;
+    @Getter
+    private final Scope scope;
 
     public ExprVarRef(@NotNull IdentifierChain identifierChain, @NotNull Scope scope) {
         this.identifierChain = identifierChain;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprVariant.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprVariant.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -11,11 +12,14 @@ import java.util.List;
 
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprVariant extends Expr {
+public final class ExprVariant extends Expr {
     @NotNull
-    public final String value;
+    @Getter
+    private final String value;
+
     @NotNull
-    public final String encoding;
+    @Getter
+    private final String encoding;
 
     public ExprVariant(@NotNull String value, @NotNull String encoding) {
         this.value = value;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/ExprWindow.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/ExprWindow.java
@@ -2,6 +2,7 @@ package org.partiql.ast.expr;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -16,21 +17,26 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class ExprWindow extends Expr {
+public final class ExprWindow extends Expr {
     @NotNull
-    public final WindowFunction windowFunction;
+    @Getter
+    private final WindowFunction windowFunction;
 
     @NotNull
-    public final Expr expression;
+    @Getter
+    private final Expr expression;
 
     @Nullable
-    public final Expr offset;
+    @Getter
+    private final Expr offset;
 
     @Nullable
-    public final Expr defaultValue;
+    @Getter
+    private final Expr defaultValue;
 
     @NotNull
-    public final Over over;
+    @Getter
+    private final Over over;
 
     public ExprWindow(@NotNull WindowFunction windowFunction, @NotNull Expr expression, @Nullable Expr offset, @Nullable Expr defaultValue, @NotNull Over over) {
         this.windowFunction = windowFunction;
@@ -68,11 +74,13 @@ public class ExprWindow extends Expr {
     public static class Over extends AstNode {
         // Empty list represents no `PARTITION BY` specifications
         @NotNull
-        public final List<Expr> partitions;
+        @Getter
+        private final List<Expr> partitions;
 
         // Empty list represents no `ORDER BY` specifications
         @NotNull
-        public final List<Sort> sorts;
+        @Getter
+        private final List<Sort> sorts;
 
         public Over(@NotNull List<Expr> partitions, @NotNull List<Sort> sorts) {
         this.partitions = partitions;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/PathStep.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/PathStep.java
@@ -1,6 +1,7 @@
 package org.partiql.ast.expr;
 
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -15,7 +16,8 @@ import java.util.List;
  */
 public abstract class PathStep extends AstNode {
     @Nullable
-    public final PathStep next;
+    @Getter
+    protected final PathStep next;
 
     protected PathStep(@Nullable PathStep _next) {
         this.next = _next;
@@ -27,7 +29,8 @@ public abstract class PathStep extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Field extends PathStep {
         @NotNull
-        public final Identifier field;
+        @Getter
+        private final Identifier field;
 
         public Field(@NotNull Identifier field, @Nullable PathStep next) {
             super(next);
@@ -56,7 +59,8 @@ public abstract class PathStep extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Element extends PathStep {
         @NotNull
-        public final Expr element;
+        @Getter
+        private final Expr element;
 
         public Element(@NotNull Expr element, @Nullable PathStep next) {
             super(next);

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/PathStep.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/PathStep.java
@@ -17,7 +17,7 @@ import java.util.List;
 public abstract class PathStep extends AstNode {
     @Nullable
     @Getter
-    protected final PathStep next;
+    private final PathStep next;
 
     protected PathStep(@Nullable PathStep _next) {
         this.next = _next;
@@ -41,6 +41,7 @@ public abstract class PathStep extends AstNode {
         @NotNull
         public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
+            PathStep next = getNext();
             if (next != null) {
                 kids.add(next);
             }
@@ -72,6 +73,7 @@ public abstract class PathStep extends AstNode {
         public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
             kids.add(element);
+            PathStep next = getNext();
             if (next != null) {
                 kids.add(next);
             }
@@ -97,6 +99,7 @@ public abstract class PathStep extends AstNode {
         @NotNull
         public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
+            PathStep next = getNext();
             if (next != null) {
                 kids.add(next);
             }
@@ -122,6 +125,7 @@ public abstract class PathStep extends AstNode {
         @NotNull
         public List<AstNode> getChildren() {
             List<AstNode> kids = new ArrayList<>();
+            PathStep next = getNext();
             if (next != null) {
                 kids.add(next);
             }

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/Scope.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/Scope.java
@@ -13,7 +13,7 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class Scope extends AstEnum {
+public final class Scope extends AstEnum {
     public static final int DEFAULT = 0;
     public static final int LOCAL = 1;
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/SessionAttribute.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/SessionAttribute.java
@@ -13,7 +13,7 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class SessionAttribute extends AstEnum {
+public final class SessionAttribute extends AstEnum {
     public static final int CURRENT_USER = 0;
     public static final int CURRENT_DATE = 1;
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/TrimSpec.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/TrimSpec.java
@@ -10,7 +10,7 @@ import java.util.Collections;
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
-public class TrimSpec extends AstEnum {
+public final class TrimSpec extends AstEnum {
     public static final int LEADING = 0;
     public static final int TRAILING = 1;
     public static final int BOTH = 2;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/TruthValue.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/TruthValue.java
@@ -12,7 +12,7 @@ import java.util.List;
  * TODO docs
  */
 @EqualsAndHashCode(callSuper = false)
-public class TruthValue extends AstEnum {
+public final class TruthValue extends AstEnum {
     public static final int TRUE = 0;
     public static final int FALSE = 1;
     public static final int UNKNOWN = 2;

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/WindowFunction.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/WindowFunction.java
@@ -13,7 +13,7 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class WindowFunction extends AstEnum {
+public final class WindowFunction extends AstEnum {
     public static final int LAG = 0;
     public static final int LEAD = 1;
 

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphDirection.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphDirection.java
@@ -13,7 +13,7 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class GraphDirection extends AstEnum {
+public final class GraphDirection extends AstEnum {
     public static final int LEFT = 0;
     public static final int UNDIRECTED = 1;
     public static final int RIGHT = 2;

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphLabel.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphLabel.java
@@ -96,11 +96,11 @@ public abstract class GraphLabel extends AstNode {
     public static class Conj extends GraphLabel {
         @NotNull
         @Getter
-        public final GraphLabel lhs;
+        private final GraphLabel lhs;
 
         @NotNull
         @Getter
-        public final GraphLabel rhs;
+        private final GraphLabel rhs;
 
         public Conj(@NotNull GraphLabel lhs, @NotNull GraphLabel rhs) {
             this.lhs = lhs;
@@ -130,11 +130,11 @@ public abstract class GraphLabel extends AstNode {
     public static class Disj extends GraphLabel {
         @NotNull
         @Getter
-        public final GraphLabel lhs;
+        private final GraphLabel lhs;
 
         @NotNull
         @Getter
-        public final GraphLabel rhs;
+        private final GraphLabel rhs;
 
         public Disj(@NotNull GraphLabel lhs, @NotNull GraphLabel rhs) {
             this.lhs = lhs;

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphLabel.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphLabel.java
@@ -2,6 +2,7 @@ package org.partiql.ast.graph;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -20,7 +21,8 @@ public abstract class GraphLabel extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Name extends GraphLabel {
         @NotNull
-        public final String name;
+        @Getter
+        private final String name;
 
         public Name(@NotNull String name) {
             this.name = name;
@@ -65,7 +67,8 @@ public abstract class GraphLabel extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Negation extends GraphLabel {
         @NotNull
-        public final GraphLabel arg;
+        @Getter
+        private final GraphLabel arg;
 
         public Negation(@NotNull GraphLabel arg) {
             this.arg = arg;
@@ -92,9 +95,11 @@ public abstract class GraphLabel extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Conj extends GraphLabel {
         @NotNull
+        @Getter
         public final GraphLabel lhs;
 
         @NotNull
+        @Getter
         public final GraphLabel rhs;
 
         public Conj(@NotNull GraphLabel lhs, @NotNull GraphLabel rhs) {
@@ -124,9 +129,11 @@ public abstract class GraphLabel extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Disj extends GraphLabel {
         @NotNull
+        @Getter
         public final GraphLabel lhs;
 
         @NotNull
+        @Getter
         public final GraphLabel rhs;
 
         public Disj(@NotNull GraphLabel lhs, @NotNull GraphLabel rhs) {

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphMatch.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphMatch.java
@@ -2,6 +2,7 @@ package org.partiql.ast.graph;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -15,12 +16,14 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class GraphMatch extends AstNode {
+public final class GraphMatch extends AstNode {
     @NotNull
-    public final List<GraphPattern> patterns;
+    @Getter
+    private final List<GraphPattern> patterns;
 
     @Nullable
-    public final GraphSelector selector;
+    @Getter
+    private final GraphSelector selector;
 
     public GraphMatch(@NotNull List<GraphPattern> patterns, @Nullable GraphSelector selector) {
         this.patterns = patterns;

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphPart.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphPart.java
@@ -2,6 +2,7 @@ package org.partiql.ast.graph;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -22,13 +23,16 @@ public abstract class GraphPart extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Node extends GraphPart {
         @Nullable
-        public final Expr prefilter;
+        @Getter
+        private final Expr prefilter;
 
         @Nullable
-        public final String variable;
+        @Getter
+        private final String variable;
 
         @Nullable
-        public final GraphLabel label;
+        @Getter
+        private final GraphLabel label;
 
         public Node(@Nullable Expr prefilter, @Nullable String variable, @Nullable GraphLabel label) {
             this.prefilter = prefilter;
@@ -62,19 +66,24 @@ public abstract class GraphPart extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Edge extends GraphPart {
         @NotNull
-        public final GraphDirection direction;
+        @Getter
+        private final GraphDirection direction;
 
         @Nullable
-        public final GraphQuantifier quantifier;
+        @Getter
+        private final GraphQuantifier quantifier;
 
         @Nullable
-        public final Expr prefilter;
+        @Getter
+        private final Expr prefilter;
 
         @Nullable
-        public final String variable;
+        @Getter
+        private final String variable;
 
         @Nullable
-        public final GraphLabel label;
+        @Getter
+        private final GraphLabel label;
 
         public Edge(@NotNull GraphDirection direction, @Nullable GraphQuantifier quantifier,
         @Nullable Expr prefilter, @Nullable String variable, @Nullable GraphLabel label) {
@@ -114,7 +123,8 @@ public abstract class GraphPart extends AstNode {
     @EqualsAndHashCode(callSuper = false)
     public static class Pattern extends GraphPart {
         @NotNull
-        public final GraphPattern pattern;
+        @Getter
+        private final GraphPattern pattern;
 
         public Pattern(@NotNull GraphPattern pattern) {
             this.pattern = pattern;

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphPattern.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphPattern.java
@@ -16,7 +16,7 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class GraphPattern extends AstNode {
+public final class GraphPattern extends AstNode {
     @Nullable
     public final GraphRestrictor restrictor;
 

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphPattern.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphPattern.java
@@ -2,6 +2,7 @@ package org.partiql.ast.graph;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -18,19 +19,24 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = false)
 public final class GraphPattern extends AstNode {
     @Nullable
-    public final GraphRestrictor restrictor;
+    @Getter
+    private final GraphRestrictor restrictor;
 
     @Nullable
-    public final Expr prefilter;
+    @Getter
+    private final Expr prefilter;
 
     @Nullable
-    public final String variable;
+    @Getter
+    private final String variable;
 
     @Nullable
-    public final GraphQuantifier quantifier;
+    @Getter
+    private final GraphQuantifier quantifier;
 
     @NotNull
-    public final List<GraphPart> parts;
+    @Getter
+    private final List<GraphPart> parts;
 
     public GraphPattern(@Nullable GraphRestrictor restrictor, @Nullable Expr prefilter,
                         @Nullable String variable, @Nullable GraphQuantifier quantifier,

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphQuantifier.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphQuantifier.java
@@ -2,6 +2,7 @@ package org.partiql.ast.graph;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
@@ -15,11 +16,13 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public class GraphQuantifier extends AstNode {
-    public final long lower;
+public final class GraphQuantifier extends AstNode {
+    @Getter
+    private final long lower;
 
     @Nullable
-    public final Long upper;
+    @Getter
+    private final Long upper;
 
     public GraphQuantifier(long lower, @Nullable Long upper) {
         this.lower = lower;

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphRestrictor.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphRestrictor.java
@@ -13,7 +13,7 @@ import java.util.List;
  * TODO docs, equals, hashcode
  */
 @EqualsAndHashCode(callSuper = false)
-public class GraphRestrictor extends AstEnum {
+public final class GraphRestrictor extends AstEnum {
     public static final int TRAIL = 0;
     public static final int ACYCLIC = 1;
     public static final int SIMPLE = 2;

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphSelector.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphSelector.java
@@ -2,6 +2,7 @@ package org.partiql.ast.graph;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
@@ -79,7 +80,8 @@ public abstract class GraphSelector extends AstNode {
     @Builder(builderClassName = "Builder")
     @EqualsAndHashCode(callSuper = false)
     public static class AnyK extends GraphSelector {
-        public final long k;
+        @Getter
+        private final long k;
 
         public AnyK(long k) {
             this.k = k;

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphSelector.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphSelector.java
@@ -105,7 +105,8 @@ public abstract class GraphSelector extends AstNode {
     @Builder(builderClassName = "Builder")
     @EqualsAndHashCode(callSuper = false)
     public static class ShortestK extends GraphSelector {
-        public final long k;
+        @Getter
+        private final long k;
 
         public ShortestK(long k) {
             this.k = k;
@@ -129,7 +130,8 @@ public abstract class GraphSelector extends AstNode {
     @Builder(builderClassName = "Builder")
     @EqualsAndHashCode(callSuper = false)
     public static class ShortestKGroup extends GraphSelector {
-        public final long k;
+        @Getter
+        private final long k;
 
         public ShortestKGroup(long k) {
             this.k = k;

--- a/partiql-ast/src/main/java/org/partiql/ast/sql/SqlDialect.kt
+++ b/partiql-ast/src/main/java/org/partiql/ast/sql/SqlDialect.kt
@@ -48,7 +48,7 @@ import org.partiql.ast.SetOp
 import org.partiql.ast.SetOpType
 import org.partiql.ast.SetQuantifier
 import org.partiql.ast.Sort
-import org.partiql.ast.ddl.Ddl
+import org.partiql.ast.ddl.CreateTable
 import org.partiql.ast.dml.Delete
 import org.partiql.ast.dml.Insert
 import org.partiql.ast.dml.Replace
@@ -822,8 +822,8 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
     }
 
     // TODO: DDL
-    override fun visitDdl(node: Ddl, ctx: SqlBlock): SqlBlock {
-        throw UnsupportedOperationException("DDL has not been supported yet in SqlDialect")
+    override fun visitCreateTable(node: CreateTable, ctx: SqlBlock): SqlBlock {
+        throw UnsupportedOperationException("CREATE TABLE has not been supported yet in SqlDialect")
     }
 
     override fun visitInsert(node: Insert?, ctx: SqlBlock?): SqlBlock {

--- a/partiql-ast/src/main/java/org/partiql/ast/sql/SqlDialect.kt
+++ b/partiql-ast/src/main/java/org/partiql/ast/sql/SqlDialect.kt
@@ -396,7 +396,7 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
     override fun visitExprLike(node: ExprLike, tail: SqlBlock): SqlBlock {
         var t = tail
         t = visitExprWrapped(node.value, t)
-        t = t concat if (node.not) " NOT LIKE " else " LIKE "
+        t = t concat if (node.isNot) " NOT LIKE " else " LIKE "
         t = visitExprWrapped(node.pattern, t)
         val escape = node.escape
         if (escape != null) {
@@ -409,7 +409,7 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
     override fun visitExprBetween(node: ExprBetween, tail: SqlBlock): SqlBlock {
         var t = tail
         t = visitExprWrapped(node.value, t)
-        t = t concat if (node.not) " NOT BETWEEN " else " BETWEEN "
+        t = t concat if (node.isNot) " NOT BETWEEN " else " BETWEEN "
         t = visitExprWrapped(node.from, t)
         t = t concat " AND "
         t = visitExprWrapped(node.to, t)
@@ -419,7 +419,7 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
     override fun visitExprInCollection(node: ExprInCollection, tail: SqlBlock): SqlBlock {
         var t = tail
         t = visitExprWrapped(node.lhs, t)
-        t = t concat if (node.not) " NOT IN " else " IN "
+        t = t concat if (node.isNot) " NOT IN " else " IN "
         t = visitExprWrapped(node.rhs, t)
         return t
     }
@@ -427,21 +427,21 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
     override fun visitExprNullPredicate(node: ExprNullPredicate, tail: SqlBlock): SqlBlock {
         var t = tail
         t = visitExprWrapped(node.value, t)
-        t = t concat if (node.not) " IS NOT NULL" else " IS NULL"
+        t = t concat if (node.isNot) " IS NOT NULL" else " IS NULL"
         return t
     }
 
     override fun visitExprMissingPredicate(node: ExprMissingPredicate, tail: SqlBlock): SqlBlock {
         var t = tail
         t = visitExprWrapped(node.value, t)
-        t = t concat if (node.not) " IS NOT MISSING" else " IS MISSING"
+        t = t concat if (node.isNot) " IS NOT MISSING" else " IS MISSING"
         return t
     }
 
     override fun visitExprBoolTest(node: ExprBoolTest, tail: SqlBlock): SqlBlock {
         var t = tail
         t = visitExprWrapped(node.value, t)
-        t = t concat if (node.not) " IS NOT " else " IS "
+        t = t concat if (node.isNot) " IS NOT " else " IS "
         t = t concat when (node.truthValue.code()) {
             TruthValue.TRUE -> "TRUE"
             TruthValue.FALSE -> "FALSE"
@@ -454,7 +454,7 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
     override fun visitExprIsType(node: ExprIsType, tail: SqlBlock): SqlBlock {
         var t = tail
         t = visitExprWrapped(node.value, t)
-        t = t concat if (node.not) " IS NOT " else " IS "
+        t = t concat if (node.isNot) " IS NOT " else " IS "
         t = visitDataType(node.type, t)
         return t
     }
@@ -631,7 +631,7 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
 
     override fun visitQueryBodySetOp(node: QueryBody.SetOp, tail: SqlBlock): SqlBlock {
         val op = mutableListOf<String>()
-        when (node.outer) {
+        when (node.isOuter) {
             true -> op.add("OUTER")
             else -> {}
         }
@@ -894,7 +894,7 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
         )
     }
 
-    private fun Identifier.sql() = when (delimited) {
+    private fun Identifier.sql() = when (isDelimited) {
         true -> "\"$symbol\""
         false -> symbol // verbatim ..
     }

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/AstRewriter.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/AstRewriter.kt
@@ -4,7 +4,7 @@ import org.partiql.ast.Ast.explain
 import org.partiql.ast.Ast.exprQuerySet
 import org.partiql.ast.Ast.identifier
 import org.partiql.ast.Ast.query
-import org.partiql.ast.ddl.Ddl
+import org.partiql.ast.ddl.CreateTable
 import org.partiql.ast.dml.ConflictAction
 import org.partiql.ast.dml.ConflictTarget
 import org.partiql.ast.dml.Delete
@@ -802,8 +802,8 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
     }
 
     // TODO: DDL
-    override fun visitDdl(node: Ddl, ctx: C): AstNode {
-        throw UnsupportedOperationException("DDL has not been supported yet in AstRewriter")
+    override fun visitCreateTable(node: CreateTable?, ctx: C): AstNode {
+        throw UnsupportedOperationException("CREATE TABLE has not been supported yet in AstRewriter")
     }
 
     override fun visitInsert(node: Insert, ctx: C): AstNode {

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/AstRewriter.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/AstRewriter.kt
@@ -114,8 +114,8 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
         val value = visitExpr(node.value, ctx) as Expr
         val from = visitExpr(node.from, ctx) as Expr
         val to = visitExpr(node.to, ctx) as Expr
-        val not = node.not
-        return if (value !== node.value || from !== node.from || to !== node.to || not != node.not) {
+        val not = node.isNot
+        return if (value !== node.value || from !== node.from || to !== node.to || not != node.isNot) {
             ExprBetween(value, from, to, not)
         } else {
             node
@@ -186,8 +186,8 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
     override fun visitExprInCollection(node: ExprInCollection, ctx: C): AstNode {
         val lhs = visitExpr(node.lhs, ctx) as Expr
         val rhs = visitExpr(node.rhs, ctx) as Expr
-        val not = node.not
-        return if (lhs !== node.lhs || rhs !== node.rhs || not != node.not) {
+        val not = node.isNot
+        return if (lhs !== node.lhs || rhs !== node.rhs || not != node.isNot) {
             ExprInCollection(lhs, rhs, not)
         } else {
             node
@@ -196,8 +196,8 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
 
     override fun visitExprMissingPredicate(node: ExprMissingPredicate, ctx: C): AstNode {
         val value = visitExpr(node.value, ctx) as Expr
-        val not = node.not
-        return if (value !== node.value || not != node.not) {
+        val not = node.isNot
+        return if (value !== node.value || not != node.isNot) {
             ExprMissingPredicate(value, not)
         } else {
             node
@@ -206,8 +206,8 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
 
     override fun visitExprNullPredicate(node: ExprNullPredicate, ctx: C): AstNode {
         val value = visitExpr(node.value, ctx) as Expr
-        val not = node.not
-        return if (value !== node.value || not != node.not) {
+        val not = node.isNot
+        return if (value !== node.value || not != node.isNot) {
             ExprNullPredicate(value, not)
         } else {
             node
@@ -216,9 +216,9 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
 
     override fun visitExprBoolTest(node: ExprBoolTest, ctx: C): AstNode {
         val value = visitExpr(node.value, ctx) as Expr
-        val not = node.not
+        val not = node.isNot
         val truthValue = node.truthValue
-        return if (value !== node.value || not != node.not || truthValue != node.truthValue) {
+        return if (value !== node.value || not != node.isNot || truthValue != node.truthValue) {
             ExprBoolTest(value, not, truthValue)
         } else {
             node
@@ -228,8 +228,8 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
     override fun visitExprIsType(node: ExprIsType, ctx: C): AstNode {
         val value = visitExpr(node.value, ctx) as Expr
         val type = node.type
-        val not = node.not
-        return if (value !== node.value || type !== node.type || not != node.not) {
+        val not = node.isNot
+        return if (value !== node.value || type !== node.type || not != node.isNot) {
             ExprIsType(value, type, not)
         } else {
             node
@@ -240,8 +240,8 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
         val value = visitExpr(node.value, ctx) as Expr
         val pattern = visitExpr(node.pattern, ctx) as Expr
         val escape = node.escape?.let { visitExpr(it, ctx) as Expr? }
-        val not = node.not
-        return if (value !== node.value || pattern !== node.pattern || escape !== node.escape || not != node.not) {
+        val not = node.isNot
+        return if (value !== node.value || pattern !== node.pattern || escape !== node.escape || not != node.isNot) {
             ExprLike(value, pattern, escape, not)
         } else {
             node
@@ -670,7 +670,7 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
 
     override fun visitIdentifier(node: Identifier, ctx: C): AstNode {
         val symbol = node.symbol
-        val isDelimited = node.delimited
+        val isDelimited = node.isDelimited
         return identifier(symbol, isDelimited)
     }
 
@@ -731,10 +731,10 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
 
     public override fun visitQueryBodySetOp(node: QueryBody.SetOp, ctx: C): AstNode {
         val type = visitSetOp(node.type, ctx) as SetOp
-        val isOuter = node.outer
+        val isOuter = node.isOuter
         val lhs = visitExpr(node.lhs, ctx) as Expr
         val rhs = visitExpr(node.rhs, ctx) as Expr
-        return if (type !== node.type || isOuter != node.outer || lhs !== node.lhs || rhs !== node.rhs) {
+        return if (type !== node.type || isOuter != node.isOuter || lhs !== node.lhs || rhs !== node.rhs) {
             QueryBody.SetOp(type, isOuter, lhs, rhs)
         } else {
             node

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/AstRewriter.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/AstRewriter.kt
@@ -218,7 +218,7 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
         val value = visitExpr(node.value, ctx) as Expr
         val not = node.not
         val truthValue = node.truthValue
-        return if (value !== node.value || not != node.not || truthValue != node.value) {
+        return if (value !== node.value || not != node.not || truthValue != node.truthValue) {
             ExprBoolTest(value, not, truthValue)
         } else {
             node
@@ -670,7 +670,7 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
 
     override fun visitIdentifier(node: Identifier, ctx: C): AstNode {
         val symbol = node.symbol
-        val isDelimited = node.isDelimited
+        val isDelimited = node.delimited
         return identifier(symbol, isDelimited)
     }
 
@@ -731,10 +731,10 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
 
     public override fun visitQueryBodySetOp(node: QueryBody.SetOp, ctx: C): AstNode {
         val type = visitSetOp(node.type, ctx) as SetOp
-        val isOuter = node.isOuter
+        val isOuter = node.outer
         val lhs = visitExpr(node.lhs, ctx) as Expr
         val rhs = visitExpr(node.rhs, ctx) as Expr
-        return if (type !== node.type || isOuter != node.isOuter || lhs !== node.lhs || rhs !== node.rhs) {
+        return if (type !== node.type || isOuter != node.outer || lhs !== node.lhs || rhs !== node.rhs) {
             QueryBody.SetOp(type, isOuter, lhs, rhs)
         } else {
             node

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -644,8 +644,8 @@ internal class PartiQLParserDefault : PartiQLParser {
             val constrName = ctx.constraintName()?.let { visitQualifiedName(it.qualifiedName()) }
             val body = visitAs<AttributeConstraint>(ctx.columnConstraint())
             when (body) {
-                is AttributeConstraint.Unique -> columnConstraintUnique(constrName, body.isPrimaryKey)
-                is AttributeConstraint.Null -> columnConstraintNullable(constrName, body.isNullable)
+                is AttributeConstraint.Unique -> columnConstraintUnique(constrName, body.primaryKey)
+                is AttributeConstraint.Null -> columnConstraintNullable(constrName, body.nullable)
                 is AttributeConstraint.Check -> columnConstraintCheck(constrName, body.searchCondition)
                 else -> throw error(ctx, "Unexpected Table Constraint Definition")
             }
@@ -676,7 +676,7 @@ internal class PartiQLParserDefault : PartiQLParser {
             val constraintName = ctx.constraintName()?.let { visitQualifiedName(it.qualifiedName()) }
             val body = visitAs<TableConstraint>(ctx.tableConstraint())
             when (body) {
-                is TableConstraint.Unique -> tableConstraintUnique(constraintName, body.columns, body.isPrimaryKey)
+                is TableConstraint.Unique -> tableConstraintUnique(constraintName, body.columns, body.primaryKey)
                 else -> throw error(ctx, "Unexpected Table Constraint Definition")
             }
         }

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -644,8 +644,8 @@ internal class PartiQLParserDefault : PartiQLParser {
             val constrName = ctx.constraintName()?.let { visitQualifiedName(it.qualifiedName()) }
             val body = visitAs<AttributeConstraint>(ctx.columnConstraint())
             when (body) {
-                is AttributeConstraint.Unique -> columnConstraintUnique(constrName, body.primaryKey)
-                is AttributeConstraint.Null -> columnConstraintNullable(constrName, body.nullable)
+                is AttributeConstraint.Unique -> columnConstraintUnique(constrName, body.isPrimaryKey)
+                is AttributeConstraint.Null -> columnConstraintNullable(constrName, body.isNullable)
                 is AttributeConstraint.Check -> columnConstraintCheck(constrName, body.searchCondition)
                 else -> throw error(ctx, "Unexpected Table Constraint Definition")
             }
@@ -676,7 +676,7 @@ internal class PartiQLParserDefault : PartiQLParser {
             val constraintName = ctx.constraintName()?.let { visitQualifiedName(it.qualifiedName()) }
             val body = visitAs<TableConstraint>(ctx.tableConstraint())
             when (body) {
-                is TableConstraint.Unique -> tableConstraintUnique(constraintName, body.columns, body.primaryKey)
+                is TableConstraint.Unique -> tableConstraintUnique(constraintName, body.columns, body.isPrimaryKey)
                 else -> throw error(ctx, "Unexpected Table Constraint Definition")
             }
         }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/AstToPlan.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/AstToPlan.kt
@@ -68,7 +68,7 @@ internal object AstToPlan {
         return Identifier.of(part(identifier))
     }
 
-    fun part(identifier: AstIdentifier): Identifier.Part = when (identifier.delimited) {
+    fun part(identifier: AstIdentifier): Identifier.Part = when (identifier.isDelimited) {
         true -> Identifier.Part.delimited(identifier.symbol)
         false -> Identifier.Part.regular(identifier.symbol)
     }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/AstToPlan.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/AstToPlan.kt
@@ -68,7 +68,7 @@ internal object AstToPlan {
         return Identifier.of(part(identifier))
     }
 
-    fun part(identifier: AstIdentifier): Identifier.Part = when (identifier.isDelimited) {
+    fun part(identifier: AstIdentifier): Identifier.Part = when (identifier.delimited) {
         true -> Identifier.Part.delimited(identifier.symbol)
         false -> Identifier.Part.regular(identifier.symbol)
     }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/NormalizeSelect.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/NormalizeSelect.kt
@@ -128,7 +128,7 @@ internal object NormalizeSelect {
                 exprQuerySet(
                     body = queryBodySetOp(
                         type = body.type,
-                        isOuter = body.outer,
+                        isOuter = body.isOuter,
                         lhs = lhs,
                         rhs = rhs
                     ),

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/NormalizeSelect.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/NormalizeSelect.kt
@@ -128,7 +128,7 @@ internal object NormalizeSelect {
                 exprQuerySet(
                     body = queryBodySetOp(
                         type = body.type,
-                        isOuter = body.isOuter,
+                        isOuter = body.outer,
                         lhs = lhs,
                         rhs = rhs
                     ),

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
@@ -532,7 +532,7 @@ internal object RelConverter {
                 null, SetQuantifier.DISTINCT -> org.partiql.planner.internal.ir.SetQuantifier.DISTINCT
                 else -> error("Unexpected SetQuantifier type: ${setExpr.type.setq}")
             }
-            val outer = setExpr.isOuter
+            val outer = setExpr.outer
             val op = when (setExpr.type.setOpType.code()) {
                 SetOpType.UNION -> Rel.Op.Union(quantifier, outer, lhs, rhs)
                 SetOpType.EXCEPT -> Rel.Op.Except(quantifier, outer, lhs, rhs)
@@ -630,7 +630,7 @@ internal object RelConverter {
         private fun stepToExcludeType(step: ExcludeStep): Rel.Op.Exclude.Type {
             return when (step) {
                 is ExcludeStep.StructField -> {
-                    when (step.symbol.isDelimited) {
+                    when (step.symbol.delimited) {
                         false -> relOpExcludeTypeStructSymbol(step.symbol.symbol)
                         true -> relOpExcludeTypeStructKey(step.symbol.symbol)
                     }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
@@ -532,7 +532,7 @@ internal object RelConverter {
                 null, SetQuantifier.DISTINCT -> org.partiql.planner.internal.ir.SetQuantifier.DISTINCT
                 else -> error("Unexpected SetQuantifier type: ${setExpr.type.setq}")
             }
-            val outer = setExpr.outer
+            val outer = setExpr.isOuter
             val op = when (setExpr.type.setOpType.code()) {
                 SetOpType.UNION -> Rel.Op.Union(quantifier, outer, lhs, rhs)
                 SetOpType.EXCEPT -> Rel.Op.Except(quantifier, outer, lhs, rhs)
@@ -630,7 +630,7 @@ internal object RelConverter {
         private fun stepToExcludeType(step: ExcludeStep): Rel.Op.Exclude.Type {
             return when (step) {
                 is ExcludeStep.StructField -> {
-                    when (step.symbol.delimited) {
+                    when (step.symbol.isDelimited) {
                         false -> relOpExcludeTypeStructSymbol(step.symbol.symbol)
                         true -> relOpExcludeTypeStructKey(step.symbol.symbol)
                     }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
@@ -409,7 +409,7 @@ internal object RexConverter {
             // > IF NOT is specified in a <boolean test>, then let BP be the contained <boolean primary> and let
             // > TV be the contained <truth value>. The <boolean test> is equivalent to:
             // >   ( NOT ( BP IS TV ) )
-            if (node.not) {
+            if (node.isNot) {
                 call = negate(call)
             }
             return rex(BOOL, call)
@@ -519,7 +519,7 @@ internal object RexConverter {
                     }
 
                     is PathStep.Field -> {
-                        when (curStep.field.delimited) {
+                        when (curStep.field.isDelimited) {
                             true -> {
                                 // case-sensitive path step becomes a key lookup
                                 rexOpPathKey(curPathNavi, rexString(curStep.field.symbol))
@@ -806,7 +806,7 @@ internal object RexConverter {
                 else -> call("like_escape", arg0, arg1, arg2)
             }
             // NOT?
-            if (node.not) {
+            if (node.isNot) {
                 call = negate(call)
             }
             return rex(type, call)
@@ -824,7 +824,7 @@ internal object RexConverter {
             // Call
             var call = call("between", arg0, arg1, arg2)
             // NOT?
-            if (node.not) {
+            if (node.isNot) {
                 call = negate(call)
             }
             rex(type, call)
@@ -851,7 +851,7 @@ internal object RexConverter {
             // Call
             var call = call("in_collection", arg0, arg1)
             // NOT?
-            if (node.not) {
+            if (node.isNot) {
                 call = negate(call)
             }
             return rex(type, call)
@@ -863,7 +863,7 @@ internal object RexConverter {
         override fun visitExprNullPredicate(node: ExprNullPredicate, ctx: Env): Rex {
             val value = visitExprCoerce(node.value, ctx)
             var call = call("is_null", value)
-            if (node.not) {
+            if (node.isNot) {
                 call = negate(call)
             }
             return rex(BOOL, call)
@@ -875,7 +875,7 @@ internal object RexConverter {
         override fun visitExprMissingPredicate(node: ExprMissingPredicate, ctx: Env): Rex {
             val value = visitExprCoerce(node.value, ctx)
             var call = call("is_missing", value)
-            if (node.not) {
+            if (node.isNot) {
                 call = negate(call)
             }
             return rex(BOOL, call)
@@ -938,7 +938,7 @@ internal object RexConverter {
                 else -> error("Unexpected DataType type: $targetType")
             }
 
-            if (node.not) {
+            if (node.isNot) {
                 call = negate(call)
             }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
@@ -519,7 +519,7 @@ internal object RexConverter {
                     }
 
                     is PathStep.Field -> {
-                        when (curStep.field.isDelimited) {
+                        when (curStep.field.delimited) {
                             true -> {
                                 // case-sensitive path step becomes a key lookup
                                 rexOpPathKey(curPathNavi, rexString(curStep.field.symbol))


### PR DESCRIPTION
## Relevant Issues
- https://github.com/partiql/partiql-lang-kotlin/issues/1610

## Description
- Makes the public AST fields private and adds Lombok getters
- Makes existing concrete classes final

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - No, v1 release not out yet.

- Any backward-incompatible changes? **[YES]**
  - Yes, but v1 release not out yet.

- Any new external dependencies? **[YES]**
  - Yes, Kotlin lombok plugin to allow for using Java lombok annotations from Kotlin (required for AstRewriter and SqlDialect)

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.