### PR TITLE
feat: add metas to PType denoting a default parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Thank you to all who have contributed!
 - **EXPERIMENTAL** add `metas` map for `PType`
 - partiql-planner: `ROW` or collection types with excluded fields resulting from `RelExclude` will include a meta
 `CONTAINS_EXCLUDED_FIELD` mapping to `true`
+- Static factories for creating `PType.decimal` and `PType.numeric` types with a precision and default scale
+- Metas attached to `PType`s indicating if a parameter (e.g. precision, scale, length) was specified
 
 ### Changed
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
@@ -1153,14 +1153,14 @@ internal object RexConverter {
                 }
                 DataType.BIGINT, DataType.INT8, DataType.INTEGER8 -> PType.bigint()
                 DataType.INT4, DataType.INTEGER4, DataType.INTEGER, DataType.INT -> PType.integer()
-                DataType.INT2, DataType.SMALLINT -> PType.smallint()
+                DataType.INT2, DataType.INTEGER2, DataType.SMALLINT -> PType.smallint()
                 DataType.TINYINT -> PType.tinyint()
                 // <numeric type> - <approximate numeric type>
                 DataType.FLOAT -> PType.real()
                 DataType.REAL -> PType.real()
                 DataType.DOUBLE_PRECISION -> PType.doublePrecision()
                 // <boolean type>
