### PR TITLE
add: `Ion` representation for `INTERVAL` in conformance tests & support `INTERVAL` in partiql-tests-runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,6 @@ rewritten to their query representation
 - Remove the extra non-character Unicode in the function name when displaying cli errors 
 - **EXPERIMENTAL** Add `Datum.getTotalMonths` to retrieve the total number of months from a year-month `Datum`
 - **EXPERIMENTAL** Add `Datum.getTotalSeconds` to retrieve the total number of seconds from a day-time `Datum`
-- `ion` representation for `INTERVAL` in conformance tests
-- Support `INTERVAL` in `partiql-tests-runner`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ rewritten to their query representation
 - Remove the extra non-character Unicode in the function name when displaying cli errors 
 - **EXPERIMENTAL** Add `Datum.getTotalMonths` to retrieve the total number of months from a year-month `Datum`
 - **EXPERIMENTAL** Add `Datum.getTotalSeconds` to retrieve the total number of seconds from a day-time `Datum`
+- `ion` representation for `INTERVAL` in conformance tests
+- Support `INTERVAL` in `partiql-tests-runner`
 
 ### Changed
 

--- a/partiql-spi/src/main/java/org/partiql/spi/value/DatumComparator.java
+++ b/partiql-spi/src/main/java/org/partiql/spi/value/DatumComparator.java
@@ -561,7 +561,7 @@ abstract class DatumComparator implements Comparator<Datum> {
 
     @SuppressWarnings({"UnusedReturnValue"})
     private static DatumComparison[] fillIntervalComparator(DatumComparison[] comps) {
-        comps[INTERVAL_YM] = (self, other, comp) -> Long.compare(self.getTotalMonths(), self.getTotalMonths());
+        comps[INTERVAL_YM] = (self, other, comp) -> Long.compare(self.getTotalMonths(), other.getTotalMonths());
         comps[INTERVAL_DT] = (self, other, comp) -> {
             int comparison = Long.compare(self.getTotalSeconds(), other.getTotalSeconds());
             if (comparison != 0) {

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/io/DatumIonReader.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/io/DatumIonReader.kt
@@ -32,7 +32,6 @@ class DatumIonReader(
     private val sourceDataFormat: DatumIonReaderBuilder.SourceDataFormat
 ) : AutoCloseable {
     private val INTERVAL_MAX_PRECISION = 9
-    
     private enum class PARTIQL_ANNOTATION(val annotation: String) {
         MISSING_ANNOTATION("\$missing"),
         BAG_ANNOTATION("\$bag"),

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/io/DatumIonReader.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/io/DatumIonReader.kt
@@ -32,6 +32,7 @@ class DatumIonReader(
     private val sourceDataFormat: DatumIonReaderBuilder.SourceDataFormat
 ) : AutoCloseable {
     private val INTERVAL_MAX_PRECISION = 9
+    private val INTERVAL_MAX_FRACTIONAL_PRECISION = 9
     private enum class PARTIQL_ANNOTATION(val annotation: String) {
         MISSING_ANNOTATION("\$missing"),
         BAG_ANNOTATION("\$bag"),
@@ -184,7 +185,7 @@ class DatumIonReader(
                 PARTIQL_ANNOTATION.TIME_ANNOTATION -> Datum.nullValue(PType.time(6))
                 PARTIQL_ANNOTATION.TIMESTAMP_ANNOTATION -> Datum.nullValue(PType.timestamp(6))
                 PARTIQL_ANNOTATION.INTERVAL_YM_ANNOTATION -> Datum.nullValue(PType.intervalYearMonth(INTERVAL_MAX_PRECISION))
-                PARTIQL_ANNOTATION.INTERVAL_DT_ANNOTATION -> Datum.nullValue(PType.intervalDaySecond(INTERVAL_MAX_PRECISION, INTERVAL_MAX_PRECISION))
+                PARTIQL_ANNOTATION.INTERVAL_DT_ANNOTATION -> Datum.nullValue(PType.intervalDaySecond(INTERVAL_MAX_PRECISION, INTERVAL_MAX_FRACTIONAL_PRECISION))
                 PARTIQL_ANNOTATION.GRAPH_ANNOTATION -> TODO("Graph not yet implemented")
                 null -> Datum.nullValue()
             }
@@ -354,7 +355,7 @@ class DatumIonReader(
                             signMultiplier * seconds,
                             signMultiplier * nanos,
                             INTERVAL_MAX_PRECISION,
-                            INTERVAL_MAX_PRECISION,
+                            INTERVAL_MAX_FRACTIONAL_PRECISION,
                         )
                     }
                     null -> fromIonGeneric(reader)

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/util/DatumUtil.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/util/DatumUtil.kt
@@ -70,7 +70,11 @@ internal fun Datum.toIonElement(): IonElement {
                 PType.INTERVAL_DT -> {
                     val fields = mutableListOf<StructField>()
                     val totalSeconds = this.totalSeconds
-                    if (totalSeconds < 0 || this.nanos < 0) fields.add(field("sign", ionString("-")))
+                    if (totalSeconds < 0 || this.nanos < 0) {
+                        fields.add(field("sign", ionString("-")))
+                    } else {
+                        fields.add(field("sign", ionString("+")))
+                    }
                     fields.add(field("days", ionInt(abs(this.days).toLong())))
                     fields.add(field("hours", ionInt(abs(this.hours).toLong())))
                     fields.add(field("minutes", ionInt(abs(this.minutes).toLong())))

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/util/DatumUtil.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/util/DatumUtil.kt
@@ -15,6 +15,7 @@ import com.amazon.ionelement.api.ionStructOf
 import com.amazon.ionelement.api.ionTimestamp
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
+import kotlin.math.abs
 
 // For error display only
 internal fun Datum.toIonElement(): IonElement {
@@ -53,6 +54,29 @@ internal fun Datum.toIonElement(): IonElement {
                     fields.add(field("timezone_hour", ionInt(timezoneHours.toLong())))
                     fields.add(field("timezone_minute", ionInt(timezoneMinutes.toLong())))
                     ionStructOf(fields).withAnnotations("\$time")
+                }
+                PType.INTERVAL_YM -> {
+                    val fields = mutableListOf<StructField>()
+                    val totalMonths = this.totalMonths
+                    if (totalMonths < 0) {
+                        fields.add(field("sign", ionString("-")))
+                    } else {
+                        fields.add(field("sign", ionString("+")))
+                    }
+                    fields.add(field("years", ionInt(abs(this.years).toLong())))
+                    fields.add(field("months", ionInt(abs(this.months).toLong())))
+                    ionStructOf(fields).withAnnotations("\$interval_ym")
+                }
+                PType.INTERVAL_DT -> {
+                    val fields = mutableListOf<StructField>()
+                    val totalSeconds = this.totalSeconds
+                    if (totalSeconds < 0 || this.nanos < 0) fields.add(field("sign", ionString("-")))
+                    fields.add(field("days", ionInt(abs(this.days).toLong())))
+                    fields.add(field("hours", ionInt(abs(this.hours).toLong())))
+                    fields.add(field("minutes", ionInt(abs(this.minutes).toLong())))
+                    fields.add(field("seconds", ionInt(abs(this.seconds).toLong())))
+                    fields.add(field("nanos", ionInt(abs(this.nanos).toLong())))
+                    ionStructOf(fields).withAnnotations("\$interval_dt")
                 }
                 PType.ARRAY -> {
                     val elements = mutableListOf<IonElement>()


### PR DESCRIPTION
## Relevant Issues
- Closes Issue #1783 

## Description
- Define `Ion` representation for `INTERVAL` in conformance tests
- Add support for `INTERVAL` in `partiql-tests-runner`

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
- Any backward-incompatible changes? **[NO]**
- Any new external dependencies? **[NO]**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md