### PR TITLE
Fixes decimal/numeric arithmetic & mistyped function bugs

### DIFF
--- a/partiql-eval/api/partiql-eval.api
+++ b/partiql-eval/api/partiql-eval.api
@@ -30,15 +30,13 @@ public class org/partiql/eval/Mode {
 }
 
 public class org/partiql/eval/Row {
+	public final field values [Lorg/partiql/spi/value/Datum;
 	public fun <init> ()V
 	public fun <init> ([Lorg/partiql/spi/value/Datum;)V
 	public fun concat (Lorg/partiql/eval/Row;)Lorg/partiql/eval/Row;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun get (I)Lorg/partiql/spi/value/Datum;
-	public fun getSize ()I
 	public fun hashCode ()I
 	public static fun of ([Lorg/partiql/spi/value/Datum;)Lorg/partiql/eval/Row;
-	public fun set (ILorg/partiql/spi/value/Datum;)V
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/partiql-eval/src/main/java/org/partiql/eval/Environment.java
+++ b/partiql-eval/src/main/java/org/partiql/eval/Environment.java
@@ -59,7 +59,7 @@ public class Environment {
      */
     public Datum get(int depth, int offset) {
         try {
-            return stack[depth].get(offset);
+            return stack[depth].values[offset];
         } catch (IndexOutOfBoundsException ex) {
             throw new RuntimeException("Invalid variable reference [$depth:$offset]\n$this");
         }

--- a/partiql-eval/src/main/java/org/partiql/eval/Row.java
+++ b/partiql-eval/src/main/java/org/partiql/eval/Row.java
@@ -10,32 +10,14 @@ import java.util.Objects;
  */
 public class Row {
 
-    private final Datum[] values;
-
     /**
-     * @param index the requested index
-     * @return the value at the given index
+     * TODO internalize values.
      */
-    public Datum get(int index) {
-        return values[index];
-    }
+    public final Datum[] values;
 
     /**
-     * @param index the requested index
-     * @param value the value to insert
-     */
-    public void set(int index, Datum value) {
-        values[index] = value;
-    }
-
-    /**
-     * @return the number of values in the record
-     */
-    public int getSize() {
-        return values.length;
-    }
-
-    /**
+     * TODO keep ??
+     *
      * @param values the values
      * @return the record
      */

--- a/partiql-eval/src/main/java/org/partiql/eval/compiler/Match.java
+++ b/partiql-eval/src/main/java/org/partiql/eval/compiler/Match.java
@@ -4,7 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.partiql.plan.Operand;
 
 /**
- * Match represents a subtree match to be sent to the {@link Strategy}.
+ * Match represents a subtree match to be sent to the
  */
 public class Match {
 

--- a/partiql-eval/src/main/java/org/partiql/eval/compiler/PartiQLCompiler.java
+++ b/partiql-eval/src/main/java/org/partiql/eval/compiler/PartiQLCompiler.java
@@ -26,14 +26,6 @@ public interface PartiQLCompiler {
         return prepare(plan, mode, Context.standard());
     }
 
-    /**
-     * Prepares the given plan into an executable PartiQL statement.
-     *
-     * @param plan The plan to compile.
-     * @param mode The mode to execute in.
-     * @param ctx The shared context object.
-     * @return The prepared statement.
-     */
     @NotNull
     public Statement prepare(@NotNull Plan plan, @NotNull Mode mode, @NotNull Context ctx);
 

--- a/partiql-eval/src/main/java/org/partiql/eval/compiler/Pattern.java
+++ b/partiql-eval/src/main/java/org/partiql/eval/compiler/Pattern.java
@@ -38,14 +38,11 @@ public class Pattern {
         this.predicate = predicate;
     }
 
-    /**
-     * @param operator the operator to match against.
-     * @return whether the operator matches the pattern.
-     */
     public boolean matches(Operator operator) {
         if (!clazz.isInstance(operator)) {
             return false;
         }
         return predicate == null || predicate.test(operator);
     }
+
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/StandardCompiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/StandardCompiler.kt
@@ -41,6 +41,7 @@ import org.partiql.eval.internal.operator.rex.ExprCaseBranch
 import org.partiql.eval.internal.operator.rex.ExprCaseSearched
 import org.partiql.eval.internal.operator.rex.ExprCast
 import org.partiql.eval.internal.operator.rex.ExprCoalesce
+import org.partiql.eval.internal.operator.rex.ExprError
 import org.partiql.eval.internal.operator.rex.ExprLit
 import org.partiql.eval.internal.operator.rex.ExprMissing
 import org.partiql.eval.internal.operator.rex.ExprNullIf
@@ -325,7 +326,11 @@ internal class StandardCompiler(strategies: List<Strategy>) : PartiQLCompiler {
         }
 
         override fun visitError(rex: RexError, ctx: Unit): ExprValue {
-            return ExprMissing(PType.unknown())
+            return when (mode.code()) {
+                Mode.PERMISSIVE -> ExprMissing(PType.unknown())
+                Mode.STRICT -> ExprError()
+                else -> throw IllegalStateException("Unsupported execution mode: $mode")
+            }
         }
 
         // OPERATORS

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/DatumArrayComparator.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/DatumArrayComparator.kt
@@ -1,20 +1,17 @@
 package org.partiql.eval.internal.helpers
 
-import org.partiql.eval.Row
 import org.partiql.spi.value.Datum
 
-internal object DatumArrayComparator : Comparator<Row> {
+internal object DatumArrayComparator : Comparator<Array<Datum>> {
     private val delegate = Datum.comparator(false)
-    override fun compare(o1: Row, o2: Row): Int {
-        val o1Size = o1.size
-        val o2Size = o2.size
-        if (o1Size < o2Size) {
+    override fun compare(o1: Array<Datum>, o2: Array<Datum>): Int {
+        if (o1.size < o2.size) {
             return -1
         }
-        if (o1Size > o2Size) {
+        if (o1.size > o2.size) {
             return 1
         }
-        for (index in 0 until o2.size) {
+        for (index in 0..o2.lastIndex) {
             val element1 = o1[index]
             val element2 = o2[index]
             val compared = delegate.compare(element1, element2)

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/RecordUtility.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/helpers/RecordUtility.kt
@@ -1,6 +1,5 @@
 package org.partiql.eval.internal.helpers
 
-import org.partiql.eval.Row
 import org.partiql.spi.value.Datum
 
 internal object RecordUtility {
@@ -9,8 +8,8 @@ internal object RecordUtility {
      * (treats null and missing as the same value) and we need to deterministically return a value. Here we use coerce
      * to null to follow the PartiQL spec's grouping function.
      */
-    fun Row.coerceMissing() {
-        for (i in 0..getSize()) {
+    fun Array<Datum>.coerceMissing() {
+        for (i in indices) {
             if (this[i].isMissing) {
                 this[i] = Datum.nullValue()
             }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpDistinct.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpDistinct.kt
@@ -16,7 +16,7 @@ internal class RelOpDistinct(private val input: ExprRelation) : RelOpPeeking() {
 
     override fun peek(): Row? {
         for (next in input) {
-            val transformed = next
+            val transformed = Array(next.values.size) { next.values[it] }
             if (seen.contains(transformed).not()) {
                 seen.add(transformed)
                 return next

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpExceptAll.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpExceptAll.kt
@@ -5,6 +5,7 @@ import org.partiql.eval.ExprRelation
 import org.partiql.eval.Row
 import org.partiql.eval.internal.helpers.DatumArrayComparator
 import org.partiql.eval.internal.helpers.RecordUtility.coerceMissing
+import org.partiql.spi.value.Datum
 import java.util.TreeMap
 
 internal class RelOpExceptAll(
@@ -12,7 +13,7 @@ internal class RelOpExceptAll(
     private val rhs: ExprRelation,
 ) : RelOpPeeking() {
 
-    private val seen = TreeMap<Row, Int>(DatumArrayComparator)
+    private val seen = TreeMap<Array<Datum>, Int>(DatumArrayComparator)
     private var init: Boolean = false
 
     override fun openPeeking(env: Environment) {
@@ -27,13 +28,13 @@ internal class RelOpExceptAll(
             seed()
         }
         for (row in lhs) {
-            row.coerceMissing()
-            val remaining = seen[row] ?: 0
+            row.values.coerceMissing()
+            val remaining = seen[row.values] ?: 0
             if (remaining > 0) {
-                seen[row] = remaining - 1
+                seen[row.values] = remaining - 1
                 continue
             }
-            return row
+            return Row(row.values)
         }
         return null
     }
@@ -50,9 +51,9 @@ internal class RelOpExceptAll(
     private fun seed() {
         init = true
         for (row in rhs) {
-            row.coerceMissing()
-            val n = seen[row] ?: 0
-            seen[row] = n + 1
+            row.values.coerceMissing()
+            val n = seen[row.values] ?: 0
+            seen[row.values] = n + 1
         }
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpExceptDistinct.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpExceptDistinct.kt
@@ -32,9 +32,9 @@ internal class RelOpExceptDistinct(
             seed()
         }
         for (row in lhs) {
-            row.coerceMissing()
-            if (!seen.contains(row)) {
-                return row
+            row.values.coerceMissing()
+            if (!seen.contains(row.values)) {
+                return Row(row.values)
             }
         }
         return null
@@ -52,8 +52,8 @@ internal class RelOpExceptDistinct(
     private fun seed() {
         init = true
         for (row in rhs) {
-            row.coerceMissing()
-            seen.add(row)
+            row.values.coerceMissing()
+            seen.add(row.values)
         }
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpExclude.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpExclude.kt
@@ -31,8 +31,8 @@ internal class RelOpExclude(
         exclusions.forEach { exclusion ->
             // TODO memoize offsets and steps (i.e. don't call getVar(), getOffset(), and getItems() every time).
             val o = exclusion.getVar().getOffset()
-            val value = record[o]
-            record[o] = value.exclude(exclusion.getItems())
+            val value = record.values[o]
+            record.values[o] = value.exclude(exclusion.getItems())
         }
         return record
     }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpIntersectAll.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpIntersectAll.kt
@@ -5,6 +5,7 @@ import org.partiql.eval.ExprRelation
 import org.partiql.eval.Row
 import org.partiql.eval.internal.helpers.DatumArrayComparator
 import org.partiql.eval.internal.helpers.RecordUtility.coerceMissing
+import org.partiql.spi.value.Datum
 import java.util.TreeMap
 
 internal class RelOpIntersectAll(
@@ -12,7 +13,7 @@ internal class RelOpIntersectAll(
     private val rhs: ExprRelation,
 ) : RelOpPeeking() {
 
-    private val seen = TreeMap<Row, Int>(DatumArrayComparator)
+    private val seen = TreeMap<Array<Datum>, Int>(DatumArrayComparator)
     private var init: Boolean = false
 
     override fun openPeeking(env: Environment) {
@@ -27,11 +28,11 @@ internal class RelOpIntersectAll(
             seed()
         }
         for (row in rhs) {
-            row.coerceMissing()
-            val remaining = seen[row] ?: 0
+            row.values.coerceMissing()
+            val remaining = seen[row.values] ?: 0
             if (remaining > 0) {
-                seen[row] = remaining - 1
-                return row
+                seen[row.values] = remaining - 1
+                return Row(row.values)
             }
         }
         return null
@@ -49,9 +50,9 @@ internal class RelOpIntersectAll(
     private fun seed() {
         init = true
         for (row in lhs) {
-            row.coerceMissing()
-            val alreadySeen = seen[row] ?: 0
-            seen[row] = alreadySeen + 1
+            row.values.coerceMissing()
+            val alreadySeen = seen[row.values] ?: 0
+            seen[row.values] = alreadySeen + 1
         }
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpIntersectDistinct.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpIntersectDistinct.kt
@@ -27,9 +27,9 @@ internal class RelOpIntersectDistinct(
             seed()
         }
         for (row in rhs) {
-            row.coerceMissing()
-            if (seen.remove(row)) {
-                return row
+            row.values.coerceMissing()
+            if (seen.remove(row.values)) {
+                return Row(row.values)
             }
         }
         return null
@@ -47,8 +47,8 @@ internal class RelOpIntersectDistinct(
     private fun seed() {
         init = true
         for (row in lhs) {
-            row.coerceMissing()
-            seen.add(row)
+            row.values.coerceMissing()
+            seen.add(row.values)
         }
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpUnionAll.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpUnionAll.kt
@@ -23,12 +23,12 @@ internal class RelOpUnionAll(
         return when (lhs.hasNext()) {
             true -> {
                 val record = lhs.next()
-                record.coerceMissing()
+                record.values.coerceMissing()
                 record
             }
             false -> {
                 val record = rhs.next()
-                record.coerceMissing()
+                record.values.coerceMissing()
                 record
             }
         }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpUnionDistinct.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpUnionDistinct.kt
@@ -26,10 +26,10 @@ internal class RelOpUnionDistinct(
 
     override fun peek(): Row? {
         for (record in input) {
-            record.coerceMissing()
-            if (!seen.contains(record)) {
-                seen.add(record)
-                return record
+            record.values.coerceMissing()
+            if (!seen.contains(record.values)) {
+                seen.add(record.values)
+                return Row(record.values)
             }
         }
         return null

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprError.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprError.kt
@@ -1,0 +1,12 @@
+package org.partiql.eval.internal.operator.rex
+
+import org.partiql.eval.Environment
+import org.partiql.eval.ExprValue
+import org.partiql.spi.errors.TypeCheckException
+import org.partiql.spi.value.Datum
+
+internal class ExprError : ExprValue {
+    override fun eval(env: Environment): Datum {
+        throw TypeCheckException("A warning has been converted into an error.")
+    }
+}

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -783,7 +783,8 @@ internal class PlanTyper(private val env: Env, config: Context) {
             val argIsAlwaysMissing = args.any { it.type.isMissingValue }
 
             if (argIsAlwaysMissing && instance.isMissingCall) {
-                return errorRexAndReport(_listener, PErrors.alwaysMissing(null))
+                _listener.report(PErrors.alwaysMissing(null))
+                return rex(CompilerType(returnType), Rex.Op.Call.Static(node.fn, args))
             }
 
             // Infer fn return type

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/util/FunctionUtils.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/util/FunctionUtils.kt
@@ -17,6 +17,7 @@ internal object FunctionUtils {
     // The following are public functions, able to be directly invoked via PartiQL text.
     const val FN_SUBSTRING: String = "substring"
     const val FN_CHAR_LENGTH: String = "char_length"
+    const val FN_MODULO: String = "mod"
 
     // The following are hidden operators, unable to be invoked via PartiQL text.
     val OP_NOT: String = hide("not")
@@ -33,7 +34,6 @@ internal object FunctionUtils {
     val OP_MINUS: String = hide("minus")
     val OP_DIVIDE: String = hide("divide")
     val OP_TIMES: String = hide("times")
-    val OP_MODULO: String = hide("modulo")
     val OP_BITWISE_AND: String = hide("bitwise_and")
     val OP_CONCAT: String = hide("concat")
     val OP_NEG: String = hide("neg")
@@ -99,7 +99,7 @@ internal object FunctionUtils {
             "-" -> OP_MINUS
             "*" -> OP_TIMES
             "/" -> OP_DIVIDE
-            "%" -> OP_MODULO
+            "%" -> FN_MODULO
             "&" -> OP_BITWISE_AND
             else -> null
         }

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/PlannerPErrorReportingTests.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/PlannerPErrorReportingTests.kt
@@ -144,6 +144,7 @@ internal class PlannerPErrorReportingTests {
                 "1 + MISSING",
                 false,
                 assertOnProblemCount(1, 0),
+                expectedType = PType.integer().toCType()
             ),
             // This will be a non-resolved function error.
             // As plus does not contain a function that match argument type with
@@ -153,6 +154,7 @@ internal class PlannerPErrorReportingTests {
                 "1 + MISSING",
                 true,
                 assertOnProblemCount(0, 1),
+                expectedType = PType.integer().toCType()
             ),
             // Attempting to do path navigation(symbol) on missing(which is not tuple)
             //  returns missing in quite mode, and error out in signal mode

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -926,7 +926,7 @@ internal class PlanTyperTestsPorted {
             ErrorTestCase(
                 name = "BITWISE_AND_MISSING_OPERAND",
                 query = "1 & MISSING",
-                expected = ANY, // TODO SHOULD BE UNKNOWN
+                expected = PType.integer(),
                 problemHandler = assertProblemExists(PErrors.alwaysMissing(null))
             ),
             ErrorTestCase(
@@ -3570,7 +3570,7 @@ internal class PlanTyperTestsPorted {
                 query = """
                     +MISSING
                 """.trimIndent(),
-                expected = ANY,
+                expected = PType.doublePrecision(),
                 problemHandler = assertProblemExists(PErrors.alwaysMissing(null))
             ),
         )

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/DiadicArithmeticOperator.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/DiadicArithmeticOperator.kt
@@ -1,12 +1,20 @@
 package org.partiql.spi.function.builtins
 
+import org.partiql.spi.function.Function
 import org.partiql.spi.function.Parameter
+import org.partiql.spi.types.PType
 
 /**
  * This carries along with it a static table containing a mapping between the input types and the implementation.
+ * @param hidesName dictates whether the [name] should be hidden; true by default.
  */
-internal abstract class DiadicArithmeticOperator(name: String) : DiadicOperator(
+internal abstract class DiadicArithmeticOperator(name: String, hidesName: Boolean = true) : DiadicOperator(
     name,
     Parameter.number("lhs"),
-    Parameter.number("rhs")
-)
+    Parameter.number("rhs"),
+    hidesName = hidesName
+) {
+    override fun getUnknownInstance(): Function.Instance? {
+        return getDoubleInstance(PType.doublePrecision(), PType.doublePrecision())
+    }
+}

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnBetween.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnBetween.kt
@@ -19,9 +19,9 @@ internal val Fn_BETWEEN__INT8_INT8_INT8__BOOL = FunctionUtils.hidden(
     ),
 
 ) { args ->
-    @Suppress("DEPRECATION") val value = args[0].byte
-    @Suppress("DEPRECATION") val lower = args[1].byte
-    @Suppress("DEPRECATION") val upper = args[2].byte
+    val value = args[0].byte
+    val lower = args[1].byte
+    val upper = args[2].byte
     Datum.bool(value in lower..upper)
 }
 

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnBitwiseAnd.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnBitwiseAnd.kt
@@ -16,8 +16,8 @@ internal object FnBitwiseAnd : DiadicArithmeticOperator("bitwise_and") {
 
     override fun getTinyIntInstance(tinyIntLhs: PType, tinyIntRhs: PType): Function.Instance {
         return basic(PType.tinyint()) { args ->
-            @Suppress("DEPRECATION") val arg0 = args[0].byte
-            @Suppress("DEPRECATION") val arg1 = args[1].byte
+            val arg0 = args[0].byte
+            val arg1 = args[1].byte
             Datum.tinyint(arg0 and arg1)
         }
     }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnGt.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnGt.kt
@@ -50,7 +50,6 @@ internal object FnGt : DiadicComparisonOperator("gt") {
         }
     }
 
-    // TODO: Update numeric to use bigDecimal rather than bigInteger.
     override fun getNumericInstance(numericLhs: PType, numericRhs: PType): Function.Instance {
         return basic(PType.bool(), DefaultNumeric.NUMERIC) { args ->
             val lhs = args[0].bigDecimal

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnGte.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnGte.kt
@@ -50,7 +50,6 @@ internal object FnGte : DiadicComparisonOperator("gte") {
         }
     }
 
-    // TODO: Update
     override fun getNumericInstance(numericLhs: PType, numericRhs: PType): Function.Instance {
         return basic(PType.bool(), DefaultNumeric.NUMERIC) { args ->
             val lhs = args[0].bigDecimal

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnLt.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnLt.kt
@@ -46,7 +46,6 @@ internal object FnLt : DiadicComparisonOperator("lt") {
         }
     }
 
-    // TODO: Update
     override fun getNumericInstance(numericLhs: PType, numericRhs: PType): Function.Instance {
         return basic(PType.bool(), DefaultNumeric.NUMERIC) { args ->
             val lhs = args[0].bigDecimal

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnLte.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnLte.kt
@@ -50,7 +50,6 @@ internal object FnLte : DiadicComparisonOperator("lte") {
         }
     }
 
-    // TODO: Update
     override fun getNumericInstance(numericLhs: PType, numericRhs: PType): Function.Instance {
         return basic(PType.bool(), DefaultNumeric.NUMERIC) { args ->
             val lhs = args[0].bigDecimal

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnMinus.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnMinus.kt
@@ -69,23 +69,24 @@ internal object FnMinus : DiadicArithmeticOperator("minus") {
         }
     }
 
-    // TODO: Delete this
     override fun getNumericInstance(numericLhs: PType, numericRhs: PType): Function.Instance {
-        return basic(DefaultNumeric.NUMERIC) { args ->
+        val (p, s) = minusPrecisionScale(numericLhs, numericRhs)
+        return Function.instance(
+            name = getName(),
+            returns = PType.numeric(p, s),
+            parameters = arrayOf(
+                Parameter("lhs", numericLhs),
+                Parameter("rhs", numericRhs),
+            )
+        ) { args ->
             val arg0 = args[0].bigDecimal
             val arg1 = args[1].bigDecimal
-            Datum.numeric(arg0 - arg1)
+            Datum.numeric(arg0 - arg1, p, s)
         }
     }
 
-    /**
-     * Precision and scale calculation:
-     * P = max(s1, s2) + max(p1 - s1, p2 - s2) + 1
-     * S = max(s1, s2)
-     */
     override fun getDecimalInstance(decimalLhs: PType, decimalRhs: PType): Function.Instance {
-        val p = Math.min(38, Math.max(decimalLhs.scale, decimalRhs.scale) + Math.max(decimalLhs.precision - decimalLhs.scale, decimalRhs.precision - decimalRhs.scale) + 1)
-        val s = Math.min(38, Math.max(decimalLhs.scale, decimalRhs.scale))
+        val (p, s) = minusPrecisionScale(decimalLhs, decimalRhs)
         return Function.instance(
             name = getName(),
             returns = PType.decimal(p, s),
@@ -98,6 +99,20 @@ internal object FnMinus : DiadicArithmeticOperator("minus") {
             val arg1 = args[1].bigDecimal
             Datum.decimal(arg0 - arg1, p, s)
         }
+    }
+
+    /**
+     * P = max(s1, s2) + max(p1 - s1, p2 - s2) + 1
+     * S = max(s1, s2)
+     */
+    private fun minusPrecisionScale(lhs: PType, rhs: PType): Pair<Int, Int> {
+        val (p1, s1) = lhs.precision to lhs.scale
+        val (p2, s2) = rhs.precision to rhs.scale
+        val p = s1.coerceAtLeast(s2) + (p1 - s1).coerceAtLeast(p2 - s2) + 1
+        val s = s1.coerceAtLeast(s2)
+        val returnedP = p.coerceAtMost(38)
+        val returnedS = s.coerceAtMost(p)
+        return returnedP to returnedS
     }
 
     override fun getRealInstance(realLhs: PType, realRhs: PType): Function.Instance {

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnModulo.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnModulo.kt
@@ -8,7 +8,7 @@ import org.partiql.spi.function.Function
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
 
-internal object FnModulo : DiadicArithmeticOperator("modulo") {
+internal object FnModulo : DiadicArithmeticOperator("mod", false) {
 
     init {
         fillTable()

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnModulo.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnModulo.kt
@@ -63,10 +63,20 @@ internal object FnModulo : DiadicArithmeticOperator("modulo") {
     }
 
     override fun getNumericInstance(numericLhs: PType, numericRhs: PType): Function.Instance {
-        return basic(DefaultNumeric.NUMERIC) { args ->
+        val (p, s) = decimalPrecisionScale(numericLhs, numericRhs)
+        return basic(PType.numeric(p, s), numericLhs, numericRhs) { args ->
             val arg0 = args[0].bigDecimal
             val arg1 = args[1].bigDecimal
-            Datum.numeric(arg0 % arg1)
+            Datum.numeric(arg0 % arg1, p, s)
+        }
+    }
+
+    override fun getDecimalInstance(decimalLhs: PType, decimalRhs: PType): Function.Instance {
+        val (p, s) = decimalPrecisionScale(decimalLhs, decimalRhs)
+        return basic(PType.decimal(p, s), decimalLhs, decimalRhs) { args ->
+            val arg0 = args[0].bigDecimal
+            val arg1 = args[1].bigDecimal
+            Datum.decimal(arg0 % arg1, p, s)
         }
     }
 
@@ -75,14 +85,14 @@ internal object FnModulo : DiadicArithmeticOperator("modulo") {
      * p = min(p1 - s1, p2 - s2) + max(s1, s2)
      * s = max(s1, s2)
      */
-    override fun getDecimalInstance(decimalLhs: PType, decimalRhs: PType): Function.Instance {
-        val p = Math.min(decimalLhs.precision - decimalLhs.scale, decimalRhs.precision - decimalRhs.scale) + Math.max(decimalLhs.scale, decimalRhs.scale)
-        val s = Math.max(decimalLhs.scale, decimalRhs.scale)
-        return basic(PType.decimal(p, s), decimalLhs, decimalRhs) { args ->
-            val arg0 = args[0].bigDecimal
-            val arg1 = args[1].bigDecimal
-            Datum.decimal(arg0 % arg1, p, s)
-        }
+    private fun decimalPrecisionScale(lhs: PType, rhs: PType): Pair<Int, Int> {
+        val (p1, s1) = lhs.precision to lhs.scale
+        val (p2, s2) = rhs.precision to rhs.scale
+        val p = (p1 - s1).coerceAtMost(p2 - s2) + s1.coerceAtLeast(s2)
+        val s = s1.coerceAtLeast(s2)
+        val returnedP = p.coerceAtMost(38)
+        val returnedS = s.coerceAtMost(p)
+        return returnedP to returnedS
     }
 
     override fun getRealInstance(realLhs: PType, realRhs: PType): Function.Instance {

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnPlus.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnPlus.kt
@@ -69,23 +69,24 @@ internal object FnPlus : DiadicArithmeticOperator("plus") {
         }
     }
 
-    // TODO: Probably remove this if we don't expose NUMERIC
     override fun getNumericInstance(numericLhs: PType, numericRhs: PType): Function.Instance {
-        return basic(DefaultNumeric.NUMERIC) { args ->
+        val (p, s) = plusPrecisionScale(numericLhs, numericRhs)
+        return Function.instance(
+            name = getName(),
+            returns = PType.numeric(p, s),
+            parameters = arrayOf(
+                Parameter("lhs", numericLhs),
+                Parameter("rhs", numericRhs),
+            )
+        ) { args ->
             val arg0 = args[0].bigDecimal
             val arg1 = args[1].bigDecimal
-            Datum.numeric(arg0 + arg1)
+            Datum.numeric(arg0 + arg1, p, s)
         }
     }
 
-    /**
-     * Precision and scale calculation:
-     * P = max(s1, s2) + max(p1 - s1, p2 - s2) + 1
-     * S = max(s1, s2)
-     */
     override fun getDecimalInstance(decimalLhs: PType, decimalRhs: PType): Function.Instance {
-        val p = Math.min(38, Math.max(decimalLhs.scale, decimalRhs.scale) + Math.max(decimalLhs.precision - decimalLhs.scale, decimalRhs.precision - decimalRhs.scale) + 1)
-        val s = Math.min(38, Math.max(decimalLhs.scale, decimalRhs.scale))
+        val (p, s) = plusPrecisionScale(decimalLhs, decimalRhs)
         return Function.instance(
             name = getName(),
             returns = PType.decimal(p, s),
@@ -98,6 +99,21 @@ internal object FnPlus : DiadicArithmeticOperator("plus") {
             val arg1 = args[1].bigDecimal
             Datum.decimal(arg0 + arg1, p, s)
         }
+    }
+
+    /**
+     * Precision and scale calculation:
+     * P = max(s1, s2) + max(p1 - s1, p2 - s2) + 1
+     * S = max(s1, s2)
+     */
+    fun plusPrecisionScale(lhs: PType, rhs: PType): Pair<Int, Int> {
+        val (p1, s1) = lhs.precision to lhs.scale
+        val (p2, s2) = rhs.precision to rhs.scale
+        val p = s1.coerceAtLeast(s2) + (p1 - s1).coerceAtLeast(p2 - s2) + 1
+        val s = s1.coerceAtLeast(s2)
+        val returnedP = p.coerceAtMost(38)
+        val returnedS = s.coerceAtMost(p)
+        return returnedP to returnedS
     }
 
     override fun getRealInstance(realLhs: PType, realRhs: PType): Function.Instance {

--- a/test/partiql-tests-runner/src/test/resources/config/eval/skip-eval.txt
+++ b/test/partiql-tests-runner/src/test/resources/config/eval/skip-eval.txt
@@ -1,4 +1,4 @@
-// TODO: Alias tests. Needed for V1 release.
+// TODO: Alias tests. Not needed for V1 release. Fixing this would not result in an API change.
 PERMISSIVE:::testing alias support
 STRICT:::testing alias support
 PERMISSIVE:::testing nested alias support
@@ -6,17 +6,11 @@ STRICT:::testing nested alias support
 PERMISSIVE:::group and order by count
 STRICT:::group and order by count
 
-// TODO: Arithmetic tests. Needed for V1 release.
-PERMISSIVE:::division with mixed StaticType
-STRICT:::division with mixed StaticType
-PERMISSIVE:::repeatingDecimal
-STRICT:::repeatingDecimal
-PERMISSIVE:::repeatingDecimalHigherPrecision
-STRICT:::repeatingDecimalHigherPrecision
-PERMISSIVE:::divDecimalInt
-STRICT:::divDecimalInt
-PERMISSIVE:::subtractionOutOfAllowedPrecision
-STRICT:::subtractionOutOfAllowedPrecision
+// TODO: Arithmetic tests.
+PERMISSIVE:::repeatingDecimal // TODO: This is wrong. 4.0000 / 3.0 = 1.3333333
+STRICT:::repeatingDecimal // TODO: This is wrong. 4.0000 / 3.0 = 1.3333333
+PERMISSIVE:::subtractionOutOfAllowedPrecision // TODO: This is wrong. 1e100 - 1e-100 = 1e100
+STRICT:::subtractionOutOfAllowedPrecision // TODO: This is wrong. 1e100 - 1e-100 = 1e100
 
 // TODO: Datetime methods for EXTRACT for TIME WITH TIMEZONE and TIMESTAMP WITH TIMEZONE
 PERMISSIVE:::EXTRACT(SECOND FROM TIME (2) '01:23:45.678')

--- a/test/partiql-tests-runner/src/test/resources/config/eval/skip-eval.txt
+++ b/test/partiql-tests-runner/src/test/resources/config/eval/skip-eval.txt
@@ -1,4 +1,4 @@
-// TODO: Alias tests. Not needed for V1 release. Fixing this would not result in an API change.
+// TODO: NOT NEEDED FOR V1 RELEASE. Alias tests. Fixing this would not result in an API change.
 PERMISSIVE:::testing alias support
 STRICT:::testing alias support
 PERMISSIVE:::testing nested alias support
@@ -6,13 +6,13 @@ STRICT:::testing nested alias support
 PERMISSIVE:::group and order by count
 STRICT:::group and order by count
 
-// TODO: Arithmetic tests.
+// TODO: NOT NEEDED FOR V1 RELEASE. Arithmetic tests. All tests are wrong.
 PERMISSIVE:::repeatingDecimal // TODO: This is wrong. 4.0000 / 3.0 = 1.3333333
 STRICT:::repeatingDecimal // TODO: This is wrong. 4.0000 / 3.0 = 1.3333333
 PERMISSIVE:::subtractionOutOfAllowedPrecision // TODO: This is wrong. 1e100 - 1e-100 = 1e100
 STRICT:::subtractionOutOfAllowedPrecision // TODO: This is wrong. 1e100 - 1e-100 = 1e100
 
-// TODO: Datetime methods for EXTRACT for TIME WITH TIMEZONE and TIMESTAMP WITH TIMEZONE
+// TODO: NEEDED. Datetime methods for EXTRACT for TIME WITH TIMEZONE and TIMESTAMP WITH TIMEZONE
 PERMISSIVE:::EXTRACT(SECOND FROM TIME (2) '01:23:45.678')
 STRICT:::EXTRACT(SECOND FROM TIME (2) '01:23:45.678')
 PERMISSIVE:::EXTRACT(HOUR FROM TIME (2) WITH TIME ZONE '01:23:45.678-06:30')
@@ -28,7 +28,7 @@ STRICT:::EXTRACT(TIMEZONE_HOUR FROM `2000-01-02T03:04:05.67-08:09`)
 PERMISSIVE:::EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67-08:09`)
 STRICT:::EXTRACT(TIMEZONE_MINUTE FROM `2000-01-02T03:04:05.67-08:09`)
 
-// TODO: Undefined variable tests. Needed for V1 release.
+// TODO: NOT NEEDED FOR V1 RELEASE. Undefined variable tests. The references are ambiguous, and tests likely need to be updated.
 PERMISSIVE:::GROUP BY binding referenced in FROM clause
 PERMISSIVE:::GROUP BY binding referenced in WHERE clause
 PERMISSIVE:::GROUP AS binding referenced in FROM clause
@@ -50,72 +50,23 @@ STRICT:::MYSQL_SELECT_20
 PERMISSIVE:::MYSQL_SELECT_21
 STRICT:::MYSQL_SELECT_21
 
-// TODO: Negative offset. Needed for V1 release.
+// TODO: NOT NEEDED FOR V1 RELEASE. Negative offset. No API change. No impact.
 PERMISSIVE:::offset -1
 STRICT:::offset -1
 STRICT:::offset 1-2
 
-// TODO: Mistyped Coll Aggs. Needed for V1 release.
-STRICT:::COLL_MAX non-collection
-STRICT:::COLL_AVG non-collection
-STRICT:::COLL_COUNT non-collection
-STRICT:::COLL_SUM non-collection
-STRICT:::COLL_MIN non-collection
-STRICT:::COLL_ANY non-collection
-STRICT:::COLL_SOME non-collection
-STRICT:::COLL_EVERY non-collection
-
-// TODO: Mistyped functions. Needed for V1 release.
-STRICT:::MOD(MISSING, 'some string')
-STRICT:::MOD('some string', MISSING)
-STRICT:::MOD(NULL, 'some string')
-STRICT:::MOD('some string', NULL)
-STRICT:::MOD(3, 'some string')
-STRICT:::MOD('some string', 3)
-STRICT:::CARDINALITY('foo') type mismatch
-STRICT:::OCTET_LENGTH invalid type
-STRICT:::CHARACTER_LENGTH invalid type
-STRICT:::ABS('foo')
-STRICT:::POSITION invalid type in string
-STRICT:::POSITION string in invalid type
-STRICT:::BIT_LENGTH invalid type
-
-// TODO: Invalid casts. Needed for V1 release.
-STRICT:::cast to int invalid target type{value:"[1, 2]",target:"LIST"}
-STRICT:::cast to int invalid target type{value:"[1]",target:"LIST"}
-STRICT:::cast to int invalid target type{value:"[]",target:"LIST"}
-STRICT:::cast to int invalid target type{value:"{'a': 1}",target:"STRUCT"}
-STRICT:::cast to int invalid target type{value:"{'a': '12'}",target:"STRUCT"}
-STRICT:::cast to int invalid target type{value:"{}",target:"STRUCT"}
-STRICT:::cast to int invalid target type{value:"<<1, 2>>",target:"BAG"}
-STRICT:::cast to int invalid target type{value:"<<1>>",target:"BAG"}
-STRICT:::cast to int invalid target type{value:"<<>>",target:"BAG"}
-
-// TODO: Special forms. Needed for V1 release.
+// TODO: NOT NEEDED FOR V1 RELEASE. Special forms. No API change.
 PERMISSIVE:::More than one character given for ESCAPE
-STRICT:::LIKE bad value type
-STRICT:::LIKE bad pattern type
-STRICT:::LIKE bad escape type
 
-// TODO: Bag ops. Needed for V1 release.
+// TODO: MAYBE NEEDED FOR V1 RELEASE. Bag ops.
 PERMISSIVE:::Example 6 - Value Coercion not union-compatible
 STRICT:::Example 6 - Value Coercion not union-compatible
 
-// TODO: Operators. Needed for V1 release.
-STRICT:::data type mismatch in comparison expression
-
-// TODO: Sexp tests. Needed for V1 release.
+// TODO: NOT NEEDED FOR V1 RELEASE. Sexp tests. This is hotly debated.
 PERMISSIVE:::projectOfSexp
 STRICT:::projectOfSexp
 
-// TODO: Miscellaneous. Needed for V1 release.
-STRICT:::invalid extract year from time
-STRICT:::invalid extract month from time
-STRICT:::invalid extract day from time
-STRICT:::invalid extract month from time with time zone
-STRICT:::invalid extract day from time with time zone
-
-// TODO: GPML. Not needed for V1 release.
+// TODO: NOT NEEDED FOR V1 RELEASE. GPML.
 PERMISSIVE:::Right with variables
 STRICT:::Right with variables
 PERMISSIVE:::Right with spots


### PR DESCRIPTION
## Description

Fixes 45 conformance tests. There are two major commits in this PR. They should be looked at individually to aid with the review.
1. Fixes arithmetic conformance tests (6 tests).
  a. Did this by flushing out NUMERIC.
  b. Fixed some overflow for the arithmetic operations of divide/multiply/etc.
  c. Made the "MOD" function public. SQL:1999 has it user-accessible.
3. Fixes typing of functions conformance tests (39 tests).
  a. I just introduced RexError to error out in STRICT mode.
  b. I also fixed the typing of operations/functions where one of the operands is the MISSING value.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.