### PR TITLE
fix: SqlDialect printing of AST literal string single quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Thank you to all who have contributed!
 - Mistyping of some Rex plan nodes
 - `OperatorRewriter` omitting types for rewritten nodes
 - fixed Aggregation function lookup so that custom overloads from `Catalog` are found
+- `SqlDialect` printing of AST literal string single quotes
 
 ### Removed
 

--- a/partiql-ast/src/main/java/org/partiql/ast/sql/SqlDialect.kt
+++ b/partiql-ast/src/main/java/org/partiql/ast/sql/SqlDialect.kt
@@ -249,7 +249,7 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
             Literal.MISSING -> "MISSING"
             Literal.BOOL -> lit.booleanValue().toString()
             Literal.APPROX_NUM, Literal.EXACT_NUM, Literal.INT_NUM -> lit.numberValue()
-            Literal.STRING -> String.format("'%s'", lit.stringValue())
+            Literal.STRING -> "'${lit.stringValue().replace("'", "''")}'"
             Literal.TYPED_STRING -> {
                 t = visitDataType(lit.dataType(), t)
                 String.format(" '%s'", lit.stringValue())

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
@@ -418,7 +418,19 @@ class SqlDialectTest {
                 "1.3", exprLit(exactNum(BigDecimal.valueOf(1.3)))
             ),
             expect(
-                """'hello'""", exprLit(string("hello"))
+                "'hello'", exprLit(string("hello"))
+            ),
+            expect(
+                "'''hello'''", exprLit(string("'hello'"))
+            ),
+            expect(
+                "'O''Riely'", exprLit(string("O'Riely"))
+            ),
+            expect(
+                """' one''two''three''"four" '""", exprLit(string(""" one'two'three'"four" """))
+            ),
+            expect(
+                "'one\\two'", exprLit(string("one\\two"))
             ),
             expect(
                 """hello""", regular("hello")


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Fixes the printing of AST literal string single quotes. Previously, `SqlDialect` would not properly escape single quotes.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**: <Explain if NO>
- Any backward-incompatible changes? **[NO]**: <Explain if YES>
- Any new external dependencies? **[NO]**: <Explain if YES>
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md