### PR TITLE
fix: handle the formatting when the nanoseconds of INTERVAL datum underflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ rewritten to their query representation
 
 ### Fixed
 - Specify the correct qualifier for `INTERVAL` datum with `MINUTE TO SECOND`
+- Handle the formatting when the nanoseconds of `INTERVAL` datum underflow
 - CLI printing of negative interval literals
 
 ### Removed

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/DatumWriterTextPretty.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/DatumWriterTextPretty.kt
@@ -1,5 +1,6 @@
 package org.partiql.cli.io
 
+import com.google.common.annotations.VisibleForTesting
 import org.partiql.spi.types.IntervalCode
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
@@ -341,21 +342,16 @@ class DatumWriterTextPretty(
         }
     }
 
-    private fun fractionalSeconds(value: Int, scale: Int): String {
+    @VisibleForTesting
+    internal fun fractionalSeconds(value: Int, scale: Int): String {
         val nanoLength = 9
         return buildString {
             append(".")
             if (scale == 0) {
                 return@buildString
             }
-            val before = value.toString()
-            val beforeLength = before.length
-            val toPadBefore = nanoLength - beforeLength
-            if (toPadBefore > 0) {
-                append("0".repeat(toPadBefore))
-            }
-            val remaining = before.substring(0, scale - toPadBefore)
-            append(remaining)
+            val paddedValue = value.toString().padStart(nanoLength, '0')
+            append(paddedValue.substring(0, minOf(scale, paddedValue.length)))
         }
     }
 


### PR DESCRIPTION
## Relevant Issues
- fix Issue #1777 

## Description
For the `INTERVAL` datum, when the `value` of nanos is less than the `10**scale`, formatter function will throw a exception, which causes a unexpected REPL exit.
I changed the formatter function logic to handle this case correctly.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**: <Explain if NO>
- Any backward-incompatible changes? **[NO]**: <Explain if YES>
- Any new external dependencies? **[NO]**: <Explain if YES>
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md