### PR TITLE
feat: add partiql fmt subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Thank you to all who have contributed!
 ## [Unreleased](https://TODO.com) - YYYY-MM-DD
 
 ### Added
-- Added `--fmt` flag to the CLI for pretty-printing PartiQL statements with width-aware formatting.
+- Added `fmt` subcommand to the CLI (`partiql fmt`) for pretty-printing PartiQL statements with width-aware formatting.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Thank you to all who have contributed!
 ## [Unreleased](https://TODO.com) - YYYY-MM-DD
 
 ### Added
+- Added `--fmt` flag to the CLI for pretty-printing PartiQL statements with width-aware formatting.
 
 ### Changed
 
@@ -39,6 +40,7 @@ Thank you to all who have contributed!
 
 ### Contributors
 Thank you to all who have contributed!
+- @XuechunHHH
 
 ## [1.3.13](https://github.com/partiql/partiql-lang-kotlin/releases/tag/v1.3.13) - 2026-05-07
 

--- a/partiql-cli/partiql.sh
+++ b/partiql-cli/partiql.sh
@@ -16,5 +16,5 @@
 cli_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
 cd "$cli_path"
-../gradlew :partiql-cli:install
+../gradlew :partiql-cli:install < /dev/null
 ../partiql-cli/build/install/partiql-cli/bin/partiql "$@"

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/FmtCommand.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/FmtCommand.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.cli
+
+import org.partiql.cli.format.pretty
+import org.partiql.parser.PartiQLParser
+import org.partiql.spi.errors.PRuntimeException
+import picocli.CommandLine
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
+
+/**
+ * The `partiql fmt` subcommand: pretty-prints PartiQL statements.
+ */
+@CommandLine.Command(
+    name = "fmt",
+    mixinStandardHelpOptions = true,
+    description = ["Format (pretty-print) PartiQL statements and print to stdout."]
+)
+internal class FmtCommand : Runnable {
+
+    @CommandLine.Option(
+        names = ["-w", "--width"],
+        description = ["Target line width for formatting."],
+        defaultValue = "80",
+        showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+    )
+    var width: Int = 80
+
+    @CommandLine.Option(
+        names = ["-i", "--input"],
+        description = ["Input file containing PartiQL statement(s)."],
+    )
+    var input: File? = null
+
+    @CommandLine.Parameters(
+        index = "0",
+        arity = "0..1",
+        description = ["An optional PartiQL statement string."],
+        paramLabel = "'statement'",
+    )
+    var statement: String? = null
+
+    override fun run() {
+        if (statement != null && input != null) {
+            error("Cannot specify both an input file and a statement string.")
+        }
+        val sql = try {
+            statement ?: readInput()
+        } catch (e: FileNotFoundException) {
+            error("Input file does not exist: ${input?.path}")
+        } catch (e: IOException) {
+            error("Failed to read input: ${e.message}")
+        }
+        try {
+            val parser = PartiQLParser.builder().build()
+            val result = parser.parse(sql)
+            val formatted = result.statements.joinToString(";\n\n") {
+                it.pretty(width = width)
+            }
+            println(formatted)
+        } catch (e: PRuntimeException) {
+            error("Failed to parse input: ${e.error}")
+        } catch (e: Exception) {
+            error("Unexpected error during formatting: ${e.message}")
+        }
+    }
+
+    private fun readInput(): String {
+        val file = input
+        return if (file != null) {
+            file.readText()
+        } else {
+            System.`in`.bufferedReader().readText()
+        }
+    }
+}

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
@@ -15,6 +15,7 @@
 
 package org.partiql.cli
 
+import org.partiql.cli.format.pretty
 import org.partiql.cli.io.DatumCsvReader
 import org.partiql.cli.io.DatumIonReaderBuilder
 import org.partiql.cli.io.DatumParquetReader
@@ -24,6 +25,7 @@ import org.partiql.cli.io.LazyCatalog
 import org.partiql.cli.pipeline.ErrorMessageFormatter
 import org.partiql.cli.pipeline.Pipeline
 import org.partiql.cli.shell.Shell
+import org.partiql.parser.PartiQLParser
 import org.partiql.spi.catalog.Catalog
 import org.partiql.spi.catalog.Name
 import org.partiql.spi.catalog.Session
@@ -95,6 +97,12 @@ internal class MainCommand : Runnable {
         description = ["File containing the global environment"],
     )
     var env: File? = null
+
+    @CommandLine.Option(
+        names = ["--fmt"],
+        description = ["Format (pretty-print) the input PartiQL statement and print to stdout."],
+    )
+    var fmt: Boolean = false
 
     @CommandLine.Option(
         names = ["--strict"],
@@ -199,8 +207,8 @@ internal class MainCommand : Runnable {
             System.err.println("========================================")
         }
         when (val statement = statement()) {
-            null -> shell()
-            else -> run(statement)
+            null -> if (fmt) fmt(System.`in`.bufferedReader().readText()) else shell()
+            else -> if (fmt) fmt(statement) else run(statement)
         }
     }
 