-                DataType.BOOL -> PType.bool()
+                DataType.BOOL, DataType.BOOLEAN -> PType.bool()
                 // <datetime type>
                 DataType.DATE -> PType.date()
                 DataType.TIME -> assertGtEqZeroAndCreate(PType.TIME, "precision", type.precision ?: 0, PType::time).also {

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/CompilerType.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/CompilerType.kt
@@ -18,6 +18,10 @@ internal class CompilerType(
     // Note: This is an experimental property.
     internal val isMissingValue: Boolean = false
 ) : PType(_delegate.code()) {
+    init {
+        this.metas = HashMap(_delegate.metas)
+    }
+
     fun getDelegate(): PType = _delegate
     override fun getFields(): MutableCollection<PTypeField> {
         return _delegate.fields.map { field ->

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PTypeMetaInPlan.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PTypeMetaInPlan.kt
@@ -1,0 +1,148 @@
+package org.partiql.planner.internal.typer
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.partiql.ast.Ast.exprCast
+import org.partiql.ast.Ast.exprLit
+import org.partiql.ast.Ast.query
+import org.partiql.ast.DataType
+import org.partiql.ast.Literal
+import org.partiql.ast.Statement
+import org.partiql.plan.Action
+import org.partiql.plan.rex.RexCast
+import org.partiql.planner.PartiQLPlanner
+import org.partiql.spi.catalog.Session
+import org.partiql.spi.types.PType
+
+private const val UNSPECIFIED_LENGTH = "UNSPECIFIED_LENGTH"
+private const val UNSPECIFIED_PRECISION = "UNSPECIFIED_PRECISION"
+private const val UNSPECIFIED_SCALE = "UNSPECIFIED_SCALE"
+
+/**
+ * Tests that PType metas are available in the plan after AST -> plan conversion and type inference.
+ */
+class PTypeMetaInPlan {
+    private val planner = PartiQLPlanner.standard()
+    private fun PType.assertHasLengthMeta() {
+        assertEquals(this.metas[UNSPECIFIED_LENGTH], true)
+    }
+
+    private fun PType.assertHasPrecisionMeta() {
+        assertEquals(this.metas[UNSPECIFIED_PRECISION], true)
+    }
+
+    private fun PType.assertHasScaleMeta() {
+        assertEquals(this.metas[UNSPECIFIED_SCALE], true)
+    }
+
+    private fun createCastStatement(dt: DataType): Statement {
+        return query(exprCast(exprLit(Literal.nul()), dt))
+    }
+
+    private fun getRexCast(dataType: DataType): RexCast {
+        val castStatement = createCastStatement(dataType)
+        val result = planner.plan(castStatement, Session.empty())
+        val rex = (result.plan.action as Action.Query).rex
+        rex as RexCast
+        return rex
+    }
+
+    @Test
+    fun `test decimal has no scale and no precision`() {
+        val decimal = getRexCast(DataType.DECIMAL()).type.pType
+        decimal.assertHasPrecisionMeta()
+        decimal.assertHasScaleMeta()
+    }
+
+    @Test
+    fun `test decimal has no scale`() {
+        val decimal = getRexCast(DataType.DECIMAL(10)).type.pType
+        decimal.assertHasScaleMeta()
+    }
+
+    @Test
+    fun `test dec has no scale and no precision`() {
+        val decimal = getRexCast(DataType.DEC()).type.pType
+        decimal.assertHasPrecisionMeta()
+        decimal.assertHasScaleMeta()
+    }
+
+    @Test
+    fun `test dec has no scale`() {
+        val decimal = getRexCast(DataType.DEC(10)).type.pType
+        decimal.assertHasScaleMeta()
+    }
+
+    @Test
+    fun `test numeric has no scale and no precision`() {
+        val numeric = getRexCast(DataType.NUMERIC()).type.pType
+        numeric.assertHasPrecisionMeta()
+        numeric.assertHasScaleMeta()
+    }
+
+    @Test
+    fun `test numeric has no scale`() {
+        val numeric = getRexCast(DataType.NUMERIC(10)).type.pType
+        numeric.assertHasScaleMeta()
+    }
+
+    @Test
+    fun `test varchar has no length`() {
+        val varchar = getRexCast(DataType.VARCHAR()).type.pType
+        varchar.assertHasLengthMeta()
+    }
+
+    @Test
+    fun `test character_varying has no length`() {
+        val varchar = getRexCast(DataType.CHARACTER_VARYING()).type.pType
+        varchar.assertHasLengthMeta()
+    }
+
+    @Test
+    fun `test character has no length`() {
+        val char = getRexCast(DataType.CHARACTER()).type.pType
+        char.assertHasLengthMeta()
+    }
+
+    @Test
+    fun `test char has no length`() {
+        val char = getRexCast(DataType.CHAR()).type.pType
+        char.assertHasLengthMeta()
+    }
+
+    @Test
+    fun `test clob has no length`() {
+        val clob = getRexCast(DataType.CLOB()).type.pType
+        clob.assertHasLengthMeta()
+    }
+
+    @Test
+    fun `test blob has no length`() {
+        val blob = getRexCast(DataType.BLOB()).type.pType
+        blob.assertHasLengthMeta()
+    }
+
+    @Test
+    fun `test time has no precision`() {
+        val time = getRexCast(DataType.TIME()).type.pType
+        time.assertHasPrecisionMeta()
+    }
+
+    @Test
+    fun `test timez has no precision`() {
+        val timez = getRexCast(DataType.TIME_WITH_TIME_ZONE()).type.pType
+        timez.assertHasPrecisionMeta()
+    }
+
+    @Test
+    fun `test timestamp has no precision`() {
+        val timestamp = getRexCast(DataType.TIMESTAMP()).type.pType
+        timestamp.assertHasPrecisionMeta()
+    }
+
+    @Test
+    fun `test timestampz has no precision`() {
+        val timestampz = getRexCast(DataType.TIMESTAMP_WITH_TIME_ZONE()).type.pType
+        timestampz.assertHasPrecisionMeta()
+    }
+}

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PTypeMetaInPlan.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PTypeMetaInPlan.kt
@@ -23,15 +23,15 @@ private const val UNSPECIFIED_SCALE = "UNSPECIFIED_SCALE"
  */
 class PTypeMetaInPlan {
     private val planner = PartiQLPlanner.standard()
-    private fun PType.assertHasLengthMeta() {
+    private fun PType.assertUnspecifiedLength() {
         assertEquals(this.metas[UNSPECIFIED_LENGTH], true)
     }
 
-    private fun PType.assertHasPrecisionMeta() {
+    private fun PType.assertUnspecifiedPrecision() {
         assertEquals(this.metas[UNSPECIFIED_PRECISION], true)
     }
 
-    private fun PType.assertHasScaleMeta() {
+    private fun PType.assertUnspecifiedScale() {
         assertEquals(this.metas[UNSPECIFIED_SCALE], true)
     }
 
@@ -50,99 +50,99 @@ class PTypeMetaInPlan {
     @Test
     fun `test decimal has no scale and no precision`() {
         val decimal = getRexCast(DataType.DECIMAL()).type.pType
-        decimal.assertHasPrecisionMeta()
-        decimal.assertHasScaleMeta()
+        decimal.assertUnspecifiedPrecision()
+        decimal.assertUnspecifiedScale()
     }
 
     @Test
     fun `test decimal has no scale`() {
         val decimal = getRexCast(DataType.DECIMAL(10)).type.pType
-        decimal.assertHasScaleMeta()
+        decimal.assertUnspecifiedScale()
     }
 
     @Test
     fun `test dec has no scale and no precision`() {
         val decimal = getRexCast(DataType.DEC()).type.pType
-        decimal.assertHasPrecisionMeta()
-        decimal.assertHasScaleMeta()
+        decimal.assertUnspecifiedPrecision()
+        decimal.assertUnspecifiedScale()
     }
 
     @Test
     fun `test dec has no scale`() {
         val decimal = getRexCast(DataType.DEC(10)).type.pType
-        decimal.assertHasScaleMeta()
+        decimal.assertUnspecifiedScale()
     }
 
     @Test
     fun `test numeric has no scale and no precision`() {
         val numeric = getRexCast(DataType.NUMERIC()).type.pType
-        numeric.assertHasPrecisionMeta()
-        numeric.assertHasScaleMeta()
+        numeric.assertUnspecifiedPrecision()
+        numeric.assertUnspecifiedScale()
     }
 
     @Test
     fun `test numeric has no scale`() {
         val numeric = getRexCast(DataType.NUMERIC(10)).type.pType
-        numeric.assertHasScaleMeta()
+        numeric.assertUnspecifiedScale()
     }
 
     @Test
     fun `test varchar has no length`() {
         val varchar = getRexCast(DataType.VARCHAR()).type.pType
-        varchar.assertHasLengthMeta()
+        varchar.assertUnspecifiedLength()
     }
 
     @Test
     fun `test character_varying has no length`() {
         val varchar = getRexCast(DataType.CHARACTER_VARYING()).type.pType
-        varchar.assertHasLengthMeta()
+        varchar.assertUnspecifiedLength()
     }
 
     @Test
     fun `test character has no length`() {
         val char = getRexCast(DataType.CHARACTER()).type.pType
-        char.assertHasLengthMeta()
+        char.assertUnspecifiedLength()
     }
 
     @Test
     fun `test char has no length`() {
         val char = getRexCast(DataType.CHAR()).type.pType
-        char.assertHasLengthMeta()
+        char.assertUnspecifiedLength()
     }
 
     @Test
     fun `test clob has no length`() {
         val clob = getRexCast(DataType.CLOB()).type.pType
-        clob.assertHasLengthMeta()
+        clob.assertUnspecifiedLength()
     }
 
     @Test
     fun `test blob has no length`() {
         val blob = getRexCast(DataType.BLOB()).type.pType
-        blob.assertHasLengthMeta()
+        blob.assertUnspecifiedLength()
     }
 
     @Test
     fun `test time has no precision`() {
         val time = getRexCast(DataType.TIME()).type.pType
-        time.assertHasPrecisionMeta()
+        time.assertUnspecifiedPrecision()
     }
 
     @Test
     fun `test timez has no precision`() {
         val timez = getRexCast(DataType.TIME_WITH_TIME_ZONE()).type.pType
-        timez.assertHasPrecisionMeta()
+        timez.assertUnspecifiedPrecision()
     }
 
     @Test
     fun `test timestamp has no precision`() {
         val timestamp = getRexCast(DataType.TIMESTAMP()).type.pType
-        timestamp.assertHasPrecisionMeta()
+        timestamp.assertUnspecifiedPrecision()
     }
 
     @Test
     fun `test timestampz has no precision`() {
         val timestampz = getRexCast(DataType.TIMESTAMP_WITH_TIME_ZONE()).type.pType
-        timestampz.assertHasPrecisionMeta()
+        timestampz.assertUnspecifiedPrecision()
     }
 }

--- a/partiql-spi/api/partiql-spi.api
+++ b/partiql-spi/api/partiql-spi.api
@@ -506,6 +506,7 @@ public abstract class org/partiql/spi/types/PType : org/partiql/spi/Enum {
 	public static final field VARIANT I
 	public field metas Ljava/util/Map;
 	protected fun <init> (I)V
+	protected fun <init> (ILjava/util/Map;)V
 	public static fun array ()Lorg/partiql/spi/types/PType;
 	public static fun array (Lorg/partiql/spi/types/PType;)Lorg/partiql/spi/types/PType;
 	public static fun bag ()Lorg/partiql/spi/types/PType;
@@ -521,6 +522,7 @@ public abstract class org/partiql/spi/types/PType : org/partiql/spi/Enum {
 	public static fun codes ()[I
 	public static fun date ()Lorg/partiql/spi/types/PType;
 	public static fun decimal ()Lorg/partiql/spi/types/PType;
+	public static fun decimal (I)Lorg/partiql/spi/types/PType;
 	public static fun decimal (II)Lorg/partiql/spi/types/PType;
 	public static fun doublePrecision ()Lorg/partiql/spi/types/PType;
 	public static fun dynamic ()Lorg/partiql/spi/types/PType;
@@ -547,6 +549,7 @@ public abstract class org/partiql/spi/types/PType : org/partiql/spi/Enum {
 	public static fun intervalYearMonth (I)Lorg/partiql/spi/types/PType;
 	public fun name ()Ljava/lang/String;
 	public static fun numeric ()Lorg/partiql/spi/types/PType;
+	public static fun numeric (I)Lorg/partiql/spi/types/PType;
 	public static fun numeric (II)Lorg/partiql/spi/types/PType;
 	public static fun of (I)Lorg/partiql/spi/types/PType;
 	public static fun real ()Lorg/partiql/spi/types/PType;

--- a/partiql-spi/src/main/java/org/partiql/spi/types/PType.java
+++ b/partiql-spi/src/main/java/org/partiql/spi/types/PType.java
@@ -37,6 +37,11 @@ public abstract class PType extends org.partiql.spi.Enum {
         super(code);
     }
 
+    protected PType(int code, Map<String, Object> metas) {
+        super(code);
+        this.metas = metas;
+    }
+
     /**
      * Additional information associated with a {@link PType}.
      * Note: This is experimental and subject to change without prior notice!
@@ -631,6 +636,22 @@ public abstract class PType extends org.partiql.spi.Enum {
      */
     public static final int INTERVAL_DT = 27;
 
+    private static final String UNSPECIFIED_LENGTH = "UNSPECIFIED_LENGTH";
+    private static final String UNSPECIFIED_PRECISION = "UNSPECIFIED_PRECISION";
+    private static final String UNSPECIFIED_SCALE = "UNSPECIFIED_SCALE";
+
+    private static void setUnspecifiedLengthMeta(PType pType) {
+        pType.metas.put(UNSPECIFIED_LENGTH, true);
+    }
+
+    private static void setUnspecifiedPrecisionMeta(PType pType) {
+        pType.metas.put(UNSPECIFIED_PRECISION, true);
+    }
+
+    private static void setUnspecifiedScaleMeta(PType pType) {
+        pType.metas.put(UNSPECIFIED_SCALE, true);
+    }
+
     /**
      * Creates a type representing INTERVAL YEAR (precision)
      * @param precision the interval's leading field precision
@@ -827,7 +848,20 @@ public abstract class PType extends org.partiql.spi.Enum {
      */
     @NotNull
     public static PType numeric() {
-        return new PTypeDecimal(NUMERIC, 38, 0);
+        PType numeric = new PTypeDecimal(NUMERIC, 38, 0);
+        setUnspecifiedPrecisionMeta(numeric);
+        setUnspecifiedScaleMeta(numeric);
+        return numeric;
+    }
+
+    /**
+     * @return a SQL:1999 NUMERIC type with provided precision and default scale 0.
+     */
+    @NotNull
+    public static PType numeric(int precision) {
+        PType numeric = new PTypeDecimal(NUMERIC, precision, 0);
+        setUnspecifiedScaleMeta(numeric);
+        return numeric;
     }
 
     /**
@@ -839,11 +873,24 @@ public abstract class PType extends org.partiql.spi.Enum {
     }
 
     /**
+     * @return a PartiQL decimal type with provided precision and default scale 0.
+     */
+    @NotNull
+    public static PType decimal(int precision) {
+        PType decimal = new PTypeDecimal(PType.DECIMAL, precision, 0);
+        setUnspecifiedScaleMeta(decimal);
+        return decimal;
+    }
+
+    /**
      * @return a PartiQL decimal type with default precision (38) and scale (0).
      */
     @NotNull
     public static PType decimal() {
-        return new PTypeDecimal(PType.DECIMAL, 38, 0);
+        PType decimal = new PTypeDecimal(PType.DECIMAL, 38, 0);
+        setUnspecifiedPrecisionMeta(decimal);
+        setUnspecifiedScaleMeta(decimal);
+        return decimal;
     }
 
     /**
@@ -878,7 +925,9 @@ public abstract class PType extends org.partiql.spi.Enum {
     @NotNull
     @SuppressWarnings("unused")
     public static PType character() {
-        return new PTypeWithMaxLength(CHAR, 1);
+        PType character = new PTypeWithMaxLength(CHAR, 1);
+        setUnspecifiedLengthMeta(character);
+        return character;
     }
 
     /**
@@ -896,7 +945,9 @@ public abstract class PType extends org.partiql.spi.Enum {
     @NotNull
     @SuppressWarnings("unused")
     public static PType varchar() {
-        return new PTypeWithMaxLength(VARCHAR, 1);
+        PType varchar = new PTypeWithMaxLength(VARCHAR, 1);
+        setUnspecifiedLengthMeta(varchar);
+        return varchar;
     }
 
     /**
@@ -921,7 +972,9 @@ public abstract class PType extends org.partiql.spi.Enum {
      */
     @NotNull
     public static PType clob() {
-        return new PTypeWithMaxLength(CLOB, Integer.MAX_VALUE);
+        PType clob = new PTypeWithMaxLength(CLOB, Integer.MAX_VALUE);
+        setUnspecifiedLengthMeta(clob);
+        return clob;
     }
 
     /**
@@ -938,7 +991,9 @@ public abstract class PType extends org.partiql.spi.Enum {
      */
     @NotNull
     public static PType blob() {
-        return new PTypeWithMaxLength(BLOB, Integer.MAX_VALUE);
+        PType blob = new PTypeWithMaxLength(BLOB, Integer.MAX_VALUE);
+        setUnspecifiedLengthMeta(blob);
+        return blob;
     }
 
     /**
@@ -962,7 +1017,9 @@ public abstract class PType extends org.partiql.spi.Enum {
      */
     @NotNull
     public static PType time() {
-        return new PTypeWithPrecisionOnly(TIME, 6);
+        PType time = new PTypeWithPrecisionOnly(TIME, 6);
+        setUnspecifiedPrecisionMeta(time);
+        return time;
     }
 
     /**
@@ -980,7 +1037,9 @@ public abstract class PType extends org.partiql.spi.Enum {
     @NotNull
     @SuppressWarnings("unused")
     public static PType timez() {
-        return new PTypeWithPrecisionOnly(TIMEZ, 6);
+        PType timez = new PTypeWithPrecisionOnly(TIMEZ, 6);
+        setUnspecifiedPrecisionMeta(timez);
+        return timez;
     }
 
     /**
@@ -996,7 +1055,9 @@ public abstract class PType extends org.partiql.spi.Enum {
      */
     @NotNull
     public static PType timestamp() {
-        return new PTypeWithPrecisionOnly(TIMESTAMP, 6);
+        PType timestamp = new PTypeWithPrecisionOnly(TIMESTAMP, 6);
+        setUnspecifiedPrecisionMeta(timestamp);
+        return timestamp;
     }
 
     /**
@@ -1014,7 +1075,9 @@ public abstract class PType extends org.partiql.spi.Enum {
     @NotNull
     @SuppressWarnings("unused")
     public static PType timestampz() {
-        return new PTypeWithPrecisionOnly(TIMESTAMPZ, 6);
+        PType timestampz = new PTypeWithPrecisionOnly(TIMESTAMPZ, 6);
+        setUnspecifiedPrecisionMeta(timestampz);
+        return timestampz;
     }
 
     /**

--- a/partiql-spi/src/test/kotlin/org/partiql/types/PTypeMetaTest.kt
+++ b/partiql-spi/src/test/kotlin/org/partiql/types/PTypeMetaTest.kt
@@ -12,89 +12,89 @@ private const val UNSPECIFIED_SCALE = "UNSPECIFIED_SCALE"
  * Tests that constructed PType instances have the correct metas.
  */
 class PTypeMetaTest {
-    private fun PType.assertHasLengthMeta() {
+    private fun PType.assertUnspecifiedLength() {
         assertEquals(this.metas[UNSPECIFIED_LENGTH], true)
     }
 
-    private fun PType.assertHasPrecisionMeta() {
+    private fun PType.assertUnspecifiedPrecision() {
         assertEquals(this.metas[UNSPECIFIED_PRECISION], true)
     }
 
-    private fun PType.assertHasScaleMeta() {
+    private fun PType.assertUnspecifiedScale() {
         assertEquals(this.metas[UNSPECIFIED_SCALE], true)
     }
 
     @Test
     fun `test decimal has no scale and no precision`() {
         val decimal = PType.decimal()
-        decimal.assertHasPrecisionMeta()
-        decimal.assertHasScaleMeta()
+        decimal.assertUnspecifiedPrecision()
+        decimal.assertUnspecifiedScale()
     }
 
     @Test
     fun `test decimal has no scale`() {
         val decimal = PType.decimal(10)
-        decimal.assertHasScaleMeta()
+        decimal.assertUnspecifiedScale()
     }
 
     @Test
     fun `test numeric has no scale and no precision`() {
         val numeric = PType.numeric()
-        numeric.assertHasPrecisionMeta()
-        numeric.assertHasScaleMeta()
+        numeric.assertUnspecifiedPrecision()
+        numeric.assertUnspecifiedScale()
     }
 
     @Test
     fun `test numeric has no scale`() {
         val numeric = PType.numeric(10)
-        numeric.assertHasScaleMeta()
+        numeric.assertUnspecifiedScale()
     }
 
     @Test
     fun `test varchar has no length`() {
         val varchar = PType.varchar()
-        varchar.assertHasLengthMeta()
+        varchar.assertUnspecifiedLength()
     }
 
     @Test
     fun `test character has no length`() {
         val char = PType.character()
-        char.assertHasLengthMeta()
+        char.assertUnspecifiedLength()
     }
 
     @Test
     fun `test clob has no length`() {
         val clob = PType.clob()
-        clob.assertHasLengthMeta()
+        clob.assertUnspecifiedLength()
     }
 
     @Test
     fun `test blob has no length`() {
         val blob = PType.blob()
-        blob.assertHasLengthMeta()
+        blob.assertUnspecifiedLength()
     }
 
     @Test
     fun `test time has no precision`() {
         val time = PType.time()
-        time.assertHasPrecisionMeta()
+        time.assertUnspecifiedPrecision()
     }
 
     @Test
     fun `test timez has no precision`() {
         val timez = PType.timez()
-        timez.assertHasPrecisionMeta()
+        timez.assertUnspecifiedPrecision()
     }
 
     @Test
     fun `test timestamp has no precision`() {
         val timestamp = PType.timestamp()
-        timestamp.assertHasPrecisionMeta()
+        timestamp.assertUnspecifiedPrecision()
     }
 
     @Test
     fun `test timestampz has no precision`() {
         val timestampz = PType.timestampz()
-        timestampz.assertHasPrecisionMeta()
+        timestampz.assertUnspecifiedPrecision()
     }
 }

--- a/partiql-spi/src/test/kotlin/org/partiql/types/PTypeMetaTest.kt
+++ b/partiql-spi/src/test/kotlin/org/partiql/types/PTypeMetaTest.kt
@@ -1,0 +1,100 @@
+package org.partiql.types
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.partiql.spi.types.PType
+
+private const val UNSPECIFIED_LENGTH = "UNSPECIFIED_LENGTH"
+private const val UNSPECIFIED_PRECISION = "UNSPECIFIED_PRECISION"
+private const val UNSPECIFIED_SCALE = "UNSPECIFIED_SCALE"
+
+/**
+ * Tests that constructed PType instances have the correct metas.
+ */
+class PTypeMetaTest {
+    private fun PType.assertHasLengthMeta() {
+        assertEquals(this.metas[UNSPECIFIED_LENGTH], true)
+    }
+
+    private fun PType.assertHasPrecisionMeta() {
+        assertEquals(this.metas[UNSPECIFIED_PRECISION], true)
+    }
+
+    private fun PType.assertHasScaleMeta() {
+        assertEquals(this.metas[UNSPECIFIED_SCALE], true)
+    }
+
+    @Test
+    fun `test decimal has no scale and no precision`() {
+        val decimal = PType.decimal()
+        decimal.assertHasPrecisionMeta()
+        decimal.assertHasScaleMeta()
+    }
+
+    @Test
+    fun `test decimal has no scale`() {
+        val decimal = PType.decimal(10)
+        decimal.assertHasScaleMeta()
+    }
+
+    @Test
+    fun `test numeric has no scale and no precision`() {
+        val numeric = PType.numeric()
+        numeric.assertHasPrecisionMeta()
+        numeric.assertHasScaleMeta()
+    }
+
+    @Test
+    fun `test numeric has no scale`() {
+        val numeric = PType.numeric(10)
+        numeric.assertHasScaleMeta()
+    }
+
+    @Test
+    fun `test varchar has no length`() {
+        val varchar = PType.varchar()
+        varchar.assertHasLengthMeta()
+    }
+
+    @Test
+    fun `test character has no length`() {
+        val char = PType.character()
+        char.assertHasLengthMeta()
+    }
+
+    @Test
+    fun `test clob has no length`() {
+        val clob = PType.clob()
+        clob.assertHasLengthMeta()
+    }
+
+    @Test
+    fun `test blob has no length`() {
+        val blob = PType.blob()
+        blob.assertHasLengthMeta()
+    }
+
+    @Test
+    fun `test time has no precision`() {
+        val time = PType.time()
+        time.assertHasPrecisionMeta()
+    }
+
+    @Test
+    fun `test timez has no precision`() {
+        val timez = PType.timez()
+        timez.assertHasPrecisionMeta()
+    }
+
+    @Test
+    fun `test timestamp has no precision`() {
+        val timestamp = PType.timestamp()
+        timestamp.assertHasPrecisionMeta()
+    }
+
+    @Test
+    fun `test timestampz has no precision`() {
+        val timestampz = PType.timestampz()
+        timestampz.assertHasPrecisionMeta()
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds metas to `PType` denoting whether a default parameter was specified or not
- Adds a couple additional `PType` static factory functions to create a decimal and numeric with a precision and default scale

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**: <Explain if NO>
- Any backward-incompatible changes? **[YES]**: <Explain if YES>
- Any new external dependencies? **[NO]**: <Explain if YES>
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md