### PR TITLE
fix: parsing `TIMESTAMP` and `TIME` with timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ rewritten to their query representation
 - Prioritize `missing` propagation when both `null` and `missing` exist in function args
 - Return `missing` instead of `null` for `NULLIF(MISSING, MISSING)`
 - CLI printing of mixed sign literals
+- Parsing `TIMESTAMP` and `TIME` with timezone
 
 ### Removed
 

--- a/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/util/DatumUtil.kt
+++ b/test/partiql-tests-runner/src/test/kotlin/org/partiql/runner/util/DatumUtil.kt
@@ -31,7 +31,8 @@ internal fun Datum.toIonElement(): IonElement {
                 PType.DECIMAL -> ionDecimal(Decimal.valueOf(this.bigDecimal))
                 PType.DOUBLE -> ionFloat(this.double)
                 PType.REAL -> ionFloat(this.float.toDouble())
-                PType.TIMESTAMP, PType.TIMESTAMPZ -> ionTimestamp(this.localDateTime.toString())
+                PType.TIMESTAMP -> ionTimestamp(this.localDateTime.toString() + "Z")
+                PType.TIMESTAMPZ -> ionTimestamp(this.localDateTime.toString())
                 PType.DATE -> ionString(this.localDate.toString()).withAnnotations("\$date")
                 PType.TIME -> {
                     val time = this.localTime


### PR DESCRIPTION
## Relevant Issues
- Closes #1795 

## Description
- Support for parsing `TIMESTAMP` and `TIME` with timezone

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**
- Any backward-incompatible changes? **[NO]**
- Any new external dependencies? **[NO]**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md