### PR TITLE
Added implicit cast for lookup key in MAP if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Thank you to all who have contributed!
 ### Added
 - Added SqlDialect support for MAP expression and type serialization
 - Added MAP functions: contains_key, map_get, map_keys, map_values, map_entries, size, exists, cardinality and `IS MAP<K, V>
+- Added implicit cast when `MAP` lookup key type does not match `MAP` key type.
  
 ### Changed
 

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathIndexMap.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathIndexMap.kt
@@ -22,6 +22,12 @@ internal class ExprPathIndexMap(
         if (input.isMissing || k.isMissing) {
             return Datum.missing(input.type.valueType)
         }
-        return input.get(k).orElseThrow { PErrors.mapKeyNotFoundException(k, input.type) }
+        val mapKeyType = input.type.keyType
+        val castKey = if (k.type.code() != mapKeyType.code()) {
+            CastTable.cast(k, mapKeyType)
+        } else {
+            k
+        }
+        return input.get(castKey).orElseThrow { PErrors.mapKeyNotFoundException(k, input.type) }
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathKeyMap.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rex/ExprPathKeyMap.kt
@@ -22,6 +22,12 @@ internal class ExprPathKeyMap(
         if (input.isMissing || k.isMissing) {
             return Datum.missing(input.type.valueType)
         }
-        return input.get(k).orElseThrow { PErrors.mapKeyNotFoundException(k, input.type) }
+        val mapKeyType = input.type.keyType
+        val castKey = if (k.type.code() != mapKeyType.code()) {
+            CastTable.cast(k, mapKeyType)
+        } else {
+            k
+        }
+        return input.get(castKey).orElseThrow { PErrors.mapKeyNotFoundException(k, input.type) }
     }
 }

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/MapTests.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/MapTests.kt
@@ -9,6 +9,7 @@ import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
 import org.partiql.spi.value.Entry
 import java.math.BigDecimal
+import java.time.LocalDate
 
 class MapTests {
 
@@ -195,6 +196,18 @@ class MapTests {
                     )
                 ),
             ),
+            SuccessTestCase(
+                name = "MAP with DATE keys",
+                input = "MAP { DATE '2024-01-15': 'holiday', DATE '2024-07-04': 'independence' };",
+                expected = Datum.map(
+                    PType.date(),
+                    PType.string(),
+                    listOf(
+                        Entry.of(Datum.date(LocalDate.of(2024, 1, 15)), Datum.string("holiday")),
+                        Entry.of(Datum.date(LocalDate.of(2024, 7, 4)), Datum.string("independence")),
+                    )
+                ),
+            ),
         )
 
         @JvmStatic
@@ -225,6 +238,27 @@ class MapTests {
             SuccessTestCase(
                 name = "MAP integer key access with bracket notation",
                 input = "MAP { 1: 'one', 2: 'two' }[1];",
+                expected = Datum.string("one"),
+            ),
+            SuccessTestCase(
+                name = "MAP DATE key access with bracket notation",
+                input = "MAP { DATE '2024-01-15': 'holiday', DATE '2024-07-04': 'independence' }[DATE '2024-07-04'];",
+                expected = Datum.string("independence"),
+            ),
+            // Key cast tests: lookup key type differs from MAP key type, implicit cast applied
+            SuccessTestCase(
+                name = "MAP integer key accessed with decimal (implicit cast to INTEGER)",
+                input = "MAP { 1: 'one', 2: 'two' }[1.0];",
+                expected = Datum.string("one"),
+            ),
+            SuccessTestCase(
+                name = "MAP integer key accessed with bigint (implicit cast to INTEGER)",
+                input = "MAP { 1: 'one', 2: 'two' }[CAST(2 AS BIGINT)];",
+                expected = Datum.string("two"),
+            ),
+            SuccessTestCase(
+                name = "MAP decimal key accessed with integer (implicit cast to DECIMAL)",
+                input = "MAP { 1.0: 'one', 2.0: 'two' }[1];",
                 expected = Datum.string("one"),
             ),
         )

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/MapTests.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/MapTests.kt
@@ -261,6 +261,28 @@ class MapTests {
                 input = "MAP { 1.0: 'one', 2.0: 'two' }[1];",
                 expected = Datum.string("one"),
             ),
+            // Static cast: heterogeneous keys coerced to DECIMAL at plan time, lookup with INTEGER
+            SuccessTestCase(
+                name = "MAP with heterogeneous keys accessed with integer (plan-time coercion to DECIMAL)",
+                input = "MAP { 2: 'two', 1.0: 'yes' }[2];",
+                expected = Datum.string("two"),
+            ),
+            SuccessTestCase(
+                name = "MAP with heterogeneous keys accessed with decimal (plan-time coercion to DECIMAL)",
+                input = "MAP { 2: 'two', 1.0: 'yes' }[1.0];",
+                expected = Datum.string("yes"),
+            ),
+            // Dynamic type: MAP type resolved at runtime via CASE expression
+            SuccessTestCase(
+                name = "Dynamic MAP from CASE accessed with integer key (runtime cast)",
+                input = "(CASE WHEN 1=1 THEN MAP { 1: 'one', 2: 'two' } ELSE MAP { 3: 'three' } END)[1];",
+                expected = Datum.string("one"),
+            ),
+            SuccessTestCase(
+                name = "Dynamic MAP from CASE accessed with decimal key (runtime cast)",
+                input = "(CASE WHEN 1=1 THEN MAP { 1: 'one', 2: 'two' } ELSE MAP { 3: 'three' } END)[1.0];",
+                expected = Datum.string("one"),
+            ),
         )
 
         @JvmStatic

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -905,10 +905,17 @@ internal class PlanTyper(private val env: Env, config: Context, private val flag
                 return Rex(CompilerType(PType.dynamic()), Rex.Op.Path.Index(root, key))
             }
 
-            // MAP index access — return the value type
+            // MAP index access — return the value type, cast key to map's key type if needed
             if (root.type.code() == PType.MAP) {
+                val mapKeyType = CompilerType(root.type.keyType)
                 val valueType = CompilerType(root.type.valueType)
-                return rex(valueType, rexOpPathIndex(root, key))
+                val castKey = if (key.type != mapKeyType) {
+                    val cast = env.resolveCast(key, mapKeyType)
+                    if (cast != null) rex(mapKeyType, cast) else key
+                } else {
+                    key
+                }
+                return rex(valueType, rexOpPathIndex(root, castKey))
             }
 
             // Check Key Type (INT or coercible to INT). TODO: Allow coercions to INT
@@ -936,25 +943,32 @@ internal class PlanTyper(private val env: Env, config: Context, private val flag
             val root = visitRex(node.root, node.root.type)
             val key = visitRex(node.key, node.key.type)
 
-            // Check Key Type (STRING). TODO: Allow coercions to STRING
-            if (key.type.code() != PType.STRING) {
-                return errorRexAndReport(_listener, PErrors.pathKeyNeverSucceeds(null))
-            }
-
             // If the root is DYNAMIC, we can't know at compile time whether it's a MAP or STRUCT; defer to runtime.
             if (root.type.code() == PType.DYNAMIC || root.type.code() == PType.VARIANT) {
                 return Rex(CompilerType(PType.dynamic()), Rex.Op.Path.Key(root, key))
             }
 
-            // Check Root Type (STRUCT)
-            if (root.type.code() != PType.STRUCT && root.type.code() != PType.ROW && root.type.code() != PType.MAP) {
-                return errorRexAndReport(_listener, PErrors.pathKeyNeverSucceeds(null), PType.unknown())
+            // MAP key access — return the value type, cast key to map's key type if needed
+            if (root.type.code() == PType.MAP) {
+                val mapKeyType = CompilerType(root.type.keyType)
+                val valueType = CompilerType(root.type.valueType)
+                val castKey = if (key.type != mapKeyType) {
+                    val cast = env.resolveCast(key, mapKeyType)
+                    if (cast != null) rex(mapKeyType, cast) else key
+                } else {
+                    key
+                }
+                return rex(valueType, rexOpPathKey(root, castKey))
             }
 
-            // MAP key access — return the value type
-            if (root.type.code() == PType.MAP) {
-                val valueType = CompilerType(root.type.valueType)
-                return rex(valueType, rexOpPathKey(root, key))
+            // Check Key Type (STRING). TODO: Allow coercions to STRING
+            if (key.type.code() != PType.STRING) {
+                return errorRexAndReport(_listener, PErrors.pathKeyNeverSucceeds(null))
+            }
+
+            // Check Root Type (STRUCT)
+            if (root.type.code() != PType.STRUCT && root.type.code() != PType.ROW) {
+                return errorRexAndReport(_listener, PErrors.pathKeyNeverSucceeds(null), PType.unknown())
             }
 
             // Get Literal Key


### PR DESCRIPTION
## Relevant Issues
- [Related To] Issue partiql/partiql-lang#8

## Description
  - Added implicit cast when `MAP` lookup key type does not match `MAP` key type.

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**: YES
- Any backward-incompatible changes? **[YES/NO]**: NO
- Any new external dependencies? **[YES/NO]**: NO
- Do your changes comply with the [contributing][cg] and [code
style][csg] guidelines? **[YES/NO]**:YES

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md