### PR TITLE
add: temporary work around string functions support for `CHAR/VARCHAR`

### DIFF
--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/Builtins.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/Builtins.kt
@@ -147,6 +147,8 @@ internal object Builtins {
         Fn_LIKE_ESCAPE__STRING_STRING_STRING__BOOL,
         Fn_LIKE_ESCAPE__CLOB_CLOB_CLOB__BOOL,
 
+        Fn_LOWER__CHAR__CHAR,
+        Fn_LOWER__VARCHAR__VARCHAR,
         Fn_LOWER__STRING__STRING,
         Fn_LOWER__CLOB__CLOB,
 
@@ -184,6 +186,8 @@ internal object Builtins {
         Fn_SUBSTRING__CLOB_INT64_INT64__CLOB,
 
         FnTimes,
+        Fn_TRIM__CHAR__CHAR,
+        Fn_TRIM__VARCHAR__VARCHAR,
         Fn_TRIM__STRING__STRING,
         Fn_TRIM__CLOB__CLOB,
 
@@ -202,6 +206,8 @@ internal object Builtins {
         Fn_TRIM_TRAILING_CHARS__STRING_STRING__STRING,
         Fn_TRIM_TRAILING_CHARS__CLOB_CLOB__CLOB,
 
+        Fn_UPPER__CHAR__CHAR,
+        Fn_UPPER__VARCHAR__VARCHAR,
         Fn_UPPER__STRING__STRING,
         Fn_UPPER__CLOB__CLOB,
 

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnLower.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnLower.kt
@@ -8,6 +8,26 @@ import org.partiql.spi.function.Parameter
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
 
+internal val Fn_LOWER__CHAR__CHAR = Function.overload(
+
+    name = "lower",
+    returns = PType.character(),
+    parameters = arrayOf(Parameter("value", PType.character())),
+
+) { args ->
+    TODO("Not yet implemented")
+}
+
+internal val Fn_LOWER__VARCHAR__VARCHAR = Function.overload(
+
+    name = "lower",
+    returns = PType.varchar(),
+    parameters = arrayOf(Parameter("value", PType.varchar())),
+
+) { args ->
+    TODO("Not yet implemented")
+}
+
 internal val Fn_LOWER__STRING__STRING = Function.overload(
 
     name = "lower",

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnTrim.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnTrim.kt
@@ -9,6 +9,26 @@ import org.partiql.spi.utils.FunctionUtils
 import org.partiql.spi.utils.StringUtils.codepointTrim
 import org.partiql.spi.value.Datum
 
+internal val Fn_TRIM__CHAR__CHAR = FunctionUtils.hidden(
+
+    name = "trim",
+    returns = PType.character(),
+    parameters = arrayOf(Parameter("value", PType.character())),
+
+) { args ->
+    TODO("Not yet implemented")
+}
+
+internal val Fn_TRIM__VARCHAR__VARCHAR = FunctionUtils.hidden(
+
+    name = "trim",
+    returns = PType.varchar(),
+    parameters = arrayOf(Parameter("value", PType.varchar())),
+
+) { args ->
+    TODO("Not yet implemented")
+}
+
 /**
  * From section 6.7 of SQL 92 spec:
  * ```

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnUpper.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnUpper.kt
@@ -8,6 +8,26 @@ import org.partiql.spi.function.Parameter
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
 
+internal val Fn_UPPER__CHAR__CHAR = Function.overload(
+
+    name = "upper",
+    returns = PType.character(),
+    parameters = arrayOf(Parameter("value", PType.character())),
+
+) { args ->
+    TODO("Not yet implemented")
+}
+
+internal val Fn_UPPER__VARCHAR__VARCHAR = Function.overload(
+
+    name = "upper",
+    returns = PType.varchar(),
+    parameters = arrayOf(Parameter("value", PType.varchar())),
+
+) { args ->
+    TODO("Not yet implemented")
+}
+
 internal val Fn_UPPER__STRING__STRING = Function.overload(
 
     name = "upper",


### PR DESCRIPTION
## Relevant Issues
- Related to Issue #1838 

## Description
- Add function signatures for `UPPER/LOWER/TRIM` on `CHAR/VARCHAR` types as a work around.
- Update the conformance test submodule.

## Other Information
- Updated Unreleased Section in CHANGELOG: **NO**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md