### PR TITLE
feat: experimental WITH representation in the plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Thank you to all who have contributed!
 `OperatorVisitor`
 - **EXPERIMENTAL** partiql-planner: add planner builder function to control whether `With` table references are 
 rewritten to their query representation
+  - **NOTE** evaluating plans without the inlined `With` rewrite will not work as expected. Users trying to evaluate
+  `With` should use the default planner.
 
 ### Changed
 
@@ -46,6 +48,7 @@ rewritten to their query representation
 ### Contributors
 Thank you to all who have contributed!
 - @zyfy29
+- @alancai98
 
 ## [1.2.2](https://github.com/partiql/partiql-lang-kotlin/releases/tag/v1.2.2) - 2025-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Thank you to all who have contributed!
 ## [Unreleased](https://TODO.com) - YYYY-MM-DD
 
 ### Added
+- partiql-ast: add `With` and `WithListElement` to `AstVisitor` and `SqlDialect`
+- **EXPERIMENTAL** partiql-plan: add representation of `RelWith` and `WithListElement` to the plan and the 
+`OperatorVisitor`
+- **EXPERIMENTAL** partiql-planner: add planner builder function to control whether `With` table references are 
+rewritten to their query representation
 
 ### Changed
 

--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -3421,6 +3421,10 @@ public abstract class org/partiql/ast/sql/SqlDialect : org/partiql/ast/AstVisito
 	public fun visitUpdate (Lorg/partiql/ast/dml/Update;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitUpsert (Lorg/partiql/ast/dml/Upsert;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitUpsert (Lorg/partiql/ast/dml/Upsert;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitWith (Lorg/partiql/ast/With;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitWith (Lorg/partiql/ast/With;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitWithListElement (Lorg/partiql/ast/WithListElement;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitWithListElement (Lorg/partiql/ast/WithListElement;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 }
 
 public final class org/partiql/ast/sql/SqlDialect$Companion {

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
@@ -101,6 +101,7 @@ import org.partiql.ast.QueryBody
 import org.partiql.ast.Select
 import org.partiql.ast.SetOpType
 import org.partiql.ast.SetQuantifier
+import org.partiql.ast.With
 import org.partiql.ast.expr.Expr
 import org.partiql.ast.expr.TrimSpec
 import org.partiql.ast.expr.TruthValue
@@ -2034,6 +2035,58 @@ class SqlDialectTest {
                     )
                 )
             ),
+            expect(
+                "WITH a AS (SELECT * FROM t) SELECT * FROM a",
+                qSet(
+                    with = Ast.with(
+                        listOf(
+                            Ast.withListElement(
+                                queryName = regular("a"),
+                                asQuery = qSet(
+                                    body = sfw(
+                                        select = selectStar(),
+                                        from = table("t")
+                                    )
+                                ),
+                                columnList = null
+                            )
+                        ),
+                        isRecursive = false
+                    ),
+                    body = sfw(
+                        select = selectStar(),
+                        from = table("a"),
+                    ),
+                )
+            ),
+            expect(
+                "WITH a (b, c, d) AS (SELECT * FROM t) SELECT * FROM a",
+                qSet(
+                    with = Ast.with(
+                        listOf(
+                            Ast.withListElement(
+                                queryName = regular("a"),
+                                asQuery = qSet(
+                                    body = sfw(
+                                        select = selectStar(),
+                                        from = table("t")
+                                    )
+                                ),
+                                columnList = listOf(
+                                    regular("b"),
+                                    regular("c"),
+                                    regular("d")
+                                )
+                            )
+                        ),
+                        isRecursive = false
+                    ),
+                    body = sfw(
+                        select = selectStar(),
+                        from = table("a"),
+                    ),
+                )
+            ),
         )
 
         @JvmStatic
@@ -2635,11 +2688,12 @@ class SqlDialectTest {
             setq = null
         )
 
-        private fun qSet(body: QueryBody, orderBy: OrderBy? = null, limit: Expr? = null, offset: Expr? = null) = exprQuerySet(
+        private fun qSet(body: QueryBody, orderBy: OrderBy? = null, limit: Expr? = null, offset: Expr? = null, with: With? = null) = exprQuerySet(
             body = body,
             orderBy = orderBy,
             limit = limit,
-            offset = offset
+            offset = offset,
+            with = with
         )
 
         private fun sfw(select: Select, from: From, exclude: Exclude? = null, let: Let? = null, where: Expr? = null, groupBy: GroupBy? = null, having: Expr? = null) = queryBodySFW(

--- a/partiql-eval/src/main/java/org/partiql/eval/Environment.java
+++ b/partiql-eval/src/main/java/org/partiql/eval/Environment.java
@@ -63,7 +63,7 @@ public class Environment {
         try {
             return stack[depth].getValues()[offset];
         } catch (IndexOutOfBoundsException ex) {
-            throw new RuntimeException("Invalid variable reference [$depth:$offset]\n$this");
+            throw new RuntimeException(String.format("Invalid variable reference [%d:%d]\n%s", depth, offset, this));
         }
     }
 

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/StandardCompiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/StandardCompiler.kt
@@ -84,6 +84,7 @@ import org.partiql.plan.rel.RelScan
 import org.partiql.plan.rel.RelSort
 import org.partiql.plan.rel.RelUnion
 import org.partiql.plan.rel.RelUnpivot
+import org.partiql.plan.rel.RelWith
 import org.partiql.plan.rex.Rex
 import org.partiql.plan.rex.RexArray
 import org.partiql.plan.rex.RexBag
@@ -332,6 +333,12 @@ internal class StandardCompiler(strategies: List<Strategy>) : PartiQLCompiler {
                 Mode.STRICT -> RelOpUnpivot.Strict(input)
                 else -> throw IllegalStateException("Unsupported execution mode: $MODE")
             }
+        }
+
+        override fun visitWith(rel: RelWith, ctx: Unit): ExprRelation {
+            // Rewrite to not include the `RelWith` (assumes the planner rewrote WITH variable references to the query
+            // representation)
+            return compile(rel.input, ctx)
         }
 
         override fun visitError(rex: RexError, ctx: Unit): ExprValue {

--- a/partiql-plan/api/partiql-plan.api
+++ b/partiql-plan/api/partiql-plan.api
@@ -291,6 +291,7 @@ public abstract interface class org/partiql/plan/OperatorVisitor {
 	public fun visitUnion (Lorg/partiql/plan/rel/RelUnion;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitUnpivot (Lorg/partiql/plan/rel/RelUnpivot;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitVar (Lorg/partiql/plan/rex/RexVar;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitWith (Lorg/partiql/plan/rel/RelWith;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class org/partiql/plan/Operators {
@@ -335,6 +336,7 @@ public abstract interface class org/partiql/plan/Operators {
 	public abstract fun union (Lorg/partiql/plan/rel/Rel;Lorg/partiql/plan/rel/Rel;Z)Lorg/partiql/plan/rel/RelUnion;
 	public abstract fun unpivot (Lorg/partiql/plan/rex/Rex;)Lorg/partiql/plan/rel/RelUnpivot;
 	public abstract fun variable (IILorg/partiql/spi/types/PType;)Lorg/partiql/plan/rex/RexVar;
+	public abstract fun with (Lorg/partiql/plan/rel/Rel;Ljava/util/List;)Lorg/partiql/plan/rel/RelWith;
 }
 
 public final class org/partiql/plan/Operators$Companion {
@@ -380,6 +382,7 @@ public final class org/partiql/plan/Operators$DefaultImpls {
 	public static fun union (Lorg/partiql/plan/Operators;Lorg/partiql/plan/rel/Rel;Lorg/partiql/plan/rel/Rel;Z)Lorg/partiql/plan/rel/RelUnion;
 	public static fun unpivot (Lorg/partiql/plan/Operators;Lorg/partiql/plan/rex/Rex;)Lorg/partiql/plan/rel/RelUnpivot;
 	public static fun variable (Lorg/partiql/plan/Operators;IILorg/partiql/spi/types/PType;)Lorg/partiql/plan/rex/RexVar;
+	public static fun with (Lorg/partiql/plan/Operators;Lorg/partiql/plan/rel/Rel;Ljava/util/List;)Lorg/partiql/plan/rel/RelWith;
 }
 
 public abstract interface class org/partiql/plan/Plan {
@@ -392,6 +395,12 @@ public class org/partiql/plan/Version : org/partiql/spi/Enum {
 	public static fun V1 ()Lorg/partiql/plan/Version;
 	public fun name ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
+}
+
+public class org/partiql/plan/WithListElement {
+	public fun <init> (Ljava/lang/String;Lorg/partiql/plan/rex/Rex;)V
+	public fun getName ()Ljava/lang/String;
+	public fun getRepresentation ()Lorg/partiql/plan/rex/Rex;
 }
 
 public abstract interface class org/partiql/plan/rel/Rel : org/partiql/plan/Operator {
@@ -617,6 +626,18 @@ public abstract class org/partiql/plan/rel/RelUnpivot : org/partiql/plan/rel/Rel
 	public abstract fun copy (Lorg/partiql/plan/rex/Rex;)Lorg/partiql/plan/rel/RelUnpivot;
 	public static fun create (Lorg/partiql/plan/rex/Rex;)Lorg/partiql/plan/rel/RelUnpivot;
 	public abstract fun getRex ()Lorg/partiql/plan/rex/Rex;
+	protected final fun operands ()Ljava/util/List;
+	protected final fun type ()Lorg/partiql/plan/rel/RelType;
+}
+
+public abstract class org/partiql/plan/rel/RelWith : org/partiql/plan/rel/RelBase {
+	public fun <init> ()V
+	public fun accept (Lorg/partiql/plan/OperatorVisitor;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun copy (Lorg/partiql/plan/rel/Rel;)Lorg/partiql/plan/rel/RelWith;
+	public abstract fun copy (Lorg/partiql/plan/rel/Rel;Ljava/util/List;)Lorg/partiql/plan/rel/RelWith;
+	public static fun create (Lorg/partiql/plan/rel/Rel;Ljava/util/List;)Lorg/partiql/plan/rel/RelWith;
+	public abstract fun getElements ()Ljava/util/List;
+	public abstract fun getInput ()Lorg/partiql/plan/rel/Rel;
 	protected final fun operands ()Ljava/util/List;
 	protected final fun type ()Lorg/partiql/plan/rel/RelType;
 }

--- a/partiql-plan/src/main/java/org/partiql/plan/OperatorVisitor.java
+++ b/partiql-plan/src/main/java/org/partiql/plan/OperatorVisitor.java
@@ -17,6 +17,7 @@ import org.partiql.plan.rel.RelScan;
 import org.partiql.plan.rel.RelSort;
 import org.partiql.plan.rel.RelUnion;
 import org.partiql.plan.rel.RelUnpivot;
+import org.partiql.plan.rel.RelWith;
 import org.partiql.plan.rex.RexArray;
 import org.partiql.plan.rex.RexBag;
 import org.partiql.plan.rex.RexCall;
@@ -132,6 +133,18 @@ public interface OperatorVisitor<R, C> {
     }
 
     default R visitUnpivot(@NotNull RelUnpivot rel, C ctx) {
+        return defaultVisit(rel, ctx);
+    }
+
+    /**
+     * <p>
+     * <b>NOTE:</b> This is experimental and subject to change without prior notice!
+     * </p>
+     * @param rel
+     * @param ctx
+     * @return
+     */
+    default R visitWith(@NotNull RelWith rel, C ctx) {
         return defaultVisit(rel, ctx);
     }
     // --[Rex]-----------------------------------------------------------------------------------------------------------

--- a/partiql-plan/src/main/java/org/partiql/plan/WithListElement.java
+++ b/partiql-plan/src/main/java/org/partiql/plan/WithListElement.java
@@ -1,0 +1,43 @@
+package org.partiql.plan;
+
+import org.jetbrains.annotations.NotNull;
+import org.partiql.plan.rex.Rex;
+
+/**
+ * <p>
+ * <b>NOTE:</b> This is experimental and subject to change without prior notice!
+ * </p>
+ * <p>
+ *
+ * Experimental representation of a WITH list element in the plan. This is currently experimental
+ * and is missing some core features such as the with column list.
+ */
+public class WithListElement {
+    private final String name;
+    private final Rex representation;
+
+    public WithListElement(@NotNull String name, @NotNull Rex representation) {
+        this.name = name;
+        this.representation = representation;
+    }
+
+    /**
+     * Returns the WITH query name.
+     * @return the query name.
+     */
+    @NotNull
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the query representation of this WITH list element.
+     * @return query representation of this WITH list element.
+     */
+    @NotNull
+    public Rex getRepresentation() {
+        return representation;
+    }
+
+    // TODO some additional static methods once this API is stabilized
+}

--- a/partiql-plan/src/main/java/org/partiql/plan/rel/RelWith.java
+++ b/partiql-plan/src/main/java/org/partiql/plan/rel/RelWith.java
@@ -1,0 +1,105 @@
+package org.partiql.plan.rel;
+
+import org.jetbrains.annotations.NotNull;
+import org.partiql.plan.Operand;
+import org.partiql.plan.OperatorVisitor;
+import org.partiql.plan.WithListElement;
+import org.partiql.plan.rex.Rex;
+
+import java.util.List;
+
+/**
+ * <p>
+ * <b>NOTE:</b> This is experimental and subject to change without prior notice!
+ * </p>
+ * <p>
+ * WITH relation expression. This is currently experimental and is currently missing some
+ * features like recursive CTEs.
+ */
+public abstract class RelWith extends RelBase {
+
+    /**
+     * Creates a new {@link RelWith} instance.
+     *
+     * @param input input rel (operand 0)
+     * @param elements with list elements
+     * @return new {@link RelWith} instance
+     */
+    @NotNull
+    public static RelWith create(@NotNull Rel input, @NotNull List<WithListElement> elements) {
+        return new Impl(input, elements);
+    }
+
+    /**
+     * Gets the input rel (operand 0).
+     * @return input rel (operand 0)
+     */
+    @NotNull
+    public abstract Rel getInput();
+
+    /**
+     * Gets the WITH list elements.
+     * @return WITH list elements.
+     */
+    @NotNull
+    public abstract List<WithListElement> getElements();
+
+    @NotNull
+    @Override
+    protected final RelType type() {
+        throw new UnsupportedOperationException("Derive type is not implemented");
+    }
+
+    @NotNull
+    @Override
+    protected final List<Operand> operands() {
+        Operand c0 = Operand.single(getInput());
+        return List.of(c0);
+    }
+
+    @Override
+    public <R, C> R accept(@NotNull OperatorVisitor<R, C> visitor, C ctx) {
+        return visitor.visitWith(this, ctx);
+    }
+
+    @NotNull
+    public abstract RelWith copy(@NotNull Rel input);
+
+    @NotNull
+    public abstract RelWith copy(@NotNull Rel input, @NotNull List<WithListElement> elements);
+
+    private static class Impl extends RelWith {
+
+        private final Rel input;
+        private final List<WithListElement> elements;
+
+        private Impl(Rel input, List<WithListElement> elements) {
+            this.input = input;
+            this.elements = elements;
+        }
+
+        @NotNull
+        @Override
+        public Rel getInput() {
+            return input;
+        }
+
+        @NotNull
+        @Override
+        public List<WithListElement> getElements() {
+            return elements;
+        }
+
+        @NotNull
+        @Override
+        public RelWith copy(@NotNull Rel input) {
+            return new Impl(input, elements);
+        }
+
+        @NotNull
+        @Override
+        public RelWith copy(@NotNull Rel input, @NotNull List<WithListElement> elements) {
+            return new Impl(input, elements);
+        }
+    }
+}

--- a/partiql-plan/src/main/kotlin/org/partiql/plan/Operators.kt
+++ b/partiql-plan/src/main/kotlin/org/partiql/plan/Operators.kt
@@ -18,6 +18,7 @@ import org.partiql.plan.rel.RelScan
 import org.partiql.plan.rel.RelSort
 import org.partiql.plan.rel.RelUnion
 import org.partiql.plan.rel.RelUnpivot
+import org.partiql.plan.rel.RelWith
 import org.partiql.plan.rex.Rex
 import org.partiql.plan.rex.RexArray
 import org.partiql.plan.rex.RexBag
@@ -236,6 +237,18 @@ public interface Operators {
      * @return
      */
     public fun unpivot(rex: Rex): RelUnpivot = RelUnpivot.create(rex)
+
+    /**
+     * <p>
+     * <b>NOTE:</b> This is experimental and subject to change without prior notice!
+     * </p>
+     * Create a [RelWith] instance.
+     *
+     * @param input
+     * @param elements
+     * @return
+     */
+    public fun with(input: Rel, elements: List<WithListElement>): RelWith = RelWith.create(input, elements)
 
     // --- REX OPERATORS -----------------------------------------------------------------------------------------------
 

--- a/partiql-planner/api/partiql-planner.api
+++ b/partiql-planner/api/partiql-planner.api
@@ -29,8 +29,8 @@ public final class org/partiql/planner/builder/PartiQLPlannerBuilder {
 	public final fun addPass (Lorg/partiql/planner/PartiQLPlannerPass;)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
 	public final fun addPasses ([Lorg/partiql/planner/PartiQLPlannerPass;)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
 	public final fun build ()Lorg/partiql/planner/PartiQLPlanner;
-	public final fun replaceWithReferences (Z)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
-	public static synthetic fun replaceWithReferences$default (Lorg/partiql/planner/builder/PartiQLPlannerBuilder;ZILjava/lang/Object;)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
+	public final fun forceInlineWithClause (Z)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
+	public static synthetic fun forceInlineWithClause$default (Lorg/partiql/planner/builder/PartiQLPlannerBuilder;ZILjava/lang/Object;)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
 	public final fun signal (Z)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
 	public static synthetic fun signal$default (Lorg/partiql/planner/builder/PartiQLPlannerBuilder;ZILjava/lang/Object;)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
 }

--- a/partiql-planner/api/partiql-planner.api
+++ b/partiql-planner/api/partiql-planner.api
@@ -29,6 +29,8 @@ public final class org/partiql/planner/builder/PartiQLPlannerBuilder {
 	public final fun addPass (Lorg/partiql/planner/PartiQLPlannerPass;)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
 	public final fun addPasses ([Lorg/partiql/planner/PartiQLPlannerPass;)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
 	public final fun build ()Lorg/partiql/planner/PartiQLPlanner;
+	public final fun replaceWithReferences (Z)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
+	public static synthetic fun replaceWithReferences$default (Lorg/partiql/planner/builder/PartiQLPlannerBuilder;ZILjava/lang/Object;)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
 	public final fun signal (Z)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
 	public static synthetic fun signal$default (Lorg/partiql/planner/builder/PartiQLPlannerBuilder;ZILjava/lang/Object;)Lorg/partiql/planner/builder/PartiQLPlannerBuilder;
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/builder/PartiQLPlannerBuilder.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/builder/PartiQLPlannerBuilder.kt
@@ -66,6 +66,8 @@ public class PartiQLPlannerBuilder {
      * **NOTE** This is experimental and subject to change without prior notice!
      *
      * Experimental planner mode to control whether WITH variable references are replaced with their definitions.
+     * Evaluating plans without the inline WITH rewrites is not yet supported. Users seeking to evaluate the WITH clause
+     * should use the default planner or set [replaceWith] to true.
      *
      * @param replaceWith denotes whether to replace WITH variable references with their definitions.
      * @return

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/builder/PartiQLPlannerBuilder.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/builder/PartiQLPlannerBuilder.kt
@@ -18,7 +18,7 @@ import org.partiql.planner.internal.SqlPlanner
  */
 public class PartiQLPlannerBuilder {
 
-    private val flags: MutableSet<PlannerFlag> = mutableSetOf(PlannerFlag.REPLACE_WITH_REFS)
+    private val flags: MutableSet<PlannerFlag> = mutableSetOf(PlannerFlag.FORCE_INLINE_WITH_CLAUSE)
     private val passes: MutableList<PartiQLPlannerPass> = mutableListOf()
 
     /**
@@ -70,11 +70,11 @@ public class PartiQLPlannerBuilder {
      * @param replaceWith denotes whether to replace WITH variable references with their definitions.
      * @return
      */
-    public fun replaceWithReferences(replaceWith: Boolean = true): PartiQLPlannerBuilder {
+    public fun forceInlineWithClause(replaceWith: Boolean = true): PartiQLPlannerBuilder {
         if (replaceWith) {
-            flags.add(PlannerFlag.REPLACE_WITH_REFS)
+            flags.add(PlannerFlag.FORCE_INLINE_WITH_CLAUSE)
         } else {
-            flags.remove(PlannerFlag.REPLACE_WITH_REFS)
+            flags.remove(PlannerFlag.FORCE_INLINE_WITH_CLAUSE)
         }
         return this
     }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/builder/PartiQLPlannerBuilder.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/builder/PartiQLPlannerBuilder.kt
@@ -18,7 +18,7 @@ import org.partiql.planner.internal.SqlPlanner
  */
 public class PartiQLPlannerBuilder {
 
-    private val flags: MutableSet<PlannerFlag> = mutableSetOf()
+    private val flags: MutableSet<PlannerFlag> = mutableSetOf(PlannerFlag.REPLACE_WITH_REFS)
     private val passes: MutableList<PartiQLPlannerPass> = mutableListOf()
 
     /**
@@ -58,6 +58,23 @@ public class PartiQLPlannerBuilder {
             flags.add(PlannerFlag.SIGNAL_MODE)
         } else {
             flags.remove(PlannerFlag.SIGNAL_MODE)
+        }
+        return this
+    }
+
+    /**
+     * **NOTE** This is experimental and subject to change without prior notice!
+     *
+     * Experimental planner mode to control whether WITH variable references are replaced with their definitions.
+     *
+     * @param replaceWith denotes whether to replace WITH variable references with their definitions.
+     * @return
+     */
+    public fun replaceWithReferences(replaceWith: Boolean = true): PartiQLPlannerBuilder {
+        if (replaceWith) {
+            flags.add(PlannerFlag.REPLACE_WITH_REFS)
+        } else {
+            flags.remove(PlannerFlag.REPLACE_WITH_REFS)
         }
         return this
     }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PlannerFlag.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PlannerFlag.kt
@@ -22,5 +22,5 @@ internal enum class PlannerFlag {
      * Experimental flag to enable planner to replace references to WITH variables with their definitions.
      * By default, this flag is included in the default planner phase.
      */
-    REPLACE_WITH_REFS
+    FORCE_INLINE_WITH_CLAUSE
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PlannerFlag.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/PlannerFlag.kt
@@ -16,5 +16,11 @@ internal enum class PlannerFlag {
      *
      *    The result plan will turn the problematic operation into a missing node.
      */
-    SIGNAL_MODE
+    SIGNAL_MODE,
+
+    /**
+     * Experimental flag to enable planner to replace references to WITH variables with their definitions.
+     * By default, this flag is included in the default planner phase.
+     */
+    REPLACE_WITH_REFS
 }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/SqlPlanner.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/SqlPlanner.kt
@@ -42,7 +42,7 @@ internal class SqlPlanner(
             val root = AstToPlan.apply(ast, env)
 
             // 3. Resolve variables
-            val typer = PlanTyper(env, ctx)
+            val typer = PlanTyper(env, ctx, flags)
             val typed = typer.resolve(root)
             val internal = org.partiql.planner.internal.ir.PartiQLPlan(typed)
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -6,6 +6,7 @@ import org.partiql.plan.Exclusion
 import org.partiql.plan.JoinType
 import org.partiql.plan.Operators
 import org.partiql.plan.Plan
+import org.partiql.plan.WithListElement
 import org.partiql.plan.rel.RelAggregate
 import org.partiql.plan.rel.RelType
 import org.partiql.plan.rex.Rex
@@ -243,11 +244,17 @@ internal class PlanTransform(private val flags: Set<PlannerFlag>) {
         }
 
         override fun visitRelOpWith(node: Rel.Op.With, ctx: PType): org.partiql.plan.rel.Rel {
-            return visitRel(node.input, ctx)
+            return operators.with(
+                input = visitRel(node.input, ctx),
+                elements = node.elements.map { visitRelOpWithWithListElement(it, ctx) }
+            )
         }
 
-        override fun visitRelOpWithWithListElement(node: Rel.Op.With.WithListElement, ctx: PType): Any? {
-            error("WITH clause element was not transformed yet.")
+        override fun visitRelOpWithWithListElement(node: Rel.Op.With.WithListElement, ctx: PType): WithListElement {
+            return WithListElement(
+                node.name,
+                visitRex(node.representation, ctx)
+            )
         }
 
         override fun visitRelOpAggregateCallUnresolved(node: IRel.Op.Aggregate.Call.Unresolved, ctx: PType): Any {

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -295,7 +295,7 @@ internal class PlanTyper(private val env: Env, config: Context, private val flag
                 element.copy(representation = representation)
             }
             // Include the WITH elements iff the `flags` contains the `REPLACE_WITH_REFS` planner flag.
-            val rewriteWith = flags.contains(PlannerFlag.REPLACE_WITH_REFS)
+            val rewriteWith = flags.contains(PlannerFlag.FORCE_INLINE_WITH_CLAUSE)
             val withElements = if (rewriteWith) {
                 elements
             } else {

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -18,6 +18,7 @@ package org.partiql.planner.internal.typer
 
 import org.partiql.planner.internal.Env
 import org.partiql.planner.internal.PErrors
+import org.partiql.planner.internal.PlannerFlag
 import org.partiql.planner.internal.exclude.ExcludeRepr
 import org.partiql.planner.internal.ir.PlanNode
 import org.partiql.planner.internal.ir.Rel
@@ -67,7 +68,7 @@ import kotlin.math.max
  *
  * @property env
  */
-internal class PlanTyper(private val env: Env, config: Context) {
+internal class PlanTyper(private val env: Env, config: Context, private val flags: Set<PlannerFlag>) {
 
     private val _listener = config.errorListener
 
@@ -293,7 +294,20 @@ internal class PlanTyper(private val env: Env, config: Context) {
                 val representation = element.representation.type(emptyList(), outer)
                 element.copy(representation = representation)
             }
-            val newStack = outer + Scope(listOf(), outer, elements)
+            // Include the WITH elements iff the `flags` contains the `REPLACE_WITH_REFS` planner flag.
+            val rewriteWith = flags.contains(PlannerFlag.REPLACE_WITH_REFS)
+            val withElements = if (rewriteWith) {
+                elements
+            } else {
+                emptyList()
+            }
+            val newStack = outer + Scope(
+                elements.map { element ->
+                    Rel.Binding(element.name, element.representation.type)
+                },
+                outer,
+                withElements
+            )
             val input = RelTyper(newStack, Strategy.LOCAL).visitRel(node.input, node.input.type)
             val type = input.type
             return Rel(type, node.copy(elements = elements, input = input))

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTest.kt
@@ -3,6 +3,7 @@ package org.partiql.planner.internal.typer
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.partiql.planner.internal.Env
+import org.partiql.planner.internal.PlannerFlag
 import org.partiql.planner.internal.ir.Rex
 import org.partiql.planner.internal.ir.Statement
 import org.partiql.planner.internal.ir.refObj
@@ -128,7 +129,7 @@ class PlanTyperTest {
                     .build(),
                 config.errorListener
             )
-            return PlanTyperWrapper(PlanTyper(env, config))
+            return PlanTyperWrapper(PlanTyper(env, config, setOf(PlannerFlag.REPLACE_WITH_REFS)))
         }
     }
 

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTest.kt
@@ -129,7 +129,7 @@ class PlanTyperTest {
                     .build(),
                 config.errorListener
             )
-            return PlanTyperWrapper(PlanTyper(env, config, setOf(PlannerFlag.REPLACE_WITH_REFS)))
+            return PlanTyperWrapper(PlanTyper(env, config, setOf(PlannerFlag.FORCE_INLINE_WITH_CLAUSE)))
         }
     }
 


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Adds an experimental, limited `With` representation in the partiql-plan
  - This is currently marked as experimental since we may choose a different modeling of CTEs in the future.
- Adds an experimental `With` configuration to the planner that controls whether `With` variable references are rewritten to their query representation.
  - This PR preserves the original behavior to rewrite `With` variable references while also providing the option to not rewrite the var refs.
- Adds some missing implementations of `With` and `WithListElement` in `SqlDialect` and `AstVisitor`

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**: <Explain if NO>
- Any backward-incompatible changes? **[NO]**: <Explain if YES>
- Any new external dependencies? **[NO]**: <Explain if YES>
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md