### PR TITLE
fix: avoid unnecessary path key expr in set operations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
 # Ignore custom ktlint rules for tests
 [**/test/**.kt]
 disabled_rules = custom-ktlint-rules:top-level-internal,custom-ktlint-rules:top-level-public
+
+[partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/RelaxedSetOpTypeMatchingTest.kt]
+disabled_rules = indent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Thank you to all who have contributed!
 
 ### Fixed
 - Fixed path expression on missing field causing errors in permissive mode instead of returning MISSING
+- Fixed extraneous struct materialization in plan when `UNION/INTERSECT/EXCEPT` requires type coercion
 
 ### Removed
 
@@ -40,6 +41,7 @@ Thank you to all who have contributed!
 
 ### Contributors
 Thank you to all who have contributed!
+- @austnwil
 
 ## [1.3.10](https://github.com/partiql/partiql-lang-kotlin/releases/tag/v1.3.10) - 2026-04-01
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -568,11 +568,25 @@ internal class PlanTyper(private val env: Env, config: Context, private val flag
             val structFields = targetFields.mapIndexed { i, targetField ->
                 val sourceField = sourceFields[i]
                 val key = Rex(CompilerType(PType.string()), Rex.Op.Lit(Datum.string(targetField.name)))
-                val extracted = Rex(CompilerType(sourceField.type), rexOpPathKey(rex, key))
+                val extracted = extractRowMember(i, sourceField, targetField, rex)
                 val coerced = coerceRex(extracted, targetField.type.toCType())
                 rexOpStructField(key, coerced)
             }
             return Rex(targetType, rexOpStruct(structFields))
+        }
+
+        /**
+         * Extract the [Rex] representing member at [index] from ROW-typed [sourceRow]. For simple ROWs where op is a
+         * [Rex.Op.Struct], the [Rex] is extracted directly from the struct. In other cases, a [Rex.Op.Path.Key] is
+         * created that resolves to the member.
+         */
+        private fun extractRowMember(index: Int, sourceField: CompilerType.PTypeField, targetField: CompilerType.PTypeField, sourceRow: Rex): Rex {
+            if (sourceRow.op is Rex.Op.Struct) {
+                return sourceRow.op.fields[index].v
+            }
+
+            val key = Rex(CompilerType(PType.string()), Rex.Op.Lit(Datum.string(targetField.name)))
+            return Rex(CompilerType(sourceField.type), rexOpPathKey(sourceRow, key))
         }
 
         /**

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/AssertingEquivalenceOperatorVisitor.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/AssertingEquivalenceOperatorVisitor.kt
@@ -1,0 +1,181 @@
+package org.partiql.planner
+
+import org.partiql.plan.Operator
+import org.partiql.plan.OperatorVisitor
+import org.partiql.plan.rel.RelAggregate
+import org.partiql.plan.rel.RelCorrelate
+import org.partiql.plan.rel.RelDistinct
+import org.partiql.plan.rel.RelExcept
+import org.partiql.plan.rel.RelExclude
+import org.partiql.plan.rel.RelFilter
+import org.partiql.plan.rel.RelIntersect
+import org.partiql.plan.rel.RelIterate
+import org.partiql.plan.rel.RelJoin
+import org.partiql.plan.rel.RelLimit
+import org.partiql.plan.rel.RelOffset
+import org.partiql.plan.rel.RelProject
+import org.partiql.plan.rel.RelScan
+import org.partiql.plan.rel.RelSort
+import org.partiql.plan.rel.RelUnion
+import org.partiql.plan.rel.RelUnpivot
+import org.partiql.plan.rex.Rex
+import org.partiql.plan.rex.RexArray
+import org.partiql.plan.rex.RexBag
+import org.partiql.plan.rex.RexCall
+import org.partiql.plan.rex.RexCase
+import org.partiql.plan.rex.RexCast
+import org.partiql.plan.rex.RexCoalesce
+import org.partiql.plan.rex.RexDispatch
+import org.partiql.plan.rex.RexError
+import org.partiql.plan.rex.RexLit
+import org.partiql.plan.rex.RexNullIf
+import org.partiql.plan.rex.RexPathIndex
+import org.partiql.plan.rex.RexPathKey
+import org.partiql.plan.rex.RexPathSymbol
+import org.partiql.plan.rex.RexPivot
+import org.partiql.plan.rex.RexSelect
+import org.partiql.plan.rex.RexSpread
+import org.partiql.plan.rex.RexStruct
+import org.partiql.plan.rex.RexSubquery
+import org.partiql.plan.rex.RexSubqueryComp
+import org.partiql.plan.rex.RexSubqueryIn
+import org.partiql.plan.rex.RexSubqueryTest
+import org.partiql.plan.rex.RexTable
+import org.partiql.plan.rex.RexVar
+import org.partiql.spi.value.Datum
+import kotlin.test.assertEquals
+
+/**
+ * Asserts structural equivalence of two operator trees.
+ *
+ * Implemented visitors assert and return Unit. Unimplemented visitors throw [NotImplementedError].
+ *
+ * TODO: Implement remaining visitors as needed.
+ */
+internal object AssertingEquivalenceOperatorVisitor : OperatorVisitor<Unit, Any> {
+
+    fun assertEquals(a: Rex, b: Rex) = a.accept(this, b)
+
+    override fun defaultReturn(operator: Operator, other: Any) {
+        throw NotImplementedError("Equivalence not implemented for ${operator::class.java.name}")
+    }
+
+    // --- Rel visitors ---
+
+    override fun visitAggregate(rel: RelAggregate, other: Any) = defaultReturn(rel, other)
+    override fun visitCorrelate(rel: RelCorrelate, other: Any) = defaultReturn(rel, other)
+    override fun visitDistinct(rel: RelDistinct, other: Any) = defaultReturn(rel, other)
+    override fun visitExclude(rel: RelExclude, other: Any) = defaultReturn(rel, other)
+    override fun visitFilter(rel: RelFilter, other: Any) = defaultReturn(rel, other)
+    override fun visitIterate(rel: RelIterate, other: Any) = defaultReturn(rel, other)
+    override fun visitJoin(rel: RelJoin, other: Any) = defaultReturn(rel, other)
+    override fun visitLimit(rel: RelLimit, other: Any) = defaultReturn(rel, other)
+    override fun visitOffset(rel: RelOffset, other: Any) = defaultReturn(rel, other)
+    override fun visitScan(rel: RelScan, other: Any) = defaultReturn(rel, other)
+    override fun visitSort(rel: RelSort, other: Any) = defaultReturn(rel, other)
+    override fun visitUnpivot(rel: RelUnpivot, other: Any) = defaultReturn(rel, other)
+
+    override fun visitExcept(rel: RelExcept, other: Any) {
+        assert(other is RelExcept) { "Expected RelExcept, got ${other::class.java.name}" }
+        other as RelExcept
+        assertEquals(rel.isAll, other.isAll, "RelExcept.isAll mismatch")
+        rel.left.accept(this, other.left)
+        rel.right.accept(this, other.right)
+    }
+
+    override fun visitIntersect(rel: RelIntersect, other: Any) {
+        assert(other is RelIntersect) { "Expected RelIntersect, got ${other::class.java.name}" }
+        other as RelIntersect
+        assertEquals(rel.isAll, other.isAll, "RelIntersect.isAll mismatch")
+        rel.left.accept(this, other.left)
+        rel.right.accept(this, other.right)
+    }
+
+    override fun visitProject(rel: RelProject, other: Any) {
+        assert(other is RelProject) { "Expected RelProject, got ${other::class.java.name}" }
+        other as RelProject
+        assertEquals(rel.projections.size, other.projections.size, "RelProject projection count mismatch")
+        rel.input.accept(this, other.input)
+        rel.projections.zip(other.projections).forEach { (a, b) -> a.accept(this, b) }
+    }
+
+    override fun visitUnion(rel: RelUnion, other: Any) {
+        assert(other is RelUnion) { "Expected RelUnion, got ${other::class.java.name}" }
+        other as RelUnion
+        assertEquals(rel.isAll, other.isAll, "RelUnion.isAll mismatch")
+        rel.left.accept(this, other.left)
+        rel.right.accept(this, other.right)
+    }
+
+    // --- Rex visitors ---
+
+    override fun visitArray(rex: RexArray, other: Any) = defaultReturn(rex, other)
+    override fun visitCall(rex: RexCall, other: Any) = defaultReturn(rex, other)
+    override fun visitCase(rex: RexCase, other: Any) = defaultReturn(rex, other)
+    override fun visitCoalesce(rex: RexCoalesce, other: Any) = defaultReturn(rex, other)
+    override fun visitDispatch(rex: RexDispatch, other: Any) = defaultReturn(rex, other)
+    override fun visitError(rex: RexError, other: Any) = defaultReturn(rex, other)
+    override fun visitNullIf(rex: RexNullIf, other: Any) = defaultReturn(rex, other)
+    override fun visitPathIndex(rex: RexPathIndex, other: Any) = defaultReturn(rex, other)
+    override fun visitPathSymbol(rex: RexPathSymbol, other: Any) = defaultReturn(rex, other)
+    override fun visitPivot(rex: RexPivot, other: Any) = defaultReturn(rex, other)
+    override fun visitSpread(rex: RexSpread, other: Any) = defaultReturn(rex, other)
+    override fun visitSubquery(rex: RexSubquery, other: Any) = defaultReturn(rex, other)
+    override fun visitSubqueryComp(rex: RexSubqueryComp, other: Any) = defaultReturn(rex, other)
+    override fun visitSubqueryIn(rex: RexSubqueryIn, other: Any) = defaultReturn(rex, other)
+    override fun visitSubqueryTest(rex: RexSubqueryTest, other: Any) = defaultReturn(rex, other)
+    override fun visitTable(rex: RexTable, other: Any) = defaultReturn(rex, other)
+
+    override fun visitPathKey(rex: RexPathKey, other: Any) {
+        assert(other is RexPathKey) { "Expected RexPathKey, got ${other::class.java.name}" }
+        other as RexPathKey
+        rex.operand.accept(this, other.operand)
+        rex.key.accept(this, other.key)
+    }
+
+    override fun visitVar(rex: RexVar, other: Any) {
+        assert(other is RexVar) { "Expected RexVar, got ${other::class.java.name}" }
+        other as RexVar
+        assertEquals(rex.scope, other.scope, "RexVar.scope mismatch")
+        assertEquals(rex.offset, other.offset, "RexVar.offset mismatch")
+    }
+
+    override fun visitCast(rex: RexCast, other: Any) {
+        assert(other is RexCast) { "Expected RexCast, got ${other::class.java.name}" }
+        other as RexCast
+        assertEquals(rex.target, other.target, "RexCast.target mismatch")
+        rex.operand.accept(this, other.operand)
+    }
+
+    override fun visitLit(rex: RexLit, other: Any) {
+        assert(other is RexLit) { "Expected RexLit, got ${other::class.java.name}" }
+        other as RexLit
+        assertEquals(0, Datum.comparator().compare(rex.datum, other.datum), "RexLit datum mismatch")
+    }
+
+    override fun visitSelect(rex: RexSelect, other: Any) {
+        assert(other is RexSelect) { "Expected RexSelect, got ${other::class.java.name}" }
+        other as RexSelect
+        rex.input.accept(this, other.input)
+        rex.constructor.accept(this, other.constructor)
+    }
+
+    override fun visitStruct(rex: RexStruct, other: Any) {
+        assert(other is RexStruct) { "Expected RexStruct, got ${other::class.java.name}" }
+        other as RexStruct
+        assertEquals(rex.fields.size, other.fields.size, "RexStruct field count mismatch")
+        rex.fields.zip(other.fields).forEach { (a, b) ->
+            a.key.accept(this, b.key)
+            a.value.accept(this, b.value)
+        }
+    }
+
+    override fun visitBag(rex: RexBag, other: Any) {
+        assert(other is RexBag) { "Expected RexBag, got ${other::class.java.name}" }
+        other as RexBag
+        val a = rex.values.toList()
+        val b = other.values.toList()
+        assertEquals(a.size, b.size, "RexBag size mismatch")
+        a.zip(b).forEach { (x, y) -> x.accept(this, y) }
+    }
+}

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/RelaxedSetOpTypeMatchingTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/RelaxedSetOpTypeMatchingTest.kt
@@ -1,0 +1,344 @@
+package org.partiql.planner.internal.typer
+
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.partiql.parser.PartiQLParser
+import org.partiql.plan.Action
+import org.partiql.plan.Operators
+import org.partiql.plan.Plan
+import org.partiql.plan.rel.Rel
+import org.partiql.plan.rel.RelExcept
+import org.partiql.plan.rel.RelIntersect
+import org.partiql.plan.rel.RelProject
+import org.partiql.plan.rel.RelUnion
+import org.partiql.plan.rex.RexSelect
+import org.partiql.plan.rex.RexStruct
+import org.partiql.planner.AssertingEquivalenceOperatorVisitor
+import org.partiql.planner.PartiQLPlanner
+import org.partiql.planner.plugins.local.LocalCatalog
+import org.partiql.planner.util.PErrorCollector
+import org.partiql.spi.Context
+import org.partiql.spi.catalog.Session
+import org.partiql.spi.types.PType
+import org.partiql.spi.types.PTypeField
+import org.partiql.spi.value.Datum
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlin.io.path.toPath
+
+/**
+ * Asserts that coerceRow's extractRowMember optimization produces direct field references
+ * (RexCast wrapping RexLit/RexVar/etc.) rather than unnecessary RexPathKey nodes when coercing
+ * struct-typed projections in set operations with disjoint but compatible field types.
+ */
+/* ktlint-disable standard:final-newline */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Suppress("ktlint:standard:indent")
+internal class RelaxedSetOpTypeMatchingTest {
+
+    private val root = this::class.java.getResource("/catalogs/default/pql")!!.toURI().toPath()
+    private val ops = Operators.STANDARD
+
+    @ParameterizedTest
+    @MethodSource("allSetOperations")
+    @Suppress("ktlint:standard:indent")
+    fun testDirectSelectDecimalWithBigInt(setOp: String) {
+        val query = """
+            SELECT
+                1.0 AS a
+            FROM << 0 >>
+            
+            $setOp SELECT
+                CAST(1 AS BIGINT) AS a
+            FROM << 0 >>
+        """.trimIndent()
+
+        val expectedLeft = ops.struct(listOf(RexStruct.field(
+            ops.lit(Datum.string("a")),
+            ops.cast(
+                ops.lit(Datum.decimal(BigDecimal.valueOf(1.0), 2, 1)),
+                PType.decimal(20, 1)
+            ),
+        )))
+        val expectedRight = ops.struct(listOf(RexStruct.field(
+            ops.lit(Datum.string("a")),
+            ops.cast(
+                ops.cast(
+                    ops.lit(Datum.integer(1)),
+                    PType.bigint()
+                ),
+                PType.decimal(20, 1)
+            ),
+        )))
+
+        assertSetOpPlan(expectedLeft, expectedRight, query)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allSetOperations")
+    @Suppress("ktlint:standard:indent")
+    fun testDirectSelectMultiMismatch(setOp: String) {
+        val query = """
+            SELECT
+                CAST(1 AS BIGINT) AS a,
+                DATE '2024-01-01' AS b,
+                15 AS c
+            FROM << 0 >>
+            
+            $setOp SELECT
+                47.5 AS a,
+                TIMESTAMP '2024-01-01 00:00:00' AS b,
+                CAST(0 AS BIGINT) AS c
+            FROM << 0 >>
+        """.trimIndent()
+
+        val expectedLeft = ops.struct(listOf(RexStruct.field(
+            ops.lit(Datum.string("a")),
+            ops.cast(
+                ops.cast(
+                    ops.lit(Datum.integer(1)),
+                    PType.bigint()
+                ),
+                PType.decimal(20, 1)
+            ),
+        ), RexStruct.field(
+            ops.lit(Datum.string("b")),
+            ops.cast(
+                ops.lit(Datum.date(LocalDate.parse("2024-01-01"))),
+                PType.timestamp(6)
+            ),
+        ), RexStruct.field(
+            ops.lit(Datum.string("c")),
+            ops.cast(
+                ops.lit(Datum.integer(15)),
+                PType.bigint()
+            ),
+        )))
+        val expectedRight = ops.struct(listOf(RexStruct.field(
+            ops.lit(Datum.string("a")),
+            ops.cast(
+                ops.lit(Datum.decimal(BigDecimal.valueOf(47.5), 3, 1)),
+                PType.decimal(20, 1)
+            ),
+        ), RexStruct.field(
+            ops.lit(Datum.string("b")),
+            ops.lit(Datum.timestamp(LocalDateTime.parse("2024-01-01T00:00:00"), 6)),
+        ), RexStruct.field(
+            ops.lit(Datum.string("c")),
+            ops.cast(
+                ops.lit(Datum.integer(0)),
+                PType.bigint()
+            ),
+        )))
+
+        assertSetOpPlan(expectedLeft, expectedRight, query)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allSetOperations")
+    @Suppress("ktlint:standard:indent")
+    fun testDirectSelectBag(setOp: String) {
+        val query = """
+            SELECT
+                << CAST(1 AS BIGINT) >> AS a
+            FROM << 0 >>
+            
+            $setOp SELECT
+                << 1.5 >> AS a
+            FROM << 0 >>
+        """.trimIndent()
+
+        val expectedLeft = ops.struct(listOf(RexStruct.field(
+            ops.lit(Datum.string("a")),
+            ops.cast(
+                ops.bag(listOf(
+                    ops.cast(
+                        ops.lit(Datum.integer(1)),
+                        PType.bigint()
+                    )
+                )),
+                PType.bag(PType.decimal(20, 1))
+            ),
+        )))
+        val expectedRight = ops.struct(listOf(RexStruct.field(
+            ops.lit(Datum.string("a")),
+            ops.cast(
+                ops.bag(listOf(
+                    ops.lit(Datum.decimal(BigDecimal.valueOf(1.5), 2, 1))
+                )),
+                PType.bag(PType.decimal(20, 1))
+            ),
+        )))
+
+        assertSetOpPlan(expectedLeft, expectedRight, query)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allSetOperations")
+    @Suppress("ktlint:standard:indent")
+    fun testDirectSelectStruct(setOp: String) {
+        val query = """
+            SELECT
+                { 'foo': CAST(1 AS BIGINT) } AS a
+            FROM << 0 >>
+            
+            $setOp SELECT
+                { 'foo': 1.5 } AS a
+            FROM << 0 >>
+        """.trimIndent()
+
+        // The struct gets its members unpacked, casted, and re-assembled, rather than
+        // the entire struct getting a path key expr on it for each field.
+        val expectedLeft = ops.struct(listOf(RexStruct.field(
+            ops.lit(Datum.string("a")),
+            ops.struct(listOf(RexStruct.field(
+                ops.lit(Datum.string("foo")),
+                ops.cast(
+                    ops.cast(
+                        ops.lit(Datum.integer(1)),
+                        PType.bigint()
+                    ),
+                    PType.decimal(20, 1)
+                ),
+            )))
+        )))
+        val expectedRight = ops.struct(listOf(RexStruct.field(
+            ops.lit(Datum.string("a")),
+            ops.struct(listOf(RexStruct.field(
+                ops.lit(Datum.string("foo")),
+                ops.cast(
+                    ops.lit(Datum.decimal(BigDecimal.valueOf(1.5), 2, 1)),
+                    PType.decimal(20, 1)
+                ),
+            )))
+        )))
+
+        assertSetOpPlan(expectedLeft, expectedRight, query)
+    }
+
+    @ParameterizedTest
+    @MethodSource("allSetOperations")
+    @Suppress("ktlint:standard:indent")
+    fun testSelectStructValuedExpression(setOp: String) {
+        val query = """
+            SELECT
+                the_struct AS a
+            FROM << { 'the_struct': { 'foo': CAST(1 AS BIGINT) } } >>
+            
+            $setOp SELECT
+                the_struct AS a
+            FROM << { 'the_struct': { 'foo': 1.5 } } >>
+        """.trimIndent()
+
+        // For row-typed expressions that cannot be unpacked, planner generates
+        // path key expression with the appropriate cast. E.g.
+        // { foo: CAST(<...>.the_struct.foo AS ...) }
+        val expectedLeft = ops.struct(listOf(RexStruct.field(
+            ops.lit(Datum.string("a")),
+            ops.struct(listOf(RexStruct.field(
+                ops.lit(Datum.string("foo")),
+                ops.cast(
+                    ops.pathKey(
+                        ops.pathKey(
+                            ops.variable(
+                                0, 0,
+                                PType.row(PTypeField.of(
+                                    "the_struct",
+                                    PType.row(PTypeField.of("foo", PType.bigint())))
+                                )
+                            ),
+                            ops.lit(Datum.string("the_struct"))
+                        ),
+                        ops.lit(Datum.string("foo"))
+                    ),
+                    PType.decimal(20, 1)
+                ),
+            )))
+        )))
+        val expectedRight = ops.struct(listOf(RexStruct.field(
+            ops.lit(Datum.string("a")),
+            ops.struct(listOf(RexStruct.field(
+                ops.lit(Datum.string("foo")),
+                ops.cast(
+                    ops.pathKey(
+                        ops.pathKey(
+                            ops.variable(
+                                0, 0,
+                                PType.row(PTypeField.of(
+                                    "the_struct",
+                                    PType.row(PTypeField.of("foo", PType.decimal(2, 1))))
+                                )
+                            ),
+                            ops.lit(Datum.string("the_struct"))
+                        ),
+                        ops.lit(Datum.string("foo"))
+                    ),
+                    PType.decimal(20, 1)
+                ),
+            )))
+        )))
+
+        assertSetOpPlan(expectedLeft, expectedRight, query)
+    }
+
+    private fun assertSetOpPlan(expectedLeft: RexStruct, expectedRight: RexStruct, query: String) {
+        val plan = plan(query)
+        val action = plan.action as Action.Query
+
+        val leftFields = (action.rex as RexSelect).input.left().projections.single() as RexStruct
+        val rightFields = (action.rex as RexSelect).input.right().projections.single() as RexStruct
+
+        AssertingEquivalenceOperatorVisitor.assertEquals(expectedLeft, leftFields)
+        AssertingEquivalenceOperatorVisitor.assertEquals(expectedRight, rightFields)
+    }
+
+    private fun Rel.left(): RelProject {
+        return when (this) {
+            is RelUnion -> this.left
+            is RelIntersect -> this.left
+            is RelExcept -> this.left
+            else -> throw IllegalArgumentException("Expected a set operation, got ${this::class.java.name}")
+        } as RelProject
+    }
+
+    private fun Rel.right(): RelProject {
+        return when (this) {
+            is RelUnion -> this.right
+            is RelIntersect -> this.right
+            is RelExcept -> this.right
+            else -> throw IllegalArgumentException("Expected a set operation, got ${this::class.java.name}")
+        } as RelProject
+    }
+
+    private fun plan(query: String): Plan {
+        val parser = PartiQLParser.standard()
+        val planner = PartiQLPlanner.standard()
+        val session = Session.builder()
+            .catalog("pql")
+            .namespace("main")
+            .catalogs(
+                LocalCatalog.builder()
+                    .name("pql")
+                    .root(root)
+                    .build()
+            )
+            .build()
+        val ast = parser.parse(query).statements[0]
+        val collector = PErrorCollector()
+        return planner.plan(ast, session, Context.of(collector)).plan
+    }
+
+    private fun allSetOperations(): List<String> {
+        // NOTE: OUTER UNION/EXCEPT/INTERSECT not supported
+        return listOf(
+            "UNION ALL",
+            "UNION DISTINCT",
+            "EXCEPT ALL",
+            "EXCEPT DISTINCT",
+            "INTERSECT ALL",
+            "INTERSECT DISTINCT",
+        )
+    }
+}


### PR DESCRIPTION
## Description
Avoid emitting unnecessary path key expressions when coercing rows to common supertype during set operations.

If a `UNION/EXCEPT/INTERSECT SELECT` uses columns of distinct but compatible types, we currently cast each field in the struct backing the projection to common supertype by wrapping a path key expression on the struct in a `CAST(...)`. For row expressions where op is a struct, this creates fields like so:

```
CAST({ foo: ..., bar: ... }.foo AS ...), CAST({ foo: ..., bar: ... }.bar AS ...)
```

This is unnecessary for literal structs; we can avoid repeatedly materializing the struct and extract/cast the field directly. For row-valued expressions that are not literal structs (e.g. a variable), we still use the path key expr. to extract each key and perform the cast.

This fixes transpilation issues in Scribe where a set operation on non-identically typed columns can cause unexpected struct literals to appear in transpiled output.

## Scribe Testing

Added the following PartiQL -> Trino tests in Scribe:

```sql
-- Input

-- No column aliases
--#[setop-06]
SELECT col_int32, col_timestamp, col_float64 FROM T_ALL_TYPES AS t1 UNION SELECT col_int64, col_date, col_decimal FROM T_ALL_TYPES AS t2;

-- Explicit column aliases
--#[setop-07]
SELECT col_int32 AS a, col_timestamp AS b, col_float64 AS c FROM T_ALL_TYPES AS t1 UNION SELECT col_int64 AS a, col_date AS b, col_decimal AS c FROM T_ALL_TYPES AS t2;

-- Expected

--#[setop-06]
(SELECT CAST("t1"."col_int32" AS BIGINT) AS "_", "t1"."col_timestamp" AS "_", "t1"."col_float64" AS "_" FROM "default"."T_ALL_TYPES" AS "t1") UNION DISTINCT (SELECT "t2"."col_int64" AS "_", CAST("t2"."col_date" AS TIMESTAMP) AS "_", CAST("t2"."col_decimal" AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t2");

--#[setop-07]
(SELECT CAST("t1"."col_int32" AS BIGINT) AS "a", "t1"."col_timestamp" AS "b", "t1"."col_float64" AS "c" FROM "default"."T_ALL_TYPES" AS "t1") UNION DISTINCT (SELECT "t2"."col_int64" AS "a", CAST("t2"."col_date" AS TIMESTAMP) AS "b", CAST("t2"."col_decimal" AS DOUBLE) AS "c" FROM "default"."T_ALL_TYPES" AS "t2");
```

Tests fail without this change, and pass with it:

```
TrinoTargetSuite > factory() > basics > setop > org.partiql.scribe.targets.trino.TrinoTargetSuite.basics__setop-06 FAILED
    java.lang.AssertionError: 
    Expect: "(SELECT CAST("t1"."col_int32" AS BIGINT) AS "_", "t1"."col_timestamp" AS "_", "t1"."col_float64" AS "_" FROM "default"."T_ALL_TYPES" AS "t1") UNION DISTINCT (SELECT "t2"."col_int64" AS "_", CAST("t2"."col_date" AS TIMESTAMP) AS "_", CAST("t2"."col_decimal" AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t2")"
    Actual: "(SELECT CAST({'col_int32': "t1"."col_int32", 'col_timestamp': "t1"."col_timestamp", 'col_float64': "t1"."col_float64"}."_" AS BIGINT) AS "_", {'col_int32': "t1"."col_int32", 'col_timestamp': "t1"."col_timestamp", 'col_float64': "t1"."col_float64"}."_" AS "_", {'col_int32': "t1"."col_int32", 'col_timestamp': "t1"."col_timestamp", 'col_float64': "t1"."col_float64"}."_" AS "_" FROM "default"."T_ALL_TYPES" AS "t1") UNION DISTINCT (SELECT {'col_int64': "t2"."col_int64", 'col_date': "t2"."col_date", 'col_decimal': "t2"."col_decimal"}."_" AS "_", CAST({'col_int64': "t2"."col_int64", 'col_date': "t2"."col_date", 'col_decimal': "t2"."col_decimal"}."_" AS TIMESTAMP) AS "_", CAST({'col_int64': "t2"."col_int64", 'col_date': "t2"."col_date", 'col_decimal': "t2"."col_decimal"}."_" AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t2")"

    Input Query: --#[setop-06]
    SELECT col_int32, col_timestamp, col_float64 FROM T_ALL_TYPES AS t1 UNION SELECT col_int64, col_date, col_decimal FROM T_ALL_TYPES AS t2;

    Expected result: --#[setop-06]
    (SELECT CAST("t1"."col_int32" AS BIGINT) AS "_", "t1"."col_timestamp" AS "_", "t1"."col_float64" AS "_" FROM "default"."T_ALL_TYPES" AS "t1") UNION DISTINCT (SELECT "t2"."col_int64" AS "_", CAST("t2"."col_date" AS TIMESTAMP) AS "_", CAST("t2"."col_decimal" AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t2");

    Actual result: (SELECT CAST({'col_int32': "t1"."col_int32", 'col_timestamp': "t1"."col_timestamp", 'col_float64': "t1"."col_float64"}."_" AS BIGINT) AS "_", {'col_int32': "t1"."col_int32", 'col_timestamp': "t1"."col_timestamp", 'col_float64': "t1"."col_float64"}."_" AS "_", {'col_int32': "t1"."col_int32", 'col_timestamp': "t1"."col_timestamp", 'col_float64': "t1"."col_float64"}."_" AS "_" FROM "default"."T_ALL_TYPES" AS "t1") UNION DISTINCT (SELECT {'col_int64': "t2"."col_int64", 'col_date': "t2"."col_date", 'col_decimal': "t2"."col_decimal"}."_" AS "_", CAST({'col_int64': "t2"."col_int64", 'col_date': "t2"."col_date", 'col_decimal': "t2"."col_decimal"}."_" AS TIMESTAMP) AS "_", CAST({'col_int64': "t2"."col_int64", 'col_date': "t2"."col_date", 'col_decimal': "t2"."col_decimal"}."_" AS DOUBLE) AS "_" FROM "default"."T_ALL_TYPES" AS "t2")

TrinoTargetSuite > factory() > basics > setop > org.partiql.scribe.targets.trino.TrinoTargetSuite.basics__setop-07 FAILED
    java.lang.AssertionError: 
    Expect: "(SELECT CAST("t1"."col_int32" AS BIGINT) AS "a", "t1"."col_timestamp" AS "b", "t1"."col_float64" AS "c" FROM "default"."T_ALL_TYPES" AS "t1") UNION DISTINCT (SELECT "t2"."col_int64" AS "a", CAST("t2"."col_date" AS TIMESTAMP) AS "b", CAST("t2"."col_decimal" AS DOUBLE) AS "c" FROM "default"."T_ALL_TYPES" AS "t2")"
    Actual: "(SELECT CAST({'a': "t1"."col_int32", 'b': "t1"."col_timestamp", 'c': "t1"."col_float64"}."a" AS BIGINT) AS "a", {'a': "t1"."col_int32", 'b': "t1"."col_timestamp", 'c': "t1"."col_float64"}."b" AS "b", {'a': "t1"."col_int32", 'b': "t1"."col_timestamp", 'c': "t1"."col_float64"}."c" AS "c" FROM "default"."T_ALL_TYPES" AS "t1") UNION DISTINCT (SELECT {'a': "t2"."col_int64", 'b': "t2"."col_date", 'c': "t2"."col_decimal"}."a" AS "a", CAST({'a': "t2"."col_int64", 'b': "t2"."col_date", 'c': "t2"."col_decimal"}."b" AS TIMESTAMP) AS "b", CAST({'a': "t2"."col_int64", 'b': "t2"."col_date", 'c': "t2"."col_decimal"}."c" AS DOUBLE) AS "c" FROM "default"."T_ALL_TYPES" AS "t2")"

    Input Query: --#[setop-07]
    SELECT col_int32 AS a, col_timestamp AS b, col_float64 AS c FROM T_ALL_TYPES AS t1 UNION SELECT col_int64 AS a, col_date AS b, col_decimal AS c FROM T_ALL_TYPES AS t2;

    Expected result: --#[setop-07]
    (SELECT CAST("t1"."col_int32" AS BIGINT) AS "a", "t1"."col_timestamp" AS "b", "t1"."col_float64" AS "c" FROM "default"."T_ALL_TYPES" AS "t1") UNION DISTINCT (SELECT "t2"."col_int64" AS "a", CAST("t2"."col_date" AS TIMESTAMP) AS "b", CAST("t2"."col_decimal" AS DOUBLE) AS "c" FROM "default"."T_ALL_TYPES" AS "t2");

    Actual result: (SELECT CAST({'a': "t1"."col_int32", 'b': "t1"."col_timestamp", 'c': "t1"."col_float64"}."a" AS BIGINT) AS "a", {'a': "t1"."col_int32", 'b': "t1"."col_timestamp", 'c': "t1"."col_float64"}."b" AS "b", {'a': "t1"."col_int32", 'b': "t1"."col_timestamp", 'c': "t1"."col_float64"}."c" AS "c" FROM "default"."T_ALL_TYPES" AS "t1") UNION DISTINCT (SELECT {'a': "t2"."col_int64", 'b': "t2"."col_date", 'c': "t2"."col_decimal"}."a" AS "a", CAST({'a': "t2"."col_int64", 'b': "t2"."col_date", 'c': "t2"."col_decimal"}."b" AS TIMESTAMP) AS "b", CAST({'a': "t2"."col_int64", 'b': "t2"."col_date", 'c': "t2"."col_decimal"}."c" AS DOUBLE) AS "c" FROM "default"."T_ALL_TYPES" AS "t2")
```

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**: <Explain if NO>
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md