### PR TITLE
Enable definition of aggregation functions in the Catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Thank you to all who have contributed!
 - `BETWEEN` operator function overloads in the partiql-planner
 - Mistyping of some Rex plan nodes
 - `OperatorRewriter` omitting types for rewritten nodes
+- fixed Aggregation function lookup so that custom overloads from `Catalog` are found
 
 ### Removed
 

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/CatalogTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/CatalogTest.kt
@@ -1,0 +1,163 @@
+package org.partiql.eval
+
+import org.junit.jupiter.api.Test
+import org.partiql.eval.compiler.PartiQLCompiler
+import org.partiql.parser.PartiQLParser
+import org.partiql.planner.PartiQLPlanner
+import org.partiql.spi.Context
+import org.partiql.spi.catalog.Catalog
+import org.partiql.spi.catalog.Session
+import org.partiql.spi.errors.PError
+import org.partiql.spi.errors.PErrorListener
+import org.partiql.spi.function.AggOverload
+import org.partiql.spi.function.FnOverload
+import org.partiql.spi.function.Parameter
+import org.partiql.spi.types.PType
+import org.partiql.spi.value.Datum
+import org.partiql.spi.value.Field
+import kotlin.math.absoluteValue
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CatalogTest {
+    companion object {
+        val parser = PartiQLParser.standard()
+        val planner = PartiQLPlanner.standard()
+        val compiler = PartiQLCompiler.standard()
+    }
+
+    @Test
+    fun absent_scalar_extension_function() {
+        val query = "SELECT abs(x) as a, foo_bar_baz(x) as b, FOO_BAR_BAZ(x) as C FROM << {'x':1}, {'x':2} >>"
+        val catalog = object : Catalog {
+            override fun getName(): String = "default"
+        }
+        val result = testQuery(query, catalog)
+        assert(result is TestResult.Failure)
+        val errs = (result as TestResult.Failure).err
+        assertTrue(errs.errors.isNotEmpty())
+        assertEquals(PError.FUNCTION_NOT_FOUND, errs.errors[0].code())
+    }
+
+    @Test
+    fun scalar_extension_function() {
+        val query = "SELECT abs(x) as a, foo_bar_baz(x) as b, FOO_BAR_BAZ(x) as C FROM << {'x':1}, {'x':2} >>"
+        val catalog = object : Catalog {
+            override fun getName(): String = "default"
+            override fun getFunctions(session: Session, name: String): Collection<FnOverload> {
+                return listOf(
+                    // Just a `abs(F64, F64) -> F64` with a different name
+                    FnOverload.Builder("foo_bar_baz")
+                        .addParameters(Parameter("value", PType.doublePrecision()))
+                        .returns(PType.doublePrecision())
+                        .body { args ->
+                            val value = args[0].double
+                            Datum.doublePrecision(value.absoluteValue)
+                        }
+                        .build()
+                )
+            }
+        }
+        val result = testQuery(query, catalog)
+        assert(result is TestResult.Success)
+        val datum = (result as TestResult.Success).result
+        val expected = Datum.bagVararg(
+            Datum.struct(
+                Field.of("a", Datum.doublePrecision(1.0)),
+                Field.of("b", Datum.doublePrecision(1.0)),
+                Field.of("C", Datum.doublePrecision(1.0))
+            ),
+            Datum.struct(
+                Field.of("a", Datum.doublePrecision(2.0)),
+                Field.of("b", Datum.doublePrecision(2.0)),
+                Field.of("C", Datum.doublePrecision(2.0))
+            )
+        )
+        assertEquals(0, Datum.comparator().compare(expected, datum))
+    }
+
+    @Test
+    fun absent_aggregate_extension_function() {
+        val query = "SELECT SUM(x) as a, foo_bar_baz(x) as b, FOO_BAR_BAZ(x) as C FROM << {'x':1}, {'x':2} >>"
+        val catalog = object : Catalog {
+            override fun getName(): String = "default"
+        }
+        val result = testQuery(query, catalog)
+        assert(result is TestResult.Failure)
+        val errs = (result as TestResult.Failure).err
+        assertTrue(errs.errors.isNotEmpty())
+        assertEquals(PError.FUNCTION_NOT_FOUND, errs.errors[0].code())
+    }
+
+    internal class AccumulatorSumDouble : org.partiql.spi.function.Accumulator {
+        var sum: Double = 0.0
+        var init = false
+
+        override fun next(args: Array<out Datum>?) {
+            val value = args!![0]
+            if (!init) {
+                init = true
+            }
+            val arg1 = value.double
+            sum += arg1
+        }
+
+        override fun value(): Datum {
+            return if (init) Datum.doublePrecision(sum) else Datum.nullValue(PType.doublePrecision())
+        }
+    }
+
+    @Test
+    fun aggregate_extension_function() {
+        val query = "SELECT SUM(x) as a, foo_bar_baz(x) as b, FOO_BAR_BAZ(x) as C FROM << {'x':1}, {'x':2} >>"
+        val catalog = object : Catalog {
+            override fun getName(): String = "default"
+            override fun getAggregations(session: Session, name: String): Collection<AggOverload> {
+                return listOf(
+                    // Just a `SUM(F64) -> F64` with a different name
+                    AggOverload.Builder("foo_bar_baz")
+                        .addParameters(PType.doublePrecision())
+                        .returns(PType.doublePrecision())
+                        .body { AccumulatorSumDouble() }
+                        .build()
+                )
+            }
+        }
+        val result = testQuery(query, catalog)
+        assert(result is TestResult.Success)
+        val datum = (result as TestResult.Success).result
+        val expected = Datum.bagVararg(
+            Datum.struct(
+                Field.of("a", Datum.doublePrecision(3.0)),
+                Field.of("b", Datum.doublePrecision(3.0)),
+                Field.of("C", Datum.doublePrecision(3.0))
+            ),
+        )
+        assertEquals(0, Datum.comparator().compare(expected, datum))
+    }
+
+    sealed class TestResult {
+        class Failure(val err: PErrorCollector) : TestResult()
+        class Success(val result: Datum) : TestResult()
+    }
+
+    private fun testQuery(query: String, catalog: Catalog): TestResult {
+        val pc = PErrorCollector()
+        val planResult = planQuery(query, catalog, pc)
+        println("pc.errors = ${pc.errors}")
+        if (pc.errors.isNotEmpty()) {
+            return TestResult.Failure(pc)
+        }
+        val exec = compiler.prepare(planResult.plan, Mode.STRICT())
+        return TestResult.Success(exec.execute())
+    }
+
+    private fun planQuery(query: String, catalog: Catalog, collector: PErrorListener): PartiQLPlanner.Result {
+        val parseResult = parser.parse(query)
+        assertEquals(1, parseResult.statements.size)
+        val ast = parseResult.statements[0]
+        val config = Context.of(collector)
+        val session = Session.builder().catalog("default").catalogs(catalog).build()
+        return planner.plan(ast, session, config)
+    }
+}

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/CatalogTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/CatalogTest.kt
@@ -9,6 +9,7 @@ import org.partiql.spi.catalog.Catalog
 import org.partiql.spi.catalog.Session
 import org.partiql.spi.errors.PError
 import org.partiql.spi.errors.PErrorListener
