### PR TITLE
route COALESCE and NULLIF to function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Thank you to all who have contributed!
 ### Added
 
 ### Changed
+- Route `NULLIF` and `COALESCE` to standard function call when parsing; 
+this change enables SLL parsing, allowing us to see significant performance improvement when parsing complicated `NULLIF`/`COALESCE` call. 
 
 ### Deprecated
 
@@ -39,6 +41,7 @@ Thank you to all who have contributed!
 
 ### Contributors
 Thank you to all who have contributed!
+- @yliuuuu
 
 ## [1.3.11](https://github.com/partiql/partiql-lang-kotlin/releases/tag/v1.3.11) - 2026-04-21
 

--- a/partiql-parser/src/main/antlr/PartiQLParser.g4
+++ b/partiql-parser/src/main/antlr/PartiQLParser.g4
@@ -951,12 +951,6 @@ exprTerm
     | tuple                          # ExprTermBase
     ;
 
-nullIf
-    : NULLIF PAREN_LEFT expr COMMA expr PAREN_RIGHT;
-
-coalesce
-    : COALESCE PAREN_LEFT expr ( COMMA expr )* PAREN_RIGHT;
-
 caseExpr
     : CASE case=expr? (WHEN whens+=expr THEN thens+=expr)+ (ELSE else=expr)? END;
 

--- a/partiql-parser/src/main/antlr/PartiQLParser.g4
+++ b/partiql-parser/src/main/antlr/PartiQLParser.g4
@@ -880,24 +880,22 @@ valueExpr
 exprPrimary
     : exprTerm                   # ExprPrimaryBase
     | cast                       # ExprPrimaryBase
-    | sequenceConstructor        # ExprPrimaryBase
-    | substring                  # ExprPrimaryBase
-    | position                   # ExprPrimaryBase
-    | overlay                    # ExprPrimaryBase
+    | sequenceConstructor        # ExprPrimaryBase // TODO: Move to function call
+    | substring                  # ExprPrimaryBase // TODO: Move to function call
+    | position                   # ExprPrimaryBase // TODO: Move the standard form to function call
+    | overlay                    # ExprPrimaryBase // TODO: Move the standard form to function call
     | canCast                    # ExprPrimaryBase  // TODO remove ahead of `v1` release
     | canLosslessCast            # ExprPrimaryBase  // TODO remove ahead of `v1` release
     | extract                    # ExprPrimaryBase
-    | coalesce                   # ExprPrimaryBase
     | dateFunction               # ExprPrimaryBase
     | trimFunction               # ExprPrimaryBase
-    | nullIf                     # ExprPrimaryBase
     | functionCall               # ExprPrimaryBase
     | exprPrimary pathStep+      # ExprPrimaryPath
     | exprGraphMatchMany         # ExprPrimaryBase
     | caseExpr                   # ExprPrimaryBase
     | windowFunction             # ExprPrimaryBase
-    | rowValueConstructor        # ExprPrimaryBase
-    | tableValueConstructor      # ExprPrimaryBase
+    | rowValueConstructor        # ExprPrimaryBase // TODO: Move the standard form to function call
+    | tableValueConstructor      # ExprPrimaryBase // TODO: Move to function call
     ;
 
 /**

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -1826,17 +1826,6 @@ internal class PartiQLParserDefault : PartiQLParser {
          *
          */
 
-        override fun visitNullIf(ctx: GeneratedParser.NullIfContext) = translate(ctx) {
-            val v1 = visitExpr(ctx.expr(0))
-            val v2 = visitExpr(ctx.expr(1))
-            exprNullIf(v1, v2)
-        }
-
-        override fun visitCoalesce(ctx: GeneratedParser.CoalesceContext) = translate(ctx) {
-            val expressions = visitOrEmpty<Expr>(ctx.expr())
-            exprCoalesce(expressions)
-        }
-
         override fun visitCaseExpr(ctx: GeneratedParser.CaseExprContext) = translate(ctx) {
             val expr = ctx.case_?.let { visitExpr(it) }
             val branches = ctx.whens.indices.map { i ->
@@ -1897,6 +1886,12 @@ internal class PartiQLParserDefault : PartiQLParser {
                         exprCall(identifier(qualifier = path, identifier = name), args, setq = null)
                     }
                 }
+                GeneratedParser.COALESCE -> exprCoalesce(args)
+                GeneratedParser.NULLIF -> {
+                    if (args.size != 2) throw error(funcName, "NULLIF requires exactly 2 arguments")
+                    exprNullIf(args[0], args[1])
+                }
+
                 else -> exprCall(visitQualifiedName(funcName), args, setq)
             }
         }

