### PR TITLE
[v1] Fix unary minus with numeric literal parsing; add data exception for unary neg overflow

### DIFF
--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DataExceptionTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DataExceptionTest.kt
@@ -226,6 +226,7 @@ class DataExceptionTest {
                 input = "-CAST(${Long.MIN_VALUE} AS BIGINT)"
             ),
             // No explicit casts
+            // Double `-`
             // INT
             FailureTestCase(
                 input = "- ${Integer.MIN_VALUE}" // space needed since `--` turns into a comment
@@ -233,6 +234,15 @@ class DataExceptionTest {
             // BIGINT
             FailureTestCase(
                 input = "- ${Long.MIN_VALUE}" // space needed since `--` turns into a comment
+            ),
+            // Triple `-`
+            // INT
+            FailureTestCase(
+                input = "- - ${Integer.MIN_VALUE}"
+            ),
+            // BIGINT
+            FailureTestCase(
+                input = "- - ${Long.MIN_VALUE}"
             )
         )
     }

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DataExceptionTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DataExceptionTest.kt
@@ -224,6 +224,15 @@ class DataExceptionTest {
             // BIGINT
             FailureTestCase(
                 input = "-CAST(${Long.MIN_VALUE} AS BIGINT)"
+            ),
+            // No explicit casts
+            // INT
+            FailureTestCase(
+                input = "- ${Integer.MIN_VALUE}" // space needed since `--` turns into a comment
+            ),
+            // BIGINT
+            FailureTestCase(
+                input = "- ${Long.MIN_VALUE}" // space needed since `--` turns into a comment
             )
         )
     }

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DataExceptionTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DataExceptionTest.kt
@@ -38,6 +38,10 @@ class DataExceptionTest {
     @MethodSource("absOverflowTests")
     fun absOverflow(tc: FailureTestCase) = tc.run()
 
+    @ParameterizedTest
+    @MethodSource("negOverflowTests")
+    fun negOverflow(tc: FailureTestCase) = tc.run()
+
     companion object {
         @JvmStatic
         fun plusOverflowTests() = listOf(
@@ -100,6 +104,14 @@ class DataExceptionTest {
             ),
             FailureTestCase(
                 input = "CAST(${Long.MIN_VALUE} AS BIGINT) - CAST(1 AS BIGINT);"
+            ),
+            // Make sure we parse Integer.MIN_VALUE as an INT rather than BIGINT
+            FailureTestCase(
+                input = "${Integer.MIN_VALUE} - 1"
+            ),
+            // Make sure we parse Long.MIN_VALUE as an BIGINT rather than DECIMAL/NUMERIC
+            FailureTestCase(
+                input = "${Long.MIN_VALUE} - 1"
             )
         )
 
@@ -192,6 +204,26 @@ class DataExceptionTest {
             // BIGINT
             FailureTestCase(
                 input = "ABS(CAST(${Long.MIN_VALUE} AS BIGINT))"
+            )
+        )
+
+        @JvmStatic
+        fun negOverflowTests() = listOf(
+            // TINYINT
+            FailureTestCase(
+                input = "-CAST(${Byte.MIN_VALUE} AS TINYINT)"
+            ),
+            // SMALLINT
+            FailureTestCase(
+                input = "-CAST(${Short.MIN_VALUE} AS SMALLINT)"
+            ),
+            // INT
+            FailureTestCase(
+                input = "-CAST(${Integer.MIN_VALUE} AS INT)"
+            ),
+            // BIGINT
+            FailureTestCase(
+                input = "-CAST(${Long.MIN_VALUE} AS BIGINT)"
             )
         )
     }

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -1463,11 +1463,24 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         // Combine unary minus with numeric literals
+        // TODO may be possible to model signed numerics within the ANTLR grammar itself
         private fun negate(lit: Literal): Literal? =
             when (lit.code()) {
-                Literal.INT_NUM -> intNum("-${lit.numberValue()}")
-                Literal.APPROX_NUM -> approxNum("-${lit.numberValue()}")
-                Literal.EXACT_NUM -> exactNum("-${lit.numberValue()}")
+                Literal.INT_NUM -> if (lit.numberValue().first() == '-') {
+                    null
+                } else {
+                    intNum("-${lit.numberValue()}")
+                }
+                Literal.APPROX_NUM -> if (lit.numberValue().first() == '-') {
+                    null
+                } else {
+                    approxNum("-${lit.numberValue()}")
+                }
+                Literal.EXACT_NUM -> if (lit.numberValue().first() == '-') {
+                    null
+                } else {
+                    exactNum("-${lit.numberValue()}")
+                }
                 else -> null
             }
 

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserOperatorTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserOperatorTests.kt
@@ -17,10 +17,10 @@ class PartiQLParserOperatorTests {
 
     @Test
     fun builtinUnaryOperator() = assertExpression(
-        "-2",
+        "+2",
         queryBody {
             exprOperator(
-                symbol = "-",
+                symbol = "+",
                 lhs = null,
                 rhs = exprLit(intNum(2))
             )

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnNeg.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnNeg.kt
@@ -3,12 +3,12 @@
 
 package org.partiql.spi.function.builtins
 
+import org.partiql.spi.errors.DataException
 import org.partiql.spi.function.Parameter
 import org.partiql.spi.function.utils.FunctionUtils
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
 
-// TODO: Handle Overflow
 internal val Fn_NEG__INT8__INT8 = FunctionUtils.hidden(
 
     name = "neg",
@@ -16,9 +16,12 @@ internal val Fn_NEG__INT8__INT8 = FunctionUtils.hidden(
     parameters = arrayOf(Parameter("value", PType.tinyint())),
 
 ) { args ->
-    @Suppress("DEPRECATION")
     val value = args[0].byte
-    Datum.tinyint(value.times(-1).toByte())
+    if (value == Byte.MIN_VALUE) {
+        throw DataException("Resulting value out of range for TINYINT: -($value)")
+    } else {
+        Datum.tinyint(value.times(-1).toByte())
+    }
 }
 
 internal val Fn_NEG__INT16__INT16 = FunctionUtils.hidden(
@@ -29,7 +32,11 @@ internal val Fn_NEG__INT16__INT16 = FunctionUtils.hidden(
 
 ) { args ->
     val value = args[0].short
-    Datum.smallint(value.times(-1).toShort())
+    if (value == Short.MIN_VALUE) {
+        throw DataException("Resulting value out of range for SMALLINT: -($value)")
+    } else {
+        Datum.smallint(value.times(-1).toShort())
+    }
 }
 
 internal val Fn_NEG__INT32__INT32 = FunctionUtils.hidden(
@@ -40,7 +47,11 @@ internal val Fn_NEG__INT32__INT32 = FunctionUtils.hidden(
 
 ) { args ->
     val value = args[0].int
-    Datum.integer(value.times(-1))
+    if (value == Int.MIN_VALUE) {
+        throw DataException("Resulting value out of range for INTEGER: -($value)")
+    } else {
+        Datum.integer(value.times(-1))
+    }
 }
 
 internal val Fn_NEG__INT64__INT64 = FunctionUtils.hidden(
@@ -51,7 +62,11 @@ internal val Fn_NEG__INT64__INT64 = FunctionUtils.hidden(
 
 ) { args ->
     val value = args[0].long
-    Datum.bigint(value.times(-1L))
+    if (value == Long.MIN_VALUE) {
+        throw DataException("Resulting value out of range for BIGINT: -($value)")
+    } else {
+        Datum.bigint(value * -1L)
+    }
 }
 
 internal val Fn_NEG__INT__INT = FunctionUtils.hidden(

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnNeg.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnNeg.kt
@@ -3,8 +3,8 @@
 
 package org.partiql.spi.function.builtins
 
-import org.partiql.spi.errors.DataException
 import org.partiql.spi.function.Parameter
+import org.partiql.spi.function.builtins.internal.PErrors
 import org.partiql.spi.function.utils.FunctionUtils
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
@@ -18,7 +18,7 @@ internal val Fn_NEG__INT8__INT8 = FunctionUtils.hidden(
 ) { args ->
     val value = args[0].byte
     if (value == Byte.MIN_VALUE) {
-        throw DataException("Resulting value out of range for TINYINT: -($value)")
+        throw PErrors.numericValueOutOfRangeException("-($value)", PType.tinyint())
     } else {
         Datum.tinyint(value.times(-1).toByte())
     }
@@ -33,7 +33,7 @@ internal val Fn_NEG__INT16__INT16 = FunctionUtils.hidden(
 ) { args ->
     val value = args[0].short
     if (value == Short.MIN_VALUE) {
-        throw DataException("Resulting value out of range for SMALLINT: -($value)")
+        throw PErrors.numericValueOutOfRangeException("-($value)", PType.smallint())
     } else {
         Datum.smallint(value.times(-1).toShort())
     }
@@ -48,7 +48,7 @@ internal val Fn_NEG__INT32__INT32 = FunctionUtils.hidden(
 ) { args ->
     val value = args[0].int
     if (value == Int.MIN_VALUE) {
-        throw DataException("Resulting value out of range for INTEGER: -($value)")
+        throw PErrors.numericValueOutOfRangeException("-($value)", PType.integer())
     } else {
         Datum.integer(value.times(-1))
     }
@@ -63,7 +63,7 @@ internal val Fn_NEG__INT64__INT64 = FunctionUtils.hidden(
 ) { args ->
     val value = args[0].long
     if (value == Long.MIN_VALUE) {
-        throw DataException("Resulting value out of range for BIGINT: -($value)")
+        throw PErrors.numericValueOutOfRangeException("-($value)", PType.bigint())
     } else {
         Datum.bigint(value * -1L)
     }

--- a/test/partiql-randomized-tests/src/test/kotlin/org/partiql/lang/randomized/eval/IntOverflowRandomizedTest.kt
+++ b/test/partiql-randomized-tests/src/test/kotlin/org/partiql/lang/randomized/eval/IntOverflowRandomizedTest.kt
@@ -163,9 +163,6 @@ class IntOverflowRandomizedTest {
             }.mapTo(parameters, transform)
 
             // Guaranteed to overflow
-            // Casts are included due to literal minus being parsed as a unary operator + unsigned int.
-            // Without the explicit cast, Int.MIN_VALUE would get parsed as an 8-byte BIGINT.
-            // We may change the parsing behavior to automatically include signed numeric literals at some point.
             parameters.add(Test.Overflow("CAST(${Int.MIN_VALUE} AS INT) / CAST(-1 AS INT)"))
             return parameters
         }


### PR DESCRIPTION
## Relevant Issues
- None, but similar to recent PRs
  - https://github.com/partiql/partiql-lang-kotlin/pull/1715
  - https://github.com/partiql/partiql-lang-kotlin/pull/1696
  - https://github.com/partiql/partiql-lang-kotlin/pull/1716
- Similar to this old PR https://github.com/partiql/partiql-lang-kotlin/pull/1484

## Description
- Fixes unary minus w/ numeric literal parsing -- now will parse as a signed int literal rather than unary minus + unsigned int literal
  - Previously, it would be impossible to parse `-2147483648` as an INT4
- Add data exception for unary negation overflow

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.