### PR TITLE
fix type mismatch for `BETWEEN` `AND` statement

### DIFF
--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpBetweenTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/predicate/OpBetweenTest.kt
@@ -43,9 +43,9 @@ class OpBetweenTest : PartiQLTyperTestBase() {
                     allTimePType,
                     allTimePType,
                 ) + cartesianProduct(
-                    allTimeStampPType,
-                    allTimeStampPType,
-                    allTimeStampPType,
+                    allTimeStampPType + allDatePType,
+                    allTimeStampPType + allDatePType,
+                    allTimeStampPType + allDatePType,
                 )
 
             val failureArgs = cartesianProduct(

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnBetween.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnBetween.kt
@@ -5,6 +5,7 @@ import org.partiql.spi.function.FnOverload
 import org.partiql.spi.function.Function.instance
 import org.partiql.spi.function.Parameter
 import org.partiql.spi.function.RoutineOverloadSignature
+import org.partiql.spi.function.builtins.TypePrecedence.TYPE_PRECEDENCE
 import org.partiql.spi.internal.SqlTypeFamily
 import org.partiql.spi.types.PType
 import org.partiql.spi.utils.FunctionUtils
@@ -29,17 +30,33 @@ internal object FnBetween : FnOverload() {
         if (args.all { SqlTypeFamily.TEXT.contains(it) }) {
             return getStringInstance(arg0, arg1, arg2)
         }
+
+        if (args.all { it.code() == PType.CLOB }) {
+            return getClobInstance(arg0, arg1, arg2)
+        }
+
+        // DATE_TIMESTAMP family: DATE, TIMESTAMP, TIMESTAMPZ
+        // Find the highest-precedence type and use it for all parameters to enable autocast.
+        if (args.all { SqlTypeFamily.DATE_TIMESTAMP.contains(it) }) {
+            val target = args.maxByOrNull { TYPE_PRECEDENCE[it.code()]!! }!!
+            return when (target.code()) {
+                PType.DATE -> getDateInstance(target, target, target)
+                PType.TIMESTAMP -> getTimestampInstance(target, target, target)
+                PType.TIMESTAMPZ -> getTimestampzInstance(target, target, target)
+                else -> null
+            }
+        }
+
         if (args.all { SqlTypeFamily.TIME.contains(it) }) {
-            return getTimeInstance(arg0, arg1, arg2)
+            val target = args.maxByOrNull { TYPE_PRECEDENCE[it.code()]!! }!!
+            return when (target.code()) {
+                PType.TIME -> getTimeInstance(target, target, target)
+                PType.TIMEZ -> getTimezInstance(target, target, target)
+                else -> null
+            }
         }
-        if (args.all { SqlTypeFamily.TIMESTAMP.contains(it) }) {
-            return getTimestampInstance(arg0, arg1, arg2)
-        }
-        return when (arg0.code() to arg1.code() to arg2.code()) {
-            (PType.CLOB to PType.CLOB to PType.CLOB) -> getClobInstance(arg0, arg1, arg2)
-            (PType.DATE to PType.DATE to PType.DATE) -> getDateInstance(arg0, arg1, arg2)
-            else -> null
-        }
+
+        return null
     }
 
     private fun getNumberInstance(arg0: PType, arg1: PType, arg2: PType): Fn {
@@ -146,6 +163,42 @@ internal object FnBetween : FnOverload() {
                 val l = args[1].localDateTime
                 val r = args[2].localDateTime
                 Datum.bool(v in l..r)
+            }
+        )
+    }
+
+    private fun getTimezInstance(arg0: PType, arg1: PType, arg2: PType): Fn {
+        return instance(
+            name = name,
+            returns = PType.bool(),
+            parameters = arrayOf(
+                Parameter("value", arg0),
+                Parameter("lower", arg1),
+                Parameter("upper", arg2)
+            ),
+            invoke = { args ->
+                val v = args[0].offsetTime
+                val l = args[1].offsetTime
+                val r = args[2].offsetTime
+                Datum.bool(v >= l && v <= r)
+            }
+        )
+    }
+
+    private fun getTimestampzInstance(arg0: PType, arg1: PType, arg2: PType): Fn {
+        return instance(
+            name = name,
+            returns = PType.bool(),
+            parameters = arrayOf(
+                Parameter("value", arg0),
+                Parameter("lower", arg1),
+                Parameter("upper", arg2)
+            ),
+            invoke = { args ->
+                val v = args[0].offsetDateTime
+                val l = args[1].offsetDateTime
+                val r = args[2].offsetDateTime
+                Datum.bool(v >= l && v <= r)
             }
         )
     }

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/internal/SqlTypeFamily.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/internal/SqlTypeFamily.kt
@@ -109,6 +109,16 @@ internal class SqlTypeFamily private constructor(
         )
 
         @JvmStatic
+        val DATE_TIMESTAMP = SqlTypeFamily(
+            preferred = PType.timestamp(),
+            members = setOf(
+                PType.DATE,
+                PType.TIMESTAMP,
+                PType.TIMESTAMPZ,
+            )
+        )
+
+        @JvmStatic
         val DATETIME = SqlTypeFamily(
             preferred = PType.date(),
             members = setOf(


### PR DESCRIPTION
## Relevant Issues
```
Date '2020-03-10' BETWEEN Timestamp '2020-03-09 01:00:00.000+00:10' AND Timestamp '2020-03-11 03:00:00'
```
will throw 
PError{code=FUNCTION_TYPE_MISMATCH, severity=WARNING, kind=SEMANTIC, location=null, properties={FN_ID=\ufdefbetween, ARG_TYPES=[DATE, TIMESTAMP(6), TIMESTAMP(6)], CANDIDATES=[org.partiql.spi.function.builtins.FnBetween@3131b41]}}

## Description
- add coercion for `between and` when resolving function 

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md