### PR TITLE
fix: display of `Ion` in PartiQL CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ rewritten to their query representation
 - CLI printing of negative interval literals
 - Fix alias collision problem when multiple table references need auto-generated aliases
 - Add `ABS` function support on `INTERVAL` field
+- Display of `Ion` in PartiQL CLI output
 
 ### Removed
 

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/DatumWriterTextPretty.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/DatumWriterTextPretty.kt
@@ -118,7 +118,7 @@ class DatumWriterTextPretty(
 
     private fun writeVariant(datum: Datum) {
         this.out.print("`")
-        this.out.print(datum.pack(Charsets.UTF_8))
+        this.out.print(String(datum.pack(Charsets.UTF_8), Charsets.UTF_8))
         this.out.print("`")
     }
 

--- a/partiql-cli/src/test/kotlin/org/partiql/cli/io/DatumWriterTextPrettyTests.kt
+++ b/partiql-cli/src/test/kotlin/org/partiql/cli/io/DatumWriterTextPrettyTests.kt
@@ -74,6 +74,7 @@ class DatumWriterTextPrettyTests {
           INTERVAL '-1:2.30' MINUTE (2) TO SECOND (2),
           INTERVAL '3:4.00' MINUTE (2) TO SECOND (2),
           INTERVAL '3:4.012345678' MINUTE (2) TO SECOND (9),
+          `{pdx:{region:foo,segmentCount:42},iad:{region:bar,segmentCount:43}}`,
           {
             'bar': [
               1,
@@ -145,6 +146,7 @@ class DatumWriterTextPrettyTests {
             Datum.intervalMinuteSecond(-1, -2, -300000000, 2, 2),
             Datum.intervalMinuteSecond(3, 4, 0, 2, 2),
             Datum.intervalMinuteSecond(3, 4, 12345678, 2, 9),
+            Datum.ion("{ pdx: { region: 'foo', segmentCount: 42 }, iad: { region: 'bar', segmentCount: 43 }}"),
             // TODO: Technically, structs and bags are unordered. This may or may not lead to issues in the future
             //  when testing. We should potentially instead rewrite these tests to re-parse the output and do a full-on
             //  comparison between the values instead. This approach, however, would not take into account the indents.


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #1788 

## Description
Previously, VARIANT types were displayed as byte array object references instead of their actual content. 
The fix converts the packed byte array to a UTF-8 string for display, allowing users to see the actual `Ion` content.

### Previous Behavior
``` partiql
partiql ▶ select t.*, t.pdx.region from `{ pdx: { region: 'foo', segmentCount: 42 }, iad: { region: 'bar', segmentCount: 43 }}` as t;

=== RESULT ===
<<
  {
    'pdx': `[B@1000d54d`,
    'region': `[B@3f4f5330`,
    'iad': `[B@14b7786`
  }
>>

OK!
```

### Current Behavior
``` partiql
partiql ▶ select t.*, t.pdx.region from `{ pdx: { region: 'foo', segmentCount: 42 }, iad: { region: 'bar', segmentCount: 43 }}` as t;

=== RESULT ===
<<
  {
    'pdx': `{region:foo,segmentCount:42}`,
    'region': `foo`,
    'iad': `{region:bar,segmentCount:43}`
  }
>>

OK!
```


## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**
- Any backward-incompatible changes? **[NO]**
- Any new external dependencies? **[NO]**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md