### PR TITLE
[v1] Remove UNKNOWN AST enum variant

### DIFF
--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -2816,11 +2816,11 @@ public class org/partiql/ast/expr/TrimSpec : org/partiql/ast/AstEnum {
 public class org/partiql/ast/expr/TruthValue : org/partiql/ast/AstEnum {
 	public static final field FALSE I
 	public static final field TRUE I
-	public static final field UNK I
+	public static final field UNKNOWN I
 	public fun <init> (I)V
 	public static fun FALSE ()Lorg/partiql/ast/expr/TruthValue;
 	public static fun TRUE ()Lorg/partiql/ast/expr/TruthValue;
-	public static fun UNK ()Lorg/partiql/ast/expr/TruthValue;
+	public static fun UNKNOWN ()Lorg/partiql/ast/expr/TruthValue;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I

--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -632,7 +632,6 @@ public class org/partiql/ast/DataType : org/partiql/ast/AstEnum {
 	public static final field TIME_WITH_TIME_ZONE I
 	public static final field TINYINT I
 	public static final field TUPLE I
-	public static final field UNKNOWN I
 	public static final field USER_DEFINED I
 	public static final field VARCHAR I
 	public static fun ARRAY ()Lorg/partiql/ast/DataType;
@@ -704,7 +703,6 @@ public class org/partiql/ast/DataType : org/partiql/ast/AstEnum {
 	public static fun TIME_WITH_TIME_ZONE (I)Lorg/partiql/ast/DataType;
 	public static fun TINYINT ()Lorg/partiql/ast/DataType;
 	public static fun TUPLE ()Lorg/partiql/ast/DataType;
-	public static fun UNKNOWN ()Lorg/partiql/ast/DataType;
 	public static fun USER_DEFINED ()Lorg/partiql/ast/DataType;
 	public static fun USER_DEFINED (Lorg/partiql/ast/IdentifierChain;)Lorg/partiql/ast/DataType;
 	public static fun VARCHAR ()Lorg/partiql/ast/DataType;
@@ -748,7 +746,6 @@ public class org/partiql/ast/DatetimeField : org/partiql/ast/AstEnum {
 	public static final field SECOND I
 	public static final field TIMEZONE_HOUR I
 	public static final field TIMEZONE_MINUTE I
-	public static final field UNKNOWN I
 	public static final field YEAR I
 	public static fun DAY ()Lorg/partiql/ast/DatetimeField;
 	public static fun HOUR ()Lorg/partiql/ast/DatetimeField;
@@ -757,7 +754,6 @@ public class org/partiql/ast/DatetimeField : org/partiql/ast/AstEnum {
 	public static fun SECOND ()Lorg/partiql/ast/DatetimeField;
 	public static fun TIMEZONE_HOUR ()Lorg/partiql/ast/DatetimeField;
 	public static fun TIMEZONE_MINUTE ()Lorg/partiql/ast/DatetimeField;
-	public static fun UNKNOWN ()Lorg/partiql/ast/DatetimeField;
 	public static fun YEAR ()Lorg/partiql/ast/DatetimeField;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
@@ -962,10 +958,8 @@ public abstract class org/partiql/ast/FromTableRef : org/partiql/ast/AstNode {
 
 public class org/partiql/ast/FromType : org/partiql/ast/AstEnum {
 	public static final field SCAN I
-	public static final field UNKNOWN I
 	public static final field UNPIVOT I
 	public static fun SCAN ()Lorg/partiql/ast/FromType;
-	public static fun UNKNOWN ()Lorg/partiql/ast/FromType;
 	public static fun UNPIVOT ()Lorg/partiql/ast/FromType;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
@@ -1021,10 +1015,8 @@ public class org/partiql/ast/GroupBy$Key$Builder {
 public class org/partiql/ast/GroupByStrategy : org/partiql/ast/AstEnum {
 	public static final field FULL I
 	public static final field PARTIAL I
-	public static final field UNKNOWN I
 	public static fun FULL ()Lorg/partiql/ast/GroupByStrategy;
 	public static fun PARTIAL ()Lorg/partiql/ast/GroupByStrategy;
-	public static fun UNKNOWN ()Lorg/partiql/ast/GroupByStrategy;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
@@ -1084,7 +1076,6 @@ public class org/partiql/ast/JoinType : org/partiql/ast/AstEnum {
 	public static final field LEFT_OUTER I
 	public static final field RIGHT I
 	public static final field RIGHT_OUTER I
-	public static final field UNKNOWN I
 	public static fun CROSS ()Lorg/partiql/ast/JoinType;
 	public static fun FULL ()Lorg/partiql/ast/JoinType;
 	public static fun FULL_OUTER ()Lorg/partiql/ast/JoinType;
@@ -1094,7 +1085,6 @@ public class org/partiql/ast/JoinType : org/partiql/ast/AstEnum {
 	public static fun LEFT_OUTER ()Lorg/partiql/ast/JoinType;
 	public static fun RIGHT ()Lorg/partiql/ast/JoinType;
 	public static fun RIGHT_OUTER ()Lorg/partiql/ast/JoinType;
-	public static fun UNKNOWN ()Lorg/partiql/ast/JoinType;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
@@ -1151,7 +1141,6 @@ public class org/partiql/ast/Literal : org/partiql/ast/AstEnum {
 	public static final field NULL I
 	public static final field STRING I
 	public static final field TYPED_STRING I
-	public static final field UNKNOWN I
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun approxNum (Ljava/lang/String;)Lorg/partiql/ast/Literal;
 	public fun bigDecimalValue ()Ljava/math/BigDecimal;
@@ -1181,10 +1170,8 @@ public class org/partiql/ast/Literal : org/partiql/ast/AstEnum {
 public class org/partiql/ast/Nulls : org/partiql/ast/AstEnum {
 	public static final field FIRST I
 	public static final field LAST I
-	public static final field UNKNOWN I
 	public static fun FIRST ()Lorg/partiql/ast/Nulls;
 	public static fun LAST ()Lorg/partiql/ast/Nulls;
-	public static fun UNKNOWN ()Lorg/partiql/ast/Nulls;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
@@ -1199,10 +1186,8 @@ public class org/partiql/ast/Nulls : org/partiql/ast/AstEnum {
 public class org/partiql/ast/Order : org/partiql/ast/AstEnum {
 	public static final field ASC I
 	public static final field DESC I
-	public static final field UNKNOWN I
 	public static fun ASC ()Lorg/partiql/ast/Order;
 	public static fun DESC ()Lorg/partiql/ast/Order;
-	public static fun UNKNOWN ()Lorg/partiql/ast/Order;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
@@ -1445,11 +1430,9 @@ public class org/partiql/ast/SetOpType : org/partiql/ast/AstEnum {
 	public static final field EXCEPT I
 	public static final field INTERSECT I
 	public static final field UNION I
-	public static final field UNKNOWN I
 	public static fun EXCEPT ()Lorg/partiql/ast/SetOpType;
 	public static fun INTERSECT ()Lorg/partiql/ast/SetOpType;
 	public static fun UNION ()Lorg/partiql/ast/SetOpType;
-	public static fun UNKNOWN ()Lorg/partiql/ast/SetOpType;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
@@ -1464,10 +1447,8 @@ public class org/partiql/ast/SetOpType : org/partiql/ast/AstEnum {
 public class org/partiql/ast/SetQuantifier : org/partiql/ast/AstEnum {
 	public static final field ALL I
 	public static final field DISTINCT I
-	public static final field UNKNOWN I
 	public static fun ALL ()Lorg/partiql/ast/SetQuantifier;
 	public static fun DISTINCT ()Lorg/partiql/ast/SetQuantifier;
-	public static fun UNKNOWN ()Lorg/partiql/ast/SetQuantifier;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
@@ -2784,10 +2765,8 @@ public class org/partiql/ast/expr/PathStep$Field : org/partiql/ast/expr/PathStep
 public class org/partiql/ast/expr/Scope : org/partiql/ast/AstEnum {
 	public static final field DEFAULT I
 	public static final field LOCAL I
-	public static final field UNKNOWN I
 	public static fun DEFAULT ()Lorg/partiql/ast/expr/Scope;
 	public static fun LOCAL ()Lorg/partiql/ast/expr/Scope;
-	public static fun UNKNOWN ()Lorg/partiql/ast/expr/Scope;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
@@ -2802,11 +2781,9 @@ public class org/partiql/ast/expr/Scope : org/partiql/ast/AstEnum {
 public class org/partiql/ast/expr/SessionAttribute : org/partiql/ast/AstEnum {
 	public static final field CURRENT_DATE I
 	public static final field CURRENT_USER I
-	public static final field UNKNOWN I
 	public fun <init> (I)V
 	public static fun CURRENT_DATE ()Lorg/partiql/ast/expr/SessionAttribute;
 	public static fun CURRENT_USER ()Lorg/partiql/ast/expr/SessionAttribute;
-	public static fun UNKNOWN ()Lorg/partiql/ast/expr/SessionAttribute;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
@@ -2822,11 +2799,9 @@ public class org/partiql/ast/expr/TrimSpec : org/partiql/ast/AstEnum {
 	public static final field BOTH I
 	public static final field LEADING I
 	public static final field TRAILING I
-	public static final field UNKNOWN I
 	public static fun BOTH ()Lorg/partiql/ast/expr/TrimSpec;
 	public static fun LEADING ()Lorg/partiql/ast/expr/TrimSpec;
 	public static fun TRAILING ()Lorg/partiql/ast/expr/TrimSpec;
-	public static fun UNKNOWN ()Lorg/partiql/ast/expr/TrimSpec;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
@@ -2842,12 +2817,10 @@ public class org/partiql/ast/expr/TruthValue : org/partiql/ast/AstEnum {
 	public static final field FALSE I
 	public static final field TRUE I
 	public static final field UNK I
-	public static final field UNKNOWN I
 	public fun <init> (I)V
 	public static fun FALSE ()Lorg/partiql/ast/expr/TruthValue;
 	public static fun TRUE ()Lorg/partiql/ast/expr/TruthValue;
 	public static fun UNK ()Lorg/partiql/ast/expr/TruthValue;
-	public static fun UNKNOWN ()Lorg/partiql/ast/expr/TruthValue;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
@@ -2855,16 +2828,15 @@ public class org/partiql/ast/expr/TruthValue : org/partiql/ast/AstEnum {
 	public fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun name ()Ljava/lang/String;
+	public static fun parse (Ljava/lang/String;)Lorg/partiql/ast/expr/TruthValue;
 }
 
 public class org/partiql/ast/expr/WindowFunction : org/partiql/ast/AstEnum {
 	public static final field LAG I
 	public static final field LEAD I
-	public static final field UNKNOWN I
 	public fun <init> (I)V
 	public static fun LAG ()Lorg/partiql/ast/expr/WindowFunction;
 	public static fun LEAD ()Lorg/partiql/ast/expr/WindowFunction;
-	public static fun UNKNOWN ()Lorg/partiql/ast/expr/WindowFunction;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
@@ -2884,7 +2856,6 @@ public class org/partiql/ast/graph/GraphDirection : org/partiql/ast/AstEnum {
 	public static final field RIGHT I
 	public static final field UNDIRECTED I
 	public static final field UNDIRECTED_OR_RIGHT I
-	public static final field UNKNOWN I
 	public static fun LEFT ()Lorg/partiql/ast/graph/GraphDirection;
 	public static fun LEFT_OR_RIGHT ()Lorg/partiql/ast/graph/GraphDirection;
 	public static fun LEFT_OR_UNDIRECTED ()Lorg/partiql/ast/graph/GraphDirection;
@@ -2892,7 +2863,6 @@ public class org/partiql/ast/graph/GraphDirection : org/partiql/ast/AstEnum {
 	public static fun RIGHT ()Lorg/partiql/ast/graph/GraphDirection;
 	public static fun UNDIRECTED ()Lorg/partiql/ast/graph/GraphDirection;
 	public static fun UNDIRECTED_OR_RIGHT ()Lorg/partiql/ast/graph/GraphDirection;
-	public static fun UNKNOWN ()Lorg/partiql/ast/graph/GraphDirection;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I
@@ -3129,11 +3099,9 @@ public class org/partiql/ast/graph/GraphRestrictor : org/partiql/ast/AstEnum {
 	public static final field ACYCLIC I
 	public static final field SIMPLE I
 	public static final field TRAIL I
-	public static final field UNKNOWN I
 	public static fun ACYCLIC ()Lorg/partiql/ast/graph/GraphRestrictor;
 	public static fun SIMPLE ()Lorg/partiql/ast/graph/GraphRestrictor;
 	public static fun TRAIL ()Lorg/partiql/ast/graph/GraphRestrictor;
-	public static fun UNKNOWN ()Lorg/partiql/ast/graph/GraphRestrictor;
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	protected fun canEqual (Ljava/lang/Object;)Z
 	public fun code ()I

--- a/partiql-ast/src/main/java/org/partiql/ast/DataType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/DataType.java
@@ -68,68 +68,63 @@ public class DataType extends AstEnum {
         }
     }
 
-    public static final int UNKNOWN = 0;
     // <character string type>
-    public static final int CHARACTER = 1;
-    public static final int CHAR = 2;
-    public static final int CHARACTER_VARYING = 3;
-    public static final int CHAR_VARYING = 4; // TODO not defined in parser yet
-    public static final int VARCHAR = 5;
-    public static final int CHARACTER_LARGE_OBJECT = 6; // TODO not defined in parser yet
-    public static final int CHAR_LARGE_OBJECT = 7; // TODO not defined in parser yet
-    public static final int CLOB = 8;
-    public static final int STRING = 9;
-    public static final int SYMBOL = 10;
+    public static final int CHARACTER = 0;
+    public static final int CHAR = 1;
+    public static final int CHARACTER_VARYING = 2;
+    public static final int CHAR_VARYING = 3; // TODO not defined in parser yet
+    public static final int VARCHAR = 4;
+    public static final int CHARACTER_LARGE_OBJECT = 5; // TODO not defined in parser yet
+    public static final int CHAR_LARGE_OBJECT = 6; // TODO not defined in parser yet
+    public static final int CLOB = 7;
+    public static final int STRING = 8;
+    public static final int SYMBOL = 9;
     // <binary large object string type>
-    public static final int BLOB = 11;
-    public static final int BINARY_LARGE_OBJECT = 12; // TODO not defined in parser yet
+    public static final int BLOB = 10;
+    public static final int BINARY_LARGE_OBJECT = 11; // TODO not defined in parser yet
     // <bit string type>
-    public static final int BIT = 13; // TODO not defined in parser yet
-    public static final int BIT_VARYING = 14; // TODO not defined in parser yet
+    public static final int BIT = 12; // TODO not defined in parser yet
+    public static final int BIT_VARYING = 13; // TODO not defined in parser yet
     // <numeric type> - <exact numeric type>
-    public static final int NUMERIC = 15;
-    public static final int DECIMAL = 16;
-    public static final int DEC = 17;
-    public static final int BIGINT = 18;
-    public static final int INT8 = 19;
-    public static final int INTEGER8 = 20;
-    public static final int INT4 = 21;
-    public static final int INTEGER4 = 22;
-    public static final int INTEGER = 23;
-    public static final int INT = 24;
-    public static final int INT2 = 25;
-    public static final int INTEGER2 = 26;
-    public static final int SMALLINT = 27;
-    public static final int TINYINT = 28; // TODO not defined in parser yet
+    public static final int NUMERIC = 14;
+    public static final int DECIMAL = 15;
+    public static final int DEC = 16;
+    public static final int BIGINT = 17;
+    public static final int INT8 = 18;
+    public static final int INTEGER8 = 19;
+    public static final int INT4 = 20;
+    public static final int INTEGER4 = 21;
+    public static final int INTEGER = 22;
+    public static final int INT = 23;
+    public static final int INT2 = 24;
+    public static final int INTEGER2 = 25;
+    public static final int SMALLINT = 26;
+    public static final int TINYINT = 27; // TODO not defined in parser yet
     // <numeric type> - <approximate numeric type>
-    public static final int FLOAT = 29;
-    public static final int REAL = 30;
-    public static final int DOUBLE_PRECISION = 31;
+    public static final int FLOAT = 28;
+    public static final int REAL = 29;
+    public static final int DOUBLE_PRECISION = 30;
     // <boolean type>
-    public static final int BOOLEAN = 32;
-    public static final int BOOL = 33;
+    public static final int BOOLEAN = 31;
+    public static final int BOOL = 32;
     // <datetime type>
-    public static final int DATE = 34;
-    public static final int TIME = 35;
-    public static final int TIME_WITH_TIME_ZONE = 36;
-    public static final int TIMESTAMP = 37;
-    public static final int TIMESTAMP_WITH_TIME_ZONE = 38;
+    public static final int DATE = 33;
+    public static final int TIME = 34;
+    public static final int TIME_WITH_TIME_ZONE = 35;
+    public static final int TIMESTAMP = 36;
+    public static final int TIMESTAMP_WITH_TIME_ZONE = 37;
     // <interval type>
-    public static final int INTERVAL = 39; // TODO not defined in parser yet
+    public static final int INTERVAL = 38; // TODO not defined in parser yet
     // <container type>
-    public static final int STRUCT = 40;
-    public static final int TUPLE = 41;
+    public static final int STRUCT = 39;
+    public static final int TUPLE = 40;
     // <collection type>
-    public static final int LIST = 42;
-    public static final int ARRAY = 43;
-    public static final int BAG = 44;
-    public static final int SEXP = 45;
+    public static final int LIST = 41;
+    public static final int ARRAY = 42;
+    public static final int BAG = 43;
+    public static final int SEXP = 44;
     // <user defined type>
-    public static final int USER_DEFINED = 46;
-
-    public static DataType UNKNOWN() {
-        return new DataType(UNKNOWN);
-    }
+    public static final int USER_DEFINED = 45;
 
     public static DataType BOOL() {
         return new DataType(BOOL);
@@ -541,7 +536,7 @@ public class DataType extends AstEnum {
             case BAG: return "BAG";
             case SEXP: return "SEXP";
             case USER_DEFINED: return "USER_DEFINED";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid DataType code: " + code);
         }
     }
 
@@ -643,7 +638,7 @@ public class DataType extends AstEnum {
             case "TIMESTAMP_WITH_TIME_ZONE": return TIMESTAMP_WITH_TIME_ZONE();
             case "INTERVAL": return INTERVAL();
             case "USER_DEFINED": return USER_DEFINED();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant DataType." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/DatetimeField.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/DatetimeField.java
@@ -11,19 +11,14 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class DatetimeField extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int YEAR = 1;
-    public static final int MONTH = 2;
-    public static final int DAY = 3;
-    public static final int HOUR = 4;
-    public static final int MINUTE = 5;
-    public static final int SECOND = 6;
-    public static final int TIMEZONE_HOUR = 7;
-    public static final int TIMEZONE_MINUTE = 8;
-
-    public static DatetimeField UNKNOWN() {
-        return new DatetimeField(UNKNOWN);
-    }
+    public static final int YEAR = 0;
+    public static final int MONTH = 1;
+    public static final int DAY = 2;
+    public static final int HOUR = 3;
+    public static final int MINUTE = 4;
+    public static final int SECOND = 5;
+    public static final int TIMEZONE_HOUR = 6;
+    public static final int TIMEZONE_MINUTE = 7;
 
     public static DatetimeField YEAR() {
         return new DatetimeField(YEAR);
@@ -80,7 +75,7 @@ public class DatetimeField extends AstEnum {
             case SECOND: return "SECOND";
             case TIMEZONE_HOUR: return "TIMEZONE_HOUR";
             case TIMEZONE_MINUTE: return "TIMEZONE_MINUTE";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid DatetimeField code: " + code);
         }
     }
 
@@ -107,7 +102,7 @@ public class DatetimeField extends AstEnum {
             case "SECOND": return SECOND();
             case "TIMEZONE_HOUR": return TIMEZONE_HOUR();
             case "TIMEZONE_MINUTE": return TIMEZONE_MINUTE();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant DatetimeField." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/FromType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/FromType.java
@@ -11,13 +11,8 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class FromType extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int SCAN = 1;
-    public static final int UNPIVOT = 2;
-
-    public static FromType UNKNOWN() {
-        return new FromType(UNKNOWN);
-    }
+    public static final int SCAN = 0;
+    public static final int UNPIVOT = 1;
 
     public static FromType SCAN() {
         return new FromType(SCAN);
@@ -44,7 +39,7 @@ public class FromType extends AstEnum {
         switch (code) {
             case SCAN: return "SCAN";
             case UNPIVOT: return "UNPIVOT";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid FromType code: " + code);
         }
     }
 
@@ -59,7 +54,7 @@ public class FromType extends AstEnum {
         switch (value) {
             case "SCAN": return SCAN();
             case "UNPIVOT": return UNPIVOT();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant FromType." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/GroupByStrategy.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/GroupByStrategy.java
@@ -11,13 +11,8 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class GroupByStrategy extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int FULL = 1;
-    public static final int PARTIAL = 2;
-
-    public static GroupByStrategy UNKNOWN() {
-        return new GroupByStrategy(UNKNOWN);
-    }
+    public static final int FULL = 0;
+    public static final int PARTIAL = 1;
 
     public static GroupByStrategy FULL() {
         return new GroupByStrategy(FULL);
@@ -50,7 +45,7 @@ public class GroupByStrategy extends AstEnum {
         switch (code) {
             case FULL: return "FULL";
             case PARTIAL: return "PARTIAL";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid GroupByStrategy code: " + code);
         }
     }
 
@@ -59,7 +54,7 @@ public class GroupByStrategy extends AstEnum {
         switch (value) {
             case "FULL": return FULL();
             case "PARTIAL": return PARTIAL();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant GroupByStrategy." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/JoinType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/JoinType.java
@@ -11,20 +11,15 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class JoinType extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int INNER = 1;
-    public static final int LEFT = 2;
-    public static final int LEFT_OUTER = 3;
-    public static final int RIGHT = 4;
-    public static final int RIGHT_OUTER = 5;
-    public static final int FULL = 6;
-    public static final int FULL_OUTER = 7;
-    public static final int CROSS = 8;
-    public static final int LEFT_CROSS = 9;
-
-    public static JoinType UNKNOWN() {
-        return new JoinType(UNKNOWN);
-    }
+    public static final int INNER = 0;
+    public static final int LEFT = 1;
+    public static final int LEFT_OUTER = 2;
+    public static final int RIGHT = 3;
+    public static final int RIGHT_OUTER = 4;
+    public static final int FULL = 5;
+    public static final int FULL_OUTER = 6;
+    public static final int CROSS = 7;
+    public static final int LEFT_CROSS = 8;
 
     public static JoinType INNER() {
         return new JoinType(INNER);
@@ -86,7 +81,7 @@ public class JoinType extends AstEnum {
             case FULL_OUTER: return "FULL_OUTER";
             case CROSS: return "CROSS";
             case LEFT_CROSS: return "LEFT_CROSS";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid JoinType code: " + code);
         }
     }
 
@@ -115,7 +110,7 @@ public class JoinType extends AstEnum {
             case "FULL_OUTER": return FULL_OUTER();
             case "CROSS": return CROSS();
             case "LEFT_CROSS": return LEFT_CROSS();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant JoinType." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Literal.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Literal.java
@@ -15,20 +15,19 @@ import static java.util.Objects.requireNonNull;
  */
 @EqualsAndHashCode(callSuper = false)
 public class Literal extends AstEnum {
-    public static final int UNKNOWN = 0;
     // absent literals
-    public static final int NULL = 1;
-    public static final int MISSING = 2;
+    public static final int NULL = 0;
+    public static final int MISSING = 1;
     // boolean literal
-    public static final int BOOL = 3;
+    public static final int BOOL = 2;
     // numeric literals
-    public static final int APPROX_NUM = 4;
-    public static final int EXACT_NUM = 5;
-    public static final int INT_NUM = 6;
+    public static final int APPROX_NUM = 3;
+    public static final int EXACT_NUM = 4;
+    public static final int INT_NUM = 5;
     // string literal
-    public static final int STRING = 7;
+    public static final int STRING = 6;
     // typed string literal
-    public static final int TYPED_STRING = 8;
+    public static final int TYPED_STRING = 7;
 
     // Literal fields
     private final int code;
@@ -97,7 +96,7 @@ public class Literal extends AstEnum {
             case INT_NUM: return "INT_NUM";
             case STRING: return "STRING";
             case TYPED_STRING: return "TYPED_STRING";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid Literal code: " + code);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Nulls.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Nulls.java
@@ -11,13 +11,8 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class Nulls extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int FIRST = 1;
-    public static final int LAST = 2;
-
-    public static Nulls UNKNOWN() {
-        return new Nulls(UNKNOWN);
-    }
+    public static final int FIRST = 0;
+    public static final int LAST = 1;
 
     public static Nulls FIRST() {
         return new Nulls(FIRST);
@@ -44,7 +39,7 @@ public class Nulls extends AstEnum {
         switch (code) {
             case FIRST: return "FIRST";
             case LAST: return "LAST";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid Nulls code: " + code);
         }
     }
 
@@ -57,10 +52,9 @@ public class Nulls extends AstEnum {
     @NotNull
     public static Nulls parse(@NotNull String value) {
         switch (value) {
-            case "UNKNOWN": return UNKNOWN();
             case "FIRST": return FIRST();
             case "LAST": return LAST();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant Nulls." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/Order.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/Order.java
@@ -8,13 +8,8 @@ import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
 public class Order extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int ASC = 1;
-    public static final int DESC = 2;
-
-    public static Order UNKNOWN() {
-        return new Order(UNKNOWN);
-    }
+    public static final int ASC = 0;
+    public static final int DESC = 1;
 
     public static Order ASC() {
         return new Order(ASC);
@@ -41,7 +36,7 @@ public class Order extends AstEnum {
         switch (code) {
             case ASC: return "ASC";
             case DESC: return "DESC";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid Order code: " + code);
         }
     }
 
@@ -56,7 +51,7 @@ public class Order extends AstEnum {
         switch (value) {
             case "ASC": return ASC();
             case "DESC": return DESC();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant Order." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/SetOpType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SetOpType.java
@@ -11,14 +11,9 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class SetOpType extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int UNION = 1;
-    public static final int INTERSECT = 2;
-    public static final int EXCEPT = 3;
-
-    public static SetOpType UNKNOWN() {
-        return new SetOpType(UNKNOWN);
-    }
+    public static final int UNION = 0;
+    public static final int INTERSECT = 1;
+    public static final int EXCEPT = 2;
 
     public static SetOpType UNION() {
         return new SetOpType(UNION);
@@ -50,7 +45,7 @@ public class SetOpType extends AstEnum {
             case UNION: return "UNION";
             case INTERSECT: return "INTERSECT";
             case EXCEPT: return "EXCEPT";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid SetOpType code: " + code);
         }
     }
 
@@ -67,7 +62,7 @@ public class SetOpType extends AstEnum {
             case "UNION": return UNION();
             case "INTERSECT": return INTERSECT();
             case "EXCEPT": return EXCEPT();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant SetOpType." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/SetQuantifier.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/SetQuantifier.java
@@ -11,13 +11,8 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class SetQuantifier extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int ALL = 1;
-    public static final int DISTINCT = 2;
-
-    public static SetQuantifier UNKNOWN() {
-        return new SetQuantifier(UNKNOWN);
-    }
+    public static final int ALL = 0;
+    public static final int DISTINCT = 1;
 
     public static SetQuantifier ALL() {
         return new SetQuantifier(ALL);
@@ -44,7 +39,7 @@ public class SetQuantifier extends AstEnum {
         switch (code) {
             case ALL: return "ALL";
             case DISTINCT: return "DISTINCT";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid SetQuantifier code: " + code);
         }
     }
 
@@ -59,7 +54,7 @@ public class SetQuantifier extends AstEnum {
         switch (value) {
             case "ALL": return ALL();
             case "DISTINCT": return DISTINCT();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant SetQuantifier." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/Scope.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/Scope.java
@@ -14,13 +14,8 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class Scope extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int DEFAULT = 1;
-    public static final int LOCAL = 2;
-
-    public static Scope UNKNOWN() {
-        return new Scope(UNKNOWN);
-    }
+    public static final int DEFAULT = 0;
+    public static final int LOCAL = 1;
 
     public static Scope DEFAULT() {
         return new Scope(DEFAULT);
@@ -47,7 +42,7 @@ public class Scope extends AstEnum {
         switch (code) {
             case DEFAULT: return "DEFAULT";
             case LOCAL: return "LOCAL";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid Scope code: " + code);
         }
     }
 
@@ -60,10 +55,9 @@ public class Scope extends AstEnum {
     @NotNull
     public static Scope parse(@NotNull String value) {
         switch (value) {
-            case "UNKNOWN": return UNKNOWN();
             case "DEFAULT": return DEFAULT();
             case "LOCAL": return LOCAL();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant Scope." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/SessionAttribute.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/SessionAttribute.java
@@ -14,13 +14,8 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class SessionAttribute extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int CURRENT_USER = 1;
-    public static final int CURRENT_DATE = 2;
-
-    public static SessionAttribute UNKNOWN() {
-        return new SessionAttribute(UNKNOWN);
-    }
+    public static final int CURRENT_USER = 0;
+    public static final int CURRENT_DATE = 1;
 
     public static SessionAttribute CURRENT_USER() {
         return new SessionAttribute(CURRENT_USER);
@@ -47,7 +42,7 @@ public class SessionAttribute extends AstEnum {
         switch (code) {
             case CURRENT_USER: return "CURRENT_USER";
             case CURRENT_DATE: return "CURRENT_DATE";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid SessionAttribute code: " + code);
         }
     }
 
@@ -62,7 +57,7 @@ public class SessionAttribute extends AstEnum {
         switch (value) {
             case "CURRENT_USER": return CURRENT_USER();
             case "CURRENT_DATE": return CURRENT_DATE();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant SessionAttribute." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/TrimSpec.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/TrimSpec.java
@@ -11,14 +11,9 @@ import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
 public class TrimSpec extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int LEADING = 1;
-    public static final int TRAILING = 2;
-    public static final int BOTH = 3;
-
-    public static TrimSpec UNKNOWN() {
-        return new TrimSpec(UNKNOWN);
-    }
+    public static final int LEADING = 0;
+    public static final int TRAILING = 1;
+    public static final int BOTH = 2;
 
     public static TrimSpec LEADING() {
         return new TrimSpec(LEADING);
@@ -50,7 +45,7 @@ public class TrimSpec extends AstEnum {
             case LEADING: return "LEADING";
             case TRAILING: return "TRAILING";
             case BOTH: return "BOTH";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid TrimSpec code: " + code);
         }
     }
 
@@ -67,7 +62,7 @@ public class TrimSpec extends AstEnum {
             case "LEADING": return LEADING();
             case "TRAILING": return TRAILING();
             case "BOTH": return BOTH();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant TrimSpec." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/TruthValue.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/TruthValue.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class TruthValue extends AstEnum {
     public static final int TRUE = 0;
     public static final int FALSE = 1;
-    public static final int UNK = 2;
+    public static final int UNKNOWN = 2;
 
     private final int code;
 
@@ -31,8 +31,8 @@ public class TruthValue extends AstEnum {
         return new TruthValue(FALSE);
     }
     
-    public static TruthValue UNK() {
-        return new TruthValue(UNK);
+    public static TruthValue UNKNOWN() {
+        return new TruthValue(UNKNOWN);
     }
 
     @Override
@@ -46,7 +46,7 @@ public class TruthValue extends AstEnum {
         switch (code) {
             case TRUE: return "TRUE";
             case FALSE: return "FALSE";
-            case UNK: return "UNK";
+            case UNKNOWN: return "UNKNOWN";
             default: throw new IllegalStateException("Invalid TruthValue code: " + code);
         }
     }
@@ -56,7 +56,7 @@ public class TruthValue extends AstEnum {
         switch (value) {
             case "TRUE": return TruthValue.TRUE();
             case "FALSE": return TruthValue.FALSE();
-            case "UNK": return TruthValue.UNK();
+            case "UNK": return TruthValue.UNKNOWN();
             default: throw new IllegalArgumentException("No enum constant TruthValue." + value);
         }
     }

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/TruthValue.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/TruthValue.java
@@ -13,10 +13,9 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class TruthValue extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int TRUE = 1;
-    public static final int FALSE = 2;
-    public static final int UNK = 3;
+    public static final int TRUE = 0;
+    public static final int FALSE = 1;
+    public static final int UNK = 2;
 
     private final int code;
 
@@ -24,10 +23,6 @@ public class TruthValue extends AstEnum {
         this.code = code;
     }
 
-    public static TruthValue UNKNOWN() {
-        return new TruthValue(UNKNOWN);
-    }
-    
     public static TruthValue TRUE() {
         return new TruthValue(TRUE);
     }
@@ -48,7 +43,22 @@ public class TruthValue extends AstEnum {
     @NotNull
     @Override
     public String name() {
-        return "";
+        switch (code) {
+            case TRUE: return "TRUE";
+            case FALSE: return "FALSE";
+            case UNK: return "UNK";
+            default: throw new IllegalStateException("Invalid TruthValue code: " + code);
+        }
+    }
+
+    @NotNull
+    public static TruthValue parse(@NotNull String value) {
+        switch (value) {
+            case "TRUE": return TruthValue.TRUE();
+            case "FALSE": return TruthValue.FALSE();
+            case "UNK": return TruthValue.UNK();
+            default: throw new IllegalArgumentException("No enum constant TruthValue." + value);
+        }
     }
 
     @NotNull

--- a/partiql-ast/src/main/java/org/partiql/ast/expr/WindowFunction.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/expr/WindowFunction.java
@@ -14,13 +14,8 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class WindowFunction extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int LAG = 1;
-    public static final int LEAD = 2;
-
-    public static WindowFunction UNKNOWN() {
-        return new WindowFunction(UNKNOWN);
-    }
+    public static final int LAG = 0;
+    public static final int LEAD = 1;
 
     public static WindowFunction LAG() {
         return new WindowFunction(LAG);
@@ -47,7 +42,7 @@ public class WindowFunction extends AstEnum {
         switch (code) {
             case LAG: return "LAG";
             case LEAD: return "LEAD";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid WindowFunction code: " + code);
         }
     }
 
@@ -62,7 +57,7 @@ public class WindowFunction extends AstEnum {
         switch (value) {
             case "LAG": return LAG();
             case "LEAD": return LEAD();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant WindowFunction." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphDirection.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphDirection.java
@@ -14,18 +14,13 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class GraphDirection extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int LEFT = 1;
-    public static final int UNDIRECTED = 2;
-    public static final int RIGHT = 3;
-    public static final int LEFT_OR_UNDIRECTED = 4;
-    public static final int UNDIRECTED_OR_RIGHT = 5;
-    public static final int LEFT_OR_RIGHT = 6;
-    public static final int LEFT_UNDIRECTED_OR_RIGHT = 7;
-
-    public static GraphDirection UNKNOWN() {
-        return new GraphDirection(UNKNOWN);
-    }
+    public static final int LEFT = 0;
+    public static final int UNDIRECTED = 1;
+    public static final int RIGHT = 2;
+    public static final int LEFT_OR_UNDIRECTED = 3;
+    public static final int UNDIRECTED_OR_RIGHT = 4;
+    public static final int LEFT_OR_RIGHT = 5;
+    public static final int LEFT_UNDIRECTED_OR_RIGHT = 6;
 
     public static GraphDirection LEFT() {
         return new GraphDirection(LEFT);
@@ -88,7 +83,7 @@ public class GraphDirection extends AstEnum {
             case UNDIRECTED_OR_RIGHT: return "UNDIRECTED_OR_RIGHT";
             case LEFT_OR_RIGHT: return "LEFT_OR_RIGHT";
             case LEFT_UNDIRECTED_OR_RIGHT: return "LEFT_UNDIRECTED_OR_RIGHT";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid GraphDirection code: " + code);
         }
     }
 
@@ -102,7 +97,7 @@ public class GraphDirection extends AstEnum {
             case "UNDIRECTED_OR_RIGHT": return UNDIRECTED_OR_RIGHT();
             case "LEFT_OR_RIGHT": return LEFT_OR_RIGHT();
             case "LEFT_UNDIRECTED_OR_RIGHT": return LEFT_UNDIRECTED_OR_RIGHT();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant GraphDirection." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/graph/GraphRestrictor.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/graph/GraphRestrictor.java
@@ -14,14 +14,9 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = false)
 public class GraphRestrictor extends AstEnum {
-    public static final int UNKNOWN = 0;
-    public static final int TRAIL = 1;
-    public static final int ACYCLIC = 2;
-    public static final int SIMPLE = 3;
-
-    public static GraphRestrictor UNKNOWN() {
-        return new GraphRestrictor(UNKNOWN);
-    }
+    public static final int TRAIL = 0;
+    public static final int ACYCLIC = 1;
+    public static final int SIMPLE = 2;
 
     public static GraphRestrictor TRAIL() {
         return new GraphRestrictor(TRAIL);
@@ -53,7 +48,7 @@ public class GraphRestrictor extends AstEnum {
             case TRAIL: return "TRAIL";
             case ACYCLIC: return "ACYCLIC";
             case SIMPLE: return "SIMPLE";
-            default: return "UNKNOWN";
+            default: throw new IllegalStateException("Invalid GraphRestrictor code: " + code);
         }
     }
 
@@ -70,7 +65,7 @@ public class GraphRestrictor extends AstEnum {
             case "TRAIL": return TRAIL();
             case "ACYCLIC": return ACYCLIC();
             case "SIMPLE": return SIMPLE();
-            default: return UNKNOWN();
+            default: throw new IllegalArgumentException("No enum constant GraphRestrictor." + value);
         }
     }
 

--- a/partiql-ast/src/main/java/org/partiql/ast/sql/SqlDialect.kt
+++ b/partiql-ast/src/main/java/org/partiql/ast/sql/SqlDialect.kt
@@ -442,7 +442,7 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
         t = t concat when (node.truthValue.code()) {
             TruthValue.TRUE -> "TRUE"
             TruthValue.FALSE -> "FALSE"
-            TruthValue.UNK -> "UNKNOWN"
+            TruthValue.UNKNOWN -> "UNKNOWN"
             else -> throw UnsupportedOperationException("Cannot print $node")
         }
         return t

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
@@ -1043,7 +1043,7 @@ class SqlDialectTest {
                 exprBoolTest(
                     value = v("x"),
                     not = false,
-                    truthValue = TruthValue.UNK()
+                    truthValue = TruthValue.UNKNOWN()
                 )
             ),
             expect(
@@ -1051,7 +1051,7 @@ class SqlDialectTest {
                 exprBoolTest(
                     value = v("x"),
                     not = true,
-                    truthValue = TruthValue.UNK()
+                    truthValue = TruthValue.UNKNOWN()
                 )
             ),
             // IS [NOT] NULL

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -623,7 +623,6 @@ internal class PartiQLParserDefault : PartiQLParser {
         // The following types are not supported in DDL yet,
         //  either as a top level type or as a element/field type in complex type declaration
         private fun isValidTypeDeclarationOrThrow(type: DataType, ctx: GeneratedParser.TypeContext) = when (type.code()) {
-            DataType.UNKNOWN,
             DataType.BAG,
             DataType.USER_DEFINED -> throw error(ctx, "declaration attribute with $type is not supported")
             else -> Unit

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -1408,7 +1408,7 @@ internal class PartiQLParserDefault : PartiQLParser {
             when (ctx.truthValue.type) {
                 GeneratedParser.TRUE -> exprBoolTest(expr, not, TruthValue.TRUE())
                 GeneratedParser.FALSE -> exprBoolTest(expr, not, TruthValue.FALSE())
-                GeneratedParser.UNKNOWN -> exprBoolTest(expr, not, TruthValue.UNK())
+                GeneratedParser.UNKNOWN -> exprBoolTest(expr, not, TruthValue.UNKNOWN())
                 else -> throw error(ctx, "Unexpected value for boolean test IS [NOT] TRUE|FALSE|UNKNOWN")
             }
         }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
@@ -402,7 +402,7 @@ internal object RexConverter {
             var call = when (node.truthValue.code()) {
                 TruthValue.TRUE -> call("is_true", value)
                 TruthValue.FALSE -> call("is_false", value)
-                TruthValue.UNK -> call("is_unknown", value)
+                TruthValue.UNKNOWN -> call("is_unknown", value)
                 else -> error("Unexpected TruthValue: ${node.truthValue}")
             }
             // See SQL99 6.30 pg 216 Rule 2 for equivalence


### PR DESCRIPTION
## Relevant Issues
- https://github.com/partiql/partiql-lang-kotlin/issues/1610

## Description
- Removes the `UNKNOWN` AST enum variant
- Renumbers enums to start from 0. We can always add back `UNKNOWN` or some "OTHER" variant in the future.
- Renames `TruthValue.UNK` to `TruthValue.UNKOWN`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.