### PR TITLE
Remove unicode non-character in the CLI error report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ rewritten to their query representation
 - Add cli option -e to load PartiQL literal data as default catalog data
 - Add toString() support for all datum types
 - Add optional `distinguishNullMissing` parameter to `Datum.comparator()` to control whether `null` and `missing` are treated as equivalent or distinct in comparisons
+- Remove the extra non-character Unicode in the function name when displaying cli errors 
 
 ### Changed
 


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #1733 

## Description
- < Explain >

## Other Information
- Updated Unreleased Section in CHANGELOG: Yes
- Any backward-incompatible changes? No
- Any new external dependencies? No
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? Yes

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md