### PR TITLE
Fix: Properly return properties from Session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Thank you to all who have contributed!
 ### Added
 
 ### Changed
+- Properly returns properties from `Session`
 
 ### Deprecated
 
@@ -38,7 +39,7 @@ Thank you to all who have contributed!
 ### Security
 
 ### Contributors
-Thank you to all who have contributed!
+- @jpschorr
 
 ## [1.0.0](https://github.com/partiql/partiql-lang-kotlin/releases/tag/v1.0.0) - 2025-01-23
 

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/catalog/Session.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/catalog/Session.kt
@@ -136,6 +136,10 @@ public interface Session {
                 val currentNamespace = Namespace.of(getCatalog(), *getNamespace().getLevels())
                 return Path.of(currentNamespace, systemCatalogNamespace)
             }
+
+            override fun getProperties(): Map<String, String> {
+                return properties
+            }
         }
     }
 }


### PR DESCRIPTION
## Relevant Issues
- N/A

## Description
- Return the properties that were set on the `Session` `Builder`.

## Other Information
- Updated Unreleased Section in CHANGELOG: YES

- Any backward-incompatible changes? NO

- Any new external dependencies? NO

- Do your changes comply with the [Contributing Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md)
  and [Code Style Guidelines](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md)? YES

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.