+import org.partiql.spi.errors.PRuntimeException
 import org.partiql.spi.function.AggOverload
 import org.partiql.spi.function.FnOverload
 import org.partiql.spi.function.Parameter
@@ -20,74 +21,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class CatalogTest {
-    companion object {
-        val parser = PartiQLParser.standard()
-        val planner = PartiQLPlanner.standard()
-        val compiler = PartiQLCompiler.standard()
-    }
-
-    @Test
-    fun absent_scalar_extension_function() {
-        val query = "SELECT abs(x) as a, foo_bar_baz(x) as b, FOO_BAR_BAZ(x) as C FROM << {'x':1}, {'x':2} >>"
-        val catalog = object : Catalog {
-            override fun getName(): String = "default"
-        }
-        val result = testQuery(query, catalog)
-        assert(result is TestResult.Failure)
-        val errs = (result as TestResult.Failure).err
-        assertTrue(errs.errors.isNotEmpty())
-        assertEquals(PError.FUNCTION_NOT_FOUND, errs.errors[0].code())
-    }
-
-    @Test
-    fun scalar_extension_function() {
-        val query = "SELECT abs(x) as a, foo_bar_baz(x) as b, FOO_BAR_BAZ(x) as C FROM << {'x':1}, {'x':2} >>"
-        val catalog = object : Catalog {
-            override fun getName(): String = "default"
-            override fun getFunctions(session: Session, name: String): Collection<FnOverload> {
-                return listOf(
-                    // Just a `abs(F64, F64) -> F64` with a different name
-                    FnOverload.Builder("foo_bar_baz")
-                        .addParameters(Parameter("value", PType.doublePrecision()))
-                        .returns(PType.doublePrecision())
-                        .body { args ->
-                            val value = args[0].double
-                            Datum.doublePrecision(value.absoluteValue)
-                        }
-                        .build()
-                )
-            }
-        }
-        val result = testQuery(query, catalog)
-        assert(result is TestResult.Success)
-        val datum = (result as TestResult.Success).result
-        val expected = Datum.bagVararg(
-            Datum.struct(
-                Field.of("a", Datum.doublePrecision(1.0)),
-                Field.of("b", Datum.doublePrecision(1.0)),
-                Field.of("C", Datum.doublePrecision(1.0))
-            ),
-            Datum.struct(
-                Field.of("a", Datum.doublePrecision(2.0)),
-                Field.of("b", Datum.doublePrecision(2.0)),
-                Field.of("C", Datum.doublePrecision(2.0))
-            )
-        )
-        assertEquals(0, Datum.comparator().compare(expected, datum))
-    }
-
-    @Test
-    fun absent_aggregate_extension_function() {
-        val query = "SELECT SUM(x) as a, foo_bar_baz(x) as b, FOO_BAR_BAZ(x) as C FROM << {'x':1}, {'x':2} >>"
-        val catalog = object : Catalog {
-            override fun getName(): String = "default"
-        }
-        val result = testQuery(query, catalog)
-        assert(result is TestResult.Failure)
-        val errs = (result as TestResult.Failure).err
-        assertTrue(errs.errors.isNotEmpty())
-        assertEquals(PError.FUNCTION_NOT_FOUND, errs.errors[0].code())
-    }
 
     internal class AccumulatorSumDouble : org.partiql.spi.function.Accumulator {
         var sum: Double = 0.0
@@ -107,22 +40,120 @@ class CatalogTest {
         }
     }
 
+    companion object {
+        val parser = PartiQLParser.standard()
+        val planner = PartiQLPlanner.standard()
+        val compiler = PartiQLCompiler.standard()
+
+        // Just a `abs(F64) -> F64` with a different name
+        val scalar_overload: (name: String) -> FnOverload = { name: String ->
+            FnOverload.Builder(name)
+                .addParameters(Parameter("value", PType.doublePrecision()))
+                .returns(PType.doublePrecision())
+                .body { args ->
+                    val value = args[0].double
+                    Datum.doublePrecision(value.absoluteValue)
+                }
+                .build()
+        }
+
+        // Just a `SUM(F64) -> F64` with a different name
+        val aggregate_overload: (name: String) -> AggOverload = { name: String ->
+            AggOverload.Builder(name)
+                .addParameters(PType.doublePrecision())
+                .returns(PType.doublePrecision())
+                .body { AccumulatorSumDouble() }
+                .build()
+        }
+    }
+
+    private fun catalog_with(fns: Collection<FnOverload>, aggs: Collection<AggOverload>): Catalog {
+        val catalog = object : Catalog {
+            val catalogFns: Map<String, Collection<FnOverload>>
+            val catalogAggs: Map<String, Collection<AggOverload>>
+
+            init {
+                val fnsBuilder: MutableMap<String, MutableList<FnOverload>> = mutableMapOf()
+                fns.map { fn -> fn.signature.name.lowercase() to fn }.forEach {
+                    fnsBuilder.getOrPut(it.first, { mutableListOf() }).add(it.second)
+                }
+                catalogFns = fnsBuilder
+
+                val aggsBuilder: MutableMap<String, MutableList<AggOverload>> = mutableMapOf()
+                aggs.map { agg -> agg.signature.name.lowercase() to agg }.forEach {
+                    aggsBuilder.getOrPut(it.first, { mutableListOf() }).add(it.second)
+                }
+                catalogAggs = aggsBuilder
+            }
+
+            override fun getName(): String = "default"
+            override fun getFunctions(session: Session, name: String) = catalogFns.get(name.lowercase()) ?: emptyList()
+            override fun getAggregations(session: Session, name: String) = catalogAggs.get(name.lowercase()) ?: emptyList()
+        }
+
+        return catalog
+    }
+
+    @Test
+    fun absent_scalar_extension_function() {
+        val query = "SELECT abs(x) as a, foo_bar_baz(x) as b, FOO_BAR_BAZ(x) as C FROM << {'x':1}, {'x':2} >>"
+        val catalog = catalog_with(emptyList(), emptyList())
+        val result = testQuery(query, catalog)
+        assert(result is TestResult.Failure)
+        val errs = (result as TestResult.Failure).err
+        assertTrue(errs.errors.isNotEmpty())
+        assertEquals(PError.FUNCTION_NOT_FOUND, errs.errors[0].code())
+    }
+
+    @Test
+    fun scalar_extension_function() {
+        val query = "SELECT abs(x) as a, foo_bar_baz(x) as b, FOO_BAR_BAZ(x) as C FROM << {'x':1}, {'x':2} >>"
+        val catalog = catalog_with(listOf(scalar_overload("foo_bar_baz")), emptyList())
+        val result = testQuery(query, catalog)
+        assert(result is TestResult.Success)
+        val datum = (result as TestResult.Success).result
+        val expected = Datum.bagVararg(
+            Datum.struct(
+                Field.of("a", Datum.doublePrecision(1.0)),
+                Field.of("b", Datum.doublePrecision(1.0)),
+                Field.of("C", Datum.doublePrecision(1.0))
+            ),
+            Datum.struct(
+                Field.of("a", Datum.doublePrecision(2.0)),
+                Field.of("b", Datum.doublePrecision(2.0)),
+                Field.of("C", Datum.doublePrecision(2.0))
+            )
+        )
+        assertEquals(0, Datum.comparator().compare(expected, datum))
+    }
+
+    @Test
+    fun scalar_extension_function_builtin_collision() {
+        val query = "SELECT abs(x) as a, count(x) as b, COUNT(x) as C FROM << {'x':1}, {'x':2} >>"
+        val catalog = catalog_with(listOf(scalar_overload("count")), emptyList())
+        val result = testQuery(query, catalog)
+
+        assert(result is TestResult.Failure)
+        val errs = (result as TestResult.Failure).err
+        assertTrue(errs.errors.isNotEmpty())
+        assertEquals(PError.INTERNAL_ERROR, errs.errors[0].code())
+    }
+
+    @Test
+    fun absent_aggregate_extension_function() {
+        val query = "SELECT SUM(x) as a, foo_bar_baz(x) as b, FOO_BAR_BAZ(x) as C FROM << {'x':1}, {'x':2} >>"
+        val catalog = catalog_with(emptyList(), emptyList())
+        val result = testQuery(query, catalog)
+        assert(result is TestResult.Failure)
+        val errs = (result as TestResult.Failure).err
+        assertTrue(errs.errors.isNotEmpty())
+        assertEquals(PError.FUNCTION_NOT_FOUND, errs.errors[0].code())
+    }
+
     @Test
     fun aggregate_extension_function() {
         val query = "SELECT SUM(x) as a, foo_bar_baz(x) as b, FOO_BAR_BAZ(x) as C FROM << {'x':1}, {'x':2} >>"
-        val catalog = object : Catalog {
-            override fun getName(): String = "default"
-            override fun getAggregations(session: Session, name: String): Collection<AggOverload> {
-                return listOf(
-                    // Just a `SUM(F64) -> F64` with a different name
-                    AggOverload.Builder("foo_bar_baz")
-                        .addParameters(PType.doublePrecision())
-                        .returns(PType.doublePrecision())
-                        .body { AccumulatorSumDouble() }
-                        .build()
-                )
-            }
-        }
+        val catalog = catalog_with(emptyList(), listOf(aggregate_overload("foo_bar_baz")))
         val result = testQuery(query, catalog)
         assert(result is TestResult.Success)
         val datum = (result as TestResult.Success).result
@@ -136,9 +167,34 @@ class CatalogTest {
         assertEquals(0, Datum.comparator().compare(expected, datum))
     }
 
+    @Test
+    fun aggregate_extension_function_builtin_collision() {
+        val query = "SELECT SUM(x) as a, upper(x) as b, UPPER(x) as C FROM << {'x':1}, {'x':2} >>"
+        val catalog = catalog_with(emptyList(), listOf(aggregate_overload("upper")))
+        val result = testQuery(query, catalog)
+
+        assert(result is TestResult.Failure)
+        val errs = (result as TestResult.Failure).err
+        assertTrue(errs.errors.isNotEmpty())
+        assertEquals(PError.INTERNAL_ERROR, errs.errors[0].code())
+    }
+
+    @Test
+    fun scalar_and_aggregate_extension_function_collision() {
+        val query = "SELECT SUM(x) as a, foo_bar_baz(x) as b, FOO_BAR_BAZ(x) as C FROM << {'x':1}, {'x':2} >>"
+        val catalog = catalog_with(listOf(scalar_overload("foo_bar_baz")), listOf(aggregate_overload("foo_bar_baz")))
+        val result = testQuery(query, catalog)
+
+        assert(result is TestResult.Failure)
+        val errs = (result as TestResult.Failure).err
+        assertTrue(errs.errors.isNotEmpty())
+        assertEquals(PError.INTERNAL_ERROR, errs.errors[0].code())
+    }
+
     sealed class TestResult {
         class Failure(val err: PErrorCollector) : TestResult()
         class Success(val result: Datum) : TestResult()
+        class Exception(val e: PRuntimeException) : TestResult()
     }
 
     private fun testQuery(query: String, catalog: Catalog): TestResult {
@@ -148,8 +204,13 @@ class CatalogTest {
         if (pc.errors.isNotEmpty()) {
             return TestResult.Failure(pc)
         }
-        val exec = compiler.prepare(planResult.plan, Mode.STRICT())
-        return TestResult.Success(exec.execute())
+
+        try {
+            val exec = compiler.prepare(planResult.plan, Mode.STRICT())
+            return TestResult.Success(exec.execute())
+        } catch (e: PRuntimeException) {
+            return TestResult.Exception(e)
+        }
     }
 
     private fun planQuery(query: String, catalog: Catalog, collector: PErrorListener): PartiQLPlanner.Result {

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/PErrorCollector.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/PErrorCollector.kt
@@ -1,0 +1,34 @@
+package org.partiql.eval
+
+import org.partiql.spi.errors.PError
+import org.partiql.spi.errors.PErrorListener
+import org.partiql.spi.errors.Severity
+
+/**
+ * An [PErrorListener] that collects all the encountered [PError]s without throwing.
+ *
+ * This is intended to be used when wanting to collect multiple problems that may be encountered (e.g. a static type
+ * inference pass that can result in multiple errors and/or warnings). This handler does not collect other exceptions
+ * that may be thrown.
+ */
+open class PErrorCollector : PErrorListener {
+    private val errorList = mutableListOf<PError>()
+    private val warningList = mutableListOf<PError>()
+
+    val problems: List<PError>
+        get() = errorList + warningList
+
+    val errors: List<PError>
+        get() = errorList
+
+    val warnings: List<PError>
+        get() = warningList
+
+    override fun report(error: PError) {
+        when (error.severity.code()) {
+            Severity.ERROR -> errorList.add(error)
+            Severity.WARNING -> warningList.add(error)
+            else -> error("Unsupported severity.")
+        }
+    }
+}

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -1817,6 +1817,7 @@ internal class PartiQLParserDefault : PartiQLParser {
 
         override fun visitFunctionCallAsterisk(ctx: GeneratedParser.FunctionCallAsteriskContext) = translate(ctx) {
             val function = visitQualifiedName(ctx.qualifiedName())
+            // Yet another special case for `COUNT(*)`
             exprCall(function, emptyList())
         }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Env.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/Env.kt
@@ -61,6 +61,15 @@ internal class Env(private val session: Session, internal val listener: PErrorLi
         return null
     }
 
+    fun hasFn(path: String): Boolean {
+        val fns = findFirstInCatalog { catalog -> catalog.getFunctions(session, path.lowercase()).ifEmpty { null } }
+        if (fns == null) {
+            return false
+        } else {
+            return fns.isNotEmpty()
+        }
+    }
+
     fun resolveFn(identifier: Identifier, args: List<Rex>): Rex? {
         return findFirstInCatalog { catalog ->
             resolveFn(identifier, args, catalog)
@@ -73,6 +82,15 @@ internal class Env(private val session: Session, internal val listener: PErrorLi
         return findFirstInCatalog { catalog ->
             getCandidates(identifier, arity, catalog)
         } ?: emptyList()
+    }
+
+    fun hasAgg(path: String): Boolean {
+        val aggs = findFirstInCatalog { catalog -> catalog.getAggregations(session, path.lowercase()).ifEmpty { null } }
+        if (aggs == null) {
+            return false
+        } else {
+            return aggs.isNotEmpty()
+        }
     }
 
     fun resolveAgg(path: String, setQuantifier: SetQuantifier, args: List<Rex>): Rel.Op.Aggregate.Call.Resolved? {
@@ -162,7 +180,7 @@ internal class Env(private val session: Session, internal val listener: PErrorLi
     }
 
     /**
-     * @return a list of candidate aggregation functions that match the [identifier] and number of [args].
+     * @return a list of candidate aggregation functions that match the [path] and [arity].
      */
     fun getAggCandidates(path: String, arity: Int, catalog: Catalog): List<AggOverload>? {
         // 1. Search in the current catalog and namespace.

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RelConverter.kt
@@ -184,7 +184,7 @@ internal object RelConverter {
                     var rel = visitFrom(sel.from, nil)
                     rel = convertWhere(rel, sel.where)
                     // kotlin does not have destructuring reassignment
-                    val (_sel, _rel) = convertAgg(rel, sel, sel.groupBy)
+                    val (_sel, _rel) = convertAgg(rel, sel, sel.groupBy, env)
                     sel = _sel
                     rel = _rel
                     // Plan.create (possibly rewritten) sel node
@@ -416,9 +416,9 @@ internal object RelConverter {
          *         1. Ast.Expr.SFW has every Ast.Expr.CallAgg replaced by a synthetic Ast.Expr.Var
          *         2. Rel which has the appropriate Rex.Agg calls and groups
          */
-        private fun convertAgg(input: Rel, select: QueryBody.SFW, groupBy: GroupBy?): Pair<QueryBody.SFW, Rel> {
+        private fun convertAgg(input: Rel, select: QueryBody.SFW, groupBy: GroupBy?, env: Env): Pair<QueryBody.SFW, Rel> {
             // Rewrite and extract all aggregations in the SELECT clause
-            val (sel, aggregations) = AggregationTransform.apply(select)
+            val (sel, aggregations) = AggregationTransform.apply(select, env)
 
             // No aggregation planning required for GROUP BY
             if (aggregations.isEmpty() && groupBy == null) {
@@ -445,6 +445,7 @@ internal object RelConverter {
                 // lowercase normalize all calls
                 val name = id.getIdentifier().getText().lowercase()
                 if (name == "count" && expr.args.isEmpty()) {
+                    // Yet another special case for `COUNT(*)`
                     relOpAggregateCallUnresolved(
                         name,
                         org.partiql.planner.internal.ir.SetQuantifier.ALL,
@@ -729,19 +730,16 @@ internal object RelConverter {
      * Rewrites a SELECT node replacing (and extracting) each aggregation `i` with a synthetic field name `$agg_i`.
      */
     private object AggregationTransform : AstRewriter<AggregationTransform.Context>() {
-        // currently hard-coded
-        @JvmStatic
-        private val aggregates = setOf("count", "avg", "sum", "min", "max", "any", "some", "every")
-
         private data class Context(
             val aggregations: MutableList<ExprCall>,
-            val keys: List<GroupBy.Key>
+            val keys: List<GroupBy.Key>,
+            val env: Env
         )
 
-        fun apply(node: QueryBody.SFW): Pair<QueryBody.SFW, List<ExprCall>> {
+        fun apply(node: QueryBody.SFW, env: Env): Pair<QueryBody.SFW, List<ExprCall>> {
             val aggs = mutableListOf<ExprCall>()
             val keys = node.groupBy?.keys ?: emptyList()
-            val context = Context(aggs, keys)
+            val context = Context(aggs, keys, env)
             val select = super.visitQueryBodySFW(node, context) as QueryBody.SFW
             return Pair(select, aggs)
         }
@@ -758,9 +756,7 @@ internal object RelConverter {
         override fun visitQueryBodySFW(node: QueryBody.SFW, ctx: Context): AstNode = node
 
         override fun visitExprCall(node: ExprCall, ctx: Context) =
-            // TODO replace w/ proper function resolution to determine whether a function call is a scalar or aggregate.
-            //  may require further modification of SPI interfaces to support
-            when (node.function.isAggregateCall()) {
+            when (node.isAggregateCall(ctx)) {
                 true -> {
                     val id = Identifier.delimited(syntheticAgg(ctx.aggregations.size))
                     ctx.aggregations += node
@@ -769,11 +765,15 @@ internal object RelConverter {
                 else -> node
             }
 
-        private fun String.isAggregateCall(): Boolean {
-            return aggregates.contains(this)
+        private fun ExprCall.isAggregateCall(ctx: Context): Boolean {
+            val fnName = this.function.identifier.text.lowercase()
+            if (fnName == "count" && this.args.isEmpty()) {
+                // Yet another special case for `COUNT(*)`
+                return ctx.env.getAggCandidates(fnName, this.args.size + 1).isNotEmpty()
+            } else {
+                return ctx.env.getAggCandidates(fnName, this.args.size).isNotEmpty()
+            }
         }
-
-        private fun Identifier.isAggregateCall(): Boolean = identifier.text.lowercase().isAggregateCall()
 
         override fun defaultReturn(node: AstNode, context: Context) = node
     }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/catalog/Session.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/catalog/Session.kt
@@ -63,6 +63,7 @@ public interface Session {
         private var catalog: String? = null
         private var system: Catalog = System.INSTANCE
         private var catalogs: Catalogs.Builder = Catalogs.builder()
+        private var catalogNames: MutableList<String> = mutableListOf()
         private var namespace: Namespace = Namespace.empty()
         private var properties: MutableMap<String, String> = mutableMapOf()
 
@@ -111,6 +112,11 @@ public interface Session {
          */
         public fun catalogs(vararg catalogs: Catalog): Builder {
             for (catalog in catalogs) {
+                val catalogName = catalog.getName()
+                if (this.catalogNames.contains(catalogName)) {
+                    throw IllegalStateException("Catalog names must be unique: $catalogName")
+                }
+                this.catalogNames.add(catalogName)
                 this.catalogs.add(catalog)
             }
             return this


### PR DESCRIPTION
## Relevant Issues
- N/A

## Description
Previously, the list of aggregation functions known to planning was hard-coded. This PR looks up aggregation functions in the catalog, allowing planning to find both built-ins and catalog-defined functions.

## Other Information
- Updated Unreleased Section in CHANGELOG: YES
- Any backward-incompatible changes? NO
- Any new external dependencies? NO
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? YES

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md