### PR TITLE
Add exception handling migration guide from v0.14.9 to v1

### DIFF
--- a/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
@@ -1,67 +1,66 @@
 package examples
 
 import org.junit.jupiter.api.assertThrows
-import org.partiql.lang.eval.EvaluationSession
 import org.partiql.parser.PartiQLParser
 import org.partiql.parser.PartiQLParserException
 import org.partiql.parser.SourceLocation
 import org.partiql.planner.PartiQLPlanner
-import java.util.*
+import java.util.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class ErrorHandlingChanges {
-
+    /**
+     * The example shows when using {@link PartiQLParser} to parse string statement,
+     * the {@link PartiQLParserException} will be thrown. The parser will stop and throw the exception
+     *  when an error occurs.
+     */
     @Test
-    fun `Parser syntax error handling`() {
+    fun `Parser error handling`() {
         val parser = PartiQLParser.default()
 
         val exception = assertThrows<PartiQLParserException> {
-            parser.parse("SELECT * FRM abd")
+            try {
+                val parseResult = parser.parse("Create Table 'mytable")
+            } catch (e: PartiQLParserException) {
+                // rethrow for exception validation in test
+                throw e
+            }
         }
 
-        assertTrue { exception.message.contains("mismatched input 'FRM'") }
-        assertEquals(SourceLocation(1, 10, 52, 3), exception.location)
-    }
-
-    @Test
-    fun `Planner function type mismatch error`() {
-        val parser = PartiQLParser.default()
-        val planner = PartiQLPlanner.default()
-        val sess = PartiQLPlanner.Session(
-            queryId = UUID.randomUUID().toString(),
-            userId = "debug"
-        )
-
-        val parseResult = parser.parse("SELECT UPPER(123)")
-        val exception = assertThrows<PartiQLParserException> {
-            val result = planner.plan(parseResult.root, sess).plan
-        }
-
-        assertTrue { exception.message.contains("extraneous input '''") }
+        assertTrue { exception.message.contains("extraneous input") }
+        assertEquals("UNRECOGNIZED", exception.tokenType)
         assertEquals(SourceLocation(1, 14, 62, 1), exception.location)
     }
 
+    /**
+     * The example shows when using {@link PartiQLPlanner} to make plan from AST.
+     * There is no specific exception defined in the planner, so the planner will throw any exception
+     *  when an error occurs.
+     */
     @Test
-    fun `Expression evaluation error`() {
-
+    fun `PLanner evaluation error`() {
         val parser = PartiQLParser.default()
         val planner = PartiQLPlanner.default()
-        val sess = PartiQLPlanner.Session(
-            queryId = UUID.randomUUID().toString(),
-            userId = "debug"
+        val session = PartiQLPlanner.Session(
+            queryId = Random().nextInt().toString(),
+            userId = "test-user",
+            currentCatalog = "default",
+            catalogs = mapOf()
         )
 
-        val session = EvaluationSession.builder().build()
-
-        val parseResult = parser.parse("SELECT UPPER(123)")
-        val exception = assertThrows<PartiQLParserException> {
-            val result = planner.plan(parseResult.root, sess).plan
-            result
+        val exception = assertThrows<Exception> {
+            try {
+                val parseResult = parser.parse("Create Table mytable")
+                val planResult = planner.plan(parseResult.root, session)
+            } catch (e: Exception) {
+                // PartiQLParserException will be thrown during PartiQL process the query in the major PartiQL components
+                throw e
+            }
         }
 
-        assertTrue { exception.message.contains("extraneous input '''") }
-        assertEquals(SourceLocation(1, 14, 62, 1), exception.location)
+        assertTrue(exception is IllegalArgumentException)
+        assertTrue(exception.message!!.contains("Unsupported statement"))
     }
 }

--- a/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
@@ -17,8 +17,8 @@ import kotlin.test.assertTrue
 
 class ErrorHandlingChanges {
     /**
-     * The example shows the error handling when using [PartiQLParser] to parse a string statement,
-     * When an error occurs, the parser will stop the parsing process by throwing the [PartiQLParserException].
+     * The example shows error handling when using [PartiQLParser] to parse a string statement,
+     * When an error occurs, the parser will stop the parsing process by throwing [PartiQLParserException].
      */
     @Test
     fun `PartiQLParser default error handling`() {
@@ -29,12 +29,12 @@ class ErrorHandlingChanges {
                 // Extra single quote is added
                 val parseResult = parser.parse("SELECT * FROM 'mytable")
             } catch (e: PartiQLParserException) {
-                // Rethrow for validating the exception in test
+                // Rethrow for validating the exception in the test
                 throw e
             }
         }
 
-        // This is a pain point with using the v0.14.9 parser. There's no proper way to extract out error information
+        // This is a pain point when using the v0.14.9 parser. There's no proper way to extract error information
         // other than looking at the error message string.
         assertTrue { exception.message.contains("extraneous input") }
         assertEquals("UNRECOGNIZED", exception.tokenType)
@@ -43,11 +43,11 @@ class ErrorHandlingChanges {
 
     /**
      *  [PartiQLPlanner] transforms an Abstract Syntax Tree (AST) from the parser into a logical query plan.
-     *  The planner does not throw for most errors. If errors occur, planner will collect multiple errors during the
+     *  The planner does not throw for most errors. If errors occur, the planner will collect multiple errors during the
      * planning phase. The planner provides an optional callback for you to handle those errors.
      *
-     * But the planner may still throw exception in certain circumstances.
-     * This example shows the error handling behavior when making a plan from a valid AST using the [PartiQLPlanner]
+     * However, the planner may still throw exception in certain circumstances.
+     * This example shows the error handling behavior when making a plan from a valid AST using [PartiQLPlanner]
      */
     @Test
     fun `PartiQLPlanner default error handling`() {
@@ -60,13 +60,13 @@ class ErrorHandlingChanges {
             catalogs = mapOf()
         )
 
-        // CREATE TABLE is not supported by planner currently
+        // The planner does not support CREATE TABLE currently
         val parseResult = parser.parse("CREATE TABLE mytable")
         val exception = assertThrows<Exception> {
             try {
                 val planResult = planner.plan(parseResult.root, session)
             } catch (e: Exception) {
-                // Rethrow for validating the exception in test
+                // Rethrow for validating the exception in the test
                 throw e
             }
         }
@@ -105,7 +105,7 @@ class ErrorHandlingChanges {
     }
 
     /**
-     * This example shows the error handling behavior of PartiQL evaluation phase.
+     * This example shows the error handling behavior of the PartiQL evaluation phase.
      */
     @Test
     fun `PartiQL evaluation phase default error handling`() {

--- a/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
@@ -24,7 +24,7 @@ class ErrorHandlingChanges {
             try {
                 val parseResult = parser.parse("Create Table 'mytable")
             } catch (e: PartiQLParserException) {
-                // rethrow for exception validation in test
+                // Rethrow for validating the exception in test
                 throw e
             }
         }
@@ -55,7 +55,7 @@ class ErrorHandlingChanges {
                 val parseResult = parser.parse("Create Table mytable")
                 val planResult = planner.plan(parseResult.root, session)
             } catch (e: Exception) {
-                // PartiQLParserException will be thrown during PartiQL process the query in the major PartiQL components
+                // Rethrow for validating the exception in test
                 throw e
             }
         }

--- a/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
@@ -1,0 +1,67 @@
+package examples
+
+import org.junit.jupiter.api.assertThrows
+import org.partiql.lang.eval.EvaluationSession
+import org.partiql.parser.PartiQLParser
+import org.partiql.parser.PartiQLParserException
+import org.partiql.parser.SourceLocation
+import org.partiql.planner.PartiQLPlanner
+import java.util.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ErrorHandlingChanges {
+
+    @Test
+    fun `Parser syntax error handling`() {
+        val parser = PartiQLParser.default()
+
+        val exception = assertThrows<PartiQLParserException> {
+            parser.parse("SELECT * FRM abd")
+        }
+
+        assertTrue { exception.message.contains("mismatched input 'FRM'") }
+        assertEquals(SourceLocation(1, 10, 52, 3), exception.location)
+    }
+
+    @Test
+    fun `Planner function type mismatch error`() {
+        val parser = PartiQLParser.default()
+        val planner = PartiQLPlanner.default()
+        val sess = PartiQLPlanner.Session(
+            queryId = UUID.randomUUID().toString(),
+            userId = "debug"
+        )
+
+        val parseResult = parser.parse("SELECT UPPER(123)")
+        val exception = assertThrows<PartiQLParserException> {
+            val result = planner.plan(parseResult.root, sess).plan
+        }
+
+        assertTrue { exception.message.contains("extraneous input '''") }
+        assertEquals(SourceLocation(1, 14, 62, 1), exception.location)
+    }
+
+    @Test
+    fun `Expression evaluation error`() {
+
+        val parser = PartiQLParser.default()
+        val planner = PartiQLPlanner.default()
+        val sess = PartiQLPlanner.Session(
+            queryId = UUID.randomUUID().toString(),
+            userId = "debug"
+        )
+
+        val session = EvaluationSession.builder().build()
+
+        val parseResult = parser.parse("SELECT UPPER(123)")
+        val exception = assertThrows<PartiQLParserException> {
+            val result = planner.plan(parseResult.root, sess).plan
+            result
+        }
+
+        assertTrue { exception.message.contains("extraneous input '''") }
+        assertEquals(SourceLocation(1, 14, 62, 1), exception.location)
+    }
+}

--- a/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
@@ -1,58 +1,69 @@
 package examples
 
 import org.junit.jupiter.api.assertThrows
+import org.partiql.errors.ErrorCode
+import org.partiql.errors.Problem
+import org.partiql.errors.ProblemSeverity
+import org.partiql.lang.CompilerPipeline
+import org.partiql.lang.eval.EvaluationException
+import org.partiql.lang.eval.EvaluationSession
 import org.partiql.parser.PartiQLParser
 import org.partiql.parser.PartiQLParserException
 import org.partiql.parser.SourceLocation
 import org.partiql.planner.PartiQLPlanner
-import java.util.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class ErrorHandlingChanges {
     /**
-     * The example shows when using {@link PartiQLParser} to parse string statement,
-     * the {@link PartiQLParserException} will be thrown. The parser will stop and throw the exception
-     *  when an error occurs.
+     * The example shows the error handling when using [PartiQLParser] to parse a string statement,
+     * When an error occurs, the parser will stop the parsing process by throwing the [PartiQLParserException].
      */
     @Test
-    fun `Parser error handling`() {
+    fun `PartiQLParser default error handling`() {
         val parser = PartiQLParser.default()
 
         val exception = assertThrows<PartiQLParserException> {
             try {
-                val parseResult = parser.parse("Create Table 'mytable")
+                // Extra single quote is added
+                val parseResult = parser.parse("SELECT * FROM 'mytable")
             } catch (e: PartiQLParserException) {
                 // Rethrow for validating the exception in test
                 throw e
             }
         }
 
+        // This is a pain point with using the v0.14.9 parser. There's no proper way to extract out error information
+        // other than looking at the error message string.
         assertTrue { exception.message.contains("extraneous input") }
         assertEquals("UNRECOGNIZED", exception.tokenType)
-        assertEquals(SourceLocation(1, 14, 62, 1), exception.location)
+        assertEquals(SourceLocation(1, 15, 666, 1), exception.location)
     }
 
     /**
-     * The example shows when using {@link PartiQLPlanner} to make plan from AST.
-     * There is no specific exception defined in the planner, so the planner will throw any exception
-     *  when an error occurs.
+     *  [PartiQLPlanner] transforms an Abstract Syntax Tree (AST) from the parser into a logical query plan.
+     *  The planner does not throw for most errors. If errors occur, planner will collect multiple errors during the
+     * planning phase. The planner provides an optional callback for you to handle those errors.
+     *
+     * But the planner may still throw exception in certain circumstances.
+     * This example shows the error handling behavior when making a plan from a valid AST using the [PartiQLPlanner]
      */
     @Test
-    fun `PLanner evaluation error`() {
+    fun `PartiQLPlanner default error handling`() {
         val parser = PartiQLParser.default()
         val planner = PartiQLPlanner.default()
         val session = PartiQLPlanner.Session(
-            queryId = Random().nextInt().toString(),
+            queryId = "testId",
             userId = "test-user",
             currentCatalog = "default",
             catalogs = mapOf()
         )
 
+        // CREATE TABLE is not supported by planner currently
+        val parseResult = parser.parse("CREATE TABLE mytable")
         val exception = assertThrows<Exception> {
             try {
-                val parseResult = parser.parse("Create Table mytable")
                 val planResult = planner.plan(parseResult.root, session)
             } catch (e: Exception) {
                 // Rethrow for validating the exception in test
@@ -62,5 +73,58 @@ class ErrorHandlingChanges {
 
         assertTrue(exception is IllegalArgumentException)
         assertTrue(exception.message!!.contains("Unsupported statement"))
+    }
+
+    /**
+     * This example shows the planner will not throw for most of the errors and an optional problem callback can be specified to
+     * handle errors from the planner.
+     */
+    @Test
+    fun `PartiQLPlanner default error handling with problem callback`() {
+        val parser = PartiQLParser.default()
+        val planner = PartiQLPlanner.default()
+        val session = PartiQLPlanner.Session(
+            queryId = "testId",
+            userId = "test-user",
+            currentCatalog = "default",
+            catalogs = mapOf()
+        )
+
+        val problemList = mutableListOf<Problem>()
+
+        fun callback(p: Problem) {
+            problemList.add(p)
+        }
+
+        val parseResult = parser.parse("UPPER(123)")
+        val planResult = planner.plan(parseResult.root, session, ::callback)
+
+        assertEquals(1, problemList.size)
+        assertEquals(ProblemSeverity.ERROR, problemList[0].details.severity)
+        assertEquals("Unknown function `upper(<int4>)", problemList[0].details.message)
+    }
+
+    /**
+     * This example shows the error handling behavior of PartiQL evaluation phase.
+     */
+    @Test
+    fun `PartiQL evaluation phase default error handling`() {
+        val pipeline = CompilerPipeline.standard()
+        val session = EvaluationSession.build { }
+
+        // Divide by zero error
+        val expression = pipeline.compile("1 / 0")
+
+        val exception = assertThrows<EvaluationException> {
+            try {
+                val result = expression.evaluate(session)
+            } catch (e: EvaluationException) {
+                // Rethrow for validating the exception in test
+                throw e
+            }
+        }
+
+        assertEquals(ErrorCode.EVALUATOR_DIVIDE_BY_ZERO, exception.errorCode)
+        assertEquals("/ by zero", exception.message)
     }
 }

--- a/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
@@ -1,0 +1,170 @@
+package examples
+
+import org.junit.jupiter.api.assertThrows
+import org.partiql.eval.Mode
+import org.partiql.eval.compiler.PartiQLCompiler
+import org.partiql.parser.PartiQLParser
+import org.partiql.planner.PartiQLPlanner
+import org.partiql.spi.Context
+import org.partiql.spi.SourceLocation
+import org.partiql.spi.catalog.Session
+import org.partiql.spi.errors.PError
+import org.partiql.spi.errors.PErrorKind
+import org.partiql.spi.errors.PErrorListener
+import org.partiql.spi.errors.PRuntimeException
+import org.partiql.spi.errors.Severity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ErrorHandlingChanges {
+    class CustomPErrorListener : PErrorListener {
+        val errorCollection: MutableList<PError> = mutableListOf()
+
+        override fun report(error: PError) {
+            when (error.severity.code()) {
+                // You may choose to customize the error message and then halt the flow by throwing the error, or you can record the error and then throw when it reaches maximum count
+                // In this case, we record only without throwing
+                Severity.ERROR -> errorCollection.add(error)
+                // You may choose to customize the error message, treat warning as an error and then halt the flow by throwing, or you can suppress all warnings.
+                // In this case, we record only without throwing
+                Severity.WARNING -> errorCollection.add(error)
+                else -> error("This shouldn't have occurred.")
+            }
+        }
+    }
+
+    private lateinit var context: Context
+    private lateinit var listener: CustomPErrorListener
+
+    @Test
+    fun `PartiQLParser error handling`() {
+        val parser = PartiQLParser.standard()
+
+        // The PRuntimeException is expected to throw when .parse called on a PartiQL query with invalid syntax.
+        val exception = assertThrows<PRuntimeException> {
+            // An invalid single quote is added before Table name foo
+            parser.parse("CREATE TABLE 'foo")
+        }
+
+        assertEquals(exception.error.code(), PError.UNEXPECTED_TOKEN)
+        assertEquals(PErrorKind.SYNTAX, exception.error.kind.code())
+        assertEquals(Severity.ERROR, exception.error.severity.code())
+        assertEquals(SourceLocation(1, 14, 1), exception.error.location)
+    }
+
+    @Test
+    fun `PartiQLParser with custom error handler`() {
+        // Register Error Listener
+        listener = CustomPErrorListener()
+        context = Context.of(listener)
+
+        val parser = PartiQLParser.standard()
+        val parseResult: PartiQLParser.Result
+        try {
+            // An invalid single quote is added before Table name foo
+            parseResult = parser.parse("CREATE TABLE 'mytable", context)
+        } catch (ex: PRuntimeException) {
+            // Since we register custom error handler to record all errors instead of throwing, these exceptions were likely unexpected.
+            // However, the PartiQL library may throw PRuntimeExceptions as well. You should be able to unwrap these exceptions and provide quality
+            // error messages to your users. In this case, we throw
+            throw ex
+        }
+
+        // Process your listener now as the errors are not thrown in this example.
+        val exception = listener.errorCollection[0]
+
+        assertEquals(PError.UNEXPECTED_TOKEN, exception.code())
+        assertEquals(PErrorKind.SYNTAX, exception.kind.code())
+        assertEquals(Severity.ERROR, exception.severity.code())
+        assertEquals(SourceLocation(1, 14, 1), exception.location)
+    }
+
+    @Test
+    fun `PartiQLPlanner error handling`() {
+        val parser = PartiQLParser.standard()
+        val planner = PartiQLPlanner.standard()
+        val session = Session.empty()
+
+        val parseResult = parser.parse("CREATE TABLE mytable")
+        val exception = assertThrows<PRuntimeException> {
+            planner.plan(parseResult.statements[0], session)
+        }
+
+        assertEquals(PError.INTERNAL_ERROR, exception.error.code())
+        assertEquals(PErrorKind.SEMANTIC, exception.error.kind.code())
+        assertEquals(Severity.ERROR, exception.error.severity.code())
+    }
+
+    @Test
+    fun `PartiQLPlanner with custom error handler`() {
+        // Register Error Listener
+        listener = CustomPErrorListener()
+        context = Context.of(listener)
+
+        val parser = PartiQLParser.standard()
+        val planner = PartiQLPlanner.standard()
+        val session = Session.empty()
+
+        val parseResult = parser.parse("CREATE TABLE mytable")
+
+        try {
+            planner.plan(parseResult.statements[0], session, context)
+        } catch (ex: PRuntimeException) {
+            throw ex
+        }
+
+        val exception = listener.errorCollection[0]
+
+        assertEquals(PError.INTERNAL_ERROR, exception.code())
+        assertEquals(PErrorKind.SEMANTIC, exception.kind.code())
+        assertEquals(Severity.ERROR, exception.severity.code())
+    }
+
+    @Test
+    fun `PartiQLCompiler error handling`() {
+        val compiler = PartiQLCompiler.standard()
+        val parser = PartiQLParser.standard()
+        val planner = PartiQLPlanner.standard()
+
+        val parseResult = parser.parse("1 / 0")
+
+        val session = Session.empty()
+        val plan = planner.plan(parseResult.statements[0], session).plan
+        val exception = assertThrows<PRuntimeException> {
+            val result = compiler.prepare(plan, Mode.STRICT()).execute()
+        }
+
+        assertEquals(PError.DIVISION_BY_ZERO, exception.error.code())
+        assertEquals(PErrorKind.EXECUTION, exception.error.kind.code())
+        assertEquals(Severity.ERROR, exception.error.severity.code())
+    }
+
+    @Test
+    fun `PartiQLCompiler with custom error handler`() {
+        // Register Error Listener
+        listener = CustomPErrorListener()
+        context = Context.of(listener)
+
+        val compiler = PartiQLCompiler.standard()
+        val parser = PartiQLParser.standard()
+        val planner = PartiQLPlanner.standard()
+
+        val parseResult = parser.parse("1 / 0")
+
+        val session = Session.empty()
+        val plan = planner.plan(parseResult.statements[0], session).plan
+        try {
+            val result = compiler.prepare(plan, Mode.STRICT(), context)
+        } catch (ex: PRuntimeException) {
+            throw ex
+        }
+
+        val exception = listener.errorCollection[0]
+
+        assertEquals(PError.DIVISION_BY_ZERO, exception.code())
+        assertEquals(PErrorKind.EXECUTION, exception.kind.code())
+        assertEquals(Severity.ERROR, exception.severity.code())
+    }
+
+
+}

--- a/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
@@ -43,8 +43,8 @@ class ErrorHandlingChanges {
                 val plan = planner.plan(parseResult.statements[0], session).plan
                 val result = compiler.prepare(plan, Mode.STRICT())
             } catch (e: PRuntimeException) {
-                // The exception should have been thrown from PartiQL. You can add your handling here.
-                // Rethrow in test for exception validation.
+                // The exception should have been thrown from PartiQL components. You can add your handling here.
+                // Rethrow for validating the exception in test
                 throw e
             }
         }
@@ -150,6 +150,7 @@ class ErrorHandlingChanges {
                 statement.execute()
             } catch (e: PRuntimeException) {
                 // A DIVISION_BY_ZERO will throw during the execution
+                // Rethrow for validating the exception in test
                 throw e
             }
         }

--- a/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
@@ -1,5 +1,6 @@
 package examples
 
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.partiql.eval.Mode
 import org.partiql.eval.compiler.PartiQLCompiler
@@ -7,6 +8,7 @@ import org.partiql.parser.PartiQLParser
 import org.partiql.planner.PartiQLPlanner
 import org.partiql.spi.Context
 import org.partiql.spi.SourceLocation
+import org.partiql.spi.catalog.Identifier
 import org.partiql.spi.catalog.Session
 import org.partiql.spi.errors.PError
 import org.partiql.spi.errors.PErrorKind
@@ -17,33 +19,51 @@ import org.partiql.spi.types.PType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+/**
+ * A unified error handling is introduced PartiQL system. [PRuntimeException] will be thrown from all components in PartiQL system
+ * to trap any errors or warnings. [PRuntimeException] warps a [PError] Java class which exposes information for users to write
+ * high quality error messages.
+ *
+ * Also [PErrorListener] is introduced to allow customized error handling. You can register a [PErrorListener] in context of
+ * major PartiQL components [PartiQLParser], [PartiQLPlanner] and [PartiQLCompiler]. It allows you to inspect each PError
+ * the component emitted and decide action on error. You may treat all warnings as errors, suppress all warnings, delay the error handling
+ * or throw custom exception with an error message.
+ *
+ * Note for the output when you choose to delay the error handling. The component will not stop and still return an output object
+ * In case the severity is [Severity.ERROR], the output may be incorrect or incomplete. You should discard the result.
+ * You may proceed with [Severity.WARNING], but be aware of the warning condition such as date accuracy loss.
+ */
 class ErrorHandlingChanges {
+    class CustomPErrorListener : PErrorListener {
+        val errorCollection: MutableList<PError> = mutableListOf()
+
+        override fun report(error: PError) {
+            when (error.severity.code()) {
+                // You may choose to customize the error message and then halt the flow by throwing the error, or you can record the error and then throw when it reaches maximum count
+                // In this case, we record only without throwing
+                Severity.ERROR -> errorCollection.add(error)
+                // You may choose to customize the error message, treat warning as an error and then halt the flow by throwing, or you can suppress all warnings.
+                // In this case, we record only without throwing
+                Severity.WARNING -> errorCollection.add(error)
+                else -> error("This shouldn't have occurred.")
+            }
+        }
+    }
 
     /**
-     * The example shows the default behavior of error handling in major PartiQL components {@link PartiQLParser},
-     * {@link PartiQLPlanner} and {@link PartiQLCompiler}. {@link PRuntimeException} will be thrown from the PartiQL system
-     * to trap any parsing errors or warnings. {@link PRuntimeException} wraps a {@link PError} which includes {@link PError#code()},
-     * {@link PError#kind}, {@link PError#severity}, {@link PError#location} and {@link PError#properties}.
-     * {@link PRuntimeException} with some enhanced information allows us for more robust and customized error control.
+     * The example shows the error handling when using [PartiQLParser] to parse a string statement,
+     * When an error occurs, the parser will stop the parsing process by throwing the [PRuntimeException].
      */
     @Test
-    fun `Default PartiQL error handling`() {
-        val compiler = PartiQLCompiler.standard()
+    fun `PartiQLParser default error handling`() {
         val parser = PartiQLParser.standard()
-        val planner = PartiQLPlanner.standard()
-        val session = Session.empty()
 
-        val query = """
-            CREATE TABLE 'mytable;
-        """.trimIndent()
-
+        // The PRuntimeException is expected to throw when .parse called on a PartiQL query with invalid syntax.
         val exception = assertThrows<PRuntimeException> {
             try {
-                val parseResult = parser.parse(query)
-                val plan = planner.plan(parseResult.statements[0], session).plan
-                val result = compiler.prepare(plan, Mode.STRICT())
+                // Extra single quote is added
+                parser.parse("SELECT * FROM 'mytable;")
             } catch (e: PRuntimeException) {
-                // The exception should have been thrown from PartiQL components. You can add your handling here.
                 // Rethrow for validating the exception in test
                 throw e
             }
@@ -52,96 +72,149 @@ class ErrorHandlingChanges {
         assertEquals(exception.error.code(), PError.UNEXPECTED_TOKEN)
         assertEquals(PErrorKind.SYNTAX, exception.error.kind.code())
         assertEquals(Severity.ERROR, exception.error.severity.code())
-        assertEquals(SourceLocation(1, 14, 1), exception.error.location)
+        assertEquals(SourceLocation(1, 15, 1), exception.error.location)
         // Inspect properties from exception
         assertEquals("UNRECOGNIZED", exception.error.get("TOKEN_NAME", String::class.java))
     }
 
     /**
-     * The example shows we registered a custom error handling in the context of major PartiQL components {@link PartiQLParser},
-     * {@link PartiQLPlanner} and {@link PartiQLCompiler} which records the errors or warning instead of throwing for deferred error processing.
-     * You can choose to treat warning as errors, or inhibit certain warnings or even ignore warnings.
-     * It might be a good idea for you to consolidate your logic of converting PErrors to user-presented messages and use that here.
+     * The example shows the error handling with custom [PErrorListener], which delays the error handling
+     * when using [PartiQLParser] to parse multiple string statements.
      */
     @Test
-    fun `PartiQLParser with custom error handler`() {
-        class CustomPErrorListener : PErrorListener {
-            val errorCollection: MutableList<PError> = mutableListOf()
-
-            override fun report(error: PError) {
-                when (error.severity.code()) {
-                    // You may choose to customize the error message and then halt the flow by throwing the error, or you can record the error and then throw when it reaches maximum count
-                    // In this case, we record only without throwing
-                    Severity.ERROR -> errorCollection.add(error)
-                    // You may choose to customize the error message, treat warning as an error and then halt the flow by throwing, or you can suppress all warnings.
-                    // In this case, we record only without throwing
-                    Severity.WARNING -> errorCollection.add(error)
-                    else -> error("This shouldn't have occurred.")
-                }
-            }
-        }
-
+    fun `PartiQLParser error handling with custom listener`() {
         // Register Error Listener
         val listener = CustomPErrorListener()
         val context = Context.of(listener)
 
-        val compiler = PartiQLCompiler.standard()
         val parser = PartiQLParser.standard()
-        val planner = PartiQLPlanner.standard()
-        val session = Session.empty()
 
+        // 1. Good statement. This one should be parsed.
+        // 2. Extra single quote. The parsing should stop here.
+        // 3. Incorrect operator. The parsing will not reach here to report error.
         val query = """
-            CREATE TABLE mytable;
-            INSERT INTO 'mytable VALUES (2,3);
+            SELECT * FROM mytable1;
+            SELECT * FROM 'mytable2;
+            SELECT 1 ++ 2 FROM mytable2;
         """.trimIndent()
 
-        // The example shows you how to implement custom error handling for PartiQL. In the example, we will record the
-        // exception for delayed processing to override the default behavior.
-        try {
-            // Parser with custom context
-            val parseResult = parser.parse(query, context)
-            // Planner with custom context
-            val plan = planner.plan(parseResult.statements[0], session, context).plan
-            // Complier with custom context
-            val result = compiler.prepare(plan, Mode.STRICT(), context)
-        } catch (e: PRuntimeException) {
-            // This will not throw as we register custom error handling, However, it is still good practice to catch this exception.
-            // PartiQL system may still throw PRuntimeException, you may want to print user friendly message.
-            throw e
+        lateinit var result: PartiQLParser.Result
+
+        assertDoesNotThrow {
+            try {
+                // Invalid single quote is added before `mytable`
+                result = parser.parse(query, context)
+            } catch (e: PRuntimeException) {
+                // It is unlikely reach here due to parsing if you use custom listener to suppress or delay error handling.
+                // However, PartiQL system still may throw the exception. You should be able to unwrap these exceptions and provide quality
+                // error messages to your users.
+                // So in this case, rethrowing should not fail the test as exception is trapped in listener.
+                throw e
+            }
         }
 
-        // Process your listener now as the errors are not thrown in this example.
-        assertEquals(2, listener.errorCollection.size)
+        // In this case, the first statement should be parsed and then the parsing process may not move forward.
+        // However, the exception is not thrown immediately. However, the result is still considered as incomplete.
+        assertEquals(1, result.statements.size)
 
-        val exception1 = listener.errorCollection[0]
-
-        assertEquals(PError.UNEXPECTED_TOKEN, exception1.code())
-        assertEquals(PErrorKind.SYNTAX, exception1.kind.code())
-        assertEquals(Severity.ERROR, exception1.severity.code())
-        assertEquals(SourceLocation(2, 13, 1), exception1.location)
+        val exception = listener.errorCollection[0]
+        assertEquals(exception.code(), PError.UNEXPECTED_TOKEN)
+        assertEquals(PErrorKind.SYNTAX, exception.kind.code())
+        assertEquals(Severity.ERROR, exception.severity.code())
+        assertEquals(SourceLocation(2, 15, 1), exception.location)
         // Inspect properties from exception
-        assertEquals("UNRECOGNIZED", exception1.get("TOKEN_NAME", String::class.java))
-
-        val exception2 = listener.errorCollection[1]
-
-        assertEquals(PError.INTERNAL_ERROR, exception2.code())
-        assertEquals(PErrorKind.SEMANTIC, exception2.kind.code())
-        assertEquals(Severity.ERROR, exception2.severity.code())
-        assertEquals("CREATE TABLE has not been supported yet in AstRewriter", exception2.get("CAUSE", Throwable::class.java)!!.message)
+        assertEquals("UNRECOGNIZED", exception.get("TOKEN_NAME", String::class.java))
     }
 
     /**
-     *  Error listeners are specifically meant to provide control over the reporting of errors for PartiQL’s
-     *  major components (parser, planner, and compiler). However, for the execution of compiled statements,
-     *  Instead, it immediately throws PRuntimeException.
+     * This example shows the error handling behavior that the [PartiQLPlanner] can proceed with most errors
+     * or warnings. However, it may still throw [PRuntimeException] in some circumstances
      */
     @Test
-    fun `PartiQL statement execution error handling`() {
+    fun `PartiQLPlanner default error handling which throws exception`() {
+        val parser = PartiQLParser.standard()
+        val planner = PartiQLPlanner.standard()
+        val session = Session.empty()
+
+        // CREATE TABLE is not supported by planner currently
+        val parseResult = parser.parse("CREATE TABLE mytable")
+        val exception = assertThrows<PRuntimeException> {
+            try {
+                // Create are not supported in current Planner
+                val plan = planner.plan(parseResult.statements[0], session).plan
+            } catch (e: PRuntimeException) {
+                // Rethrow for validating the exception in test
+                throw e
+            }
+        }
+
+        assertEquals(PError.INTERNAL_ERROR, exception.error.code())
+        assertEquals(PErrorKind.SEMANTIC, exception.error.kind.code())
+        assertEquals(Severity.ERROR, exception.error.severity.code())
+    }
+
+    /**
+     * This example shows the error handling behavior that the [PartiQLPlanner] can proceed with most errors
+     * or warnings and will not throw.
+     */
+    @Test
+    fun `PartiQLPlanner default error handling which does not throw`() {
+        val parser = PartiQLParser.standard()
+        val planner = PartiQLPlanner.standard()
+        val session = Session.empty()
+
+        // Invalid expression adding number and string
+        val parseResult = parser.parse("SELECT 1 + 'string' FROM mytable")
+        assertDoesNotThrow {
+            val plan = planner.plan(parseResult.statements[0], session).plan
+        }
+    }
+
+    /**
+     * This example shows the error handling behavior that the [PartiQLPlanner] can proceed with most errors
+     * or warnings and will not throw. But we use error listener to trap errors or warnings from the planner.
+     */
+    @Test
+    fun `PartiQLPlanner error handling with custom listener`() {
+        // Register Error Listener
+        val listener = CustomPErrorListener()
+        val context = Context.of(listener)
+
+        val parser = PartiQLParser.standard()
+        val planner = PartiQLPlanner.standard()
+        val session = Session.empty()
+
+        // Invalid expression adding number and string
+        val parseResult = parser.parse("SELECT 1 + 'string' FROM mytable")
+        assertDoesNotThrow {
+            val plan = planner.plan(parseResult.statements[0], session, context).plan
+        }
+        assertEquals(2, listener.errorCollection.size)
+
+        val exception1 = listener.errorCollection[0]
+        assertEquals(PError.VAR_REF_NOT_FOUND, exception1.code())
+        assertEquals(PErrorKind.SEMANTIC, exception1.kind.code())
+        assertEquals(Severity.WARNING, exception1.severity.code())
+        assertEquals("mytable", exception1.get("ID", Identifier::class.java).toString())
+
+        val exception2 = listener.errorCollection[1]
+        assertEquals(PError.FUNCTION_TYPE_MISMATCH, exception2.code())
+        assertEquals(PErrorKind.SEMANTIC, exception2.kind.code())
+        assertEquals(Severity.WARNING, exception2.severity.code())
+        assertEquals("\"\uFDEFplus\"", exception2.get("FN_ID", Identifier::class.java).toString())
+    }
+
+    /**
+     *  For the execution of compiled statements, the PartiQL system will immediately throw [PRuntimeException].
+     */
+    @Test
+    fun `PartiQL evaluation phase default error handling`() {
         val compiler = PartiQLCompiler.standard()
         val parser = PartiQLParser.standard()
         val planner = PartiQLPlanner.standard()
         val session = Session.empty()
 
+        // Divide by zero
         val parseResult = parser.parse("1 / 0")
         val plan = planner.plan(parseResult.statements[0], session).plan
         val statement = compiler.prepare(plan, Mode.STRICT())

--- a/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
@@ -13,158 +13,151 @@ import org.partiql.spi.errors.PErrorKind
 import org.partiql.spi.errors.PErrorListener
 import org.partiql.spi.errors.PRuntimeException
 import org.partiql.spi.errors.Severity
+import org.partiql.spi.types.PType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class ErrorHandlingChanges {
-    class CustomPErrorListener : PErrorListener {
-        val errorCollection: MutableList<PError> = mutableListOf()
 
-        override fun report(error: PError) {
-            when (error.severity.code()) {
-                // You may choose to customize the error message and then halt the flow by throwing the error, or you can record the error and then throw when it reaches maximum count
-                // In this case, we record only without throwing
-                Severity.ERROR -> errorCollection.add(error)
-                // You may choose to customize the error message, treat warning as an error and then halt the flow by throwing, or you can suppress all warnings.
-                // In this case, we record only without throwing
-                Severity.WARNING -> errorCollection.add(error)
-                else -> error("This shouldn't have occurred.")
-            }
-        }
-    }
-
-    private lateinit var context: Context
-    private lateinit var listener: CustomPErrorListener
-
+    /**
+     * The example shows the default behavior of error handling in major PartiQL components {@link PartiQLParser},
+     * {@link PartiQLPlanner} and {@link PartiQLCompiler}. {@link PRuntimeException} will be thrown from the PartiQL system
+     * to trap any parsing errors or warnings. {@link PRuntimeException} wraps a {@link PError} which includes {@link PError#code()},
+     * {@link PError#kind}, {@link PError#severity}, {@link PError#location} and {@link PError#properties}.
+     * {@link PRuntimeException} with some enhanced information allows us for more robust and customized error control.
+     */
     @Test
-    fun `PartiQLParser error handling`() {
+    fun `Default PartiQL error handling`() {
+        val compiler = PartiQLCompiler.standard()
         val parser = PartiQLParser.standard()
+        val planner = PartiQLPlanner.standard()
+        val session = Session.empty()
 
-        // The PRuntimeException is expected to throw when .parse called on a PartiQL query with invalid syntax.
+        val query = """
+            CREATE TABLE 'mytable;
+        """.trimIndent()
+
         val exception = assertThrows<PRuntimeException> {
-            // An invalid single quote is added before Table name foo
-            parser.parse("CREATE TABLE 'foo")
+            try {
+                val parseResult = parser.parse(query)
+                val plan = planner.plan(parseResult.statements[0], session).plan
+                val result = compiler.prepare(plan, Mode.STRICT())
+            } catch (e: PRuntimeException) {
+                // The exception should have been thrown from PartiQL. You can add your handling here.
+                // Rethrow in test for exception validation.
+                throw e
+            }
         }
 
         assertEquals(exception.error.code(), PError.UNEXPECTED_TOKEN)
         assertEquals(PErrorKind.SYNTAX, exception.error.kind.code())
         assertEquals(Severity.ERROR, exception.error.severity.code())
         assertEquals(SourceLocation(1, 14, 1), exception.error.location)
+        // Inspect properties from exception
+        assertEquals("UNRECOGNIZED", exception.error.get("TOKEN_NAME", String::class.java))
     }
 
+    /**
+     * The example shows we registered a custom error handling in the context of major PartiQL components {@link PartiQLParser},
+     * {@link PartiQLPlanner} and {@link PartiQLCompiler} which records the errors or warning instead of throwing for deferred error processing.
+     * You can choose to treat warning as errors, or inhibit certain warnings or even ignore warnings.
+     * It might be a good idea for you to consolidate your logic of converting PErrors to user-presented messages and use that here.
+     */
     @Test
     fun `PartiQLParser with custom error handler`() {
-        // Register Error Listener
-        listener = CustomPErrorListener()
-        context = Context.of(listener)
+        class CustomPErrorListener : PErrorListener {
+            val errorCollection: MutableList<PError> = mutableListOf()
 
+            override fun report(error: PError) {
+                when (error.severity.code()) {
+                    // You may choose to customize the error message and then halt the flow by throwing the error, or you can record the error and then throw when it reaches maximum count
+                    // In this case, we record only without throwing
+                    Severity.ERROR -> errorCollection.add(error)
+                    // You may choose to customize the error message, treat warning as an error and then halt the flow by throwing, or you can suppress all warnings.
+                    // In this case, we record only without throwing
+                    Severity.WARNING -> errorCollection.add(error)
+                    else -> error("This shouldn't have occurred.")
+                }
+            }
+        }
+
+        // Register Error Listener
+        val listener = CustomPErrorListener()
+        val context = Context.of(listener)
+
+        val compiler = PartiQLCompiler.standard()
         val parser = PartiQLParser.standard()
-        val parseResult: PartiQLParser.Result
+        val planner = PartiQLPlanner.standard()
+        val session = Session.empty()
+
+        val query = """
+            CREATE TABLE mytable;
+            INSERT INTO 'mytable VALUES (2,3);
+        """.trimIndent()
+
+        // The example shows you how to implement custom error handling for PartiQL. In the example, we will record the
+        // exception for delayed processing to override the default behavior.
         try {
-            // An invalid single quote is added before Table name foo
-            parseResult = parser.parse("CREATE TABLE 'mytable", context)
-        } catch (ex: PRuntimeException) {
-            // Since we register custom error handler to record all errors instead of throwing, these exceptions were likely unexpected.
-            // However, the PartiQL library may throw PRuntimeExceptions as well. You should be able to unwrap these exceptions and provide quality
-            // error messages to your users. In this case, we throw
-            throw ex
+            // Parser with custom context
+            val parseResult = parser.parse(query, context)
+            // Planner with custom context
+            val plan = planner.plan(parseResult.statements[0], session, context).plan
+            // Complier with custom context
+            val result = compiler.prepare(plan, Mode.STRICT(), context)
+        } catch (e: PRuntimeException) {
+            // This will not throw as we register custom error handling, However, it is still good practice to catch this exception.
+            // PartiQL system may still throw PRuntimeException, you may want to print user friendly message.
+            throw e
         }
 
         // Process your listener now as the errors are not thrown in this example.
-        val exception = listener.errorCollection[0]
+        assertEquals(2, listener.errorCollection.size)
 
-        assertEquals(PError.UNEXPECTED_TOKEN, exception.code())
-        assertEquals(PErrorKind.SYNTAX, exception.kind.code())
-        assertEquals(Severity.ERROR, exception.severity.code())
-        assertEquals(SourceLocation(1, 14, 1), exception.location)
+        val exception1 = listener.errorCollection[0]
+
+        assertEquals(PError.UNEXPECTED_TOKEN, exception1.code())
+        assertEquals(PErrorKind.SYNTAX, exception1.kind.code())
+        assertEquals(Severity.ERROR, exception1.severity.code())
+        assertEquals(SourceLocation(2, 13, 1), exception1.location)
+        // Inspect properties from exception
+        assertEquals("UNRECOGNIZED", exception1.get("TOKEN_NAME", String::class.java))
+
+        val exception2 = listener.errorCollection[1]
+
+        assertEquals(PError.INTERNAL_ERROR, exception2.code())
+        assertEquals(PErrorKind.SEMANTIC, exception2.kind.code())
+        assertEquals(Severity.ERROR, exception2.severity.code())
+        assertEquals("CREATE TABLE has not been supported yet in AstRewriter", exception2.get("CAUSE", Throwable::class.java)!!.message)
     }
 
+    /**
+     *  Error listeners are specifically meant to provide control over the reporting of errors for PartiQL’s
+     *  major components (parser, planner, and compiler). However, for the execution of compiled statements,
+     *  Instead, it immediately throws PRuntimeException.
+     */
     @Test
-    fun `PartiQLPlanner error handling`() {
-        val parser = PartiQLParser.standard()
-        val planner = PartiQLPlanner.standard()
-        val session = Session.empty()
-
-        val parseResult = parser.parse("CREATE TABLE mytable")
-        val exception = assertThrows<PRuntimeException> {
-            planner.plan(parseResult.statements[0], session)
-        }
-
-        assertEquals(PError.INTERNAL_ERROR, exception.error.code())
-        assertEquals(PErrorKind.SEMANTIC, exception.error.kind.code())
-        assertEquals(Severity.ERROR, exception.error.severity.code())
-    }
-
-    @Test
-    fun `PartiQLPlanner with custom error handler`() {
-        // Register Error Listener
-        listener = CustomPErrorListener()
-        context = Context.of(listener)
-
-        val parser = PartiQLParser.standard()
-        val planner = PartiQLPlanner.standard()
-        val session = Session.empty()
-
-        val parseResult = parser.parse("CREATE TABLE mytable")
-
-        try {
-            planner.plan(parseResult.statements[0], session, context)
-        } catch (ex: PRuntimeException) {
-            throw ex
-        }
-
-        val exception = listener.errorCollection[0]
-
-        assertEquals(PError.INTERNAL_ERROR, exception.code())
-        assertEquals(PErrorKind.SEMANTIC, exception.kind.code())
-        assertEquals(Severity.ERROR, exception.severity.code())
-    }
-
-    @Test
-    fun `PartiQLCompiler error handling`() {
+    fun `PartiQL statement execution error handling`() {
         val compiler = PartiQLCompiler.standard()
         val parser = PartiQLParser.standard()
         val planner = PartiQLPlanner.standard()
+        val session = Session.empty()
 
         val parseResult = parser.parse("1 / 0")
-
-        val session = Session.empty()
         val plan = planner.plan(parseResult.statements[0], session).plan
+        val statement = compiler.prepare(plan, Mode.STRICT())
         val exception = assertThrows<PRuntimeException> {
-            val result = compiler.prepare(plan, Mode.STRICT()).execute()
+            try {
+                statement.execute()
+            } catch (e: PRuntimeException) {
+                // A DIVISION_BY_ZERO will throw during the execution
+                throw e
+            }
         }
 
-        assertEquals(PError.DIVISION_BY_ZERO, exception.error.code())
+        assertEquals(exception.error.code(), PError.DIVISION_BY_ZERO)
         assertEquals(PErrorKind.EXECUTION, exception.error.kind.code())
         assertEquals(Severity.ERROR, exception.error.severity.code())
+        assertEquals("1", exception.error.get("DIVIDEND", String::class.java))
+        assertEquals(PType.integer(), exception.error.get("DIVIDEND_TYPE", PType::class.java))
     }
-
-    @Test
-    fun `PartiQLCompiler with custom error handler`() {
-        // Register Error Listener
-        listener = CustomPErrorListener()
-        context = Context.of(listener)
-
-        val compiler = PartiQLCompiler.standard()
-        val parser = PartiQLParser.standard()
-        val planner = PartiQLPlanner.standard()
-
-        val parseResult = parser.parse("1 / 0")
-
-        val session = Session.empty()
-        val plan = planner.plan(parseResult.statements[0], session).plan
-        try {
-            val result = compiler.prepare(plan, Mode.STRICT(), context)
-        } catch (ex: PRuntimeException) {
-            throw ex
-        }
-
-        val exception = listener.errorCollection[0]
-
-        assertEquals(PError.DIVISION_BY_ZERO, exception.code())
-        assertEquals(PErrorKind.EXECUTION, exception.kind.code())
-        assertEquals(Severity.ERROR, exception.severity.code())
-    }
-
-
 }

--- a/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
+++ b/docs/upgrades/v0.14-to-v1-upgrade/upgraded-examples/src/test/kotlin/examples/ErrorHandlingChanges.kt
@@ -169,9 +169,9 @@ class ErrorHandlingChanges {
         val planner = PartiQLPlanner.standard()
         val session = Session.empty()
 
-        // There are two warnings in when .plan is called on planner
+        // There are two warnings when calling the planner on the following query:
         // 1. Invalid expression adding number and string
-        // 2. `mytable` reference is not found
+        // 2. The reference of table `mytable` is not found
         val parseResult = parser.parse("SELECT 1 + 'string' FROM mytable")
         assertDoesNotThrow {
             val plan = planner.plan(parseResult.statements[0], session).plan


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
- Add exception handling migration guide from v0.14.9 to v1

## Other Information
Updated Unreleased Section in CHANGELOG: No, No feature released/change
Any backward-incompatible changes? NO
Any new external dependencies? NO
Do your changes comply with the [contributing](https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md) and [code style](https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md) guidelines? YES

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md