### PR TITLE
[v1] Change integer types to error on overflow; give explicit data exception on div/mod by 0

### DIFF
--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DataExceptionTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DataExceptionTest.kt
@@ -1,0 +1,179 @@
+package org.partiql.eval.internal
+
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+/**
+ * E2E evaluation tests that give a data exception.
+ */
+class DataExceptionTest {
+
+    @ParameterizedTest
+    @MethodSource("plusOverflowTests")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun plusOverflow(tc: FailureTestCase) = tc.run()
+
+    @ParameterizedTest
+    @MethodSource("minusOverflowTests")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun minusOverflow(tc: FailureTestCase) = tc.run()
+
+    @ParameterizedTest
+    @MethodSource("timesOverflowTests")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun timesOverflow(tc: FailureTestCase) = tc.run()
+
+    @ParameterizedTest
+    @MethodSource("divideTests")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun divideOverflow(tc: FailureTestCase) = tc.run()
+
+    @ParameterizedTest
+    @MethodSource("divideByZeroTests")
+    fun divideByZero(tc: FailureTestCase) = tc.run()
+
+    companion object {
+        @JvmStatic
+        fun plusOverflowTests() = listOf(
+            // TINYINT
+            // TODO add parsing and planning support for TINYINT
+//            FailureTestCase(
+//                input = "CAST(${Byte.MAX_VALUE} AS TINYINT) + CAST(1 AS TINYINT);"
+//            ),
+//            FailureTestCase(
+//                input = "CAST(${Byte.MIN_VALUE} AS TINYINT) + CAST(-1 AS TINYINT);"
+//            ),
+            // SMALLINT
+            FailureTestCase(
+                input = "CAST(${Short.MAX_VALUE} AS SMALLINT) + CAST(1 AS SMALLINT);"
+            ),
+            FailureTestCase(
+                input = "CAST(${Short.MIN_VALUE} AS SMALLINT) + CAST(-1 AS SMALLINT);"
+            ),
+            // INT
+            FailureTestCase(
+                input = "CAST(${Integer.MAX_VALUE} AS INT) + CAST(1 AS INT);"
+            ),
+            FailureTestCase(
+                input = "CAST(${Integer.MIN_VALUE} AS INT) + CAST(-1 AS INT);"
+            ),
+            // BIGINT
+            FailureTestCase(
+                input = "CAST(${Long.MAX_VALUE} AS BIGINT) + CAST(1 AS BIGINT);"
+            ),
+            FailureTestCase(
+                input = "CAST(${Long.MIN_VALUE} AS BIGINT) + CAST(-1 AS BIGINT);"
+            )
+        )
+
+        @JvmStatic
+        fun minusOverflowTests() = listOf(
+            // TINYINT
+            // TODO add parsing and planning support for TINYINT
+//            FailureTestCase(
+//                input = "CAST(${Byte.MAX_VALUE} AS TINYINT) - CAST(-1 AS TINYINT);"
+//            ),
+//            FailureTestCase(
+//                input = "CAST(${Byte.MIN_VALUE} AS TINYINT) - CAST(1 AS TINYINT);"
+//            ),
+            // SMALLINT
+            FailureTestCase(
+                input = "CAST(${Short.MAX_VALUE} AS SMALLINT) - CAST(-1 AS SMALLINT);"
+            ),
+            FailureTestCase(
+                input = "CAST(${Short.MIN_VALUE} AS SMALLINT) - CAST(1 AS SMALLINT);"
+            ),
+            // INT
+            FailureTestCase(
+                input = "CAST(${Integer.MAX_VALUE} AS INT) - CAST(-1 AS INT);"
+            ),
+            FailureTestCase(
+                input = "CAST(${Integer.MIN_VALUE} AS INT) - CAST(1 AS INT);"
+            ),
+            // BIGINT
+            FailureTestCase(
+                input = "CAST(${Long.MAX_VALUE} AS BIGINT) - CAST(-1 AS BIGINT);"
+            ),
+            FailureTestCase(
+                input = "CAST(${Long.MIN_VALUE} AS BIGINT) - CAST(1 AS BIGINT);"
+            )
+        )
+
+        @JvmStatic
+        fun timesOverflowTests() = listOf(
+            // TINYINT
+            // TODO add parsing and planning support for TINYINT
+//            FailureTestCase(
+//                input = "CAST(${Byte.MAX_VALUE} AS TINYINT) * CAST(2 AS TINYINT);"
+//            ),
+//            FailureTestCase(
+//                input = "CAST(${Byte.MIN_VALUE} AS TINYINT) * CAST(2 AS TINYINT);"
+//            ),
+            // SMALLINT
+            FailureTestCase(
+                input = "CAST(${Short.MAX_VALUE} AS SMALLINT) * CAST(2 AS SMALLINT);"
+            ),
+            FailureTestCase(
+                input = "CAST(${Short.MIN_VALUE} AS SMALLINT) * CAST(2 AS SMALLINT);"
+            ),
+            // INT
+            FailureTestCase(
+                input = "CAST(${Integer.MAX_VALUE} AS INT) * CAST(2 AS INT);"
+            ),
+            FailureTestCase(
+                input = "CAST(${Integer.MIN_VALUE} AS INT) * CAST(2 AS INT);"
+            ),
+            // BIGINT
+            FailureTestCase(
+                input = "CAST(${Long.MAX_VALUE} AS BIGINT) * CAST(2 AS BIGINT);"
+            ),
+            FailureTestCase(
+                input = "CAST(${Long.MIN_VALUE} AS BIGINT) * CAST(2 AS BIGINT);"
+            )
+        )
+
+        @JvmStatic
+        fun divideTests() = listOf(
+            // TINYINT
+            // TODO add parsing and planning support for TINYINT
+//            FailureTestCase(
+//                input = "CAST(${Byte.MIN_VALUE} AS TINYINT) / CAST(-1 AS TINYINT)"
+//            ),
+            // SMALLINT
+            FailureTestCase(
+                input = "CAST(${Short.MIN_VALUE} AS SMALLINT) / CAST(-1 AS SMALLINT)"
+            ),
+            // INT
+            FailureTestCase(
+                input = "CAST(${Integer.MIN_VALUE} AS INT) / CAST(-1 AS INT)"
+            ),
+            // BIGINT
+            FailureTestCase(
+                input = "CAST(${Long.MIN_VALUE} AS BIGINT) / CAST(-1 AS BIGINT)"
+            )
+        )
+
+        @JvmStatic
+        fun divideByZeroTests() = listOf(
+            // TINYINT
+            // TODO add parsing and planning support for TINYINT
+//            FailureTestCase(
+//                input = "CAST(1 AS TINYINT) / CAST(0 AS TINYINT)"
+//            ),
+            // SMALLINT
+            FailureTestCase(
+                input = "CAST(1 AS SMALLINT) / CAST(0 AS SMALLINT)"
+            ),
+            // INT
+            FailureTestCase(
+                input = "CAST(1 AS INT) / CAST(0 AS INT)"
+            ),
+            // BIGINT
+            FailureTestCase(
+                input = "CAST(1 AS BIGINT) / CAST(0 AS BIGINT)"
+            )
+        )
+    }
+}

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEvaluatorTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PartiQLEvaluatorTest.kt
@@ -127,7 +127,7 @@ class PartiQLEvaluatorTest {
                     int64Value(2),
                 ),
                 globals = listOf(
-                    SuccessTestCase.Global(
+                    Global(
                         name = "t",
                         value = """
                             [
@@ -150,7 +150,7 @@ class PartiQLEvaluatorTest {
                     int64Value(2),
                 ),
                 globals = listOf(
-                    SuccessTestCase.Global(
+                    Global(
                         name = "t",
                         value = """
                             [
@@ -177,7 +177,7 @@ class PartiQLEvaluatorTest {
                     ),
                 ),
                 globals = listOf(
-                    SuccessTestCase.Global(
+                    Global(
                         name = "customers",
                         value = """
                             [{id:1, name: "Mary"},
@@ -186,7 +186,7 @@ class PartiQLEvaluatorTest {
                             ]
                         """
                     ),
-                    SuccessTestCase.Global(
+                    Global(
                         name = "orders",
                         value = """
                             [{custId:1, name: "foo"},

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PlusTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/PlusTest.kt
@@ -76,7 +76,7 @@ class PlusTest {
                 mode = Mode.STRICT(),
                 expected = Datum.decimal(BigDecimal.valueOf(457023), 14, 7),
                 globals = listOf(
-                    SuccessTestCase.Global(
+                    Global(
                         "dynamic_decimal",
                         "456789.0000000"
                     )

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
@@ -21,7 +21,7 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
             if (arg1 == 0.toByte()) {
                 throw DataException("Division by zero for TINYINT: $arg0 / $arg1")
             } else if (arg0 == Byte.MIN_VALUE && arg1.toInt() == -1) {
-                throw DataException("Overflow for TINYINT: $arg0 / $arg1")
+                throw DataException("Resulting value out of range for: $arg0 / $arg1")
             }
             Datum.tinyint((arg0 / arg1).toByte())
         }
@@ -34,7 +34,7 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
             if (arg1 == 0.toShort()) {
                 throw DataException("Division by zero for SMALLINT: $arg0 / $arg1")
             } else if (arg0 == Short.MIN_VALUE && arg1.toInt() == -1) {
-                throw DataException("Overflow for SMALLINT: $arg0 / $arg1")
+                throw DataException("Resulting value out of range for: $arg0 / $arg1")
             }
             Datum.smallint((arg0 / arg1).toShort())
         }
@@ -47,7 +47,7 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
             if (arg1 == 0) {
                 throw DataException("Division by zero for INT: $arg0 / $arg1")
             } else if (arg0 == Int.MIN_VALUE && arg1 == -1) {
-                throw DataException("Overflow for INT: $arg0 / $arg1")
+                throw DataException("Resulting value out of range for INT: $arg0 / $arg1")
             }
             Datum.integer(arg0 / arg1)
         }
@@ -60,7 +60,7 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
             if (arg1 == 0L) {
                 throw DataException("Division by zero for BIGINT: $arg0 / $arg1")
             } else if (arg0 == Long.MIN_VALUE && arg1 == -1L) {
-                throw DataException("Overflow for BIGINT: $arg0 / $arg1")
+                throw DataException("Resulting value out of range for BIGINT: $arg0 / $arg1")
             }
             Datum.bigint(arg0 / arg1)
         }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
@@ -3,6 +3,7 @@
 
 package org.partiql.spi.function.builtins
 
+import org.partiql.spi.errors.DataException
 import org.partiql.spi.function.Function
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
@@ -15,8 +16,13 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
 
     override fun getTinyIntInstance(tinyIntLhs: PType, tinyIntRhs: PType): Function.Instance {
         return basic(PType.tinyint()) { args ->
-            @Suppress("DEPRECATION") val arg0 = args[0].byte
-            @Suppress("DEPRECATION") val arg1 = args[1].byte
+            val arg0 = args[0].byte
+            val arg1 = args[1].byte
+            if (arg1 == 0.toByte()) {
+                throw DataException("Division by zero for TINYINT: $arg0 / $arg1")
+            } else if (arg0 == Byte.MIN_VALUE && arg1.toInt() == -1) {
+                throw DataException("Overflow for TINYINT: $arg0 / $arg1")
+            }
             Datum.tinyint((arg0 / arg1).toByte())
         }
     }
@@ -25,6 +31,11 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
         return basic(PType.smallint()) { args ->
             val arg0 = args[0].short
             val arg1 = args[1].short
+            if (arg1 == 0.toShort()) {
+                throw DataException("Division by zero for SMALLINT: $arg0 / $arg1")
+            } else if (arg0 == Short.MIN_VALUE && arg1.toInt() == -1) {
+                throw DataException("Overflow for SMALLINT: $arg0 / $arg1")
+            }
             Datum.smallint((arg0 / arg1).toShort())
         }
     }
@@ -33,6 +44,11 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
         return basic(PType.integer()) { args ->
             val arg0 = args[0].int
             val arg1 = args[1].int
+            if (arg1 == 0) {
+                throw DataException("Division by zero for INT: $arg0 / $arg1")
+            } else if (arg0 == Int.MIN_VALUE && arg1 == -1) {
+                throw DataException("Overflow for INT: $arg0 / $arg1")
+            }
             Datum.integer(arg0 / arg1)
         }
     }
@@ -41,6 +57,11 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
         return basic(PType.bigint()) { args ->
             val arg0 = args[0].long
             val arg1 = args[1].long
+            if (arg1 == 0L) {
+                throw DataException("Division by zero for BIGINT: $arg0 / $arg1")
+            } else if (arg0 == Long.MIN_VALUE && arg1 == -1L) {
+                throw DataException("Overflow for BIGINT: $arg0 / $arg1")
+            }
             Datum.bigint(arg0 / arg1)
         }
     }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnMinus.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnMinus.kt
@@ -23,7 +23,7 @@ internal object FnMinus : DiadicArithmeticOperator("minus") {
             val arg1 = args[1].byte
             val result = arg0 - arg1
             if (result.byteOverflows()) {
-                throw DataException("Numeric value out of range for TINYINT: $arg0 - $arg1")
+                throw DataException("Resulting value out of range for TINYINT: $arg0 - $arg1")
             } else {
                 Datum.tinyint(result.toByte())
             }
@@ -36,7 +36,7 @@ internal object FnMinus : DiadicArithmeticOperator("minus") {
             val arg1 = args[1].short
             val result = arg0 - arg1
             if (result.shortOverflows()) {
-                throw DataException("Numeric value out of range for SMALLINT: $arg0 - $arg1")
+                throw DataException("Resulting value out of range for SMALLINT: $arg0 - $arg1")
             } else {
                 Datum.smallint(result.toShort())
             }
@@ -51,7 +51,7 @@ internal object FnMinus : DiadicArithmeticOperator("minus") {
                 val result = Math.subtractExact(arg0, arg1)
                 Datum.integer(result)
             } catch (e: ArithmeticException) {
-                throw DataException("Numeric value out of range for INT: $arg0 - $arg1")
+                throw DataException("Resulting value out of range for INT: $arg0 - $arg1")
             }
         }
     }
@@ -64,7 +64,7 @@ internal object FnMinus : DiadicArithmeticOperator("minus") {
                 val result = Math.subtractExact(arg0, arg1)
                 Datum.bigint(result)
             } catch (e: ArithmeticException) {
-                throw DataException("Numeric value out of range for BIGINT: $arg0 - $arg1")
+                throw DataException("Resulting value out of range for BIGINT: $arg0 - $arg1")
             }
         }
     }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnMinus.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnMinus.kt
@@ -3,8 +3,11 @@
 
 package org.partiql.spi.function.builtins
 
+import org.partiql.spi.errors.DataException
 import org.partiql.spi.function.Function
 import org.partiql.spi.function.Parameter
+import org.partiql.spi.internal.byteOverflows
+import org.partiql.spi.internal.shortOverflows
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
 
@@ -14,19 +17,16 @@ internal object FnMinus : DiadicArithmeticOperator("minus") {
         fillTable()
     }
 
-    override fun getIntegerInstance(integerLhs: PType, integerRhs: PType): Function.Instance {
-        return basic(PType.integer()) { args ->
-            val arg0 = args[0].int
-            val arg1 = args[1].int
-            Datum.integer(arg0 - arg1)
-        }
-    }
-
     override fun getTinyIntInstance(tinyIntLhs: PType, tinyIntRhs: PType): Function.Instance {
         return basic(PType.tinyint()) { args ->
-            @Suppress("DEPRECATION") val arg0 = args[0].byte
-            @Suppress("DEPRECATION") val arg1 = args[1].byte
-            Datum.tinyint((arg0 - arg1).toByte())
+            val arg0 = args[0].byte
+            val arg1 = args[1].byte
+            val result = arg0 - arg1
+            if (result.byteOverflows()) {
+                throw DataException("Numeric value out of range for TINYINT: $arg0 - $arg1")
+            } else {
+                Datum.tinyint(result.toByte())
+            }
         }
     }
 
@@ -34,7 +34,25 @@ internal object FnMinus : DiadicArithmeticOperator("minus") {
         return basic(PType.smallint()) { args ->
             val arg0 = args[0].short
             val arg1 = args[1].short
-            Datum.smallint((arg0 - arg1).toShort())
+            val result = arg0 - arg1
+            if (result.shortOverflows()) {
+                throw DataException("Numeric value out of range for SMALLINT: $arg0 - $arg1")
+            } else {
+                Datum.smallint(result.toShort())
+            }
+        }
+    }
+
+    override fun getIntegerInstance(integerLhs: PType, integerRhs: PType): Function.Instance {
+        return basic(PType.integer()) { args ->
+            val arg0 = args[0].int
+            val arg1 = args[1].int
+            try {
+                val result = Math.subtractExact(arg0, arg1)
+                Datum.integer(result)
+            } catch (e: ArithmeticException) {
+                throw DataException("Numeric value out of range for INT: $arg0 - $arg1")
+            }
         }
     }
 
@@ -42,7 +60,12 @@ internal object FnMinus : DiadicArithmeticOperator("minus") {
         return basic(PType.bigint()) { args ->
             val arg0 = args[0].long
             val arg1 = args[1].long
-            Datum.bigint((arg0 - arg1))
+            try {
+                val result = Math.subtractExact(arg0, arg1)
+                Datum.bigint(result)
+            } catch (e: ArithmeticException) {
+                throw DataException("Numeric value out of range for BIGINT: $arg0 - $arg1")
+            }
         }
     }
 

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnModulo.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnModulo.kt
@@ -3,6 +3,7 @@
 
 package org.partiql.spi.function.builtins
 
+import org.partiql.spi.errors.DataException
 import org.partiql.spi.function.Function
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
@@ -15,9 +16,13 @@ internal object FnModulo : DiadicArithmeticOperator("modulo") {
 
     override fun getTinyIntInstance(tinyIntLhs: PType, tinyIntRhs: PType): Function.Instance {
         return basic(PType.tinyint()) { args ->
-            @Suppress("DEPRECATION") val arg0 = args[0].byte
-            @Suppress("DEPRECATION") val arg1 = args[1].byte
-            Datum.tinyint((arg0 % arg1).toByte())
+            val arg0 = args[0].byte
+            val arg1 = args[1].byte
+            if (arg1 == 0.toByte()) {
+                throw DataException("Division by zero for TINYINT: $arg0 % $arg1")
+            } else {
+                Datum.tinyint((arg0 % arg1).toByte())
+            }
         }
     }
 
@@ -25,7 +30,11 @@ internal object FnModulo : DiadicArithmeticOperator("modulo") {
         return basic(PType.smallint()) { args ->
             val arg0 = args[0].short
             val arg1 = args[1].short
-            Datum.smallint((arg0 % arg1).toShort())
+            if (arg1 == 0.toShort()) {
+                throw DataException("Division by zero for SMALLINT: $arg0 % $arg1")
+            } else {
+                Datum.smallint((arg0 % arg1).toShort())
+            }
         }
     }
 
@@ -33,7 +42,11 @@ internal object FnModulo : DiadicArithmeticOperator("modulo") {
         return basic(PType.integer()) { args ->
             val arg0 = args[0].int
             val arg1 = args[1].int
-            Datum.integer(arg0 % arg1)
+            if (arg1 == 0) {
+                throw DataException("Division by zero for INT: $arg0 % $arg1")
+            } else {
+                Datum.integer(arg0 % arg1)
+            }
         }
     }
 
@@ -41,7 +54,11 @@ internal object FnModulo : DiadicArithmeticOperator("modulo") {
         return basic(PType.bigint()) { args ->
             val arg0 = args[0].long
             val arg1 = args[1].long
-            Datum.bigint(arg0 % arg1)
+            if (arg1 == 0L) {
+                throw DataException("Division by zero for BIGINT: $arg0 % $arg1")
+            } else {
+                Datum.bigint(arg0 % arg1)
+            }
         }
     }
 

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnPlus.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnPlus.kt
@@ -23,7 +23,7 @@ internal object FnPlus : DiadicArithmeticOperator("plus") {
             val arg1 = args[1].byte
             val result = arg0 + arg1
             if (result.byteOverflows()) {
-                throw DataException("Numeric value out of range for TINYINT: $arg0 + $arg1")
+                throw DataException("Resulting value out of range for TINYINT: $arg0 + $arg1")
             } else {
                 Datum.tinyint(result.toByte())
             }
@@ -36,7 +36,7 @@ internal object FnPlus : DiadicArithmeticOperator("plus") {
             val arg1 = args[1].short
             val result = arg0 + arg1
             if (result.shortOverflows()) {
-                throw DataException("Numeric value out of range for SMALLINT: $arg0 + $arg1")
+                throw DataException("Resulting value out of range for SMALLINT: $arg0 + $arg1")
             } else {
                 Datum.smallint(result.toShort())
             }
@@ -51,7 +51,7 @@ internal object FnPlus : DiadicArithmeticOperator("plus") {
                 val result = Math.addExact(arg0, arg1)
                 Datum.integer(result)
             } catch (e: ArithmeticException) {
-                throw DataException("Numeric value out of range for INT: $arg0 + $arg1")
+                throw DataException("Resulting value out of range for INT: $arg0 + $arg1")
             }
         }
     }
@@ -64,7 +64,7 @@ internal object FnPlus : DiadicArithmeticOperator("plus") {
                 val result = Math.addExact(arg0, arg1)
                 Datum.bigint(result)
             } catch (e: ArithmeticException) {
-                throw DataException("Numeric value out of range for BIGINT: $arg0 + $arg1")
+                throw DataException("Resulting value out of range for BIGINT: $arg0 + $arg1")
             }
         }
     }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnPlus.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnPlus.kt
@@ -3,8 +3,11 @@
 
 package org.partiql.spi.function.builtins
 
+import org.partiql.spi.errors.DataException
 import org.partiql.spi.function.Function
 import org.partiql.spi.function.Parameter
+import org.partiql.spi.internal.byteOverflows
+import org.partiql.spi.internal.shortOverflows
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
 
@@ -16,9 +19,14 @@ internal object FnPlus : DiadicArithmeticOperator("plus") {
 
     override fun getTinyIntInstance(tinyIntLhs: PType, tinyIntRhs: PType): Function.Instance {
         return basic(PType.tinyint()) { args ->
-            @Suppress("DEPRECATION") val arg0 = args[0].byte
-            @Suppress("DEPRECATION") val arg1 = args[1].byte
-            Datum.tinyint((arg0 + arg1).toByte())
+            val arg0 = args[0].byte
+            val arg1 = args[1].byte
+            val result = arg0 + arg1
+            if (result.byteOverflows()) {
+                throw DataException("Numeric value out of range for TINYINT: $arg0 + $arg1")
+            } else {
+                Datum.tinyint(result.toByte())
+            }
         }
     }
 
@@ -26,7 +34,12 @@ internal object FnPlus : DiadicArithmeticOperator("plus") {
         return basic(PType.smallint()) { args ->
             val arg0 = args[0].short
             val arg1 = args[1].short
-            Datum.smallint((arg0 + arg1).toShort())
+            val result = arg0 + arg1
+            if (result.shortOverflows()) {
+                throw DataException("Numeric value out of range for SMALLINT: $arg0 + $arg1")
+            } else {
+                Datum.smallint(result.toShort())
+            }
         }
     }
 
@@ -34,7 +47,12 @@ internal object FnPlus : DiadicArithmeticOperator("plus") {
         return basic(PType.integer()) { args ->
             val arg0 = args[0].int
             val arg1 = args[1].int
-            Datum.integer(arg0 + arg1)
+            try {
+                val result = Math.addExact(arg0, arg1)
+                Datum.integer(result)
+            } catch (e: ArithmeticException) {
+                throw DataException("Numeric value out of range for INT: $arg0 + $arg1")
+            }
         }
     }
 
@@ -42,7 +60,12 @@ internal object FnPlus : DiadicArithmeticOperator("plus") {
         return basic(PType.bigint()) { args ->
             val arg0 = args[0].long
             val arg1 = args[1].long
-            Datum.bigint(arg0 + arg1)
+            try {
+                val result = Math.addExact(arg0, arg1)
+                Datum.bigint(result)
+            } catch (e: ArithmeticException) {
+                throw DataException("Numeric value out of range for BIGINT: $arg0 + $arg1")
+            }
         }
     }
 

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnTimes.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnTimes.kt
@@ -22,7 +22,7 @@ internal object FnTimes : DiadicArithmeticOperator("times") {
             val arg1 = args[1].byte
             val result = arg0 * arg1
             if (result.byteOverflows()) {
-                throw DataException("Numeric value out of range for TINYINT: $arg0 * $arg1")
+                throw DataException("Resulting value out of range for TINYINT: $arg0 * $arg1")
             } else {
                 Datum.tinyint(result.toByte())
             }
@@ -35,7 +35,7 @@ internal object FnTimes : DiadicArithmeticOperator("times") {
             val arg1 = args[1].short
             val result = arg0 * arg1
             if (result.shortOverflows()) {
-                throw DataException("Numeric value out of range for SMALLINT: $arg0 * $arg1")
+                throw DataException("Resulting value out of range for SMALLINT: $arg0 * $arg1")
             } else {
                 Datum.smallint(result.toShort())
             }
@@ -50,7 +50,7 @@ internal object FnTimes : DiadicArithmeticOperator("times") {
                 val result = Math.multiplyExact(arg0, arg1)
                 return@basic Datum.integer(result)
             } catch (e: ArithmeticException) {
-                throw DataException("Numeric value out of range for INT: $arg0 * $arg1")
+                throw DataException("Resulting value out of range for INT: $arg0 * $arg1")
             }
         }
     }
@@ -63,7 +63,7 @@ internal object FnTimes : DiadicArithmeticOperator("times") {
                 val result = Math.multiplyExact(arg0, arg1)
                 return@basic Datum.bigint(result)
             } catch (e: ArithmeticException) {
-                throw DataException("Numeric value out of range for BIGINT: $arg0 * $arg1")
+                throw DataException("Resulting value out of range for BIGINT: $arg0 * $arg1")
             }
         }
     }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnTimes.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnTimes.kt
@@ -3,7 +3,10 @@
 
 package org.partiql.spi.function.builtins
 
+import org.partiql.spi.errors.DataException
 import org.partiql.spi.function.Function
+import org.partiql.spi.internal.byteOverflows
+import org.partiql.spi.internal.shortOverflows
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
 
@@ -15,9 +18,14 @@ internal object FnTimes : DiadicArithmeticOperator("times") {
 
     override fun getTinyIntInstance(tinyIntLhs: PType, tinyIntRhs: PType): Function.Instance {
         return basic(PType.tinyint()) { args ->
-            @Suppress("DEPRECATION") val arg0 = args[0].byte
-            @Suppress("DEPRECATION") val arg1 = args[1].byte
-            Datum.tinyint((arg0 * arg1).toByte())
+            val arg0 = args[0].byte
+            val arg1 = args[1].byte
+            val result = arg0 * arg1
+            if (result.byteOverflows()) {
+                throw DataException("Numeric value out of range for TINYINT: $arg0 * $arg1")
+            } else {
+                Datum.tinyint(result.toByte())
+            }
         }
     }
 
@@ -25,7 +33,12 @@ internal object FnTimes : DiadicArithmeticOperator("times") {
         return basic(PType.smallint()) { args ->
             val arg0 = args[0].short
             val arg1 = args[1].short
-            Datum.smallint((arg0 * arg1).toShort())
+            val result = arg0 * arg1
+            if (result.shortOverflows()) {
+                throw DataException("Numeric value out of range for SMALLINT: $arg0 * $arg1")
+            } else {
+                Datum.smallint(result.toShort())
+            }
         }
     }
 
@@ -33,7 +46,12 @@ internal object FnTimes : DiadicArithmeticOperator("times") {
         return basic(PType.integer()) { args ->
             val arg0 = args[0].int
             val arg1 = args[1].int
-            Datum.integer(arg0 * arg1)
+            try {
+                val result = Math.multiplyExact(arg0, arg1)
+                return@basic Datum.integer(result)
+            } catch (e: ArithmeticException) {
+                throw DataException("Numeric value out of range for INT: $arg0 * $arg1")
+            }
         }
     }
 
@@ -41,7 +59,12 @@ internal object FnTimes : DiadicArithmeticOperator("times") {
         return basic(PType.bigint()) { args ->
             val arg0 = args[0].long
             val arg1 = args[1].long
-            Datum.bigint(arg0 * arg1)
+            try {
+                val result = Math.multiplyExact(arg0, arg1)
+                return@basic Datum.bigint(result)
+            } catch (e: ArithmeticException) {
+                throw DataException("Numeric value out of range for BIGINT: $arg0 * $arg1")
+            }
         }
     }
 

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/internal/NumberExtensions.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/internal/NumberExtensions.kt
@@ -232,3 +232,7 @@ internal val Number.isPosInf
         is Double -> isInfinite() && this > 0
         else -> false
     }
+
+internal fun Int.byteOverflows() = this < Byte.MIN_VALUE || this > Byte.MAX_VALUE
+
+internal fun Int.shortOverflows() = this < Short.MIN_VALUE || this > Short.MAX_VALUE


### PR DESCRIPTION
## Relevant Issues
- Closes https://github.com/partiql/partiql-lang-kotlin/issues/1697

## Description
- Changes integer types to error on overflow
- Changes integer types division and modulo by 0 to give an explicit data exception

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.