### PR TITLE
fix: missing propagation behavior in functions args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ rewritten to their query representation
 - Add `ABS` function support on `INTERVAL` field
 - Display of `Ion` in PartiQL CLI output
 - Support `INTERVAL` times and divide with numerics
+- `missing` propagation behavior in functions args
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ rewritten to their query representation
 - Add `ABS` function support on `INTERVAL` field
 - Display of `Ion` in PartiQL CLI output
 - Support `INTERVAL` times and divide with numerics
-- `missing` propagation behavior in functions args
+- Prioritize `missing` propagation when both `null` and `missing` exist in function args
 
 ### Removed
 

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCall.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprCall.kt
@@ -22,13 +22,9 @@ internal class ExprCall(
     private var missing = { Datum.missing(function.signature.returns) }
 
     override fun eval(env: Environment): Datum {
-        // Evaluate arguments
-        val args = Array(args.size) { i ->
-            val arg = args[i].eval(env)
-            if (isNullCall && arg.isNull) return nil()
-            if (isMissingCall && arg.isMissing) return missing()
-            arg
-        }
+        val args = Array(args.size) { i -> args[i].eval(env) }
+        if (isMissingCall && args.any { it.isMissing }) return missing()
+        if (isNullCall && args.any { it.isNull }) return nil()
         return function.invoke(args)
     }
 }


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #1800 

## Description
- Fix the bug mentioned in the above issue

### Current Behavior

```
partiql ▶ null OVERLAPS missing;
w: [semantic] Expression always returns missing

=== RESULT ===
missing

OK!
partiql ▶ missing OVERLAPS null;
w: [semantic] Expression always returns missing

=== RESULT ===
missing

OK!
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**
- Any backward-incompatible changes? **[NO]**
- Any new external dependencies? **[NO]**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md