### PR TITLE
Feature/cli dir multi format reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Thank you to all who have contributed!
 ## [Unreleased](https://TODO.com) - YYYY-MM-DD
 
 ### Added
+- Implemented `--dir` CLI option to load a directory of data files (.ion, .json, .csv, .tsv, .pql, .parquet) as tables with lazy loading
 
 ### Changed
 
@@ -39,6 +40,7 @@ Thank you to all who have contributed!
 
 ### Contributors
 Thank you to all who have contributed!
+- @AugustineFu
 
 ## [1.3.10](https://github.com/partiql/partiql-lang-kotlin/releases/tag/v1.3.10) - 2026-04-01
 

--- a/buildSrc/src/main/kotlin/partiql.versions.kt
+++ b/buildSrc/src/main/kotlin/partiql.versions.kt
@@ -44,6 +44,8 @@ object Versions {
     const val kotlinxCoroutinesJdk8 = "1.8.1"
     const val ktlint = "0.42.1" // we're on an old version of ktlint. TODO upgrade https://github.com/partiql/partiql-lang-kotlin/issues/1418
     const val lombok = "1.18.34"
+    const val parquet = "1.14.1"
+    const val hadoop = "3.3.6"
 
     // Testing
     const val assertj = "3.11.0"
@@ -85,6 +87,9 @@ object Deps {
     const val kotlinxCoroutinesJdk8 = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:${Versions.kotlinxCoroutinesJdk8}"
     const val ktlint = "com.pinterest.ktlint:ktlint-core:${Versions.ktlint}"
     const val lombok = "org.projectlombok:lombok:${Versions.lombok}"
+    const val parquetHadoop = "org.apache.parquet:parquet-hadoop:${Versions.parquet}"
+    const val hadoopCommon = "org.apache.hadoop:hadoop-common:${Versions.hadoop}"
+    const val hadoopMapreduceClient = "org.apache.hadoop:hadoop-mapreduce-client-core:${Versions.hadoop}"
 
     // Testing
     const val assertj = "org.assertj:assertj-core:${Versions.assertj}"

--- a/partiql-cli/build.gradle.kts
+++ b/partiql-cli/build.gradle.kts
@@ -36,6 +36,13 @@ dependencies {
     implementation(Deps.picoCli)
     implementation(Deps.kotlinReflect)
     implementation(Deps.kotlinxCoroutines)
+    implementation(Deps.parquetHadoop)
+    implementation(Deps.hadoopCommon) {
+        exclude(group = "org.apache.curator")
+        exclude(group = "org.apache.zookeeper")
+        exclude(group = "org.apache.kerby")
+    }
+    implementation(Deps.hadoopMapreduceClient)
     testImplementation(Deps.mockito)
 }
 

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
@@ -477,9 +477,6 @@ internal class MainCommand : Runnable {
             error("Not a directory: ${directory.path}")
         }
         val supportedExtensions = setOf("ion", "pql", "csv", "tsv", "json", "parquet")
-        directory.listFiles()
-            ?.filter { it.isFile && it.extension !in supportedExtensions }
-            ?.forEach { System.err.println("Warning: skipping '${it.name}' (unsupported extension '.${it.extension}'). Supported: $supportedExtensions") }
         return LazyCatalog("default", directory, supportedExtensions) { file ->
             debug("Loading table '${file.nameWithoutExtension}' from ${file.name}")
             when (file.extension) {

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
@@ -16,6 +16,7 @@
 package org.partiql.cli
 
 import org.partiql.cli.io.DatumCsvReader
+import org.partiql.cli.io.DatumParquetReader
 import org.partiql.cli.io.DatumIonReaderBuilder
 import org.partiql.cli.io.DatumWriterTextPretty
 import org.partiql.cli.io.Format
@@ -479,7 +480,7 @@ internal class MainCommand : Runnable {
         val supportedExtensions = setOf("ion", "pql", "csv", "tsv", "json", "parquet")
         return LazyCatalog("default", directory, supportedExtensions) { file ->
             debug("Loading table '${file.nameWithoutExtension}' from ${file.name}")
-            when (file.extension) {
+            when (file.extension.lowercase()) {
                 "ion", "json" -> {
                     val reader = DatumIonReaderBuilder.standard().build(file.inputStream())
                     val first = try { reader.read() } catch (_: IOException) { return@LazyCatalog Datum.nullValue() }
@@ -508,6 +509,7 @@ internal class MainCommand : Runnable {
                 }
                 "csv" -> DatumCsvReader.read(file.inputStream(), ',')
                 "tsv" -> DatumCsvReader.read(file.inputStream(), '\t')
+                "parquet" -> DatumParquetReader.read(file)
                 "pql" -> {
                     val text = file.readText(Charsets.UTF_8)
                     pipeline().execute(text, Session.empty())

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
@@ -15,9 +15,11 @@
 
 package org.partiql.cli
 
+import org.partiql.cli.io.DatumCsvReader
 import org.partiql.cli.io.DatumIonReaderBuilder
 import org.partiql.cli.io.DatumWriterTextPretty
 import org.partiql.cli.io.Format
+import org.partiql.cli.io.LazyCatalog
 import org.partiql.cli.pipeline.ErrorMessageFormatter
 import org.partiql.cli.pipeline.Pipeline
 import org.partiql.cli.shell.Shell
@@ -83,8 +85,7 @@ internal class MainCommand : Runnable {
 
     @CommandLine.Option(
         names = ["-d", "--dir"],
-        description = ["Path to the database directory"],
-        hidden = true
+        description = ["Path to the database directory. Each file becomes a table (e.g. users.ion -> table 'users')."],
     )
     var dir: File? = null
 
@@ -265,10 +266,7 @@ internal class MainCommand : Runnable {
             error("Cannot specify both a database directory and a list of files.")
         }
         if (dir != null) {
-            TODO("Local directory plugin not implemented")
-            // var root = dir!!
-            // val connector = LocalPlugin.create(root.toPath())
-            // return mapOf("default" to connector)
+            return listOf(loadDir(dir!!))
         }
 
         checkFormat(format)
@@ -470,6 +468,52 @@ internal class MainCommand : Runnable {
             } else {
                 // statement string
                 (str.trim('\'') to (null as File?))
+            }
+        }
+    }
+
+    private fun loadDir(directory: File): Catalog {
+        if (!directory.isDirectory) {
+            error("Not a directory: ${directory.path}")
+        }
+        val supportedExtensions = setOf("ion", "pql", "csv", "tsv", "json", "parquet")
+        directory.listFiles()
+            ?.filter { it.isFile && it.extension !in supportedExtensions }
+            ?.forEach { System.err.println("Warning: skipping '${it.name}' (unsupported extension '.${it.extension}'). Supported: $supportedExtensions") }
+        return LazyCatalog("default", directory, supportedExtensions) { file ->
+            debug("Loading table '${file.nameWithoutExtension}' from ${file.name}")
+            when (file.extension) {
+                "ion", "json" -> {
+                    val reader = DatumIonReaderBuilder.standard().build(file.inputStream())
+                    val first = try { reader.read() } catch (_: IOException) { return@LazyCatalog Datum.nullValue() }
+                    val second = try { reader.read() } catch (_: IOException) { return@LazyCatalog first }
+                    Datum.bag(Iterable {
+                        var state = 0
+                        object : Iterator<Datum> {
+                            private var next: Datum? = null
+                            override fun hasNext(): Boolean {
+                                if (next != null) return true
+                                next = when (state) {
+                                    0 -> { state = 1; first }
+                                    1 -> { state = 2; second }
+                                    else -> try { reader.read() } catch (_: IOException) { null }
+                                }
+                                return next != null
+                            }
+                            override fun next(): Datum {
+                                if (!hasNext()) throw NoSuchElementException()
+                                return next!!.also { next = null }
+                            }
+                        }
+                    })
+                }
+                "csv" -> DatumCsvReader.read(file.inputStream(), ',')
+                "tsv" -> DatumCsvReader.read(file.inputStream(), '\t')
+                "pql" -> {
+                    val text = file.readText(Charsets.UTF_8)
+                    pipeline().execute(text, Session.empty())
+                }
+                else -> Datum.nullValue()
             }
         }
     }

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
@@ -483,8 +483,18 @@ internal class MainCommand : Runnable {
             when (file.extension.lowercase()) {
                 "ion", "json" -> {
                     val reader = DatumIonReaderBuilder.standard().build(file.inputStream())
-                    val first = try { reader.read() } catch (_: IOException) { return@LazyCatalog Datum.nullValue() }
-                    val second = try { reader.read() } catch (_: IOException) { return@LazyCatalog first }
+                    val first = try {
+                        reader.read()
+                    } catch (_: IOException) {
+                        reader.close()
+                        return@LazyCatalog Datum.nullValue()
+                    }
+                    val second = try {
+                        reader.read()
+                    } catch (_: IOException) {
+                        reader.close()
+                        return@LazyCatalog first
+                    }
                     Datum.bag(
                         Iterable {
                             var state = 0
@@ -495,7 +505,12 @@ internal class MainCommand : Runnable {
                                     next = when (state) {
                                         0 -> { state = 1; first }
                                         1 -> { state = 2; second }
-                                        else -> try { reader.read() } catch (_: IOException) { null }
+                                        else -> try {
+                                            reader.read()
+                                        } catch (_: IOException) {
+                                            reader.close()
+                                            null
+                                        }
                                     }
                                     return next != null
                                 }

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
@@ -16,8 +16,8 @@
 package org.partiql.cli
 
 import org.partiql.cli.io.DatumCsvReader
-import org.partiql.cli.io.DatumParquetReader
 import org.partiql.cli.io.DatumIonReaderBuilder
+import org.partiql.cli.io.DatumParquetReader
 import org.partiql.cli.io.DatumWriterTextPretty
 import org.partiql.cli.io.Format
 import org.partiql.cli.io.LazyCatalog

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
@@ -487,25 +487,27 @@ internal class MainCommand : Runnable {
                     val reader = DatumIonReaderBuilder.standard().build(file.inputStream())
                     val first = try { reader.read() } catch (_: IOException) { return@LazyCatalog Datum.nullValue() }
                     val second = try { reader.read() } catch (_: IOException) { return@LazyCatalog first }
-                    Datum.bag(Iterable {
-                        var state = 0
-                        object : Iterator<Datum> {
-                            private var next: Datum? = null
-                            override fun hasNext(): Boolean {
-                                if (next != null) return true
-                                next = when (state) {
-                                    0 -> { state = 1; first }
-                                    1 -> { state = 2; second }
-                                    else -> try { reader.read() } catch (_: IOException) { null }
+                    Datum.bag(
+                        Iterable {
+                            var state = 0
+                            object : Iterator<Datum> {
+                                private var next: Datum? = null
+                                override fun hasNext(): Boolean {
+                                    if (next != null) return true
+                                    next = when (state) {
+                                        0 -> { state = 1; first }
+                                        1 -> { state = 2; second }
+                                        else -> try { reader.read() } catch (_: IOException) { null }
+                                    }
+                                    return next != null
                                 }
-                                return next != null
-                            }
-                            override fun next(): Datum {
-                                if (!hasNext()) throw NoSuchElementException()
-                                return next!!.also { next = null }
+                                override fun next(): Datum {
+                                    if (!hasNext()) throw NoSuchElementException()
+                                    return next!!.also { next = null }
+                                }
                             }
                         }
-                    })
+                    )
                 }
                 "csv" -> DatumCsvReader.read(file.inputStream(), ',')
                 "tsv" -> DatumCsvReader.read(file.inputStream(), '\t')

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/DatumCsvReader.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/DatumCsvReader.kt
@@ -22,19 +22,21 @@ internal object DatumCsvReader {
             .withIgnoreEmptyLines()
             .withTrim()
         val parser = CSVParser.parse(input, Charsets.UTF_8, format)
-        return Datum.bag(Iterable {
-            val iter = parser.iterator()
-            object : Iterator<Datum> {
-                override fun hasNext(): Boolean = iter.hasNext()
-                override fun next(): Datum {
-                    val record = iter.next()
-                    val fields = record.toMap().map { (key, value) ->
-                        Field.of(key, inferDatum(value))
+        return Datum.bag(
+            Iterable {
+                val iter = parser.iterator()
+                object : Iterator<Datum> {
+                    override fun hasNext(): Boolean = iter.hasNext()
+                    override fun next(): Datum {
+                        val record = iter.next()
+                        val fields = record.toMap().map { (key, value) ->
+                            Field.of(key, inferDatum(value))
+                        }
+                        return Datum.struct(fields)
                     }
-                    return Datum.struct(fields)
                 }
             }
-        })
+        )
     }
 
     private fun inferDatum(value: String?): Datum {

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/DatumCsvReader.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/DatumCsvReader.kt
@@ -26,7 +26,11 @@ internal object DatumCsvReader {
             Iterable {
                 val iter = parser.iterator()
                 object : Iterator<Datum> {
-                    override fun hasNext(): Boolean = iter.hasNext()
+                    override fun hasNext(): Boolean {
+                        val has = iter.hasNext()
+                        if (!has) parser.close()
+                        return has
+                    }
                     override fun next(): Datum {
                         val record = iter.next()
                         val fields = record.toMap().map { (key, value) ->

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/DatumCsvReader.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/DatumCsvReader.kt
@@ -1,0 +1,56 @@
+package org.partiql.cli.io
+
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVParser
+import org.partiql.spi.value.Datum
+import org.partiql.spi.value.Field
+import java.io.InputStream
+import java.math.BigDecimal
+
+/**
+ * Reads CSV or TSV files into a [Datum] bag of structs.
+ * The first row is treated as column headers.
+ * Values are auto-typed: null, boolean, integer, decimal, or string.
+ */
+internal object DatumCsvReader {
+
+    fun read(input: InputStream, delimiter: Char): Datum {
+        val format = CSVFormat.DEFAULT
+            .withHeader()
+            .withSkipHeaderRecord()
+            .withDelimiter(delimiter)
+            .withIgnoreEmptyLines()
+            .withTrim()
+        val parser = CSVParser.parse(input, Charsets.UTF_8, format)
+        return Datum.bag(Iterable {
+            val iter = parser.iterator()
+            object : Iterator<Datum> {
+                override fun hasNext(): Boolean = iter.hasNext()
+                override fun next(): Datum {
+                    val record = iter.next()
+                    val fields = record.toMap().map { (key, value) ->
+                        Field.of(key, inferDatum(value))
+                    }
+                    return Datum.struct(fields)
+                }
+            }
+        })
+    }
+
+    private fun inferDatum(value: String?): Datum {
+        if (value.isNullOrEmpty()) return Datum.nullValue()
+        // boolean
+        if (value.equals("true", ignoreCase = true)) return Datum.bool(true)
+        if (value.equals("false", ignoreCase = true)) return Datum.bool(false)
+        // integer
+        value.toLongOrNull()?.let { return Datum.bigint(it) }
+        // decimal
+        try {
+            return Datum.decimal(BigDecimal(value))
+        } catch (_: NumberFormatException) {
+            // not a number
+        }
+        // string
+        return Datum.string(value)
+    }
+}

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/DatumParquetReader.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/DatumParquetReader.kt
@@ -1,0 +1,101 @@
+package org.partiql.cli.io
+
+import org.apache.parquet.example.data.simple.SimpleGroup
+import org.apache.parquet.example.data.simple.convert.GroupRecordConverter
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.io.ColumnIOFactory
+import org.apache.parquet.io.LocalInputFile
+import org.apache.parquet.schema.LogicalTypeAnnotation
+import org.apache.parquet.schema.MessageType
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
+import org.partiql.spi.value.Datum
+import org.partiql.spi.value.Field
+import java.io.File
+import java.math.BigDecimal
+import java.math.BigInteger
+
+/**
+ * Reads Parquet files into a [Datum] bag of structs.
+ * Data is streamed Row Group by Row Group.
+ */
+internal object DatumParquetReader {
+
+    fun read(file: File): Datum {
+        val inputFile = LocalInputFile(file.toPath())
+        val schema = ParquetFileReader.open(inputFile).use { it.footer.fileMetaData.schema }
+        return Datum.bag(
+            Iterable {
+                iterator {
+                    ParquetFileReader.open(inputFile).use { reader ->
+                        var store = reader.readNextRowGroup()
+                        while (store != null) {
+                            val columnIO = ColumnIOFactory().getColumnIO(schema)
+                            val recordReader = columnIO.getRecordReader(
+                                store,
+                                GroupRecordConverter(schema)
+                            )
+                            for (i in 0 until store.rowCount) {
+                                yield(groupToDatum(recordReader.read() as SimpleGroup, schema))
+                            }
+                            store = reader.readNextRowGroup()
+                        }
+                    }
+                }
+            }
+        )
+    }
+
+    private fun groupToDatum(group: SimpleGroup, schema: MessageType): Datum {
+        val fields = (0 until schema.fieldCount).map { i ->
+            val value = if (group.getFieldRepetitionCount(i) == 0) {
+                Datum.nullValue()
+            } else {
+                convertValue(group, i, schema.getType(i))
+            }
+            Field.of(schema.getFieldName(i), value)
+        }
+        return Datum.struct(fields)
+    }
+
+    private fun convertValue(
+        group: SimpleGroup,
+        i: Int,
+        type: org.apache.parquet.schema.Type,
+    ): Datum {
+        if (!type.isPrimitive) {
+            return groupToDatum(
+                group.getGroup(i, 0) as SimpleGroup,
+                type.asGroupType() as MessageType
+            )
+        }
+        val pt = type.asPrimitiveType()
+        val logical = pt.logicalTypeAnnotation
+        return when (pt.primitiveTypeName) {
+            PrimitiveTypeName.BOOLEAN -> Datum.bool(group.getBoolean(i, 0))
+            PrimitiveTypeName.INT32 ->
+                if (logical is LogicalTypeAnnotation.DateLogicalTypeAnnotation) {
+                    Datum.date(java.time.LocalDate.ofEpochDay(group.getInteger(i, 0).toLong()))
+                } else {
+                    Datum.integer(group.getInteger(i, 0))
+                }
+            PrimitiveTypeName.INT64 -> Datum.bigint(group.getLong(i, 0))
+            PrimitiveTypeName.FLOAT -> Datum.doublePrecision(group.getFloat(i, 0).toDouble())
+            PrimitiveTypeName.DOUBLE -> Datum.doublePrecision(group.getDouble(i, 0))
+            PrimitiveTypeName.BINARY ->
+                if (logical is LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
+                    val bytes = group.getBinary(i, 0).bytes
+                    Datum.decimal(BigDecimal(BigInteger(bytes), logical.scale), logical.precision, logical.scale)
+                } else {
+                    Datum.string(group.getString(i, 0))
+                }
+            PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY ->
+                if (logical is LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
+                    val bytes = group.getBinary(i, 0).bytes
+                    Datum.decimal(BigDecimal(BigInteger(bytes), logical.scale), logical.precision, logical.scale)
+                } else {
+                    Datum.string(group.getValueToString(i, 0))
+                }
+            else -> Datum.string(group.getValueToString(i, 0))
+        }
+    }
+}

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyCatalog.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyCatalog.kt
@@ -7,6 +7,7 @@ import org.partiql.spi.catalog.Session
 import org.partiql.spi.catalog.Table
 import org.partiql.spi.value.Datum
 import java.io.File
+import java.io.FileFilter
 
 /**
  * A catalog backed by a directory of data files. The directory is scanned on each
@@ -25,6 +26,8 @@ internal class LazyCatalog(
     private val loader: (File) -> Datum,
 ) : Catalog {
 
+    private val supportedFilter = FileFilter { it.isFile && it.extension.lowercase() in supportedExtensions }
+
     override fun getName(): String = name
 
     override fun getTable(session: Session, name: Name): Table? {
@@ -34,25 +37,25 @@ internal class LazyCatalog(
 
     override fun resolveTable(session: Session, identifier: Identifier): Name? {
         val target = identifier.first()
-        val file = directory.listFiles()
-            ?.filter { it.isFile && it.extension.lowercase() in supportedExtensions }
+        val file = directory.listFiles(supportedFilter)
             ?.firstOrNull { target.matches(it.nameWithoutExtension) }
         if (file != null) return Name.of(file.nameWithoutExtension)
-        // Check if there's a file with a matching name but unsupported extension
-        val unsupported = directory.listFiles()
-            ?.firstOrNull {
-                it.isFile && it.extension.lowercase() !in supportedExtensions &&
-                    target.matches(it.nameWithoutExtension)
-            }
+
+        val unsupportedFilter = FileFilter {
+            it.isFile && it.extension.lowercase() !in supportedExtensions && target.matches(it.nameWithoutExtension)
+        }
+        val unsupported = directory.listFiles(unsupportedFilter)?.firstOrNull()
         if (unsupported != null) {
-            System.err.println("Warning: '${unsupported.name}' has unsupported extension '.${unsupported.extension}'. Supported: $supportedExtensions")
+            System.err.println(
+                "Warning: '${unsupported.name}' has unsupported extension " +
+                    "'.${unsupported.extension}'. Supported: $supportedExtensions"
+            )
         }
         return null
     }
 
     private fun findFile(tableName: String): File? {
-        return directory.listFiles()
-            ?.filter { it.isFile && it.extension.lowercase() in supportedExtensions }
+        return directory.listFiles(supportedFilter)
             ?.firstOrNull { it.nameWithoutExtension.equals(tableName, ignoreCase = true) }
     }
 

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyCatalog.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyCatalog.kt
@@ -1,0 +1,53 @@
+package org.partiql.cli.io
+
+import org.partiql.spi.catalog.Catalog
+import org.partiql.spi.catalog.Identifier
+import org.partiql.spi.catalog.Name
+import org.partiql.spi.catalog.Session
+import org.partiql.spi.catalog.Table
+import org.partiql.spi.value.Datum
+import java.io.File
+
+/**
+ * A catalog backed by a directory of data files. Table metadata (names) is loaded eagerly
+ * at construction time, but file contents are loaded lazily on first access.
+ *
+ * @param name the catalog name
+ * @param directory the directory containing data files
+ * @param supportedExtensions the file extensions to recognize as tables
+ * @param loader a function that reads a file into a [Datum]
+ */
+internal class LazyCatalog(
+    private val name: String,
+    directory: File,
+    supportedExtensions: Set<String>,
+    loader: (File) -> Datum,
+) : Catalog {
+
+    private val tables: Map<Name, Table>
+
+    init {
+        val files = directory.listFiles()?.filter { it.isFile && it.extension in supportedExtensions } ?: emptyList()
+        tables = files.associate { file ->
+            val tableName = Name.of(file.nameWithoutExtension)
+            tableName to when (file.extension) {
+                "parquet" -> ParquetTable(tableName, file)
+                else -> LazyTable(tableName, file, loader)
+            }
+        }
+    }
+
+    override fun getName(): String = name
+
+    override fun getTable(session: Session, name: Name): Table? = tables[name]
+
+    override fun resolveTable(session: Session, identifier: Identifier): Name? {
+        val first = identifier.first()
+        for ((name, _) in tables) {
+            if (first.matches(name.getName())) {
+                return name
+            }
+        }
+        return null
+    }
+}

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyCatalog.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyCatalog.kt
@@ -9,8 +9,9 @@ import org.partiql.spi.value.Datum
 import java.io.File
 
 /**
- * A catalog backed by a directory of data files. Table metadata (names) is loaded eagerly
- * at construction time, but file contents are loaded lazily on first access.
+ * A catalog backed by a directory of data files. The directory is scanned on each
+ * [getTable]/[resolveTable] call so that file renames, additions, and deletions
+ * are picked up without restarting the CLI.
  *
  * @param name the catalog name
  * @param directory the directory containing data files
@@ -19,35 +20,41 @@ import java.io.File
  */
 internal class LazyCatalog(
     private val name: String,
-    directory: File,
-    supportedExtensions: Set<String>,
-    loader: (File) -> Datum,
+    private val directory: File,
+    private val supportedExtensions: Set<String>,
+    private val loader: (File) -> Datum,
 ) : Catalog {
-
-    private val tables: Map<Name, Table>
-
-    init {
-        val files = directory.listFiles()?.filter { it.isFile && it.extension in supportedExtensions } ?: emptyList()
-        tables = files.associate { file ->
-            val tableName = Name.of(file.nameWithoutExtension)
-            tableName to when (file.extension) {
-                "parquet" -> ParquetTable(tableName, file)
-                else -> LazyTable(tableName, file, loader)
-            }
-        }
-    }
 
     override fun getName(): String = name
 
-    override fun getTable(session: Session, name: Name): Table? = tables[name]
+    override fun getTable(session: Session, name: Name): Table? {
+        val file = findFile(name.getName()) ?: return null
+        return createTable(name, file)
+    }
 
     override fun resolveTable(session: Session, identifier: Identifier): Name? {
-        val first = identifier.first()
-        for ((name, _) in tables) {
-            if (first.matches(name.getName())) {
-                return name
-            }
+        val target = identifier.first()
+        val file = directory.listFiles()
+            ?.filter { it.isFile && it.extension in supportedExtensions }
+            ?.firstOrNull { target.matches(it.nameWithoutExtension) }
+        if (file != null) return Name.of(file.nameWithoutExtension)
+        // Check if there's a file with a matching name but unsupported extension
+        val unsupported = directory.listFiles()
+            ?.firstOrNull { it.isFile && it.extension !in supportedExtensions && target.matches(it.nameWithoutExtension) }
+        if (unsupported != null) {
+            System.err.println("Warning: '${unsupported.name}' has unsupported extension '.${unsupported.extension}'. Supported: $supportedExtensions")
         }
         return null
+    }
+
+    private fun findFile(tableName: String): File? {
+        return directory.listFiles()
+            ?.filter { it.isFile && it.extension in supportedExtensions }
+            ?.firstOrNull { it.nameWithoutExtension.equals(tableName, ignoreCase = true) }
+    }
+
+    private fun createTable(name: Name, file: File): Table = when (file.extension) {
+        "parquet" -> ParquetTable(name, file)
+        else -> LazyTable(name, file, loader)
     }
 }

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyCatalog.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyCatalog.kt
@@ -35,12 +35,15 @@ internal class LazyCatalog(
     override fun resolveTable(session: Session, identifier: Identifier): Name? {
         val target = identifier.first()
         val file = directory.listFiles()
-            ?.filter { it.isFile && it.extension in supportedExtensions }
+            ?.filter { it.isFile && it.extension.lowercase() in supportedExtensions }
             ?.firstOrNull { target.matches(it.nameWithoutExtension) }
         if (file != null) return Name.of(file.nameWithoutExtension)
         // Check if there's a file with a matching name but unsupported extension
         val unsupported = directory.listFiles()
-            ?.firstOrNull { it.isFile && it.extension !in supportedExtensions && target.matches(it.nameWithoutExtension) }
+            ?.firstOrNull {
+                it.isFile && it.extension.lowercase() !in supportedExtensions &&
+                    target.matches(it.nameWithoutExtension)
+            }
         if (unsupported != null) {
             System.err.println("Warning: '${unsupported.name}' has unsupported extension '.${unsupported.extension}'. Supported: $supportedExtensions")
         }
@@ -49,11 +52,11 @@ internal class LazyCatalog(
 
     private fun findFile(tableName: String): File? {
         return directory.listFiles()
-            ?.filter { it.isFile && it.extension in supportedExtensions }
+            ?.filter { it.isFile && it.extension.lowercase() in supportedExtensions }
             ?.firstOrNull { it.nameWithoutExtension.equals(tableName, ignoreCase = true) }
     }
 
-    private fun createTable(name: Name, file: File): Table = when (file.extension) {
+    private fun createTable(name: Name, file: File): Table = when (file.extension.lowercase()) {
         "parquet" -> ParquetTable(name, file)
         else -> LazyTable(name, file, loader)
     }

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyTable.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyTable.kt
@@ -12,7 +12,7 @@ import java.io.File
  */
 internal open class LazyTable(
     private val name: Name,
-    private val file: File,
+    protected val file: File,
     private val loader: (File) -> Datum,
 ) : Table {
 

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyTable.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyTable.kt
@@ -10,7 +10,7 @@ import java.io.File
  * A table that lazily loads its data from a file on first access to [getDatum].
  * Only the file path is stored at construction time; the file is read when data is needed.
  */
-internal class LazyTable(
+internal open class LazyTable(
     private val name: Name,
     private val file: File,
     private val loader: (File) -> Datum,
@@ -21,7 +21,7 @@ internal class LazyTable(
 
     override fun getName(): Name = name
 
-    // TODO: Infer schema from file metadata (e.g., CSV headers, Parquet footer) without consuming the lazy iterator.
+    // TODO: Infer schema from file metadata without consuming the lazy iterator.
     override fun getSchema(): PType = PType.dynamic()
 
     override fun getDatum(): Datum {

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyTable.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/LazyTable.kt
@@ -1,0 +1,33 @@
+package org.partiql.cli.io
+
+import org.partiql.spi.catalog.Name
+import org.partiql.spi.catalog.Table
+import org.partiql.spi.types.PType
+import org.partiql.spi.value.Datum
+import java.io.File
+
+/**
+ * A table that lazily loads its data from a file on first access to [getDatum].
+ * Only the file path is stored at construction time; the file is read when data is needed.
+ */
+internal class LazyTable(
+    private val name: Name,
+    private val file: File,
+    private val loader: (File) -> Datum,
+) : Table {
+
+    @Volatile
+    private var cached: Datum? = null
+
+    override fun getName(): Name = name
+
+    // TODO: Infer schema from file metadata (e.g., CSV headers, Parquet footer) without consuming the lazy iterator.
+    override fun getSchema(): PType = PType.dynamic()
+
+    override fun getDatum(): Datum {
+        if (cached == null) {
+            cached = loader(file)
+        }
+        return cached!!
+    }
+}

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/ParquetTable.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/ParquetTable.kt
@@ -1,0 +1,107 @@
+package org.partiql.cli.io
+
+import org.apache.parquet.example.data.simple.SimpleGroup
+import org.apache.parquet.example.data.simple.convert.GroupRecordConverter
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.io.ColumnIOFactory
+import org.apache.parquet.io.LocalInputFile
+import org.apache.parquet.schema.LogicalTypeAnnotation
+import org.apache.parquet.schema.MessageType
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
+import org.partiql.spi.catalog.Name
+import org.partiql.spi.catalog.Table
+import org.partiql.spi.types.PType
+import org.partiql.spi.types.PTypeField
+import org.partiql.spi.value.Datum
+import org.partiql.spi.value.Field
+import java.io.File
+import java.math.BigDecimal
+import java.math.BigInteger
+
+/**
+ * A [Table] backed by a Parquet file. Reads only the footer at construction time
+ * to extract schema. Data is streamed Row Group by Row Group on iteration.
+ */
+internal class ParquetTable(
+    private val name: Name,
+    private val file: File,
+) : Table {
+
+    private val inputFile = LocalInputFile(file.toPath())
+    private val footer = ParquetFileReader.open(inputFile).use { it.footer }
+    private val parquetSchema: MessageType = footer.fileMetaData.schema
+
+    override fun getName(): Name = name
+
+    override fun getSchema(): PType {
+        val fields = parquetSchema.fields.map { PTypeField.of(it.name, parquetTypeToPType(it)) }
+        return PType.bag(PType.row(fields))
+    }
+
+    override fun getDatum(): Datum = Datum.bag(Iterable { rowGroupIterator() })
+
+    private fun rowGroupIterator(): Iterator<Datum> = iterator {
+        ParquetFileReader.open(inputFile).use { reader ->
+            var store = reader.readNextRowGroup()
+            while (store != null) {
+                val columnIO = ColumnIOFactory().getColumnIO(parquetSchema)
+                val recordReader = columnIO.getRecordReader(store, GroupRecordConverter(parquetSchema))
+                for (i in 0 until store.rowCount) {
+                    yield(groupToDatum(recordReader.read() as SimpleGroup, parquetSchema))
+                }
+                store = reader.readNextRowGroup()
+            }
+        }
+    }
+
+    private fun groupToDatum(group: SimpleGroup, schema: MessageType): Datum {
+        val fields = (0 until schema.fieldCount).map { i ->
+            val value = if (group.getFieldRepetitionCount(i) == 0) Datum.nullValue()
+            else convertValue(group, i, schema.getType(i))
+            Field.of(schema.getFieldName(i), value)
+        }
+        return Datum.struct(fields)
+    }
+
+    private fun convertValue(group: SimpleGroup, i: Int, type: org.apache.parquet.schema.Type): Datum {
+        if (!type.isPrimitive) {
+            return groupToDatum(group.getGroup(i, 0) as SimpleGroup, type.asGroupType() as MessageType)
+        }
+        val pt = type.asPrimitiveType()
+        val logical = pt.logicalTypeAnnotation
+        return when (pt.primitiveTypeName) {
+            PrimitiveTypeName.BOOLEAN -> Datum.bool(group.getBoolean(i, 0))
+            PrimitiveTypeName.INT32 -> if (logical is LogicalTypeAnnotation.DateLogicalTypeAnnotation)
+                Datum.date(java.time.LocalDate.ofEpochDay(group.getInteger(i, 0).toLong()))
+            else Datum.integer(group.getInteger(i, 0))
+            PrimitiveTypeName.INT64 -> Datum.bigint(group.getLong(i, 0))
+            PrimitiveTypeName.FLOAT -> Datum.doublePrecision(group.getFloat(i, 0).toDouble())
+            PrimitiveTypeName.DOUBLE -> Datum.doublePrecision(group.getDouble(i, 0))
+            PrimitiveTypeName.BINARY -> if (logical is LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
+                Datum.decimal(BigDecimal(BigInteger(group.getBinary(i, 0).bytes), logical.scale), logical.precision, logical.scale)
+            } else Datum.string(group.getString(i, 0))
+            PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY -> if (logical is LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
+                Datum.decimal(BigDecimal(BigInteger(group.getBinary(i, 0).bytes), logical.scale), logical.precision, logical.scale)
+            } else Datum.string(group.getValueToString(i, 0))
+            else -> Datum.string(group.getValueToString(i, 0))
+        }
+    }
+
+    companion object {
+        fun parquetTypeToPType(type: org.apache.parquet.schema.Type): PType {
+            if (!type.isPrimitive) return PType.struct()
+            val pt = type.asPrimitiveType()
+            val logical = pt.logicalTypeAnnotation
+            return when (pt.primitiveTypeName) {
+                PrimitiveTypeName.BOOLEAN -> PType.bool()
+                PrimitiveTypeName.INT32 -> if (logical is LogicalTypeAnnotation.DateLogicalTypeAnnotation) PType.date() else PType.integer()
+                PrimitiveTypeName.INT64 -> PType.bigint()
+                PrimitiveTypeName.FLOAT, PrimitiveTypeName.DOUBLE -> PType.doublePrecision()
+                PrimitiveTypeName.BINARY, PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY ->
+                    if (logical is LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) PType.decimal(logical.precision, logical.scale)
+                    else PType.string()
+                else -> PType.dynamic()
+            }
+        }
+    }
+}

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/ParquetTable.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/ParquetTable.kt
@@ -19,8 +19,9 @@ internal class ParquetTable(
     file: File,
 ) : LazyTable(name, file, { DatumParquetReader.read(it) }) {
 
-    private val parquetSchema: MessageType =
+    private val parquetSchema: MessageType by lazy {
         ParquetFileReader.open(LocalInputFile(file.toPath())).use { it.footer.fileMetaData.schema }
+    }
 
     override fun getSchema(): PType {
         val fields = parquetSchema.fields.map { PTypeField.of(it.name, parquetTypeToPType(it)) }

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/io/ParquetTable.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/io/ParquetTable.kt
@@ -1,107 +1,53 @@
 package org.partiql.cli.io
 
-import org.apache.parquet.example.data.simple.SimpleGroup
-import org.apache.parquet.example.data.simple.convert.GroupRecordConverter
 import org.apache.parquet.hadoop.ParquetFileReader
-import org.apache.parquet.io.ColumnIOFactory
 import org.apache.parquet.io.LocalInputFile
 import org.apache.parquet.schema.LogicalTypeAnnotation
 import org.apache.parquet.schema.MessageType
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName
 import org.partiql.spi.catalog.Name
-import org.partiql.spi.catalog.Table
 import org.partiql.spi.types.PType
 import org.partiql.spi.types.PTypeField
-import org.partiql.spi.value.Datum
-import org.partiql.spi.value.Field
 import java.io.File
-import java.math.BigDecimal
-import java.math.BigInteger
 
 /**
- * A [Table] backed by a Parquet file. Reads only the footer at construction time
- * to extract schema. Data is streamed Row Group by Row Group on iteration.
+ * A [LazyTable] backed by a Parquet file. Reads only the footer at construction time
+ * to extract schema. Data reading is delegated to [DatumParquetReader].
  */
 internal class ParquetTable(
-    private val name: Name,
-    private val file: File,
-) : Table {
+    name: Name,
+    file: File,
+) : LazyTable(name, file, { DatumParquetReader.read(it) }) {
 
-    private val inputFile = LocalInputFile(file.toPath())
-    private val footer = ParquetFileReader.open(inputFile).use { it.footer }
-    private val parquetSchema: MessageType = footer.fileMetaData.schema
-
-    override fun getName(): Name = name
+    private val parquetSchema: MessageType =
+        ParquetFileReader.open(LocalInputFile(file.toPath())).use { it.footer.fileMetaData.schema }
 
     override fun getSchema(): PType {
         val fields = parquetSchema.fields.map { PTypeField.of(it.name, parquetTypeToPType(it)) }
         return PType.bag(PType.row(fields))
     }
 
-    override fun getDatum(): Datum = Datum.bag(Iterable { rowGroupIterator() })
-
-    private fun rowGroupIterator(): Iterator<Datum> = iterator {
-        ParquetFileReader.open(inputFile).use { reader ->
-            var store = reader.readNextRowGroup()
-            while (store != null) {
-                val columnIO = ColumnIOFactory().getColumnIO(parquetSchema)
-                val recordReader = columnIO.getRecordReader(store, GroupRecordConverter(parquetSchema))
-                for (i in 0 until store.rowCount) {
-                    yield(groupToDatum(recordReader.read() as SimpleGroup, parquetSchema))
-                }
-                store = reader.readNextRowGroup()
-            }
-        }
-    }
-
-    private fun groupToDatum(group: SimpleGroup, schema: MessageType): Datum {
-        val fields = (0 until schema.fieldCount).map { i ->
-            val value = if (group.getFieldRepetitionCount(i) == 0) Datum.nullValue()
-            else convertValue(group, i, schema.getType(i))
-            Field.of(schema.getFieldName(i), value)
-        }
-        return Datum.struct(fields)
-    }
-
-    private fun convertValue(group: SimpleGroup, i: Int, type: org.apache.parquet.schema.Type): Datum {
-        if (!type.isPrimitive) {
-            return groupToDatum(group.getGroup(i, 0) as SimpleGroup, type.asGroupType() as MessageType)
-        }
+    private fun parquetTypeToPType(type: org.apache.parquet.schema.Type): PType {
+        if (!type.isPrimitive) return PType.struct()
         val pt = type.asPrimitiveType()
         val logical = pt.logicalTypeAnnotation
         return when (pt.primitiveTypeName) {
-            PrimitiveTypeName.BOOLEAN -> Datum.bool(group.getBoolean(i, 0))
-            PrimitiveTypeName.INT32 -> if (logical is LogicalTypeAnnotation.DateLogicalTypeAnnotation)
-                Datum.date(java.time.LocalDate.ofEpochDay(group.getInteger(i, 0).toLong()))
-            else Datum.integer(group.getInteger(i, 0))
-            PrimitiveTypeName.INT64 -> Datum.bigint(group.getLong(i, 0))
-            PrimitiveTypeName.FLOAT -> Datum.doublePrecision(group.getFloat(i, 0).toDouble())
-            PrimitiveTypeName.DOUBLE -> Datum.doublePrecision(group.getDouble(i, 0))
-            PrimitiveTypeName.BINARY -> if (logical is LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
-                Datum.decimal(BigDecimal(BigInteger(group.getBinary(i, 0).bytes), logical.scale), logical.precision, logical.scale)
-            } else Datum.string(group.getString(i, 0))
-            PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY -> if (logical is LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
-                Datum.decimal(BigDecimal(BigInteger(group.getBinary(i, 0).bytes), logical.scale), logical.precision, logical.scale)
-            } else Datum.string(group.getValueToString(i, 0))
-            else -> Datum.string(group.getValueToString(i, 0))
-        }
-    }
-
-    companion object {
-        fun parquetTypeToPType(type: org.apache.parquet.schema.Type): PType {
-            if (!type.isPrimitive) return PType.struct()
-            val pt = type.asPrimitiveType()
-            val logical = pt.logicalTypeAnnotation
-            return when (pt.primitiveTypeName) {
-                PrimitiveTypeName.BOOLEAN -> PType.bool()
-                PrimitiveTypeName.INT32 -> if (logical is LogicalTypeAnnotation.DateLogicalTypeAnnotation) PType.date() else PType.integer()
-                PrimitiveTypeName.INT64 -> PType.bigint()
-                PrimitiveTypeName.FLOAT, PrimitiveTypeName.DOUBLE -> PType.doublePrecision()
-                PrimitiveTypeName.BINARY, PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY ->
-                    if (logical is LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) PType.decimal(logical.precision, logical.scale)
-                    else PType.string()
-                else -> PType.dynamic()
-            }
+            PrimitiveTypeName.BOOLEAN -> PType.bool()
+            PrimitiveTypeName.INT32 ->
+                if (logical is LogicalTypeAnnotation.DateLogicalTypeAnnotation) {
+                    PType.date()
+                } else {
+                    PType.integer()
+                }
+            PrimitiveTypeName.INT64 -> PType.bigint()
+            PrimitiveTypeName.FLOAT, PrimitiveTypeName.DOUBLE -> PType.doublePrecision()
+            PrimitiveTypeName.BINARY, PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY ->
+                if (logical is LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
+                    PType.decimal(logical.precision, logical.scale)
+                } else {
+                    PType.string()
+                }
+            else -> PType.dynamic()
         }
     }
 }

--- a/partiql-cli/src/main/resources/log4j.properties
+++ b/partiql-cli/src/main/resources/log4j.properties
@@ -1,0 +1,1 @@
+log4j.rootLogger=OFF


### PR DESCRIPTION
## Description
- Add multi-format file (Parquet/CSV/TSV/Ion/JSON) support for the --dir CLI option using lazy iterators instead of loading entire files into memory

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**: NO
- Any backward-incompatible changes? **[YES/NO]**: NO
- Any new external dependencies? **[YES/NO]**: YES
   -  parquet-hadoop 1.14.1, hadoop-common 3.3.6 (with exclusions), hadoop-mapreduce-client-core 3.3.6 — required by Parquet Java for reading .parquet files.
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES/NO]**: YES

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md