### PR TITLE
feat: add additional meta for unspecified INTERVAL precision and frac precision

### DIFF
--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
@@ -1213,7 +1213,6 @@ internal object RexConverter {
                 DataType.USER_DEFINED -> TODO("Custom type not supported ")
                 // <interval type>
                 DataType.INTERVAL -> {
-                    // TODO meta for interval when precision is unspecified
                     when (val q = type.intervalQualifier) {
                         is IntervalQualifier.Single -> {
                             val precision = q.precision ?: INTERVAL_DEFAULT_PRECISON
@@ -1226,6 +1225,13 @@ internal object RexConverter {
                                 DatetimeField.MINUTE -> PType.intervalMinute(precision)
                                 DatetimeField.SECOND -> PType.intervalSecond(precision, fractionalPrecision)
                                 else -> error("Unsupported DatetimeField: ${q.field}")
+                            }.also {
+                                if (q.precision == null) {
+                                    it.setUnspecifiedPrecisionMeta()
+                                }
+                                if (q.fractionalPrecision == null) {
+                                    it.setUnspecifiedFractionalPrecisionMeta()
+                                }
                             }
                         }
                         is IntervalQualifier.Range -> {
@@ -1242,6 +1248,13 @@ internal object RexConverter {
                                 DatetimeField.HOUR to DatetimeField.SECOND -> PType.intervalHourSecond(precision, scale)
                                 DatetimeField.MINUTE to DatetimeField.SECOND -> PType.intervalMinuteSecond(precision, scale)
                                 else -> error("Unsupported DatetimeField: $lhsField to $rhsField")
+                            }.also {
+                                if (q.startFieldPrecision == null) {
+                                    it.setUnspecifiedPrecisionMeta()
+                                }
+                                if (q.endFieldFractionalPrecision == null) {
+                                    it.setUnspecifiedFractionalPrecisionMeta()
+                                }
                             }
                         }
                         else -> error("Unsupported IntervalQualifier: $q")


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Followup to previous PR (https://github.com/partiql/partiql-lang-kotlin/pull/1774). Needed to also add the specified precision metas when converting `DataType`s in the AST -> Plan conversion

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**: <Explain if NO> already covered in previous CHANGELOG update
- Any backward-incompatible changes? **[NO]**: <Explain if YES>
- Any new external dependencies? **[NO]**: <Explain if YES>
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md