### PR TITLE
add migration example for partiQL parser

### DIFF
--- a/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ParserChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ParserChanges.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.assertThrows
 import org.partiql.ast.Statement
 import org.partiql.parser.PartiQLParser
 import org.partiql.parser.PartiQLParserException
+import org.partiql.parser.SourceLocation
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -11,16 +12,15 @@ import kotlin.test.assertTrue
 
 class ParserChanges {
     @Test
-    fun `Parser initialization`() {
+    fun `PartiQLParser initialization`() {
         val parserDefault = PartiQLParser.default()
-        val parserWithBuilder = PartiQLParser.builder().build()
 
-        assertNotNull(parserDefault)
-        assertNotNull(parserWithBuilder)
+        // Builder returns the default for now and no additional options present
+        val parserWithBuilder = PartiQLParser.builder().build()
     }
 
     @Test
-    fun `Parse a create table statement`() {
+    fun `Parse the 'CREATE TABLE' statement`() {
         val parser = PartiQLParser.default()
         val query = "CREATE TABLE myTable"
 
@@ -33,7 +33,7 @@ class ParserChanges {
     }
 
     @Test
-    fun `Parse a insert into table statement`() {
+    fun `Parse the 'INSERT INTO' statement`() {
         val parser = PartiQLParser.default()
         val query = "INSERT INTO tbl VALUES (1, 2, 3)"
 
@@ -46,7 +46,7 @@ class ParserChanges {
     }
 
     @Test
-    fun `Parse a select table statement`() {
+    fun `Parse the 'SELECT FROM' statement`() {
         val parser = PartiQLParser.default()
         val query = "SELECT * FROM tbl WHERE id = 123"
 
@@ -62,10 +62,10 @@ class ParserChanges {
     fun `Parser error handling`() {
         val parser = PartiQLParser.default()
         val exception = assertThrows<PartiQLParserException> {
-            val ast = parser.parse("CREATE TABLE 'foo asd")
+            val ast = parser.parse("CREATE TABLE 'foo")
         }
 
         assertTrue { exception.message.contains("extraneous input '''") }
-        assertNotNull(exception.location)
+        assertEquals(SourceLocation(1, 14, 62, 1), exception.location)
     }
 }

--- a/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ParserChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ParserChanges.kt
@@ -1,0 +1,71 @@
+package examples
+
+import org.junit.jupiter.api.assertThrows
+import org.partiql.ast.Statement
+import org.partiql.parser.PartiQLParser
+import org.partiql.parser.PartiQLParserException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ParserChanges {
+    @Test
+    fun `Parser initialization`() {
+        val parserDefault = PartiQLParser.default()
+        val parserWithBuilder = PartiQLParser.builder().build()
+
+        assertNotNull(parserDefault)
+        assertNotNull(parserWithBuilder)
+    }
+
+    @Test
+    fun `Parse a create table statement`() {
+        val parser = PartiQLParser.default()
+        val query = "CREATE TABLE myTable"
+
+        val result: PartiQLParser.Result = parser.parse(query)
+
+        assertNotNull(result)
+        assertEquals(query, result.source)
+        assertTrue(result.root is Statement.DDL.CreateTable)
+        assertNotNull(result.locations.get(result.root.tag))
+    }
+
+    @Test
+    fun `Parse a insert into table statement`() {
+        val parser = PartiQLParser.default()
+        val query = "INSERT INTO tbl VALUES (1, 2, 3)"
+
+        val result: PartiQLParser.Result = parser.parse(query)
+
+        assertNotNull(result)
+        assertEquals(query, result.source)
+        assertTrue(result.root is Statement.DML.Insert)
+        assertNotNull(result.locations.get(result.root.tag))
+    }
+
+    @Test
+    fun `Parse a select table statement`() {
+        val parser = PartiQLParser.default()
+        val query = "SELECT * FROM tbl WHERE id = 123"
+
+        val result: PartiQLParser.Result = parser.parse(query)
+
+        assertNotNull(result)
+        assertEquals(query, result.source)
+        assertTrue(result.root is Statement.Query)
+        assertNotNull(result.locations.get(result.root.tag))
+    }
+
+    @Test
+    fun `Parser error handling`() {
+        val parser = PartiQLParser.default()
+        val exception = assertThrows<PartiQLParserException> {
+            val ast = parser.parse("CREATE TABLE 'foo asd")
+        }
+
+        assertTrue { exception.message.contains("extraneous input '''") }
+        assertNotNull(exception.location)
+    }
+}

--- a/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ParserChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ParserChanges.kt
@@ -5,55 +5,71 @@ import org.partiql.ast.Query
 import org.partiql.ast.ddl.CreateTable
 import org.partiql.ast.dml.Insert
 import org.partiql.parser.PartiQLParser
+import org.partiql.spi.Context
+import org.partiql.spi.SourceLocation
 import org.partiql.spi.errors.PError
+import org.partiql.spi.errors.PErrorKind
+import org.partiql.spi.errors.PErrorListener
 import org.partiql.spi.errors.PRuntimeException
+import org.partiql.spi.errors.Severity
 import kotlin.test.Test
-import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class ParserChanges {
     @Test
-    fun `Parser initialization`() {
+    fun `PartiQLParser initialization`() {
+        // Renamed from default() to standard()
         val parserDefault = PartiQLParser.standard()
-        val parserWithBuilder = PartiQLParser.builder().build()
 
-        assertNotNull(parserDefault)
-        assertNotNull(parserWithBuilder)
+        // Builder returns the standard for now and no additional options present
+        val parserWithBuilder = PartiQLParser.builder().build()
     }
 
     @Test
-    fun `Parse a create table statement`() {
+    fun `Parse the 'CREATE TABLE' statement`() {
         val parser = PartiQLParser.standard()
         val query = "CREATE TABLE myTable"
 
         val result: PartiQLParser.Result = parser.parse(query)
 
+        // The Source property of the result object is removed.
+        // A list of ASTs is returned in the result object to support multiple statement parsing
+        // and AST classes are refactoring to different classes
+        // Tag is an integer type instead of String
         assertNotNull(result)
         assertTrue(result.statements[0] is CreateTable)
         assertNotNull(result.locations.get(result.statements[0].tag))
     }
 
     @Test
-    fun `Parse a insert into table statement`() {
+    fun `Parse the 'INSERT INTO' statement`() {
         val parser = PartiQLParser.standard()
         val query = "INSERT INTO tbl VALUES (1, 2, 3)"
 
         val result: PartiQLParser.Result = parser.parse(query)
 
+        // The Source property of the result object is removed.
+        // A list of ASTs is returned in the result object to support multiple statement parsing
+        // and AST classes are refactoring to different classes
+        // Tag is an integer type instead of String
         assertNotNull(result)
         assertTrue(result.statements[0] is Insert)
         assertNotNull(result.locations.get(result.statements[0].tag))
     }
 
     @Test
-    fun `Parse a select table statement`() {
+    fun `Parse the 'SELECT FROM' statement`() {
         val parser = PartiQLParser.standard()
         val query = "SELECT * FROM tbl WHERE id = 123"
 
         val result: PartiQLParser.Result = parser.parse(query)
 
+        // The Source property of the result object is removed.
+        // A list of ASTs is returned in the result object to support multiple statement parsing
+        // and AST classes are refactoring to different classes
+        // Tag is an integer type instead of String
         assertNotNull(result)
         assertTrue(result.statements[0] is Query)
         assertNotNull(result.locations.get(result.statements[0].tag))
@@ -61,6 +77,9 @@ class ParserChanges {
 
     @Test
     fun `Parse multiple statements`() {
+
+        // Parsing multiple statements in one call is not supported before v1
+        // A list of statement is returned in the result object after parsing ,u
         val parser = PartiQLParser.standard()
         val query = """
             CREATE TABLE myTable;
@@ -72,16 +91,66 @@ class ParserChanges {
 
         assertNotNull(result)
         assertEquals(3, result.statements.size)
-        assertContentEquals(listOf("CreateTable", "Insert", "Query"), result.statements.map { s -> s.javaClass.simpleName })
+        assertTrue(result.statements[0] is CreateTable)
+        assertTrue(result.statements[1] is Insert)
+        assertTrue(result.statements[2] is Query)
     }
 
     @Test
     fun `Parser error handling`() {
         val parser = PartiQLParser.standard()
+
         val exception = assertThrows<PRuntimeException> {
-            val ast = parser.parse("CREATE TABLE 'foo")
+            // an invalid single quote is added before Table name foo
+            parser.parse("CREATE TABLE 'foo")
         }
 
         assertEquals(exception.error.code(), PError.UNEXPECTED_TOKEN)
+        assertEquals(PErrorKind.SYNTAX, exception.error.kind.code())
+        assertEquals(Severity.ERROR, exception.error.severity.code())
+        assertEquals(SourceLocation(1, 14, 1), exception.error.location)
+    }
+
+    @Test
+    fun `Parser with custom error handler`() {
+        class CustomPErrorListener : PErrorListener {
+            val errorCollection: MutableList<PError> = mutableListOf()
+
+            override fun report(error: PError) {
+                when (error.severity.code()) {
+                    // You may consider a customizing error message and throw the error, or you can record the error and then throw when it reaches maximum count
+                    // In this case, we record only without throwing
+                    Severity.ERROR -> errorCollection.add(error)
+                    // You may consider a customizing error message, treat warning as an error and then throw, or you can suppress all warnings.
+                    // In this case, we record only without throwing
+                    Severity.WARNING -> errorCollection.add(error)
+                    else -> error("This shouldn't have occurred.")
+                }
+            }
+        }
+
+        // Register Error Listener
+        val listener = CustomPErrorListener()
+        val context: Context = Context.of(listener)
+
+        val parser = PartiQLParser.standard()
+        val parseResult: PartiQLParser.Result
+        try {
+            // an invalid single quote is added before Table name foo
+            parseResult = parser.parse("CREATE TABLE 'foo", context)
+        } catch (ex: PRuntimeException) {
+            // Since we register custom error handler to record all errors instead of throwing, these exceptions were likely unexpected.
+            // However, the PartiQL library may throw PRuntimeExceptions as well. You should be able to unwrap these exceptions and provide quality
+            // error messages to your users. In this case, we throw
+            throw ex
+        }
+
+        // process your listener
+        val exception = listener.errorCollection[0]
+
+        assertEquals(PError.UNEXPECTED_TOKEN, exception.code())
+        assertEquals(PErrorKind.SYNTAX, exception.kind.code())
+        assertEquals(Severity.ERROR, exception.severity.code())
+        assertEquals(SourceLocation(1, 14, 1), exception.location)
     }
 }

--- a/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ParserChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ParserChanges.kt
@@ -114,10 +114,10 @@ class ParserChanges {
 
             override fun report(error: PError) {
                 when (error.severity.code()) {
-                    // You may consider a customizing error message and throw the error, or you can record the error and then throw when it reaches maximum count
+                    // You may choose to customize the error message and then throw the error, or you can record the error and then throw when it reaches maximum count
                     // In this case, we record only without throwing
                     Severity.ERROR -> errorCollection.add(error)
-                    // You may consider a customizing error message, treat warning as an error and then throw, or you can suppress all warnings.
+                    // You may choose to customize the error message, treat warning as an error and then throw, or you can suppress all warnings.
                     // In this case, we record only without throwing
                     Severity.WARNING -> errorCollection.add(error)
                     else -> error("This shouldn't have occurred.")
@@ -132,7 +132,7 @@ class ParserChanges {
         val parser = PartiQLParser.standard()
         val parseResult: PartiQLParser.Result
         try {
-            // an invalid single quote is added before Table name foo
+            // An invalid single quote is added before Table name foo
             parseResult = parser.parse("CREATE TABLE 'foo", context)
         } catch (ex: PRuntimeException) {
             // Since we register custom error handler to record all errors instead of throwing, these exceptions were likely unexpected.

--- a/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ParserChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ParserChanges.kt
@@ -1,0 +1,87 @@
+package examples
+
+import org.junit.jupiter.api.assertThrows
+import org.partiql.ast.Query
+import org.partiql.ast.ddl.CreateTable
+import org.partiql.ast.dml.Insert
+import org.partiql.parser.PartiQLParser
+import org.partiql.spi.errors.PError
+import org.partiql.spi.errors.PRuntimeException
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ParserChanges {
+    @Test
+    fun `Parser initialization`() {
+        val parserDefault = PartiQLParser.standard()
+        val parserWithBuilder = PartiQLParser.builder().build()
+
+        assertNotNull(parserDefault)
+        assertNotNull(parserWithBuilder)
+    }
+
+    @Test
+    fun `Parse a create table statement`() {
+        val parser = PartiQLParser.standard()
+        val query = "CREATE TABLE myTable"
+
+        val result: PartiQLParser.Result = parser.parse(query)
+
+        assertNotNull(result)
+        assertTrue(result.statements[0] is CreateTable)
+        assertNotNull(result.locations.get(result.statements[0].tag))
+    }
+
+    @Test
+    fun `Parse a insert into table statement`() {
+        val parser = PartiQLParser.standard()
+        val query = "INSERT INTO tbl VALUES (1, 2, 3)"
+
+        val result: PartiQLParser.Result = parser.parse(query)
+
+        assertNotNull(result)
+        assertTrue(result.statements[0] is Insert)
+        assertNotNull(result.locations.get(result.statements[0].tag))
+    }
+
+    @Test
+    fun `Parse a select table statement`() {
+        val parser = PartiQLParser.standard()
+        val query = "SELECT * FROM tbl WHERE id = 123"
+
+        val result: PartiQLParser.Result = parser.parse(query)
+
+        assertNotNull(result)
+        assertTrue(result.statements[0] is Query)
+        assertNotNull(result.locations.get(result.statements[0].tag))
+    }
+
+    @Test
+    fun `Parse multiple statements`() {
+        val parser = PartiQLParser.standard()
+        val query = """
+            CREATE TABLE myTable;
+            INSERT INTO tbl VALUES (1, 2, 3);
+            SELECT * FROM tbl WHERE id = 123;
+        """.trimIndent()
+
+        val result: PartiQLParser.Result = parser.parse(query)
+
+        assertNotNull(result)
+        assertEquals(3, result.statements.size)
+        assertContentEquals(listOf("CreateTable", "Insert", "Query"), result.statements.map { s -> s.javaClass.simpleName })
+    }
+
+    @Test
+    fun `Parser error handling`() {
+        val parser = PartiQLParser.standard()
+        val exception = assertThrows<PRuntimeException> {
+            val ast = parser.parse("CREATE TABLE 'foo")
+        }
+
+        assertEquals(exception.error.code(), PError.UNEXPECTED_TOKEN)
+    }
+}

--- a/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ParserChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ParserChanges.kt
@@ -34,10 +34,13 @@ class ParserChanges {
 
         val result: PartiQLParser.Result = parser.parse(query)
 
-        // The Source property of the result object is removed.
-        // A list of ASTs is returned in the result object to support multiple statement parsing
-        // and AST classes are refactoring to different classes
-        // Tag is an integer type instead of String
+        // The result object has the following properties.
+        // 1. 'Statements' property contains the list of parsed ASTs as v1 supports multiple statement parsing
+        // 2. 'Locations' property stores the locations of the parsed elements in the ASTs.
+        // Other changes:
+        // 1. AST classes are refactored to different classes
+        // 2. Tag is an Integer type instead of String
+        // 3. The 'Source' property is removed since v1
         assertNotNull(result)
         assertTrue(result.statements[0] is CreateTable)
         assertNotNull(result.locations.get(result.statements[0].tag))
@@ -50,10 +53,6 @@ class ParserChanges {
 
         val result: PartiQLParser.Result = parser.parse(query)
 
-        // The Source property of the result object is removed.
-        // A list of ASTs is returned in the result object to support multiple statement parsing
-        // and AST classes are refactoring to different classes
-        // Tag is an integer type instead of String
         assertNotNull(result)
         assertTrue(result.statements[0] is Insert)
         assertNotNull(result.locations.get(result.statements[0].tag))
@@ -66,10 +65,6 @@ class ParserChanges {
 
         val result: PartiQLParser.Result = parser.parse(query)
 
-        // The Source property of the result object is removed.
-        // A list of ASTs is returned in the result object to support multiple statement parsing
-        // and AST classes are refactoring to different classes
-        // Tag is an integer type instead of String
         assertNotNull(result)
         assertTrue(result.statements[0] is Query)
         assertNotNull(result.locations.get(result.statements[0].tag))
@@ -79,7 +74,7 @@ class ParserChanges {
     fun `Parse multiple statements`() {
 
         // Parsing multiple statements in one call is not supported before v1
-        // A list of statement is returned in the result object after parsing ,u
+        // A list of statements is returned in the result object after parsing.
         val parser = PartiQLParser.standard()
         val query = """
             CREATE TABLE myTable;
@@ -100,8 +95,9 @@ class ParserChanges {
     fun `Parser error handling`() {
         val parser = PartiQLParser.standard()
 
+        // The PRuntimeException is expected to throw when .parse called on a PartiQL query with invalid syntax.
         val exception = assertThrows<PRuntimeException> {
-            // an invalid single quote is added before Table name foo
+            // An invalid single quote is added before Table name foo
             parser.parse("CREATE TABLE 'foo")
         }
 
@@ -145,7 +141,7 @@ class ParserChanges {
             throw ex
         }
 
-        // process your listener
+        // Process your listener now as the errors are not thrown in this example.
         val exception = listener.errorCollection[0]
 
         assertEquals(PError.UNEXPECTED_TOKEN, exception.code())


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
- add migration example for partiQL parser

## Other Information
- Updated Unreleased Section in CHANGELOG: No, No feature released/change
- Any backward-incompatible changes? NO
- Any new external dependencies? NO
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? YES

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md