### PR TITLE
fix: correct qualifier for INTERVAL datum with MINUTE_SECOND (#1771)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Thank you to all who have contributed!
 ### Deprecated
 
 ### Fixed
+- Specify the correct qualifier for `INTERVAL` datum with `MINUTE TO SECOND`
 
 ### Removed
 
@@ -39,6 +40,7 @@ Thank you to all who have contributed!
 
 ### Contributors
 Thank you to all who have contributed!
+- @zyfy29
 
 ## [1.2.2](https://github.com/partiql/partiql-lang-kotlin/releases/tag/v1.2.2) - 2025-06-26
 

--- a/partiql-cli/src/test/kotlin/org/partiql/cli/io/DatumWriterTextPrettyTests.kt
+++ b/partiql-cli/src/test/kotlin/org/partiql/cli/io/DatumWriterTextPrettyTests.kt
@@ -64,7 +64,7 @@ class DatumWriterTextPrettyTests {
           INTERVAL '1 2:3:4.50' DAY (2) TO SECOND (2),
           INTERVAL '1:2' HOUR (2) TO MINUTE,
           INTERVAL '1:2:3.40' HOUR (2) TO SECOND (2),
-          INTERVAL '0:1:2.30' HOUR (2) TO SECOND (2),
+          INTERVAL '1:2.30' MINUTE (2) TO SECOND (2),
           {
             'bar': [
               1,

--- a/partiql-spi/src/main/java/org/partiql/spi/value/Datum.java
+++ b/partiql-spi/src/main/java/org/partiql/spi/value/Datum.java
@@ -1118,7 +1118,7 @@ public interface Datum extends Iterable<Datum> {
         DatumIntervalHelpers.checkUsingPrecision(minutes, precision);
         DatumIntervalHelpers.checkSeconds(seconds);
         int newNanos = DatumIntervalHelpers.coerceNanos(nanos, fractionalPrecision);
-        return new DatumIntervalDayTime(0, 0, minutes, seconds, newNanos, precision, fractionalPrecision, IntervalCode.HOUR_SECOND);
+        return new DatumIntervalDayTime(0, 0, minutes, seconds, newNanos, precision, fractionalPrecision, IntervalCode.MINUTE_SECOND);
     }
 
     /**


### PR DESCRIPTION
## Relevant Issues
- fix Issue #1771 

## Description
- Fix the interval code for `INTERVAL` datum with `MINUTE_SECOND` case to display the interval correctly.
## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**: <Explain if NO>
- Any backward-incompatible changes? **[NO]**: <Explain if YES>
- Any new external dependencies? **[NO]**: <Explain if YES>
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md