### PR TITLE
feat: add metas to PType; annotate PType ROWs and collections with excluded fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Thank you to all who have contributed!
 ## [Unreleased](https://TODO.com) - YYYY-MM-DD
 
 ### Added
+- **EXPERIMENTAL** add `metas` map for `PType`
+- partiql-planner: `ROW` or collection types with excluded fields resulting from `RelExclude` will include a meta
+`CONTAINS_EXCLUDED_FIELD` mapping to `true`
 
 ### Changed
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/util/TypeUtils.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/util/TypeUtils.kt
@@ -6,6 +6,11 @@ import org.partiql.planner.internal.typer.PlanTyper.Companion.toCType
 import org.partiql.spi.types.PType
 
 internal object TypeUtils {
+    // Meta indicating whether the given `ROW` or collection type has an excluded field
+    private fun PType.addExcludedFieldMeta() {
+        this.metas["CONTAINS_EXCLUDED_FIELD"] = true
+    }
+
     /**
      * Applies the given exclusion path to produce the reduced [CompilerType]. [lastStepOptional] indicates if a previous
      * step in the exclude path includes a collection index exclude step. Currently, for paths with the last step as
@@ -23,7 +28,7 @@ internal object TypeUtils {
         return steps.fold(type) { acc, step ->
             when (acc.code()) {
                 PType.DYNAMIC -> CompilerType(PType.dynamic())
-                PType.ROW -> acc.excludeStruct(step, lastStepOptional)
+                PType.ROW -> acc.excludeRow(step, lastStepOptional)
                 PType.STRUCT -> acc
                 PType.ARRAY, PType.BAG -> acc.excludeCollection(step, lastStepOptional)
                 else -> acc
@@ -31,32 +36,37 @@ internal object TypeUtils {
         }
     }
 
+    private fun CompilerType.PTypeField.applyExclusion(substeps: List<Rel.Op.Exclude.Step>, lastStepOptional: Boolean): CompilerType.PTypeField? {
+        val field = this
+        return if (substeps.isEmpty()) {
+            if (lastStepOptional) {
+                CompilerType.PTypeField(field.name, field.type)
+            } else {
+                null
+            }
+        } else {
+            val k = field.name
+            val v = field.type.exclude(substeps, lastStepOptional)
+            CompilerType.PTypeField(k, v)
+        }
+    }
+
     /**
-     * Applies exclusions to struct fields.
+     * Applies exclusions to `ROW` fields. Any `ROW`s that have an excluded field will also include the meta
+     * `CONTAINS_EXCLUDED_FIELD` set to true.
      *
      * @param step
      * @param lastStepOptional
      * @return
      */
-    internal fun CompilerType.excludeStruct(step: Rel.Op.Exclude.Step, lastStepOptional: Boolean = false): CompilerType {
+    internal fun CompilerType.excludeRow(step: Rel.Op.Exclude.Step, lastStepOptional: Boolean = false): CompilerType {
         val type = step.type
         val substeps = step.substeps
         val output = fields.mapNotNull { field ->
-            val newField = if (substeps.isEmpty()) {
-                if (lastStepOptional) {
-                    CompilerType.PTypeField(field.name, field.type)
-                } else {
-                    null
-                }
-            } else {
-                val k = field.name
-                val v = field.type.exclude(substeps, lastStepOptional)
-                CompilerType.PTypeField(k, v)
-            }
             when (type) {
                 is Rel.Op.Exclude.Type.StructSymbol -> {
                     if (type.symbol.equals(field.name, ignoreCase = true)) {
-                        newField
+                        field.applyExclusion(substeps, lastStepOptional)
                     } else {
                         field
                     }
@@ -64,20 +74,24 @@ internal object TypeUtils {
 
                 is Rel.Op.Exclude.Type.StructKey -> {
                     if (type.key == field.name) {
-                        newField
+                        field.applyExclusion(substeps, lastStepOptional)
                     } else {
                         field
                     }
                 }
-                is Rel.Op.Exclude.Type.StructWildcard -> newField
+                is Rel.Op.Exclude.Type.StructWildcard -> field.applyExclusion(substeps, lastStepOptional)
                 else -> field
             }
         }
-        return CompilerType(PType.row(output))
+        val res = CompilerType(PType.row(output))
+        this.addExcludedFieldMeta()
+        res.metas = this.metas
+        return res
     }
 
     /**
-     * Applies exclusions to collection element type.
+     * Applies exclusions to collection element type. Any collections that have an excluded field will also include
+     * the meta `CONTAINS_EXCLUDED_FIELD` set to true.
      *
      * @param step
      * @param lastStepOptional
@@ -106,10 +120,13 @@ internal object TypeUtils {
                 // the future
             }
         }
-        return when (this.code()) {
+        val res = when (this.code()) {
             PType.ARRAY -> PType.array(e).toCType()
             PType.BAG -> PType.bag(e).toCType()
             else -> throw IllegalStateException()
         }
+        this.addExcludedFieldMeta()
+        res.metas = this.metas
+        return res
     }
 }

--- a/partiql-spi/api/partiql-spi.api
+++ b/partiql-spi/api/partiql-spi.api
@@ -504,6 +504,7 @@ public abstract class org/partiql/spi/types/PType : org/partiql/spi/Enum {
 	public static final field UNKNOWN I
 	public static final field VARCHAR I
 	public static final field VARIANT I
+	public field metas Ljava/util/Map;
 	protected fun <init> (I)V
 	public static fun array ()Lorg/partiql/spi/types/PType;
 	public static fun array (Lorg/partiql/spi/types/PType;)Lorg/partiql/spi/types/PType;

--- a/partiql-spi/src/main/java/org/partiql/spi/types/PType.java
+++ b/partiql-spi/src/main/java/org/partiql/spi/types/PType.java
@@ -5,6 +5,8 @@ import org.partiql.spi.UnsupportedCodeException;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This represents a PartiQL type, whether it be a PartiQL primitive or user-defined.
@@ -34,6 +36,12 @@ public abstract class PType extends org.partiql.spi.Enum {
     protected PType(int code) {
         super(code);
     }
+
+    /**
+     * Additional information associated with a {@link PType}.
+     * Note: This is experimental and subject to change without prior notice!
+     */
+    public Map<String, Object> metas = new HashMap<>();
 
     /**
      * The fields of the type


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds `metas` field to `PType`
  - These were previously part of the type system (see StaticType from 0.14.9 -- https://github.com/partiql/partiql-lang-kotlin/blob/v0.14.9/partiql-types/src/main/kotlin/org/partiql/types/StaticType.kt#L117). However PLK 1.x omitted this field.
  - They can be useful for passing along additional information in the typing passes 
- partiql-planner: as part of the EXCLUDE typing pass, add a new meta for any ROWs and collections that contain excluded fields. This is helpful for some rewrites using the typed logical plan in Scribe.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**: <Explain if NO>
- Any backward-incompatible changes? **[NO]**: <Explain if YES>
- Any new external dependencies? **[NO]**: <Explain if YES>
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md