--- a/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
+++ b/partiql-parser/src/main/kotlin/org/partiql/parser/internal/PartiQLParserDefault.kt
@@ -1872,7 +1872,7 @@ internal class PartiQLParserDefault : PartiQLParser {
         }
 
         /**
-         * Handles the reserved scalar function names (MOD, CHAR_LENGTH)
+         * Handles the reserved scalar function names (MOD, CHAR_LENGTH, COALESCE, NULLIF)
          */
         private fun exprCallHandleReserved(funcName: QualifiedNameContext, args: List<Expr>, setq: SetQuantifier?): Expr {
             return when (funcName.name.start.type) {

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/ParserTestCaseSLL.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/ParserTestCaseSLL.kt
@@ -1,0 +1,46 @@
+package org.partiql.parser.internal
+
+import org.antlr.v4.runtime.BailErrorStrategy
+import org.antlr.v4.runtime.CharStreams
+import org.antlr.v4.runtime.CommonTokenStream
+import org.antlr.v4.runtime.atn.PredictionMode
+import org.antlr.v4.runtime.misc.ParseCancellationException
+import org.junit.jupiter.api.fail
+import org.partiql.parser.internal.antlr.PartiQLParser as GeneratedParser
+import org.partiql.parser.internal.antlr.PartiQLTokens as GeneratedLexer
+
+/**
+ * This test case cares about whether the [input] can be parsed through SLL mode.
+ */
+class ParserTestCaseSLL(
+    private val name: String,
+    private val input: String,
+    private val sllValid: Boolean
+) : PTestDef {
+    override fun name(): String = name
+
+    override fun assert() {
+        val lexer = GeneratedLexer(CharStreams.fromString(input))
+        val tokens = CommonTokenStream(lexer)
+        val parser = GeneratedParser(tokens)
+        parser.removeErrorListeners()
+        parser.interpreter.predictionMode = PredictionMode.SLL
+        parser.errorHandler = BailErrorStrategy()
+        if (sllValid) {
+            try {
+                parser.statements()
+            } catch (_: ParseCancellationException) {
+                fail { "Expect success, but parsing the statement under SLL mode failed." }
+            }
+        } else {
+            try {
+                parser.statements()
+                fail { "Expect failure, but parsing the statement under SLL mode succeeded." }
+            } catch (_: ParseCancellationException) { }
+        }
+    }
+
+    override fun toString(): String {
+        return name
+    }
+}

--- a/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserSLLTests.kt
+++ b/partiql-parser/src/test/kotlin/org/partiql/parser/internal/PartiQLParserSLLTests.kt
@@ -1,0 +1,21 @@
+package org.partiql.parser.internal
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+
+class PartiQLParserSLLTests {
+    @ParameterizedTest
+    @ArgumentsSource(SLLTestCases::class)
+    fun `parses in SLL mode`(tc: PTestDef) {
+        tc.assert()
+    }
+
+    object SLLTestCases : ArgumentsProviderBase() {
+        override fun getParameters() = listOf(
+            ParserTestCaseSLL("single COALESCE should succeed", "SELECT COALESCE(a, b) FROM T", true),
+            ParserTestCaseSLL("nested COALESCE should succeed", "SELECT COALESCE(COALESCE(a, b), c) FROM T", true),
+            ParserTestCaseSLL("NULLIF should succeed", "SELECT NULLIF(a, b) FROM T", true),
+            ParserTestCaseSLL("SUBSTRING should failed", "SELECT SUBSTRING(a, b) FROM T", false)
+        )
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] N/A

## Description
- Route COALESCE and NULLIF to function call. 
- Added a PTestDef to assert on whether a given query can be parsed under SLL mode. 

### Some superficial notes on SLL and LL. 

SLL:  the fast path. The parser first tries SLL prediction, which makes decisions based only on the lookahead tokens without considering the full parser 
call stack (the parsing context). This is fast because it doesn't track which rule invoked the current rule. For unambiguous grammars, SLL always gets the right 
answer.

LL: the fallback. When SLL encounters an ambiguity — two or more grammar alternatives that could match the same input — it can't decide which path to take. At that 
point, the parser falls back to full LL prediction, which considers the complete call stack context. LL can resolve ambiguities that SLL cannot, but it's significantly
more expensive.

The exponential problem with LL:  In LL mode, when the parser hits an ambiguous construct, it must walk through all candidate grammar alternatives to determine if the 
ambiguity is real. For each ambiguous point, it re-examines the sub-expressions beneath it. If those sub-expressions themselves contain ambiguous constructs (e.g., 
nested function calls that trigger the same ambiguity), the parser walks them again for each outer alternative.  

### Literature reference
Post the [LL algorithm  paper](https://www.antlr.org/papers/allstar-techreport.pdf) by ANTLR, so that I, (and others) can go back to deep dive into this when available. 


## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**:  Yes. 
- Any backward-incompatible changes? **[YES/NO]**: No. 
- Any new external dependencies? **[YES/NO]**: No.
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES/NO]** Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md