### PR TITLE
fix: LOWER(clob) datum return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Thank you to all who have contributed!
 ### Deprecated
 
 ### Fixed
+- Datum return type for `LOWER` on a CLOB value
 
 ### Removed
 

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnLower.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnLower.kt
@@ -27,7 +27,7 @@ internal val Fn_LOWER__CLOB__CLOB = Function.overload(
     parameters = arrayOf(Parameter("value", PType.clob(Int.MAX_VALUE))),
 
 ) { args ->
-    val string = args[0].string
+    val string = args[0].bytes.toString(Charsets.UTF_8)
     val result = string.lowercase()
     Datum.clob(result.toByteArray())
 }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnLower.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnLower.kt
@@ -29,5 +29,5 @@ internal val Fn_LOWER__CLOB__CLOB = Function.overload(
 ) { args ->
     val string = args[0].string
     val result = string.lowercase()
-    Datum.string(result)
+    Datum.clob(result.toByteArray())
 }


### PR DESCRIPTION
## Relevant Issues
- None

## Description
- Fix returned datum for calling `LOWER` on a clob. Previously was returning a string datum when it should have been a clob.
- Behavior now follows what we do for `UPPER`.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**: <Explain if NO>
- Any backward-incompatible changes? **[NO]**: <Explain if YES>
- Any new external dependencies? **[NO]**: <Explain if YES>
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md