### PR TITLE
fix: parsing of LIMIT, OFFSET, ORDER BY applied to a set op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Thank you to all who have contributed!
 - `OperatorRewriter` omitting types for rewritten nodes
 - fixed Aggregation function lookup so that custom overloads from `Catalog` are found
 - `SqlDialect` printing of AST literal string single quotes
+- Parsing of `LIMIT`, `OFFSET`, and `ORDER BY` on set operators
 
 ### Removed
 

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -863,7 +863,11 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         override fun visitQueryExpression(ctx: GeneratedParser.QueryExpressionContext) = translate(ctx) {
-            val body = visitAs<QueryBody>(ctx.queryExpressionBody())
+            val body = when (val node = visit(ctx.queryExpressionBody())) {
+                is QueryBody -> node
+                is ExprQuerySet -> node.body
+                else -> throw error(ctx, "Unexpected QueryExpression")
+            }
             val with = visitOrNull<With>(ctx.withClause())
             val orderBy = ctx.orderByClause()?.let { visitOrderByClause(it) }
             val limit = ctx.limitClause()?.let { visitLimitClause(it) }


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Updates the `partiql-tests` git submodule
- LIMIT, OFFSET, and ORDER BY applied to the set op failed to parse. This PR fixes this parsing issue

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**: <Explain if NO>
- Any backward-incompatible changes? **[NO]**: <Explain if YES>
- Any new external dependencies? **[NO]**: <Explain if YES>
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md