### PR TITLE
[v1] Remove top-level DDL node in AST

### DIFF
--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -257,8 +257,8 @@ public abstract class org/partiql/ast/AstRewriter : org/partiql/ast/AstVisitor {
 	public fun visitConflictTargetConstraint (Lorg/partiql/ast/dml/ConflictTarget$Constraint;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitConflictTargetIndex (Lorg/partiql/ast/dml/ConflictTarget$Index;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitConflictTargetIndex (Lorg/partiql/ast/dml/ConflictTarget$Index;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
-	public synthetic fun visitDdl (Lorg/partiql/ast/ddl/Ddl;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun visitDdl (Lorg/partiql/ast/ddl/Ddl;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
+	public synthetic fun visitCreateTable (Lorg/partiql/ast/ddl/CreateTable;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitCreateTable (Lorg/partiql/ast/ddl/CreateTable;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitDelete (Lorg/partiql/ast/dml/Delete;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDelete (Lorg/partiql/ast/dml/Delete;Ljava/lang/Object;)Lorg/partiql/ast/AstNode;
 	public synthetic fun visitDoReplaceActionExcluded (Lorg/partiql/ast/dml/DoReplaceAction$Excluded;Ljava/lang/Object;)Ljava/lang/Object;
@@ -461,7 +461,6 @@ public abstract class org/partiql/ast/AstVisitor {
 	public fun visitConflictTargetIndex (Lorg/partiql/ast/dml/ConflictTarget$Index;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitCreateTable (Lorg/partiql/ast/ddl/CreateTable;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDataType (Lorg/partiql/ast/DataType;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun visitDdl (Lorg/partiql/ast/ddl/Ddl;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDelete (Lorg/partiql/ast/dml/Delete;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDoReplaceAction (Lorg/partiql/ast/dml/DoReplaceAction;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDoReplaceActionExcluded (Lorg/partiql/ast/dml/DoReplaceAction$Excluded;Ljava/lang/Object;)Ljava/lang/Object;
@@ -1514,7 +1513,7 @@ public class org/partiql/ast/ddl/ColumnDefinition$Builder {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class org/partiql/ast/ddl/CreateTable : org/partiql/ast/ddl/Ddl {
+public final class org/partiql/ast/ddl/CreateTable : org/partiql/ast/Statement {
 	public fun <init> (Lorg/partiql/ast/IdentifierChain;Ljava/util/List;Ljava/util/List;Lorg/partiql/ast/ddl/PartitionBy;Ljava/util/List;)V
 	public fun accept (Lorg/partiql/ast/AstVisitor;Ljava/lang/Object;)Ljava/lang/Object;
 	public static fun builder ()Lorg/partiql/ast/ddl/CreateTable$Builder;
@@ -1536,10 +1535,6 @@ public class org/partiql/ast/ddl/CreateTable$Builder {
 	public fun partitionBy (Lorg/partiql/ast/ddl/PartitionBy;)Lorg/partiql/ast/ddl/CreateTable$Builder;
 	public fun tableProperties (Ljava/util/List;)Lorg/partiql/ast/ddl/CreateTable$Builder;
 	public fun toString ()Ljava/lang/String;
-}
-
-public abstract class org/partiql/ast/ddl/Ddl : org/partiql/ast/Statement {
-	public fun <init> ()V
 }
 
 public final class org/partiql/ast/ddl/KeyValue : org/partiql/ast/AstNode {
@@ -3176,10 +3171,10 @@ public abstract class org/partiql/ast/sql/SqlDialect : org/partiql/ast/AstVisito
 	public fun defaultReturn (Lorg/partiql/ast/AstNode;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public static final fun getSTANDARD ()Lorg/partiql/ast/sql/SqlDialect;
 	public final fun transform (Lorg/partiql/ast/AstNode;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitCreateTable (Lorg/partiql/ast/ddl/CreateTable;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitCreateTable (Lorg/partiql/ast/ddl/CreateTable;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitDataType (Lorg/partiql/ast/DataType;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDataType (Lorg/partiql/ast/DataType;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
-	public synthetic fun visitDdl (Lorg/partiql/ast/ddl/Ddl;Ljava/lang/Object;)Ljava/lang/Object;
-	public fun visitDdl (Lorg/partiql/ast/ddl/Ddl;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitDelete (Lorg/partiql/ast/dml/Delete;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitDelete (Lorg/partiql/ast/dml/Delete;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExclude (Lorg/partiql/ast/Exclude;Ljava/lang/Object;)Ljava/lang/Object;

--- a/partiql-ast/src/main/java/org/partiql/ast/AstVisitor.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/AstVisitor.java
@@ -3,7 +3,6 @@ package org.partiql.ast;
 import org.partiql.ast.ddl.AttributeConstraint;
 import org.partiql.ast.ddl.ColumnDefinition;
 import org.partiql.ast.ddl.CreateTable;
-import org.partiql.ast.ddl.Ddl;
 import org.partiql.ast.ddl.KeyValue;
 import org.partiql.ast.ddl.PartitionBy;
 import org.partiql.ast.ddl.TableConstraint;
@@ -88,10 +87,6 @@ public abstract class AstVisitor<R, C> {
     //
     // DDL
     //
-    public R visitDdl(Ddl node, C ctx) {
-        return defaultVisit(node, ctx);
-    }
-
     public R visitCreateTable(CreateTable node, C ctx) {
         return defaultVisit(node, ctx);
     }

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/CreateTable.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/CreateTable.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import org.partiql.ast.AstNode;
 import org.partiql.ast.AstVisitor;
 import org.partiql.ast.IdentifierChain;
+import org.partiql.ast.Statement;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.List;
  */
 @Builder(builderClassName = "Builder")
 @EqualsAndHashCode(callSuper = false)
-public final class CreateTable extends Ddl {
+public final class CreateTable extends Statement {
 
     @NotNull
     @Getter

--- a/partiql-ast/src/main/java/org/partiql/ast/ddl/Ddl.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/ddl/Ddl.java
@@ -1,9 +1,0 @@
-package org.partiql.ast.ddl;
-
-import org.partiql.ast.Statement;
-
-/**
- * TODO docs, equals, hashcode
- */
-public abstract class Ddl extends Statement {
-}

--- a/partiql-ast/src/main/java/org/partiql/ast/sql/SqlDialect.kt
+++ b/partiql-ast/src/main/java/org/partiql/ast/sql/SqlDialect.kt
@@ -48,7 +48,7 @@ import org.partiql.ast.SetOp
 import org.partiql.ast.SetOpType
 import org.partiql.ast.SetQuantifier
 import org.partiql.ast.Sort
-import org.partiql.ast.ddl.Ddl
+import org.partiql.ast.ddl.CreateTable
 import org.partiql.ast.dml.Delete
 import org.partiql.ast.dml.Insert
 import org.partiql.ast.dml.Replace
@@ -822,8 +822,8 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
     }
 
     // TODO: DDL
-    override fun visitDdl(node: Ddl, ctx: SqlBlock): SqlBlock {
-        throw UnsupportedOperationException("DDL has not been supported yet in SqlDialect")
+    override fun visitCreateTable(node: CreateTable, ctx: SqlBlock): SqlBlock {
+        throw UnsupportedOperationException("CREATE TABLE has not been supported yet in SqlDialect")
     }
 
     override fun visitInsert(node: Insert?, ctx: SqlBlock?): SqlBlock {

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/AstRewriter.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/AstRewriter.kt
@@ -4,7 +4,7 @@ import org.partiql.ast.Ast.explain
 import org.partiql.ast.Ast.exprQuerySet
 import org.partiql.ast.Ast.identifier
 import org.partiql.ast.Ast.query
-import org.partiql.ast.ddl.Ddl
+import org.partiql.ast.ddl.CreateTable
 import org.partiql.ast.dml.ConflictAction
 import org.partiql.ast.dml.ConflictTarget
 import org.partiql.ast.dml.Delete
@@ -802,8 +802,8 @@ public abstract class AstRewriter<C> : AstVisitor<AstNode, C>() {
     }
 
     // TODO: DDL
-    override fun visitDdl(node: Ddl, ctx: C): AstNode {
-        throw UnsupportedOperationException("DDL has not been supported yet in AstRewriter")
+    override fun visitCreateTable(node: CreateTable?, ctx: C): AstNode {
+        throw UnsupportedOperationException("CREATE TABLE has not been supported yet in AstRewriter")
     }
 
     override fun visitInsert(node: Insert, ctx: C): AstNode {


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- In the AST, changes the DDL statements to directly extend `Statement`
- Removes the top-level DDL AST node that had extended `Statement`

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
  - No, on unreleased v1.

- Any backward-incompatible changes? **[YES]**
  - Yes, but v1 has not yet been released.

- Any new external dependencies? **[NO]**

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.