### PR TITLE
Fix `INTERVAL` precision containing a range of fields

### DIFF
--- a/partiql-ast/src/main/java/org/partiql/ast/IntervalQualifier.java
+++ b/partiql-ast/src/main/java/org/partiql/ast/IntervalQualifier.java
@@ -16,8 +16,8 @@ import java.util.Set;
  */
 public abstract class IntervalQualifier extends AstNode {
 
-    // TODO: Determine what the maximum precision is for PartiQL
-    private static final int MAX_PRECISION = 6;
+    // The maximum precision is 9 for PartiQL INTERVAL
+    private static final int MAX_PRECISION = 9;
 
     /**
      * <p>


### PR DESCRIPTION
## Relevant Issues
- Closes #1820 

## Description
- Set the maximum precision as 9 for PartiQL `INTERVAL` in the AST

### Current Behavior
```
partiql ▶ INTERVAL '999999999-11' YEAR(9) to MONTH;

=== RESULT ===
INTERVAL '999999999-11' YEAR (9) TO MONTH

OK!

partiql ▶ INTERVAL '99:59.123456789' MINUTE(2) TO SECOND(9);

=== RESULT ===
INTERVAL '99:59.123456789' MINUTE (2) TO SECOND (9)

OK!
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **[NO]**
- Any backward-incompatible changes? **[NO]**
- Any new external dependencies? **[NO]**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md