@@ -221,6 +229,15 @@ internal class MainCommand : Runnable {
     private fun shell() {
         val pipeline = pipeline()
         Shell(pipeline, session(), debug).start()
+    }
+
+    private fun fmt(statement: String) {
+        val parser = PartiQLParser.builder().build()
+        val result = parser.parse(statement)
+        val formatted = result.statements.joinToString(";\n\n") {
+            it.pretty(width = 80)
+        }
+        println(formatted)
     }
 
     private fun pipeline(): Pipeline {

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/Main.kt
@@ -15,7 +15,6 @@
 
 package org.partiql.cli
 
-import org.partiql.cli.format.pretty
 import org.partiql.cli.io.DatumCsvReader
 import org.partiql.cli.io.DatumIonReaderBuilder
 import org.partiql.cli.io.DatumParquetReader
@@ -25,7 +24,6 @@ import org.partiql.cli.io.LazyCatalog
 import org.partiql.cli.pipeline.ErrorMessageFormatter
 import org.partiql.cli.pipeline.Pipeline
 import org.partiql.cli.shell.Shell
-import org.partiql.parser.PartiQLParser
 import org.partiql.spi.catalog.Catalog
 import org.partiql.spi.catalog.Name
 import org.partiql.spi.catalog.Session
@@ -77,7 +75,8 @@ internal class Version : CommandLine.IVersionProvider {
         "@|bold,underline OPTIONS|@%n",
         "Execute `partiql` without a query or without -i to launch an interactive shell%n",
     ],
-    showDefaultValues = true
+    showDefaultValues = true,
+    subcommands = [FmtCommand::class]
 )
 internal class MainCommand : Runnable {
     // TODO: Need to add tests to CLI. All tests were removed in the same commit as this TODO. See Git blame.
@@ -97,12 +96,6 @@ internal class MainCommand : Runnable {
         description = ["File containing the global environment"],
     )
     var env: File? = null
-
-    @CommandLine.Option(
-        names = ["--fmt"],
-        description = ["Format (pretty-print) the input PartiQL statement and print to stdout."],
-    )
-    var fmt: Boolean = false
 
     @CommandLine.Option(
         names = ["--strict"],
@@ -207,8 +200,8 @@ internal class MainCommand : Runnable {
             System.err.println("========================================")
         }
         when (val statement = statement()) {
-            null -> if (fmt) fmt(System.`in`.bufferedReader().readText()) else shell()
-            else -> if (fmt) fmt(statement) else run(statement)
+            null -> shell()
+            else -> run(statement)
         }
     }
 
@@ -229,15 +222,6 @@ internal class MainCommand : Runnable {
     private fun shell() {
         val pipeline = pipeline()
         Shell(pipeline, session(), debug).start()
-    }
-
-    private fun fmt(statement: String) {
-        val parser = PartiQLParser.builder().build()
-        val result = parser.parse(statement)
-        val formatted = result.statements.joinToString(";\n\n") {
-            it.pretty(width = 80)
-        }
-        println(formatted)
     }
 
     private fun pipeline(): Pipeline {

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/format/Doc.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/format/Doc.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.cli.format
+
+// TODO: Extend with PartiQL-specific nodes for full AST-to-Doc formatting (bags, arrays, CASE, paths).
+
+/**
+ * Pretty-printing document algebra based on Wadler's "A Prettier Printer" (1997).
+ *
+ * Documents describe multiple possible layouts; the renderer picks the best fit
+ * for a target line width. Example:
+ *
+ * ```
+ * val doc = group(text("SELECT") cat nest(4, Line cat text("a, b, c")))
+ * render(doc, width = 40)  // → "SELECT a, b, c"         (fits on one line)
+ * render(doc, width = 10)  // → "SELECT\n    a, b, c"    (broken)
+ * ```
+ *
+ * See: http://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf
+ */
+internal sealed interface Doc {
+    data object Nil : Doc
+    /** Literal text (never broken across lines). */
+    data class Text(val s: String) : Doc
+    data class Keyword(val s: String) : Doc
+    /** Newline when broken, space when flat. */
+    data object Line : Doc
+    /** Always a newline (cannot be flattened). */
+    data object HardLine : Doc
+    data class Concat(val a: Doc, val b: Doc) : Doc
+    /** Indent [doc] by [n] spaces. */
+    data class Nest(val n: Int, val doc: Doc) : Doc
+    /** Flat layout if it fits, otherwise broken layout. */
+    data class Union(val flat: Doc, val broken: Doc) : Doc
+}
+
+// Constructors & Combinators
+
+internal fun text(s: String): Doc = if (s.isEmpty()) Doc.Nil else Doc.Text(s)
+internal fun keyword(s: String): Doc = Doc.Keyword(s)
+internal fun nest(n: Int, doc: Doc): Doc = Doc.Nest(n, doc)
+
+internal infix fun Doc.cat(other: Doc): Doc = when {
+    this is Doc.Nil -> other
+    other is Doc.Nil -> this
+    else -> Doc.Concat(this, other)
+}
+
+/** Try flat layout; fall back to broken if it doesn't fit within the line width. */
+internal fun group(doc: Doc): Doc {
+    val f = flatten(doc) ?: return doc
+    return Doc.Union(f, doc)
+}
+
+/** Returns the single-line form, or null if the doc contains [Doc.HardLine]. */
+private fun flatten(doc: Doc): Doc? {
+    return when (doc) {
+        is Doc.Nil -> Doc.Nil
+        is Doc.Text -> doc
+        is Doc.Keyword -> doc
+        is Doc.Line -> Doc.Text(" ")
+        is Doc.HardLine -> null
+        is Doc.Concat -> {
+            val a = flatten(doc.a) ?: return null
+            val b = flatten(doc.b) ?: return null
+            Doc.Concat(a, b)
+        }
+        is Doc.Nest -> {
+            val inner = flatten(doc.doc) ?: return null
+            Doc.Nest(doc.n, inner)
+        }
+        is Doc.Union -> flatten(doc.flat)
+    }
+}
+
+// Renderer
+
+/** Render a [Doc] to a string, choosing the best layout for the given [width]. */
+internal fun render(doc: Doc, width: Int = 80): String {
+    val sb = StringBuilder()
+    best(sb, width, 0, listOf(Triple(0, Mode.BREAK, doc)))
+    return sb.toString().trimEnd()
+}
+
+private enum class Mode { FLAT, BREAK }
+
+private fun best(sb: StringBuilder, width: Int, col: Int, docs: List<Triple<Int, Mode, Doc>>) {
+    var k = col
+    val stack = ArrayDeque(docs)
+    while (stack.isNotEmpty()) {
+        val (i, mode, doc) = stack.removeFirst()
+        when (doc) {
+            is Doc.Nil -> {}
+            is Doc.Text -> { sb.append(doc.s); k += doc.s.length }
+            is Doc.Keyword -> { sb.append(doc.s); k += doc.s.length }
+            is Doc.HardLine -> { sb.append('\n'); repeat(i) { sb.append(' ') }; k = i }
+            is Doc.Line -> when (mode) {
+                Mode.FLAT -> { sb.append(' '); k += 1 }
+                Mode.BREAK -> { sb.append('\n'); repeat(i) { sb.append(' ') }; k = i }
+            }
+            is Doc.Concat -> {
+                stack.addFirst(Triple(i, mode, doc.b))
+                stack.addFirst(Triple(i, mode, doc.a))
+            }
+            is Doc.Nest -> {
+                stack.addFirst(Triple(i + doc.n, mode, doc.doc))
+            }
+            is Doc.Union -> {
+                if (fits(width - k, listOf(Triple(i, Mode.FLAT, doc.flat)))) {
+                    stack.addFirst(Triple(i, Mode.FLAT, doc.flat))
+                } else {
+                    stack.addFirst(Triple(i, Mode.BREAK, doc.broken))
+                }
+            }
+        }
+    }
+}
+
+private fun fits(remaining: Int, docs: List<Triple<Int, Mode, Doc>>): Boolean {
+    var w = remaining
+    val stack = ArrayDeque(docs)
+    while (stack.isNotEmpty()) {
+        if (w < 0) return false
+        val (i, mode, doc) = stack.removeFirst()
+        when (doc) {
+            is Doc.Nil -> {}
+            is Doc.Text -> w -= doc.s.length
+            is Doc.Keyword -> w -= doc.s.length
+            is Doc.Line -> when (mode) {
+                Mode.FLAT -> w -= 1
+                Mode.BREAK -> return true
+            }
+            is Doc.HardLine -> return true
+            is Doc.Concat -> {
+                stack.addFirst(Triple(i, mode, doc.b))
+                stack.addFirst(Triple(i, mode, doc.a))
+            }
+            is Doc.Nest -> stack.addFirst(Triple(i + doc.n, mode, doc.doc))
+            is Doc.Union -> stack.addFirst(Triple(i, Mode.FLAT, doc.flat))
+        }
+    }
+    return w >= 0
+}

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/format/Doc.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/format/Doc.kt
@@ -14,33 +14,24 @@
 
 package org.partiql.cli.format
 
-// TODO: Extend with PartiQL-specific nodes for full AST-to-Doc formatting (bags, arrays, CASE, paths).
-
 /**
  * Pretty-printing document algebra based on Wadler's "A Prettier Printer" (1997).
  *
  * Documents describe multiple possible layouts; the renderer picks the best fit
- * for a target line width. Example:
- *
- * ```
- * val doc = group(text("SELECT") cat nest(4, Line cat text("a, b, c")))
- * render(doc, width = 40)  // → "SELECT a, b, c"         (fits on one line)
- * render(doc, width = 10)  // → "SELECT\n    a, b, c"    (broken)
- * ```
+ * for a target line width.
  *
  * See: http://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf
  */
 internal sealed interface Doc {
     data object Nil : Doc
-    /** Literal text (never broken across lines). */
     data class Text(val s: String) : Doc
-    data class Keyword(val s: String) : Doc
     /** Newline when broken, space when flat. */
     data object Line : Doc
+    /** Newline when broken, empty string when flat. Used inside brackets. */
+    data object SoftBreak : Doc
     /** Always a newline (cannot be flattened). */
     data object HardLine : Doc
     data class Concat(val a: Doc, val b: Doc) : Doc
-    /** Indent [doc] by [n] spaces. */
     data class Nest(val n: Int, val doc: Doc) : Doc
     /** Flat layout if it fits, otherwise broken layout. */
     data class Union(val flat: Doc, val broken: Doc) : Doc
@@ -49,7 +40,6 @@ internal sealed interface Doc {
 // Constructors & Combinators
 
 internal fun text(s: String): Doc = if (s.isEmpty()) Doc.Nil else Doc.Text(s)
-internal fun keyword(s: String): Doc = Doc.Keyword(s)
 internal fun nest(n: Int, doc: Doc): Doc = Doc.Nest(n, doc)
 
 internal infix fun Doc.cat(other: Doc): Doc = when {
@@ -64,13 +54,26 @@ internal fun group(doc: Doc): Doc {
     return Doc.Union(f, doc)
 }
 
+/** Join a list of docs with a separator between each pair. */
+internal fun join(docs: List<Doc>, sep: Doc): Doc {
+    if (docs.isEmpty()) return Doc.Nil
+    return docs.reduce { acc, doc -> acc cat sep cat doc }
+}
+
+/** Join with comma + Line between items (break after comma). */
+internal fun commaJoin(docs: List<Doc>): Doc = join(docs, text(",") cat Doc.Line)
+
+/** Bracket: open + SoftBreak + nested content + SoftBreak + close. */
+internal fun bracket(open: String, doc: Doc, close: String, indent: Int = 4): Doc =
+    group(text(open) cat nest(indent, Doc.SoftBreak cat doc) cat Doc.SoftBreak cat text(close))
+
 /** Returns the single-line form, or null if the doc contains [Doc.HardLine]. */
 private fun flatten(doc: Doc): Doc? {
     return when (doc) {
         is Doc.Nil -> Doc.Nil
         is Doc.Text -> doc
-        is Doc.Keyword -> doc
         is Doc.Line -> Doc.Text(" ")
+        is Doc.SoftBreak -> Doc.Nil
         is Doc.HardLine -> null
         is Doc.Concat -> {
             val a = flatten(doc.a) ?: return null
@@ -104,8 +107,11 @@ private fun best(sb: StringBuilder, width: Int, col: Int, docs: List<Triple<Int,
         when (doc) {
             is Doc.Nil -> {}
             is Doc.Text -> { sb.append(doc.s); k += doc.s.length }
-            is Doc.Keyword -> { sb.append(doc.s); k += doc.s.length }
             is Doc.HardLine -> { sb.append('\n'); repeat(i) { sb.append(' ') }; k = i }
+            is Doc.SoftBreak -> when (mode) {
+                Mode.FLAT -> {} // empty string when flat
+                Mode.BREAK -> { sb.append('\n'); repeat(i) { sb.append(' ') }; k = i }
+            }
             is Doc.Line -> when (mode) {
                 Mode.FLAT -> { sb.append(' '); k += 1 }
                 Mode.BREAK -> { sb.append('\n'); repeat(i) { sb.append(' ') }; k = i }
@@ -137,7 +143,10 @@ private fun fits(remaining: Int, docs: List<Triple<Int, Mode, Doc>>): Boolean {
         when (doc) {
             is Doc.Nil -> {}
             is Doc.Text -> w -= doc.s.length
-            is Doc.Keyword -> w -= doc.s.length
+            is Doc.SoftBreak -> when (mode) {
+                Mode.FLAT -> {} // contributes 0 width
+                Mode.BREAK -> return true
+            }
             is Doc.Line -> when (mode) {
                 Mode.FLAT -> w -= 1
                 Mode.BREAK -> return true

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/format/PrettyPrinter.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/format/PrettyPrinter.kt
@@ -387,7 +387,7 @@ private class DocVisitor : AstVisitor<Doc, Unit>() {
         }
         val terms = flattenOperator(node)
         val docs = terms.mapIndexed { idx, term ->
-            val operandDoc = visitOperand(term.operand, operatorPrecedence(node.symbol))
+            val operandDoc = visitOperand(term.operand, operatorPrecedence(node.symbol), isRight = idx > 0)
             if (idx == 0) operandDoc
             else text(" ${term.precedingOp} ") cat operandDoc
         }
@@ -397,11 +397,11 @@ private class DocVisitor : AstVisitor<Doc, Unit>() {
     private data class OpTerm(val operand: Expr, val precedingOp: String?)
 
     private fun flattenOperator(node: ExprOperator): List<OpTerm> {
-        val precedence = operatorPrecedence(node.symbol)
+        val symbol = node.symbol
         val result = mutableListOf<OpTerm>()
         fun collect(e: Expr, op: String?) {
-            if (e is ExprOperator && e.lhs != null && operatorPrecedence(e.symbol) == precedence) {
-                collect(e.lhs!!, null)
+            if (e is ExprOperator && e.lhs != null && e.symbol == symbol) {
+                collect(e.lhs!!, op)
                 collect(e.rhs, e.symbol)
             } else {
                 result.add(OpTerm(e, op))
@@ -412,11 +412,14 @@ private class DocVisitor : AstVisitor<Doc, Unit>() {
         return result
     }
 
-    private fun visitOperand(expr: Expr, parentPrecedence: Int): Doc {
+    private fun visitOperand(expr: Expr, parentPrecedence: Int, isRight: Boolean = false): Doc {
         return when {
             expr is ExprQuerySet -> bracket("(", visitExprQuerySet(expr, Unit), ")")
-            expr is ExprOperator && expr.lhs != null && operatorPrecedence(expr.symbol) < parentPrecedence ->
-                bracket("(", visit(expr, Unit), ")")
+            expr is ExprOperator && expr.lhs != null -> {
+                val childPrec = operatorPrecedence(expr.symbol)
+                val needsParens = if (isRight) childPrec <= parentPrecedence else childPrec < parentPrecedence
+                if (needsParens) bracket("(", visit(expr, Unit), ")") else visit(expr, Unit)
+            }
             else -> visit(expr, Unit)
         }
     }

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/format/PrettyPrinter.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/format/PrettyPrinter.kt
@@ -69,18 +69,13 @@ private fun splitClauses(sql: String): List<Pair<String, String>> {
         // DQL
         "SELECT ", "FROM ", "WHERE ", "GROUP BY ", "HAVING ",
         "ORDER BY ", "LIMIT ", "OFFSET ", "WINDOW ", "LET ", "EXCLUDE ",
-        // Set operations
+        // Set operations (OUTER variants first, then ALL before bare)
+        "OUTER UNION ALL ", "OUTER UNION ", "OUTER INTERSECT ALL ", "OUTER INTERSECT ",
+        "OUTER EXCEPT ALL ", "OUTER EXCEPT ",
         "UNION ALL ", "UNION ", "INTERSECT ALL ", "INTERSECT ", "EXCEPT ALL ", "EXCEPT ",
-        // Joins (indented)
+        // Joins (longer matches first)
         "INNER JOIN ", "LEFT OUTER JOIN ", "RIGHT OUTER JOIN ", "FULL OUTER JOIN ",
-        "LEFT JOIN ", "RIGHT JOIN ", "CROSS JOIN ", "FULL JOIN ",
-        // DML
-        "INSERT INTO ", "INSERT ", "UPDATE ", "DELETE FROM ", "DELETE ",
-        "SET ", "VALUES ", "RETURNING ",
-        // DDL
-        "CREATE TABLE ", "CREATE INDEX ", "CREATE ",
-        "DROP TABLE ", "DROP INDEX ", "DROP ",
-        "ALTER TABLE ", "ALTER ",
+        "LEFT CROSS JOIN ", "LEFT JOIN ", "RIGHT JOIN ", "CROSS JOIN ", "FULL JOIN ", "JOIN ",
         // WITH
         "WITH RECURSIVE ", "WITH ",
     )

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/format/PrettyPrinter.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/format/PrettyPrinter.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.cli.format
+
+import org.partiql.ast.AstNode
+import org.partiql.ast.sql.SqlDialect
+import org.partiql.ast.sql.SqlLayout
+import org.partiql.ast.sql.sql
+
+// TODO: Replace with a full AST-to-Doc visitor for per-expression layout control.
+//  See CockroachDB's sqlfmt: https://github.com/cockroachdb/cockroach/tree/master/pkg/util/pretty
+
+/**
+ * Pretty-prints a PartiQL [AstNode] using Wadler's document algebra.
+ *
+ * Serializes the AST to normalized SQL via [SqlDialect.STANDARD], then splits at
+ * clause boundaries into a [Doc] tree for width-aware rendering.
+ *
+ * ```
+ * // Short query (fits in 80 chars) → single line:
+ * "SELECT a, b FROM t WHERE x > 1"
+ *
+ * // Long query → clause per line:
+ * "SELECT a, b, c, d, e\nFROM some_long_table_name\nWHERE x > 1 AND y < 100"
+ *
+ * // Very long clause body → keyword + indented body:
+ * "SELECT\n    a, b, c, d, e, f, g, h\nFROM t"
+ * ```
+ */
+internal fun AstNode.pretty(width: Int = 80): String {
+    val sql = this.sql(layout = SqlLayout.ONELINE, dialect = SqlDialect.STANDARD)
+    val doc = sqlToDoc(sql)
+    return render(doc, width)
+}
+
+/** Converts normalized SQL into a [Doc] tree with [group] nodes at clause boundaries. */
+private fun sqlToDoc(sql: String): Doc {
+    val clauses = splitClauses(sql)
+    if (clauses.size <= 1) return text(sql)
+
+    val docs = clauses.map { (kw, body) ->
+        if (kw.isEmpty()) {
+            text(body.trim())
+        } else if (body.isEmpty()) {
+            keyword(kw)
+        } else {
+            group(keyword(kw) cat nest(4, Doc.Line cat text(body.trim())))
+        }
+    }
+    return group(docs.reduce { acc, doc -> acc cat Doc.Line cat doc })
+}
+
+/** Splits SQL into (keyword, body) pairs at top-level clause boundaries (paren/quote-aware). */
+private fun splitClauses(sql: String): List<Pair<String, String>> {
+    // Keywords that start a new clause at depth 0
+    val clauseKeywords = listOf(
+        // DQL
+        "SELECT ", "FROM ", "WHERE ", "GROUP BY ", "HAVING ",
+        "ORDER BY ", "LIMIT ", "OFFSET ", "WINDOW ", "LET ", "EXCLUDE ",
+        // Set operations
+        "UNION ALL ", "UNION ", "INTERSECT ALL ", "INTERSECT ", "EXCEPT ALL ", "EXCEPT ",
+        // Joins (indented)
+        "INNER JOIN ", "LEFT OUTER JOIN ", "RIGHT OUTER JOIN ", "FULL OUTER JOIN ",
+        "LEFT JOIN ", "RIGHT JOIN ", "CROSS JOIN ", "FULL JOIN ",
+        // DML
+        "INSERT INTO ", "INSERT ", "UPDATE ", "DELETE FROM ", "DELETE ",
+        "SET ", "VALUES ", "RETURNING ",
+        // DDL
+        "CREATE TABLE ", "CREATE INDEX ", "CREATE ",
+        "DROP TABLE ", "DROP INDEX ", "DROP ",
+        "ALTER TABLE ", "ALTER ",
+        // WITH
+        "WITH RECURSIVE ", "WITH ",
+    )
+
+    data class ClauseMatch(val pos: Int, val keyword: String)
+
+    val matches = mutableListOf<ClauseMatch>()
+    var i = 0
+    var depth = 0
+
+    while (i < sql.length) {
+        val c = sql[i]
+        // Track paren depth
+        if (c == '(') { depth++; i++; continue }
+        if (c == ')') { depth--; i++; continue }
+        // Skip string literals and quoted identifiers
+        if (c == '\'' || c == '"') {
+            i = skipQuoted(sql, i, c)
+            continue
+        }
+        // Only match at depth 0
+        if (depth == 0) {
+            // Check if we're at a word boundary (start of string or preceded by space)
+            val atBoundary = i == 0 || sql[i - 1] == ' '
+            if (atBoundary) {
+                val matched = clauseKeywords.firstOrNull { kw ->
+                    sql.regionMatches(i, kw, 0, kw.length, ignoreCase = false)
+                }
+                if (matched != null) {
+                    matches.add(ClauseMatch(i, matched.trimEnd()))
+                    i += matched.length
+                    continue
+                }
+            }
+        }
+        i++
+    }
+
+    // Build clause pairs
+    if (matches.isEmpty()) return listOf("" to sql)
+
+    val result = mutableListOf<Pair<String, String>>()
+    // Text before first keyword (if any)
+    if (matches.first().pos > 0) {
+        result.add("" to sql.substring(0, matches.first().pos))
+    }
+    for (idx in matches.indices) {
+        val start = matches[idx].pos + matches[idx].keyword.length + 1 // +1 for trailing space
+        val end = if (idx + 1 < matches.size) matches[idx + 1].pos else sql.length
+        val body = sql.substring(start.coerceAtMost(sql.length), end).trim()
+        result.add(matches[idx].keyword to body)
+    }
+    return result
+}
+
+/** Advance past a quoted span (single or double), handling escaped quotes ('' or ""). */
+private fun skipQuoted(sql: String, start: Int, quote: Char): Int {
+    var i = start + 1
+    while (i < sql.length) {
+        if (sql[i] == quote) {
+            i++
+            if (i < sql.length && sql[i] == quote) { i++; continue }
+            break
+        }
+        i++
+    }
+    return i
+}

--- a/partiql-cli/src/main/kotlin/org/partiql/cli/format/PrettyPrinter.kt
+++ b/partiql-cli/src/main/kotlin/org/partiql/cli/format/PrettyPrinter.kt
@@ -15,132 +15,567 @@
 package org.partiql.cli.format
 
 import org.partiql.ast.AstNode
+import org.partiql.ast.AstVisitor
+import org.partiql.ast.Exclude
+import org.partiql.ast.From
+import org.partiql.ast.FromExpr
+import org.partiql.ast.FromJoin
+import org.partiql.ast.FromTableRef
+import org.partiql.ast.GroupBy
+import org.partiql.ast.GroupByStrategy
+import org.partiql.ast.JoinType
+import org.partiql.ast.Let
+import org.partiql.ast.OrderBy
+import org.partiql.ast.Query
+import org.partiql.ast.QueryBody
+import org.partiql.ast.Select
+import org.partiql.ast.SelectItem
+import org.partiql.ast.SelectList
+import org.partiql.ast.SelectPivot
+import org.partiql.ast.SelectStar
+import org.partiql.ast.SelectValue
+import org.partiql.ast.SetOpType
+import org.partiql.ast.SetQuantifier
+import org.partiql.ast.WindowClause
+import org.partiql.ast.With
+import org.partiql.ast.expr.Expr
+import org.partiql.ast.expr.ExprAnd
+import org.partiql.ast.expr.ExprArray
+import org.partiql.ast.expr.ExprBag
+import org.partiql.ast.expr.ExprBetween
+import org.partiql.ast.expr.ExprCall
+import org.partiql.ast.expr.ExprCase
+import org.partiql.ast.expr.ExprCast
+import org.partiql.ast.expr.ExprCoalesce
+import org.partiql.ast.expr.ExprInCollection
+import org.partiql.ast.expr.ExprLike
+import org.partiql.ast.expr.ExprMatch
+import org.partiql.ast.expr.ExprNot
+import org.partiql.ast.expr.ExprOperator
+import org.partiql.ast.expr.ExprOr
+import org.partiql.ast.expr.ExprQuerySet
+import org.partiql.ast.expr.ExprStruct
 import org.partiql.ast.sql.SqlDialect
 import org.partiql.ast.sql.SqlLayout
 import org.partiql.ast.sql.sql
 
-// TODO: Replace with a full AST-to-Doc visitor for per-expression layout control.
-//  See CockroachDB's sqlfmt: https://github.com/cockroachdb/cockroach/tree/master/pkg/util/pretty
-
 /**
- * Pretty-prints a PartiQL [AstNode] using Wadler's document algebra.
+ * Pretty-prints a PartiQL [AstNode] using Wadler's document algebra with full AST traversal.
  *
- * Serializes the AST to normalized SQL via [SqlDialect.STANDARD], then splits at
- * clause boundaries into a [Doc] tree for width-aware rendering.
- *
- * ```
- * // Short query (fits in 80 chars) → single line:
- * "SELECT a, b FROM t WHERE x > 1"
- *
- * // Long query → clause per line:
- * "SELECT a, b, c, d, e\nFROM some_long_table_name\nWHERE x > 1 AND y < 100"
- *
- * // Very long clause body → keyword + indented body:
- * "SELECT\n    a, b, c, d, e, f, g, h\nFROM t"
- * ```
+ * Walks the AST to produce a [Doc] tree, allowing width-aware line breaks at:
+ * - Clause boundaries (SELECT, FROM, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, LET, EXCLUDE, WINDOW)
+ * - Join boundaries (each JOIN on its own line)
+ * - Boolean operators (AND/OR within WHERE/ON)
+ * - Comma-separated lists (SELECT items, function args, GROUP BY keys)
+ * - Subqueries and collection constructors in brackets
  */
 internal fun AstNode.pretty(width: Int = 80): String {
-    val sql = this.sql(layout = SqlLayout.ONELINE, dialect = SqlDialect.STANDARD)
-    val doc = sqlToDoc(sql)
+    val doc = DocVisitor().visit(this, Unit)
     return render(doc, width)
 }
 
-/** Converts normalized SQL into a [Doc] tree with [group] nodes at clause boundaries. */
-private fun sqlToDoc(sql: String): Doc {
-    val clauses = splitClauses(sql)
-    if (clauses.size <= 1) return text(sql)
+// ============================================================================================
+// AST-to-Doc Visitor
+// ============================================================================================
 
-    val docs = clauses.map { (kw, body) ->
-        if (kw.isEmpty()) {
-            text(body.trim())
-        } else if (body.isEmpty()) {
-            keyword(kw)
+private class DocVisitor : AstVisitor<Doc, Unit>() {
+
+    // --- A. Defaults ---
+
+    override fun defaultReturn(node: AstNode, ctx: Unit): Doc {
+        return text(node.sql(layout = SqlLayout.ONELINE, dialect = SqlDialect.STANDARD))
+    }
+
+    override fun defaultVisit(node: AstNode, ctx: Unit): Doc {
+        return defaultReturn(node, ctx)
+    }
+
+    // --- B. Entry Point ---
+
+    override fun visitQuery(node: Query, ctx: Unit): Doc {
+        return visit(node.expr, ctx)
+    }
+
+    // --- C. Query-Level: ExprQuerySet ---
+
+    override fun visitExprQuerySet(node: ExprQuerySet, ctx: Unit): Doc {
+        val clauses = mutableListOf<Doc>()
+
+        val w = node.with
+        if (w != null) {
+            clauses.add(visitWithClause(w))
+        }
+
+        when (val body = node.body) {
+            is QueryBody.SFW -> appendSFWClauses(body, clauses)
+            is QueryBody.SetOp -> clauses.add(visitSetOp(body))
+            else -> clauses.add(defaultReturn(node, ctx))
+        }
+
+        val ob = node.orderBy
+        if (ob != null) {
+            clauses.add(visitOrderByClause(ob))
+        }
+        val lim = node.limit
+        if (lim != null) {
+            clauses.add(clause("LIMIT", visit(lim, ctx)))
+        }
+        val off = node.offset
+        if (off != null) {
+            clauses.add(clause("OFFSET", visit(off, ctx)))
+        }
+
+        return if (clauses.size <= 1) {
+            clauses.firstOrNull() ?: Doc.Nil
         } else {
-            group(keyword(kw) cat nest(4, Doc.Line cat text(body.trim())))
+            group(join(clauses, Doc.Line))
         }
     }
-    return group(docs.reduce { acc, doc -> acc cat Doc.Line cat doc })
-}
 
-/** Splits SQL into (keyword, body) pairs at top-level clause boundaries (paren/quote-aware). */
-private fun splitClauses(sql: String): List<Pair<String, String>> {
-    // Keywords that start a new clause at depth 0
-    val clauseKeywords = listOf(
-        // DQL
-        "SELECT ", "FROM ", "WHERE ", "GROUP BY ", "HAVING ",
-        "ORDER BY ", "LIMIT ", "OFFSET ", "WINDOW ", "LET ", "EXCLUDE ",
-        // Set operations (OUTER variants first, then ALL before bare)
-        "OUTER UNION ALL ", "OUTER UNION ", "OUTER INTERSECT ALL ", "OUTER INTERSECT ",
-        "OUTER EXCEPT ALL ", "OUTER EXCEPT ",
-        "UNION ALL ", "UNION ", "INTERSECT ALL ", "INTERSECT ", "EXCEPT ALL ", "EXCEPT ",
-        // Joins (longer matches first)
-        "INNER JOIN ", "LEFT OUTER JOIN ", "RIGHT OUTER JOIN ", "FULL OUTER JOIN ",
-        "LEFT CROSS JOIN ", "LEFT JOIN ", "RIGHT JOIN ", "CROSS JOIN ", "FULL JOIN ", "JOIN ",
-        // WITH
-        "WITH RECURSIVE ", "WITH ",
-    )
+    // --- D. SFW Clause Assembly ---
 
-    data class ClauseMatch(val pos: Int, val keyword: String)
+    private fun appendSFWClauses(sfw: QueryBody.SFW, clauses: MutableList<Doc>) {
+        clauses.add(visitSelect(sfw.select))
+        appendFromClauses(sfw.from, clauses)
+        val let = sfw.let; if (let != null) clauses.add(visitLetClause(let))
+        val where = sfw.where; if (where != null) clauses.add(visitWhereClause(where))
+        val groupBy = sfw.groupBy; if (groupBy != null) clauses.add(visitGroupByClause(groupBy))
+        val having = sfw.having; if (having != null) clauses.add(visitHavingClause(having))
+        val window = sfw.window; if (window != null) clauses.add(visitWindowClause(window))
+        val exclude = sfw.exclude; if (exclude != null) clauses.add(visitExcludeClause(exclude))
+    }
 
-    val matches = mutableListOf<ClauseMatch>()
-    var i = 0
-    var depth = 0
+    // --- E. SELECT Variants ---
 
-    while (i < sql.length) {
-        val c = sql[i]
-        // Track paren depth
-        if (c == '(') { depth++; i++; continue }
-        if (c == ')') { depth--; i++; continue }
-        // Skip string literals and quoted identifiers
-        if (c == '\'' || c == '"') {
-            i = skipQuoted(sql, i, c)
-            continue
-        }
-        // Only match at depth 0
-        if (depth == 0) {
-            // Check if we're at a word boundary (start of string or preceded by space)
-            val atBoundary = i == 0 || sql[i - 1] == ' '
-            if (atBoundary) {
-                val matched = clauseKeywords.firstOrNull { kw ->
-                    sql.regionMatches(i, kw, 0, kw.length, ignoreCase = false)
+    private fun visitSelect(select: Select): Doc {
+        return when (select) {
+            is SelectStar -> {
+                val kw = when (select.setq?.code()) {
+                    SetQuantifier.ALL -> "SELECT ALL *"
+                    SetQuantifier.DISTINCT -> "SELECT DISTINCT *"
+                    else -> "SELECT *"
                 }
-                if (matched != null) {
-                    matches.add(ClauseMatch(i, matched.trimEnd()))
-                    i += matched.length
-                    continue
+                text(kw)
+            }
+            is SelectList -> {
+                val kw = when (select.setq?.code()) {
+                    SetQuantifier.ALL -> "SELECT ALL"
+                    SetQuantifier.DISTINCT -> "SELECT DISTINCT"
+                    else -> "SELECT"
+                }
+                val items = select.items.map { visitSelectItem(it) }
+                commaSeparated(kw, items)
+            }
+            is SelectValue -> {
+                val kw = when (select.setq?.code()) {
+                    SetQuantifier.ALL -> "SELECT ALL VALUE"
+                    SetQuantifier.DISTINCT -> "SELECT DISTINCT VALUE"
+                    else -> "SELECT VALUE"
+                }
+                clause(kw, visit(select.constructor, Unit))
+            }
+            is SelectPivot -> {
+                clause("PIVOT", visit(select.key, Unit) cat text(" AT ") cat visit(select.value, Unit))
+            }
+            else -> defaultReturn(select, Unit)
+        }
+    }
+
+    private fun visitSelectItem(item: SelectItem): Doc {
+        return when (item) {
+            is SelectItem.Expr -> {
+                val base = visit(item.expr, Unit)
+                val alias = item.asAlias
+                if (alias != null) base cat text(" AS ${alias.sql()}") else base
+            }
+            is SelectItem.Star -> {
+                visit(item.expr, Unit) cat text(".*")
+            }
+            else -> defaultReturn(item, Unit)
+        }
+    }
+
+    // --- F. FROM / JOIN ---
+
+    private fun appendFromClauses(from: From, clauses: MutableList<Doc>) {
+        val refs = from.tableRefs
+        if (refs.size == 1 && refs[0] is FromJoin) {
+            flattenJoins(refs[0], clauses)
+        } else {
+            val refDocs = refs.map { leafExpr(it) }
+            clauses.add(commaSeparated("FROM", refDocs))
+        }
+    }
+
+    private fun flattenJoins(ref: FromTableRef, parts: MutableList<Doc>) {
+        when (ref) {
+            is FromJoin -> {
+                flattenJoins(ref.lhs, parts)
+                val joinKw = joinKeyword(ref.joinType)
+                val rhsDoc = leafExpr(ref.rhs)
+                val cond = ref.condition
+                if (cond != null) {
+                    val condDoc = visitBooleanExpr(cond)
+                    parts.add(
+                        group(
+                            text(joinKw) cat
+                                nest(4, Doc.Line cat rhsDoc) cat
+                                nest(4, Doc.Line cat text("ON ") cat condDoc)
+                        )
+                    )
+                } else {
+                    parts.add(
+                        group(text(joinKw) cat nest(4, Doc.Line cat rhsDoc))
+                    )
                 }
             }
+            is FromExpr -> {
+                parts.add(clause("FROM", leafExpr(ref)))
+            }
+            else -> {
+                parts.add(clause("FROM", leafExpr(ref)))
+            }
         }
-        i++
     }
 
-    // Build clause pairs
-    if (matches.isEmpty()) return listOf("" to sql)
-
-    val result = mutableListOf<Pair<String, String>>()
-    // Text before first keyword (if any)
-    if (matches.first().pos > 0) {
-        result.add("" to sql.substring(0, matches.first().pos))
-    }
-    for (idx in matches.indices) {
-        val start = matches[idx].pos + matches[idx].keyword.length + 1 // +1 for trailing space
-        val end = if (idx + 1 < matches.size) matches[idx + 1].pos else sql.length
-        val body = sql.substring(start.coerceAtMost(sql.length), end).trim()
-        result.add(matches[idx].keyword to body)
-    }
-    return result
-}
-
-/** Advance past a quoted span (single or double), handling escaped quotes ('' or ""). */
-private fun skipQuoted(sql: String, start: Int, quote: Char): Int {
-    var i = start + 1
-    while (i < sql.length) {
-        if (sql[i] == quote) {
-            i++
-            if (i < sql.length && sql[i] == quote) { i++; continue }
-            break
+    private fun joinKeyword(joinType: JoinType?): String {
+        return when (joinType?.code()) {
+            JoinType.INNER -> "INNER JOIN"
+            JoinType.LEFT -> "LEFT JOIN"
+            JoinType.LEFT_OUTER -> "LEFT OUTER JOIN"
+            JoinType.RIGHT -> "RIGHT JOIN"
+            JoinType.RIGHT_OUTER -> "RIGHT OUTER JOIN"
+            JoinType.FULL -> "FULL JOIN"
+            JoinType.FULL_OUTER -> "FULL OUTER JOIN"
+            JoinType.CROSS -> "CROSS JOIN"
+            JoinType.LEFT_CROSS -> "LEFT CROSS JOIN"
+            null -> "JOIN"
+            else -> "JOIN"
         }
-        i++
     }
-    return i
+
+    // --- G. Boolean Expressions (AND/OR/NOT) ---
+
+    private fun visitBooleanExpr(expr: Expr): Doc {
+        return when (expr) {
+            is ExprAnd -> {
+                val operands = flattenAnd(expr)
+                val docs = operands.map { visitBooleanExpr(it) }
+                group(
+                    docs.reduceIndexed { idx, acc, doc ->
+                        if (idx > 0) acc cat Doc.Line cat text("AND ") cat doc else doc
+                    }
+                )
+            }
+            is ExprOr -> {
+                val operands = flattenOr(expr)
+                val docs = operands.map { visitBooleanExpr(it) }
+                group(
+                    docs.reduceIndexed { idx, acc, doc ->
+                        if (idx > 0) acc cat Doc.Line cat text("OR ") cat doc else doc
+                    }
+                )
+            }
+            is ExprNot -> {
+                text("NOT ") cat bracket("(", visitBooleanExpr(expr.value), ")")
+            }
+            is ExprQuerySet -> {
+                bracket("(", visitExprQuerySet(expr, Unit), ")")
+            }
+            else -> visit(expr, Unit)
+        }
+    }
+
+    private fun flattenAnd(expr: ExprAnd): List<Expr> {
+        val result = mutableListOf<Expr>()
+        fun collect(e: Expr) {
+            if (e is ExprAnd) { collect(e.lhs); collect(e.rhs) } else result.add(e)
+        }
+        collect(expr)
+        return result
+    }
+
+    private fun flattenOr(expr: ExprOr): List<Expr> {
+        val result = mutableListOf<Expr>()
+        fun collect(e: Expr) {
+            if (e is ExprOr) { collect(e.lhs); collect(e.rhs) } else result.add(e)
+        }
+        collect(expr)
+        return result
+    }
+
+    // --- H. Expressions with Internal Breakpoints ---
+
+    override fun visitExprCall(node: ExprCall, ctx: Unit): Doc {
+        val funcName = node.function.sql(layout = SqlLayout.ONELINE, dialect = SqlDialect.STANDARD)
+        if (node.args.isEmpty()) {
+            return text("$funcName()")
+        }
+        val setq = when (node.setq?.code()) {
+            SetQuantifier.ALL -> "ALL "
+            SetQuantifier.DISTINCT -> "DISTINCT "
+            else -> ""
+        }
+        val args = node.args.map { visit(it, ctx) }
+        val argsDoc = if (setq.isNotEmpty()) {
+            text(setq) cat commaJoin(args)
+        } else {
+            commaJoin(args)
+        }
+        return text(funcName) cat bracket("(", argsDoc, ")")
+    }
+
+    override fun visitExprCase(node: ExprCase, ctx: Unit): Doc {
+        val parts = mutableListOf<Doc>()
+        val caseKw = if (node.expr != null) {
+            text("CASE ") cat visit(node.expr, ctx)
+        } else {
+            text("CASE")
+        }
+        parts.add(caseKw)
+        for (branch in node.branches) {
+            parts.add(
+                nest(
+                    4,
+                    Doc.HardLine cat text("WHEN ") cat visit(branch.condition, ctx) cat
+                        text(" THEN ") cat visit(branch.expr, ctx)
+                )
+            )
+        }
+        if (node.defaultExpr != null) {
+            parts.add(nest(4, Doc.HardLine cat text("ELSE ") cat visit(node.defaultExpr, ctx)))
+        }
+        parts.add(Doc.HardLine cat text("END"))
+        return parts.reduce { acc, doc -> acc cat doc }
+    }
+
+    override fun visitExprCoalesce(node: ExprCoalesce, ctx: Unit): Doc {
+        val args = node.args.map { visit(it, ctx) }
+        return text("COALESCE") cat bracket("(", commaJoin(args), ")")
+    }
+
+    override fun visitExprCast(node: ExprCast, ctx: Unit): Doc {
+        val valueDoc = visit(node.value, ctx)
+        val typeText = node.asType.sql(layout = SqlLayout.ONELINE, dialect = SqlDialect.STANDARD)
+        return text("CAST") cat bracket("(", valueDoc cat text(" AS $typeText"), ")")
+    }
+
+    override fun visitExprBag(node: ExprBag, ctx: Unit): Doc {
+        if (node.values.isEmpty()) return text("<<>>")
+        val items = node.values.map { visit(it, ctx) }
+        return bracket("<<", commaJoin(items), ">>")
+    }
+
+    override fun visitExprArray(node: ExprArray, ctx: Unit): Doc {
+        if (node.values.isEmpty()) return text("[]")
+        val items = node.values.map { visit(it, ctx) }
+        return bracket("[", commaJoin(items), "]")
+    }
+
+    override fun visitExprStruct(node: ExprStruct, ctx: Unit): Doc {
+        if (node.fields.isEmpty()) return text("{}")
+        val fields = node.fields.map { f ->
+            visit(f.name, ctx) cat text(": ") cat visit(f.value, ctx)
+        }
+        return bracket("{", commaJoin(fields), "}")
+    }
+
+    override fun visitExprOperator(node: ExprOperator, ctx: Unit): Doc {
+        val lhs = node.lhs
+        if (lhs == null) {
+            return text(node.symbol) cat visit(node.rhs, ctx)
+        }
+        val terms = flattenOperator(node)
+        val docs = terms.mapIndexed { idx, term ->
+            val operandDoc = visitOperand(term.operand, operatorPrecedence(node.symbol))
+            if (idx == 0) operandDoc
+            else text(" ${term.precedingOp} ") cat operandDoc
+        }
+        return group(docs.reduce { acc, doc -> acc cat doc })
+    }
+
+    private data class OpTerm(val operand: Expr, val precedingOp: String?)
+
+    private fun flattenOperator(node: ExprOperator): List<OpTerm> {
+        val precedence = operatorPrecedence(node.symbol)
+        val result = mutableListOf<OpTerm>()
+        fun collect(e: Expr, op: String?) {
+            if (e is ExprOperator && e.lhs != null && operatorPrecedence(e.symbol) == precedence) {
+                collect(e.lhs!!, null)
+                collect(e.rhs, e.symbol)
+            } else {
+                result.add(OpTerm(e, op))
+            }
+        }
+        collect(node.lhs!!, null)
+        collect(node.rhs, node.symbol)
+        return result
+    }
+
+    private fun visitOperand(expr: Expr, parentPrecedence: Int): Doc {
+        return when {
+            expr is ExprQuerySet -> bracket("(", visitExprQuerySet(expr, Unit), ")")
+            expr is ExprOperator && expr.lhs != null && operatorPrecedence(expr.symbol) < parentPrecedence ->
+                bracket("(", visit(expr, Unit), ")")
+            else -> visit(expr, Unit)
+        }
+    }
+
+    private fun operatorPrecedence(symbol: String): Int = when (symbol) {
+        "*", "/", "%" -> 3
+        "+", "-" -> 2
+        else -> 0
+    }
+
+    override fun visitExprInCollection(node: ExprInCollection, ctx: Unit): Doc {
+        val lhsDoc = visit(node.lhs, ctx)
+        val notStr = if (node.isNot) " NOT IN " else " IN "
+        val rhsDoc = if (node.rhs is ExprQuerySet) {
+            bracket("(", visitExprQuerySet(node.rhs as ExprQuerySet, ctx), ")")
+        } else {
+            visit(node.rhs, ctx)
+        }
+        return lhsDoc cat text(notStr) cat rhsDoc
+    }
+
+    override fun visitExprLike(node: ExprLike, ctx: Unit): Doc {
+        val valueDoc = visit(node.value, ctx)
+        val kw = if (node.isNot) " NOT LIKE " else " LIKE "
+        val patternDoc = visit(node.pattern, ctx)
+        val escape = node.escape
+        return if (escape != null) {
+            valueDoc cat text(kw) cat patternDoc cat text(" ESCAPE ") cat visit(escape, ctx)
+        } else {
+            valueDoc cat text(kw) cat patternDoc
+        }
+    }
+
+    override fun visitExprBetween(node: ExprBetween, ctx: Unit): Doc {
+        val valueDoc = visit(node.value, ctx)
+        val kw = if (node.isNot) " NOT BETWEEN " else " BETWEEN "
+        val fromDoc = visit(node.from, ctx)
+        val toDoc = visit(node.to, ctx)
+        return group(
+            valueDoc cat text(kw) cat fromDoc cat Doc.Line cat text("AND ") cat toDoc
+        )
+    }
+
+    override fun visitExprMatch(node: ExprMatch, ctx: Unit): Doc {
+        val exprDoc = visit(node.expr, ctx)
+        val patternDoc = visit(node.pattern, ctx)
+        return group(exprDoc cat Doc.Line cat text("MATCH ") cat patternDoc)
+    }
+
+    override fun visitExprAnd(node: ExprAnd, ctx: Unit): Doc = visitBooleanExpr(node)
+    override fun visitExprOr(node: ExprOr, ctx: Unit): Doc = visitBooleanExpr(node)
+    override fun visitExprNot(node: ExprNot, ctx: Unit): Doc = visitBooleanExpr(node)
+
+    // --- I. Set Operations ---
+
+    private fun visitSetOp(setOp: QueryBody.SetOp): Doc {
+        val lhsDoc = visitExprAsDoc(setOp.lhs)
+        val rhsDoc = visitExprAsDoc(setOp.rhs)
+        val op = buildString {
+            if (setOp.isOuter) append("OUTER ")
+            when (setOp.type.setOpType.code()) {
+                SetOpType.UNION -> append("UNION")
+                SetOpType.INTERSECT -> append("INTERSECT")
+                SetOpType.EXCEPT -> append("EXCEPT")
+            }
+            when (setOp.type.setq?.code()) {
+                SetQuantifier.ALL -> append(" ALL")
+                SetQuantifier.DISTINCT -> append(" DISTINCT")
+            }
+        }
+        return group(lhsDoc cat Doc.Line cat text(op) cat Doc.Line cat rhsDoc)
+    }
+
+    private fun visitExprAsDoc(expr: Expr): Doc {
+        return when (expr) {
+            is ExprQuerySet -> visitExprQuerySet(expr, Unit)
+            else -> visit(expr, Unit)
+        }
+    }
+
+    // --- J. Other Clauses ---
+
+    private fun visitWhereClause(expr: Expr): Doc {
+        return group(text("WHERE") cat nest(4, Doc.Line cat visitBooleanExpr(expr)))
+    }
+
+    private fun visitHavingClause(expr: Expr): Doc {
+        return group(text("HAVING") cat nest(4, Doc.Line cat visitBooleanExpr(expr)))
+    }
+
+    private fun visitGroupByClause(groupBy: GroupBy): Doc {
+        val kw = when (groupBy.strategy.code()) {
+            GroupByStrategy.PARTIAL -> "GROUP PARTIAL BY"
+            else -> "GROUP BY"
+        }
+        val keys = groupBy.keys.map { key ->
+            val keyDoc = visit(key.expr, Unit)
+            val alias = key.asAlias
+            if (alias != null) keyDoc cat text(" AS ${alias.sql()}") else keyDoc
+        }
+        val base = commaSeparated(kw, keys)
+        val groupAlias = groupBy.asAlias
+        return if (groupAlias != null) {
+            base cat text(" GROUP AS ${groupAlias.sql()}")
+        } else {
+            base
+        }
+    }
+
+    private fun visitOrderByClause(orderBy: OrderBy): Doc {
+        val sorts = orderBy.sorts.map { leafExpr(it) }
+        return commaSeparated("ORDER BY", sorts)
+    }
+
+    private fun visitLetClause(let: Let): Doc {
+        val bindings = let.bindings.map { b ->
+            visit(b.expr, Unit) cat text(" AS ${b.asAlias.sql()}")
+        }
+        return commaSeparated("LET", bindings)
+    }
+
+    private fun visitExcludeClause(exclude: Exclude): Doc {
+        val paths = exclude.excludePaths.map { leafExpr(it) }
+        return commaSeparated("EXCLUDE", paths)
+    }
+
+    private fun visitWithClause(with: With): Doc {
+        val kw = if (with.isRecursive) "WITH RECURSIVE" else "WITH"
+        val elements = with.elements.map { elem ->
+            val name = elem.queryName.sql()
+            val cols = elem.columnList
+            val colsPart = if (cols != null && cols.isNotEmpty()) {
+                text("(${cols.joinToString(", ") { it.sql() }}) ")
+            } else {
+                Doc.Nil
+            }
+            text("$name ") cat colsPart cat text("AS ") cat
+                bracket("(", visitExprQuerySet(elem.asQuery, Unit), ")")
+        }
+        return commaSeparated(kw, elements)
+    }
+
+    private fun visitWindowClause(window: WindowClause): Doc {
+        val defs = window.definitions.map { leafExpr(it) }
+        return commaSeparated("WINDOW", defs)
+    }
+
+    // --- K. Helpers ---
+
+    private fun clause(kw: String, body: Doc): Doc {
+        return group(text(kw) cat nest(4, Doc.Line cat body))
+    }
+
+    private fun commaSeparated(kw: String, items: List<Doc>): Doc {
+        if (items.isEmpty()) return text(kw)
+        return group(text(kw) cat nest(4, Doc.Line cat commaJoin(items)))
+    }
+
+    private fun leafExpr(node: AstNode): Doc {
+        return text(node.sql(layout = SqlLayout.ONELINE, dialect = SqlDialect.STANDARD))
+    }
 }

--- a/partiql-cli/src/test/kotlin/org/partiql/cli/format/PrettyPrinterTest.kt
+++ b/partiql-cli/src/test/kotlin/org/partiql/cli/format/PrettyPrinterTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ * A copy of the License is located at:
+ *
+ *      http://aws.amazon.com/apache2.0/
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ *  language governing permissions and limitations under the License.
+ */
+
+package org.partiql.cli.format
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.partiql.parser.PartiQLParser
+
+class PrettyPrinterTest {
+
+    private val parser = PartiQLParser.builder().build()
+
+    private fun fmt(sql: String, width: Int = 80): String {
+        val result = parser.parse(sql)
+        return result.statements.joinToString(";\n\n") { it.pretty(width = width) }
+    }
+
+    @Test
+    fun complexQueryIsIdempotent() {
+        val input = """
+            SELECT pt.* FROM "CSMLA_RS"."O_CUSTOMER_TRAFFIC_HITS".V4 pt LEFT JOIN "AMAZON_CONSENT_ENGINE_PROD"."PRIVACY_SCOPES".V4 dma_privacy_scope ON cast(pt."marketplace_id" as bigint) = (CASE WHEN dma_privacy_scope.locality_type = 'marketplace_id' THEN cast(dma_privacy_scope.locality_value as bigint) ELSE NULL END) AND dma_privacy_scope.locality_type = 'marketplace_id' AND dma_privacy_scope.privacy_scope = 'EU_CROSS_LOB_DATA_SHARING_V1' AND dma_privacy_scope.is_deleted = 'N' LEFT JOIN "AMAZON_CONSENT_ENGINE_PROD"."CUSTOMER_CONSENT_DIRECTIVES".V4 dma_customer_consent ON dma_customer_consent.record_type = 'actual' AND dma_customer_consent.is_deleted = 'N' AND dma_customer_consent.id_type = 'customer' AND dma_customer_consent.customer_id = cast(pt."customer_id" as bigint) AND dma_customer_consent.requester_lob_id = (SELECT CASE WHEN count(lob_id)=1 THEN max(lob_id) ELSE 0 END as lob_id FROM BDT_ANALYTICS_PROD.D_ANDES_IDENTITY_TO_LOB_MAPPING.V2 dma_idty_to_lob_mapping WHERE identity_arn = current_user AND lob_id >=0 AND is_deleted = 'N') LEFT JOIN "AMAZON_CONSENT_ENGINE_PROD"."CUSTOMER_CONSENT_DIRECTIVES".V4 dma_fallback_consent ON dma_fallback_consent.record_type = 'default' AND dma_fallback_consent.is_deleted = 'N' AND dma_fallback_consent.id_type = 'customer' AND dma_fallback_consent.customer_id = 0 AND dma_fallback_consent.requester_lob_id = (SELECT CASE WHEN count(lob_id)=1 THEN max(lob_id) ELSE 0 END as lob_id FROM BDT_ANALYTICS_PROD.D_ANDES_IDENTITY_TO_LOB_MAPPING.V2 dma_idty_to_lob_mapping WHERE identity_arn = current_user AND lob_id >=0 AND is_deleted = 'N') WHERE NOT(NOT ( ( cast ( pt."marketplace_id" as BIGINT ) IS NOT NULL AND dma_privacy_scope.locality_value IS NULL ) OR ( ( CAST ( COALESCE ( (line_of_business = '21' or line_of_business LIKE '21u%' or line_of_business LIKE '%u21u%' or line_of_business LIKE '%u21') and (line_of_business NOT LIKE '%x%'), FALSE ) AS INT ) * cast ( pow ( 2, 21-1 ) as int ) + CAST ( COALESCE ( (line_of_business = '18' or line_of_business LIKE '18u%' or line_of_business LIKE '%u18u%' or line_of_business LIKE '%u18') and (line_of_business NOT LIKE '%x%'), FALSE ) AS INT ) * cast ( pow ( 2, 18-1 ) as int ) + CAST ( COALESCE ( (line_of_business = '13' or line_of_business LIKE '13u%' or line_of_business LIKE '%u13u%' or line_of_business LIKE '%u13') and (line_of_business NOT LIKE '%x%'), FALSE ) AS INT ) * cast ( pow ( 2, 13-1 ) as int ) ) = -1 OR ( COALESCE( ( CAST ( COALESCE ( (line_of_business = '21' or line_of_business LIKE '21u%' or line_of_business LIKE '%u21u%' or line_of_business LIKE '%u21') and (line_of_business NOT LIKE '%x%'), FALSE ) AS INT ) * cast ( pow ( 2, 21-1 ) as int ) + CAST ( COALESCE ( (line_of_business = '18' or line_of_business LIKE '18u%' or line_of_business LIKE '%u18u%' or line_of_business LIKE '%u18') and (line_of_business NOT LIKE '%x%'), FALSE ) AS INT ) * cast ( pow ( 2, 18-1 ) as int ) ), 0) = 0 AND dma_customer_consent.can_cross_use_all_data = 'Y' ) ) ) )
+        """.trimIndent()
+        val first = fmt(input)
+        val second = fmt(first)
+        assertEquals(first, second, "Formatting the monster query should be idempotent")
+        assertTrue(first.lines().size > 10, "Monster query should break across many lines")
+        assertTrue(
+            first.lines().any { it.startsWith("LEFT JOIN") },
+            "JOINs should be on their own lines"
+        )
+        assertTrue(
+            first.lines().any { it.trimStart().startsWith("AND ") },
+            "AND should break within ON clauses"
+        )
+    }
+}


### PR DESCRIPTION
## Description

  Adds a partiql fmt subcommand for pretty-printing PartiQL statements based on [Wadler's "A Prettier Printer" (1997)](https://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf).

## Usage
```
  partiql fmt 'SELECT a, b FROM t WHERE x > 1'
  partiql fmt -i query.sql
  partiql fmt -w 120 'SELECT ...'
  cat query.sql | partiql fmt
```

## Architecture

  Input SQL
    → PartiQLParser.parse()
    → DocVisitor.visit(ast)    -- AST-to-Doc visitor (walks AST directly)
    → Doc tree                 -- group/nest/line at every breakpoint
    → render(width=80)         -- greedy best-fit picks flat vs broken
    → formatted SQL string

## Implementation

  - Doc.kt: Wadler document algebra (Nil, Text, Line, SoftBreak, HardLine, Concat, Nest, Union) with greedy best-fit renderer
  - PrettyPrinter.kt: AST-to-Doc visitor that produces Doc trees with breakpoints at:
    - Clause boundaries (SELECT, FROM, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, LET, EXCLUDE, WINDOW)
    - JOIN boundaries (binary tree flattened to one join per line)
    - Boolean operators (AND/OR chains flattened)
    - Comma-separated lists (SELECT items, function args, GROUP BY keys)
    - Subqueries and collection constructors in brackets
  - Operator flattening: same-precedence chains (a + b + c) stay flat; only inserts parens when precedence differs
  - FmtCommand.kt: picocli subcommand with -i (file input) and -w (width) options

 ### References:
  1. Philip Wadler, "A Prettier Printer" (1997) - http://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf
  2. CockroachDB sqlfmt - https://github.com/cockroachdb/cockroach/tree/master/pkg/util/pretty

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES]**
- Any backward-incompatible changes? **[NO]**
- Any new external dependencies? **[NO]**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES]**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md