### PR TITLE
Updates default impls of Catalog#getFunctions and Catalog#getAggregations

### DIFF
--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PartiQLTyperTestBase.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PartiQLTyperTestBase.kt
@@ -49,14 +49,13 @@ abstract class PartiQLTyperTestBase {
 
     val inputs = PartiQLTestProvider().apply { load() }
 
-    private val testingPipeline: ((String, String, Catalog, PErrorListener) -> PartiQLPlanner.Result) =
-        { query, catalog, metadata, collector ->
-            val parseResult = parser.parse(query)
-            assertEquals(1, parseResult.statements.size)
-            val ast = parseResult.statements[0]
-            val config = Context.of(collector)
-            planner.plan(ast, session(catalog, metadata), config)
-        }
+    private fun testingPipeline(query: String, catalog: String, metadata: Catalog, collector: PErrorListener): PartiQLPlanner.Result {
+        val parseResult = parser.parse(query)
+        assertEquals(1, parseResult.statements.size)
+        val ast = parseResult.statements[0]
+        val config = Context.of(collector)
+        return planner.plan(ast, session(catalog, metadata), config)
+    }
 
     /**
      * Build a ConnectorMetadata instance from the list of types.

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/catalog/Catalog.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/catalog/Catalog.kt
@@ -2,7 +2,6 @@ package org.partiql.spi.catalog
 
 import org.partiql.spi.catalog.impl.StandardCatalog
 import org.partiql.spi.function.Aggregation
-import org.partiql.spi.function.Builtins
 import org.partiql.spi.function.Function
 
 /**
@@ -46,12 +45,12 @@ public interface Catalog {
     /**
      * Returns a collection of scalar functions in this catalog with the given name, or an empty list if none.
      */
-    public fun getFunctions(session: Session, name: String): Collection<Function> = Builtins.getFunctions(name)
+    public fun getFunctions(session: Session, name: String): Collection<Function> = emptyList()
 
     /**
      * Returns a collection of aggregation functions in this catalog with the given name, or an empty list if none.
      */
-    public fun getAggregations(session: Session, name: String): Collection<Aggregation> = Builtins.getAggregations(name)
+    public fun getAggregations(session: Session, name: String): Collection<Aggregation> = emptyList()
 
     public companion object {
 

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/catalog/Path.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/catalog/Path.kt
@@ -4,7 +4,8 @@ import java.util.Spliterator
 import java.util.function.Consumer
 
 /**
- * The routine resolution path, accessible via PATH.
+ * The routine resolution path, accessible via PATH. Each of these namespaces have the catalog name as the first
+ * element in the namespace.
  */
 public class Path private constructor(
     private val namespaces: List<Namespace>,

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/catalog/Session.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/catalog/Session.kt
@@ -30,7 +30,7 @@ public interface Session {
      *
      * Default implementation returns the current namespace.
      */
-    public fun getPath(): Path = Path.of(getNamespace())
+    public fun getPath(): Path = Path.of(Namespace.of(getCatalog()).append(*getNamespace().getLevels()))
 
     /**
      * Arbitrary session properties that may be used in planning or custom plan passes.
@@ -133,7 +133,7 @@ public interface Session {
             override fun getNamespace(): Namespace = namespace
 
             override fun getPath(): Path {
-                val currentNamespace = getNamespace()
+                val currentNamespace = Namespace.of(getCatalog(), *getNamespace().getLevels())
                 return Path.of(currentNamespace, systemCatalogNamespace)
             }
         }


### PR DESCRIPTION
## Description
- As I was writing the "Implementing a Catalog" usage guide, I realized that the default implementations weren't what I wanted.
- This is a simple PR to change the default, and update the fnResolver to loop through the SQL Path when resolving a function.

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.