### PR TITLE
fix: typing of Rex nodes in the plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Thank you to all who have contributed!
 
 ### Fixed
 - `BETWEEN` operator function overloads in the partiql-planner
+- Mistyping of some Rex plan nodes
 
 ### Removed
 

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/InternalToPublicPlanTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/InternalToPublicPlanTest.kt
@@ -10,10 +10,14 @@ import org.partiql.spi.catalog.Session
 import org.partiql.spi.types.PType
 import kotlin.test.Test
 
+/**
+ * Tests for converting the internal PartiQL plan to the public PartiQL plan.
+ */
 class InternalToPublicPlanTest {
     val parser = PartiQLParser.standard()
     val planner = PartiQLPlanner.standard()
 
+    // Test that the types are converted correctly from the internal plan to the public plan.
     @Test
     fun testCollectionArgs() {
         val parserResult = parser.parse("<<1>>")

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/InternalToPublicPlanTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/InternalToPublicPlanTest.kt
@@ -1,0 +1,29 @@
+package org.partiql.planner.internal.typer
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.partiql.parser.PartiQLParser
+import org.partiql.plan.Action.Query
+import org.partiql.plan.rex.RexBag
+import org.partiql.plan.rex.RexType
+import org.partiql.planner.PartiQLPlanner
+import org.partiql.spi.catalog.Session
+import org.partiql.spi.types.PType
+import kotlin.test.Test
+
+class InternalToPublicPlanTest {
+    val parser = PartiQLParser.standard()
+    val planner = PartiQLPlanner.standard()
+
+    @Test
+    fun testCollectionArgs() {
+        val parserResult = parser.parse("<<1>>")
+        val plannerResult = planner.plan(parserResult.statements.first(), Session.empty())
+        val rex = ((plannerResult.plan.action) as Query).rex
+
+        assertEquals(rex.type, RexType.of(PType.bag(PType.integer())))
+
+        rex as RexBag
+        val firstElement = rex.values.first()
+        assertEquals(firstElement.type, RexType.of(PType.integer()))
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Some more Rex nodes in the plan were getting mistyped as the outer context's type. See this comment from prior PR for the same issue https://github.com/partiql/partiql-lang-kotlin/pull/1749#discussion_r2074294215

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**: <Explain if NO>
- Any backward-incompatible changes? **[NO]**: <Explain if YES>
- Any new external dependencies? **[NO]**: <Explain if YES>
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md