### PR TITLE
Add SqlDialect support for MAP expression and type serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Thank you to all who have contributed!
 ## [Unreleased](https://TODO.com) - YYYY-MM-DD
 
 ### Added
+- Added SqlDialect support for MAP expression and type serialization
 
 ### Changed
 

--- a/partiql-ast/api/partiql-ast.api
+++ b/partiql-ast/api/partiql-ast.api
@@ -59,6 +59,8 @@ public final class org/partiql/ast/Ast {
 	public static final fun exprLike (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Z)Lorg/partiql/ast/expr/ExprLike;
 	public static synthetic fun exprLike$default (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;ZILjava/lang/Object;)Lorg/partiql/ast/expr/ExprLike;
 	public static final fun exprLit (Lorg/partiql/ast/Literal;)Lorg/partiql/ast/expr/ExprLit;
+	public static final fun exprMap (Ljava/util/List;)Lorg/partiql/ast/expr/ExprMap;
+	public static final fun exprMapEntry (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprMap$Entry;
 	public static final fun exprMatch (Lorg/partiql/ast/expr/Expr;Lorg/partiql/ast/graph/GraphMatch;)Lorg/partiql/ast/expr/ExprMatch;
 	public static final fun exprMissingPredicate (Lorg/partiql/ast/expr/Expr;Z)Lorg/partiql/ast/expr/ExprMissingPredicate;
 	public static final fun exprNot (Lorg/partiql/ast/expr/Expr;)Lorg/partiql/ast/expr/ExprNot;
@@ -3685,6 +3687,10 @@ public abstract class org/partiql/ast/sql/SqlDialect : org/partiql/ast/AstVisito
 	public fun visitExprLike (Lorg/partiql/ast/expr/ExprLike;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprLit (Lorg/partiql/ast/expr/ExprLit;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprLit (Lorg/partiql/ast/expr/ExprLit;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitExprMap (Lorg/partiql/ast/expr/ExprMap;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprMap (Lorg/partiql/ast/expr/ExprMap;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
+	public synthetic fun visitExprMapEntry (Lorg/partiql/ast/expr/ExprMap$Entry;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitExprMapEntry (Lorg/partiql/ast/expr/ExprMap$Entry;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprMissingPredicate (Lorg/partiql/ast/expr/ExprMissingPredicate;Ljava/lang/Object;)Ljava/lang/Object;
 	public fun visitExprMissingPredicate (Lorg/partiql/ast/expr/ExprMissingPredicate;Lorg/partiql/ast/sql/SqlBlock;)Lorg/partiql/ast/sql/SqlBlock;
 	public synthetic fun visitExprNot (Lorg/partiql/ast/expr/ExprNot;Ljava/lang/Object;)Ljava/lang/Object;

--- a/partiql-ast/src/main/java/org/partiql/ast/sql/SqlDialect.kt
+++ b/partiql-ast/src/main/java/org/partiql/ast/sql/SqlDialect.kt
@@ -76,6 +76,7 @@ import org.partiql.ast.expr.ExprInCollection
 import org.partiql.ast.expr.ExprIsType
 import org.partiql.ast.expr.ExprLike
 import org.partiql.ast.expr.ExprLit
+import org.partiql.ast.expr.ExprMap
 import org.partiql.ast.expr.ExprMissingPredicate
 import org.partiql.ast.expr.ExprNot
 import org.partiql.ast.expr.ExprNullIf
@@ -339,6 +340,14 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
             DataType.INTERVAL -> visit(node.intervalQualifier, tail concat "INTERVAL ")
             // <container type>
             DataType.STRUCT, DataType.TUPLE -> tail concat node.name()
+            DataType.MAP -> {
+                var t = tail concat "MAP<"
+                t = visitDataType(node.keyType, t)
+                t = t concat ", "
+                t = visitDataType(node.elementType, t)
+                t = t concat ">"
+                t
+            }
             // <collection type>
             DataType.LIST, DataType.BAG, DataType.SEXP -> tail concat node.name()
             // <user defined type>
@@ -535,6 +544,19 @@ public abstract class SqlDialect : AstVisitor<SqlBlock, SqlBlock>() {
     override fun visitExprStructField(node: ExprStruct.Field, tail: SqlBlock): SqlBlock {
         var t = tail
         t = visitExprWrapped(node.name, t)
+        t = t concat ": "
+        t = visitExprWrapped(node.value, t)
+        return t
+    }
+
+    @Suppress("DEPRECATION")
+    override fun visitExprMap(node: ExprMap, tail: SqlBlock): SqlBlock =
+        tail concat list("MAP {", "}") { node.entries }
+
+    @Suppress("DEPRECATION")
+    override fun visitExprMapEntry(node: ExprMap.Entry, tail: SqlBlock): SqlBlock {
+        var t = tail
+        t = visitExprWrapped(node.key, t)
         t = t concat ": "
         t = visitExprWrapped(node.value, t)
         return t

--- a/partiql-ast/src/main/kotlin/org/partiql/ast/Ast.kt
+++ b/partiql-ast/src/main/kotlin/org/partiql/ast/Ast.kt
@@ -36,6 +36,7 @@ import org.partiql.ast.expr.ExprInCollection
 import org.partiql.ast.expr.ExprIsType
 import org.partiql.ast.expr.ExprLike
 import org.partiql.ast.expr.ExprLit
+import org.partiql.ast.expr.ExprMap
 import org.partiql.ast.expr.ExprMatch
 import org.partiql.ast.expr.ExprMissingPredicate
 import org.partiql.ast.expr.ExprNot
@@ -255,6 +256,18 @@ public object Ast {
     @JvmStatic
     public fun exprStructField(name: Expr, value: Expr): ExprStruct.Field {
         return ExprStruct.Field(name, value)
+    }
+
+    @Deprecated("This feature is experimental and is subject to change.")
+    @JvmStatic
+    public fun exprMap(entries: List<ExprMap.Entry>): ExprMap {
+        return ExprMap(entries)
+    }
+
+    @Deprecated("This feature is experimental and is subject to change.")
+    @JvmStatic
+    public fun exprMapEntry(key: Expr, value: Expr): ExprMap.Entry {
+        return ExprMap.Entry(key, value)
     }
 
     @JvmStatic

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
@@ -35,6 +35,8 @@ import org.partiql.ast.Ast.exprInCollection
 import org.partiql.ast.Ast.exprIsType
 import org.partiql.ast.Ast.exprLike
 import org.partiql.ast.Ast.exprLit
+import org.partiql.ast.Ast.exprMap
+import org.partiql.ast.Ast.exprMapEntry
 import org.partiql.ast.Ast.exprMissingPredicate
 import org.partiql.ast.Ast.exprNot
 import org.partiql.ast.Ast.exprNullIf
@@ -186,6 +188,11 @@ class SqlDialectTest {
     @Execution(ExecutionMode.CONCURRENT)
     fun testExprStruct(case: Case) = case.assert()
 
+    @ParameterizedTest(name = "expr.map #{index}")
+    @MethodSource("exprMapCases")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun testExprMap(case: Case) = case.assert()
+
     @ParameterizedTest(name = "special form #{index}")
     @MethodSource("exprSpecialFormCases")
     @Execution(ExecutionMode.CONCURRENT)
@@ -305,8 +312,13 @@ class SqlDialectTest {
             expect("TIME (1)", DataType.TIME(1)),
             expect("TIME WITH TIME ZONE", DataType.TIME_WITH_TIME_ZONE()),
             expect("TIME (1) WITH TIME ZONE", DataType.TIME_WITH_TIME_ZONE(1)),
-            // TODO TIMESTAMP
-            // TODO INTERVAL
+            expect("TIMESTAMP (3)", DataType.TIMESTAMP(3)),
+            expect("TIMESTAMP WITH TIME ZONE", DataType.TIMESTAMP_WITH_TIME_ZONE()),
+            expect("TIMESTAMP (6) WITH TIME ZONE", DataType.TIMESTAMP_WITH_TIME_ZONE(6)),
+            expect("INTERVAL YEAR", DataType.INTERVAL(IntervalQualifier.Single(DatetimeField.YEAR(), null, null))),
+            expect("INTERVAL DAY (3)", DataType.INTERVAL(IntervalQualifier.Single(DatetimeField.DAY(), 3, null))),
+            expect("INTERVAL DAY TO SECOND", DataType.INTERVAL(IntervalQualifier.Range(DatetimeField.DAY(), null, DatetimeField.SECOND(), null))),
+            expect("INTERVAL DAY (2) TO SECOND (6)", DataType.INTERVAL(IntervalQualifier.Range(DatetimeField.DAY(), 2, DatetimeField.SECOND(), 6))),
             // TODO other types in `DataType`
             // PartiQL
             expect("STRING", DataType.STRING()),
@@ -316,6 +328,7 @@ class SqlDialectTest {
             expect("LIST", DataType.LIST()),
             expect("SEXP", DataType.SEXP()),
             expect("BAG", DataType.BAG()),
+            expect("MAP<VARCHAR, INT>", DataType.MAP(DataType.VARCHAR(), DataType.INT())),
             // Other (??)
             expect("INT4", DataType.INT4()),
             expect("INT8", DataType.INT8()),
@@ -940,6 +953,56 @@ class SqlDialectTest {
                         exprStructField(
                             name = v("b"),
                             value = exprLit(bool(false))
+                        )
+                    )
+                )
+            ),
+        )
+
+        @Suppress("DEPRECATION")
+        @JvmStatic
+        fun exprMapCases() = listOf(
+            expect(
+                "MAP {}",
+                exprMap(emptyList())
+            ),
+            expect(
+                "MAP {'a': 1}",
+                exprMap(
+                    listOf(
+                        exprMapEntry(
+                            exprLit(string("a")),
+                            exprLit(intNum(1))
+                        )
+                    )
+                )
+            ),
+            expect(
+                "MAP {'a': 1, 'b': 2, 'c': 3}",
+                exprMap(
+                    listOf(
+                        exprMapEntry(
+                            exprLit(string("a")),
+                            exprLit(intNum(1))
+                        ),
+                        exprMapEntry(
+                            exprLit(string("b")),
+                            exprLit(intNum(2))
+                        ),
+                        exprMapEntry(
+                            exprLit(string("c")),
+                            exprLit(intNum(3))
+                        )
+                    )
+                )
+            ),
+            expect(
+                "MAP {x: y}",
+                exprMap(
+                    listOf(
+                        exprMapEntry(
+                            v("x"),
+                            v("y")
                         )
                     )
                 )

--- a/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
+++ b/partiql-ast/src/test/kotlin/org/partiql/ast/sql/SqlDialectTest.kt
@@ -329,6 +329,7 @@ class SqlDialectTest {
             expect("SEXP", DataType.SEXP()),
             expect("BAG", DataType.BAG()),
             expect("MAP<VARCHAR, INT>", DataType.MAP(DataType.VARCHAR(), DataType.INT())),
+            expect("MAP<VARCHAR, MAP<DECIMAL, BOOL>>", DataType.MAP(DataType.VARCHAR(), DataType.MAP(DataType.DECIMAL(), DataType.BOOL()))),
             // Other (??)
             expect("INT4", DataType.INT4()),
             expect("INT8", DataType.INT8()),


### PR DESCRIPTION
## Relevant Issues
- [Related To] Issue https://github.com/partiql/partiql-lang/issues/8

## Description
 - Implement visitExprMap/visitExprMapEntry in SqlDialect to serialize MAP
  constructor expressions (e.g. MAP {'a': 1, 'b': 2}). 
- Add MAP<K, V> rendering for DataType.MAP. 
- Include factory methods exprMap/exprMapEntry
  in Ast.kt. 
- Fill in TODO test cases for TIMESTAMP and INTERVAL types.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**: YES
- Any backward-incompatible changes? **[YES/NO]**: NO
- Any new external dependencies? **[YES/NO]**: NO
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES/NO]**:YES

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md