### PR TITLE
Misc cleanup of errors and docs

### DIFF
--- a/partiql-ast/src/main/java/org/partiql/ast/DataType.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/DataType.java
@@ -38,7 +38,7 @@ public final class DataType extends AstEnum {
 
         private final boolean optional;
 
-        @Nullable
+        @NotNull
         private final List<AttributeConstraint> constraints;
 
         @Nullable
@@ -48,7 +48,7 @@ public final class DataType extends AstEnum {
                 @NotNull Identifier.Simple name,
                 @NotNull DataType type,
                 boolean optional,
-                @Nullable List<AttributeConstraint> constraints,
+                @NotNull List<AttributeConstraint> constraints,
                 @Nullable String comment) {
             this.name = name;
             this.type = type;
@@ -86,7 +86,7 @@ public final class DataType extends AstEnum {
             return this.optional;
         }
 
-        @Nullable
+        @NotNull
         public List<AttributeConstraint> getConstraints() {
             return this.constraints;
         }

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/pipeline/ErrorMessageFormatter.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/pipeline/ErrorMessageFormatter.kt
@@ -123,10 +123,10 @@ object ErrorMessageFormatter {
      */
     private fun divisionByZero(error: PError): String {
         val dividendType = error.getOrNull("DIVIDEND_TYPE", PType::class.java)
-        val dividendTypeStr = prepare(dividendType.toString(), " of ")
+        val dividendTypeStr = prepare(dividendType.toString(), " of type ")
         val dividend = error.getOrNull("DIVIDEND", String::class.java)
-        val dividendStr = prepare(dividend.toString(), " -- ", " / 0")
-        return "Division$dividendTypeStr by zero$dividendStr$dividendTypeStr."
+        val dividendStr = prepare(dividend.toString(), " ")
+        return "Cannot divide$dividendStr$dividendTypeStr by zero."
     }
 
     /**

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DataExceptionTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DataExceptionTest.kt
@@ -11,6 +11,11 @@ import org.junit.jupiter.params.provider.MethodSource
 class DataExceptionTest {
 
     @ParameterizedTest
+    @MethodSource("sandboxT")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun sandbox(tc: FailureTestCase) = tc.run()
+
+    @ParameterizedTest
     @MethodSource("plusOverflowTests")
     @Execution(ExecutionMode.CONCURRENT)
     fun plusOverflow(tc: FailureTestCase) = tc.run()
@@ -47,6 +52,14 @@ class DataExceptionTest {
     fun negOverflow(tc: FailureTestCase) = tc.run()
 
     companion object {
+        @JvmStatic
+        fun sandboxT() = listOf(
+            // TINYINT
+            FailureTestCase(
+                input = "SELECT x + 1 FROM << 1, 2e0, MISSING>> AS x;"
+            )
+        )
+
         @JvmStatic
         fun plusOverflowTests() = listOf(
             // TINYINT

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DataExceptionTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DataExceptionTest.kt
@@ -35,6 +35,10 @@ class DataExceptionTest {
     fun divideByZero(tc: FailureTestCase) = tc.run()
 
     @ParameterizedTest
+    @MethodSource("modByZeroTests")
+    fun modByZero(tc: FailureTestCase) = tc.run()
+
+    @ParameterizedTest
     @MethodSource("absOverflowTests")
     fun absOverflow(tc: FailureTestCase) = tc.run()
 
@@ -184,6 +188,58 @@ class DataExceptionTest {
             // BIGINT
             FailureTestCase(
                 input = "CAST(1 AS BIGINT) / CAST(0 AS BIGINT)"
+            ),
+            // DECIMAL
+            FailureTestCase(
+                input = "CAST(1.0 AS DECIMAL) / CAST(0.0 AS DECIMAL)"
+            ),
+            // NUMERIC
+            FailureTestCase(
+                input = "CAST(1.0 AS NUMERIC) / CAST(0.0 AS NUMERIC)"
+            ),
+            // FLOAT
+            FailureTestCase(
+                input = "CAST(1.0e0 AS FLOAT) / CAST(0.0 AS FLOAT)"
+            ),
+            // REAL
+            FailureTestCase(
+                input = "CAST(1.0e0 AS DOUBLE PRECISION) / CAST(0.0 AS DOUBLE PRECISION)"
+            )
+        )
+
+        @JvmStatic
+        fun modByZeroTests() = listOf(
+            // TINYINT
+            FailureTestCase(
+                input = "CAST(1 AS TINYINT) % CAST(0 AS TINYINT)"
+            ),
+            // SMALLINT
+            FailureTestCase(
+                input = "CAST(1 AS SMALLINT) % CAST(0 AS SMALLINT)"
+            ),
+            // INT
+            FailureTestCase(
+                input = "CAST(1 AS INT) % CAST(0 AS INT)"
+            ),
+            // BIGINT
+            FailureTestCase(
+                input = "CAST(1 AS BIGINT) % CAST(0 AS BIGINT)"
+            ),
+            // DECIMAL
+            FailureTestCase(
+                input = "CAST(1.0 AS DECIMAL) % CAST(0.0 AS DECIMAL)"
+            ),
+            // NUMERIC
+            FailureTestCase(
+                input = "CAST(1.0 AS NUMERIC) % CAST(0.0 AS NUMERIC)"
+            ),
+            // FLOAT
+            FailureTestCase(
+                input = "CAST(1.0e0 AS FLOAT) % CAST(0.0 AS FLOAT)"
+            ),
+            // REAL
+            FailureTestCase(
+                input = "CAST(1.0e0 AS DOUBLE PRECISION) % CAST(0.0 AS DOUBLE PRECISION)"
             )
         )
 

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -2044,7 +2044,13 @@ internal class PartiQLParserDefault : PartiQLParser {
                 GeneratedParser.INT8 -> DataType.INT8()
                 GeneratedParser.INTEGER8 -> DataType.INTEGER8()
                 GeneratedParser.FLOAT -> DataType.FLOAT()
-                GeneratedParser.DOUBLE -> TODO() // not sure if DOUBLE is to be supported
+                GeneratedParser.DOUBLE -> {
+                    if (ctx.stop.type == GeneratedParser.PRECISION) {
+                        DataType.DOUBLE_PRECISION()
+                    } else {
+                        throw error(ctx, "Unknown atomic type.")
+                    }
+                } // not sure if DOUBLE is to be supported
                 GeneratedParser.REAL -> DataType.REAL()
                 GeneratedParser.TIMESTAMP -> DataType.TIMESTAMP()
                 GeneratedParser.CHAR -> DataType.CHAR()

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/catalog/Identifier.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/catalog/Identifier.kt
@@ -15,7 +15,8 @@ public class Identifier private constructor(
 ) : Iterable<Identifier.Simple> {
 
     /**
-     * Returns the unqualified name part.
+     * Returns the right-most simple identifier of the qualified identifier. For example, for an identifier
+     * a.b.c this method would return c.
      */
     public fun getIdentifier(): Simple = identifier
 

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
@@ -5,6 +5,7 @@ package org.partiql.spi.function.builtins
 
 import org.partiql.spi.function.Function
 import org.partiql.spi.function.builtins.internal.PErrors
+import org.partiql.spi.internal.isZero
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
 import java.math.RoundingMode
@@ -72,6 +73,9 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
         return basic(PType.numeric(p, s), numericLhs, numericRhs) { args ->
             val arg0 = args[0].bigDecimal
             val arg1 = args[1].bigDecimal
+            if (arg1.isZero()) {
+                throw PErrors.divisionByZeroException(arg0, PType.numeric(p, s))
+            }
             val result = arg0.divide(arg1, s, RoundingMode.HALF_UP)
             Datum.numeric(result, p, s)
         }
@@ -82,6 +86,9 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
         return basic(PType.decimal(p, s), decimalLhs, decimalRhs) { args ->
             val arg0 = args[0].bigDecimal
             val arg1 = args[1].bigDecimal
+            if (arg1.isZero()) {
+                throw PErrors.divisionByZeroException(arg0, PType.decimal(p, s))
+            }
             val result = arg0.divide(arg1, s, RoundingMode.HALF_UP)
             Datum.decimal(result, p, s)
         }
@@ -105,6 +112,9 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
         return basic(PType.real()) { args ->
             val arg0 = args[0].float
             val arg1 = args[1].float
+            if (arg1.isZero()) {
+                throw PErrors.divisionByZeroException(arg0, PType.real())
+            }
             Datum.real(arg0 / arg1)
         }
     }
@@ -113,6 +123,9 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
         return basic(PType.doublePrecision()) { args ->
             val arg0 = args[0].double
             val arg1 = args[1].double
+            if (arg1.isZero()) {
+                throw PErrors.divisionByZeroException(arg0, PType.doublePrecision())
+            }
             Datum.doublePrecision(arg0 / arg1)
         }
     }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnModulo.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnModulo.kt
@@ -5,6 +5,7 @@ package org.partiql.spi.function.builtins
 
 import org.partiql.spi.function.Function
 import org.partiql.spi.function.builtins.internal.PErrors
+import org.partiql.spi.internal.isZero
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
 
@@ -67,6 +68,9 @@ internal object FnModulo : DiadicArithmeticOperator("mod", false) {
         return basic(PType.numeric(p, s), numericLhs, numericRhs) { args ->
             val arg0 = args[0].bigDecimal
             val arg1 = args[1].bigDecimal
+            if (arg1.isZero()) {
+                throw PErrors.divisionByZeroException(arg0, PType.numeric(p, s))
+            }
             Datum.numeric(arg0 % arg1, p, s)
         }
     }
@@ -76,6 +80,9 @@ internal object FnModulo : DiadicArithmeticOperator("mod", false) {
         return basic(PType.decimal(p, s), decimalLhs, decimalRhs) { args ->
             val arg0 = args[0].bigDecimal
             val arg1 = args[1].bigDecimal
+            if (arg1.isZero()) {
+                throw PErrors.divisionByZeroException(arg0, PType.decimal(p, s))
+            }
             Datum.decimal(arg0 % arg1, p, s)
         }
     }
@@ -99,6 +106,9 @@ internal object FnModulo : DiadicArithmeticOperator("mod", false) {
         return basic(PType.real()) { args ->
             val arg0 = args[0].float
             val arg1 = args[1].float
+            if (arg1.isZero()) {
+                throw PErrors.divisionByZeroException(arg0, PType.real())
+            }
             Datum.real(arg0 % arg1)
         }
     }
@@ -107,6 +117,9 @@ internal object FnModulo : DiadicArithmeticOperator("mod", false) {
         return basic(PType.doublePrecision()) { args ->
             val arg0 = args[0].double
             val arg1 = args[1].double
+            if (arg1.isZero()) {
+                throw PErrors.divisionByZeroException(arg0, PType.doublePrecision())
+            }
             Datum.doublePrecision(arg0 % arg1)
         }
     }


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Cleanup of AST DDL annotation
- Copies over AST identifier comment over to SPI identifier
- Fix error message string for `/` and `%`
- Use a PartiQL divide-by-zero error rather than use Java's default arithmetic error for `/` and `%` of decimals + numerics
- Fix strict mode behavior w/ missing literal to not error
- Update partiql-tests submodule

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.