### PR TITLE
Support Correlated Join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Thank you to all who have contributed!
 - Added implicit cast for `MAP` lookup key type if needed for bracket notation, map_contains_key function and map_get function.
 - Added MAP type operation support: CAST and UNPIVOT
 - Added `MAP` type parsing in DatumIonReader for CLI and Conformance tests
+- Added Support for correlated Join.
 
 ### Changed
 
@@ -45,6 +46,7 @@ Thank you to all who have contributed!
 ### Contributors
 Thank you to all who have contributed!
 - @xd1313113
+- @yliuuuu
 
 ## [1.4.0](https://github.com/partiql/partiql-lang-kotlin/releases/tag/v1.4.0) - 2026-06-05
 

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/OperatorCompiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/OperatorCompiler.kt
@@ -7,6 +7,8 @@ import org.partiql.eval.internal.helpers.checkInterrupted
 import org.partiql.eval.internal.operator.Aggregate
 import org.partiql.eval.internal.operator.rel.Collation
 import org.partiql.eval.internal.operator.rel.RelOpAggregate
+import org.partiql.eval.internal.operator.rel.RelOpCorrelateInner
+import org.partiql.eval.internal.operator.rel.RelOpCorrelateLeft
 import org.partiql.eval.internal.operator.rel.RelOpDistinct
 import org.partiql.eval.internal.operator.rel.RelOpExceptAll
 import org.partiql.eval.internal.operator.rel.RelOpExceptDistinct
@@ -16,8 +18,6 @@ import org.partiql.eval.internal.operator.rel.RelOpIntersectAll
 import org.partiql.eval.internal.operator.rel.RelOpIntersectDistinct
 import org.partiql.eval.internal.operator.rel.RelOpIterate
 import org.partiql.eval.internal.operator.rel.RelOpIteratePermissive
-import org.partiql.eval.internal.operator.rel.RelOpCorrelateInner
-import org.partiql.eval.internal.operator.rel.RelOpCorrelateLeft
 import org.partiql.eval.internal.operator.rel.RelOpJoinInner
 import org.partiql.eval.internal.operator.rel.RelOpJoinOuterFull
 import org.partiql.eval.internal.operator.rel.RelOpJoinOuterLeft

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/OperatorCompiler.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/OperatorCompiler.kt
@@ -16,6 +16,8 @@ import org.partiql.eval.internal.operator.rel.RelOpIntersectAll
 import org.partiql.eval.internal.operator.rel.RelOpIntersectDistinct
 import org.partiql.eval.internal.operator.rel.RelOpIterate
 import org.partiql.eval.internal.operator.rel.RelOpIteratePermissive
+import org.partiql.eval.internal.operator.rel.RelOpCorrelateInner
+import org.partiql.eval.internal.operator.rel.RelOpCorrelateLeft
 import org.partiql.eval.internal.operator.rel.RelOpJoinInner
 import org.partiql.eval.internal.operator.rel.RelOpJoinOuterFull
 import org.partiql.eval.internal.operator.rel.RelOpJoinOuterLeft
@@ -201,6 +203,16 @@ internal class OperatorCompiler(
                     PJoinType.LEFT -> RelOpJoinOuterLeft(lhs, rhs, condition, rhsType)
                     PJoinType.RIGHT -> RelOpJoinOuterRight(lhs, rhs, condition, lhsType)
                     PJoinType.FULL -> RelOpJoinOuterFull(lhs, rhs, condition, lhsType, rhsType)
+                }
+            }
+            is PRel.Correlate -> {
+                val lhs = compileRel(rel.lhs)
+                val rhs = compileRel(rel.rhs)
+                val rhsType = rel.rhs.type!!
+                when (rel.joinType) {
+                    PJoinType.INNER -> RelOpCorrelateInner(lhs, rhs)
+                    PJoinType.LEFT -> RelOpCorrelateLeft(lhs, rhs, rhsType)
+                    else -> error("Unsupported correlate join type: ${rel.joinType}")
                 }
             }
             is PRel.Sort -> RelOpSort(compileRel(rel.input), rel.collations.map { toCollation(it) })

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/PlanToExecTransform.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/PlanToExecTransform.kt
@@ -8,6 +8,7 @@ import org.partiql.eval.compiler.Strategy
 import org.partiql.eval.internal.plan.ExecutionPlanImpl
 import org.partiql.eval.internal.plan.PCollation
 import org.partiql.eval.internal.plan.PExpr
+import org.partiql.spi.value.Datum
 import org.partiql.eval.internal.plan.PJoinType
 import org.partiql.eval.internal.plan.PMeasure
 import org.partiql.eval.internal.plan.PRel
@@ -21,6 +22,7 @@ import org.partiql.plan.OperatorVisitor
 import org.partiql.plan.Plan
 import org.partiql.plan.rel.Rel
 import org.partiql.plan.rel.RelAggregate
+import org.partiql.plan.rel.RelCorrelate
 import org.partiql.plan.rel.RelDistinct
 import org.partiql.plan.rel.RelExcept
 import org.partiql.plan.rel.RelExclude
@@ -233,6 +235,16 @@ internal class PlanToExecTransform(
             else -> error("Unsupported join type: ${rel.joinType}")
         }
         return PRel.Join(visitRel(rel.left), visitRel(rel.right), visitRex(rel.condition), joinType, rel.type)
+    }
+
+    override fun visitCorrelate(rel: RelCorrelate, ctx: Unit): Any {
+        val joinType = when (rel.joinType.code()) {
+            JoinType.INNER -> PJoinType.INNER
+            JoinType.LEFT -> PJoinType.LEFT
+            else -> error("Unsupported correlate join type: ${rel.joinType}")
+        }
+        val condition = PExpr.Lit(Datum.bool(true))
+        return PRel.Join(visitRel(rel.left), visitRel(rel.right), condition, joinType, rel.type)
     }
 
     override fun visitSort(rel: RelSort, ctx: Unit): Any =

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/PlanToExecTransform.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/PlanToExecTransform.kt
@@ -8,7 +8,6 @@ import org.partiql.eval.compiler.Strategy
 import org.partiql.eval.internal.plan.ExecutionPlanImpl
 import org.partiql.eval.internal.plan.PCollation
 import org.partiql.eval.internal.plan.PExpr
-import org.partiql.spi.value.Datum
 import org.partiql.eval.internal.plan.PJoinType
 import org.partiql.eval.internal.plan.PMeasure
 import org.partiql.eval.internal.plan.PRel

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/PlanToExecTransform.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/compiler/PlanToExecTransform.kt
@@ -243,8 +243,7 @@ internal class PlanToExecTransform(
             JoinType.LEFT -> PJoinType.LEFT
             else -> error("Unsupported correlate join type: ${rel.joinType}")
         }
-        val condition = PExpr.Lit(Datum.bool(true))
-        return PRel.Join(visitRel(rel.left), visitRel(rel.right), condition, joinType, rel.type)
+        return PRel.Correlate(visitRel(rel.left), visitRel(rel.right), joinType, rel.type)
     }
 
     override fun visitSort(rel: RelSort, ctx: Unit): Any =

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpCorrelateInner.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpCorrelateInner.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file.
+ */
+
+package org.partiql.eval.internal.operator.rel
+
+import org.partiql.eval.Environment
+import org.partiql.eval.ExprRelation
+import org.partiql.eval.Row
+import org.partiql.eval.internal.helpers.checkInterrupted
+
+/**
+ * Correlated (lateral) inner join. The RHS is opened per LHS row with the LHS row pushed into the environment.
+ *
+ * Algorithm:
+ * ```
+ * for lhsRecord in lhs:
+ *   for rhsRecord in rhs(lhsRecord):
+ *     yield(lhsRecord + rhsRecord)
+ * ```
+ */
+internal class RelOpCorrelateInner(
+    private val lhs: ExprRelation,
+    private val rhs: ExprRelation,
+) : RelOpPeeking() {
+
+    private lateinit var env: Environment
+    private lateinit var iterator: Iterator<Row>
+
+    override fun openPeeking(env: Environment) {
+        this.env = env
+        lhs.open(env)
+        iterator = implementation()
+    }
+
+    override fun peek(): Row? {
+        return when (iterator.hasNext()) {
+            true -> iterator.next()
+            false -> null
+        }
+    }
+
+    override fun closePeeking() {
+        lhs.close()
+        rhs.close()
+        iterator = emptyList<Row>().iterator()
+    }
+
+    private fun implementation() = iterator {
+        for (lhsRecord in lhs) {
+            rhs.open(env.push(lhsRecord))
+            for (rhsRecord in rhs) {
+                checkInterrupted()
+                yield(lhsRecord.concat(rhsRecord))
+            }
+        }
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpCorrelateInner.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpCorrelateInner.kt
@@ -61,6 +61,7 @@ internal class RelOpCorrelateInner(
                 checkInterrupted()
                 yield(lhsRecord.concat(rhsRecord))
             }
+            rhs.close()
         }
     }
 }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpCorrelateLeft.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpCorrelateLeft.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file.
+ */
+
+package org.partiql.eval.internal.operator.rel
+
+import org.partiql.eval.Environment
+import org.partiql.eval.ExprRelation
+import org.partiql.eval.Row
+import org.partiql.eval.internal.helpers.checkInterrupted
+import org.partiql.plan.rel.RelType
+import org.partiql.spi.value.Datum
+
+/**
+ * Correlated (lateral) left outer join. The RHS is opened per LHS row with the LHS row pushed into the environment.
+ * LHS rows with no RHS match are preserved with NULL-padded RHS.
+ *
+ * Algorithm:
+ * ```
+ * for lhsRecord in lhs:
+ *   matched = false
+ *   for rhsRecord in rhs(lhsRecord):
+ *     matched = true
+ *     yield(lhsRecord + rhsRecord)
+ *   if (!matched):
+ *     yield(lhsRecord + NULL_RECORD)
+ * ```
+ */
+internal class RelOpCorrelateLeft(
+    private val lhs: ExprRelation,
+    private val rhs: ExprRelation,
+    rhsType: RelType,
+) : RelOpPeeking() {
+
+    private val rhsPadded = Row(
+        rhsType.getFields().map { Datum.nullValue(it.type) }.toTypedArray()
+    )
+
+    private lateinit var env: Environment
+    private lateinit var iterator: Iterator<Row>
+
+    override fun openPeeking(env: Environment) {
+        this.env = env
+        lhs.open(env)
+        iterator = implementation()
+    }
+
+    override fun peek(): Row? {
+        return when (iterator.hasNext()) {
+            true -> iterator.next()
+            false -> null
+        }
+    }
+
+    override fun closePeeking() {
+        lhs.close()
+        rhs.close()
+        iterator = emptyList<Row>().iterator()
+    }
+
+    private fun implementation() = iterator {
+        for (lhsRecord in lhs) {
+            var lhsMatched = false
+            rhs.open(env.push(lhsRecord))
+            for (rhsRecord in rhs) {
+                checkInterrupted()
+                lhsMatched = true
+                yield(lhsRecord.concat(rhsRecord))
+            }
+            rhs.close()
+            if (!lhsMatched) {
+                yield(lhsRecord.concat(rhsPadded))
+            }
+        }
+    }
+}

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpJoinInner.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpJoinInner.kt
@@ -8,10 +8,8 @@ import org.partiql.eval.internal.helpers.ValueUtility.isTrue
 import org.partiql.eval.internal.helpers.checkInterrupted
 
 /**
- * Inner Join returns all joined records from the [lhs] and [rhs] when the [condition] evaluates to true.
- *
- * Note: This is currently the lateral version of the inner join. In the future, the two implementations
- * (lateral vs non-lateral) may be separated for performance improvements.
+ * Non-lateral inner join. Both sides are opened independently. The RHS is materialized once and
+ * rescanned for each LHS row. The condition is evaluated on the combined row.
  */
 internal class RelOpJoinInner(
     private val lhs: ExprRelation,
@@ -25,8 +23,16 @@ internal class RelOpJoinInner(
     override fun openPeeking(env: Environment) {
         this.env = env
         lhs.open(env)
+        rhs.open(env)
+        // Materialize RHS so we can rescan per LHS row
+        rhsRows = mutableListOf<Row>().also { list ->
+            for (row in rhs) { list.add(row) }
+        }
+        rhs.close()
         iterator = implementation()
     }
+
+    private lateinit var rhsRows: List<Row>
 
     override fun peek(): Row? {
         return when (iterator.hasNext()) {
@@ -37,28 +43,24 @@ internal class RelOpJoinInner(
 
     override fun closePeeking() {
         lhs.close()
-        rhs.close()
         iterator = emptyList<Row>().iterator()
     }
 
     /**
-     * INNER JOIN (LATERAL)
+     * INNER JOIN (NON-LATERAL)
      *
      * Algorithm:
      * ```
+     * rhsRows = materialize(rhs)
      * for lhsRecord in lhs:
-     *   for rhsRecord in rhs(lhsRecord):
+     *   for rhsRecord in rhsRows:
      *     if (condition matches):
-     *       conditionMatched = true
      *       yield(lhsRecord + rhsRecord)
      * ```
-     *
-     * Development Note: The non-lateral version wouldn't need to push to the current environment.
      */
     private fun implementation() = iterator {
         for (lhsRecord in lhs) {
-            rhs.open(env.push(lhsRecord))
-            for (rhsRecord in rhs) {
+            for (rhsRecord in rhsRows) {
                 checkInterrupted()
                 val input = lhsRecord.concat(rhsRecord)
                 val result = condition.eval(env.push(input))

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpJoinInner.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpJoinInner.kt
@@ -19,6 +19,7 @@ internal class RelOpJoinInner(
 
     private lateinit var env: Environment
     private lateinit var iterator: Iterator<Row>
+    private lateinit var rhsRows: List<Row>
 
     override fun openPeeking(env: Environment) {
         this.env = env
@@ -31,8 +32,6 @@ internal class RelOpJoinInner(
         rhs.close()
         iterator = implementation()
     }
-
-    private lateinit var rhsRows: List<Row>
 
     override fun peek(): Row? {
         return when (iterator.hasNext()) {

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpJoinOuterLeft.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpJoinOuterLeft.kt
@@ -10,11 +10,8 @@ import org.partiql.plan.rel.RelType
 import org.partiql.spi.value.Datum
 
 /**
- * Left Outer Join returns all joined records from the [lhs] and [rhs] when the [condition] evaluates to true. For all
- * records from the [lhs] that do not evaluate to true, these are also returned along with a NULL record from the [rhs].
- *
- * Note: This is currently the lateral version of the left outer join. In the future, the two implementations
- * (lateral vs non-lateral) may be separated for performance improvements.
+ * Non-lateral left outer join. Both sides are opened independently. The RHS is materialized once
+ * and rescanned for each LHS row. LHS rows with no match are preserved with NULL-padded RHS.
  */
 internal class RelOpJoinOuterLeft(
     private val lhs: ExprRelation,
@@ -23,19 +20,23 @@ internal class RelOpJoinOuterLeft(
     rhsType: RelType,
 ) : RelOpPeeking() {
 
-    // TODO BETTER MECHANISM FOR NULL PADDING
-    private val rhsPadded =
-        Row(
-            rhsType.getFields().map { Datum.nullValue(it.type) }
-                .toTypedArray()
-        )
+    private val rhsPadded = Row(
+        rhsType.getFields().map { Datum.nullValue(it.type) }.toTypedArray()
+    )
 
     private lateinit var env: Environment
     private lateinit var iterator: Iterator<Row>
+    private lateinit var rhsRows: List<Row>
 
     override fun openPeeking(env: Environment) {
         this.env = env
         lhs.open(env)
+        rhs.open(env)
+        // Materialize RHS so we can rescan per LHS row
+        rhsRows = mutableListOf<Row>().also { list ->
+            for (row in rhs) { list.add(row) }
+        }
+        rhs.close()
         iterator = implementation()
     }
 
@@ -48,31 +49,29 @@ internal class RelOpJoinOuterLeft(
 
     override fun closePeeking() {
         lhs.close()
-        rhs.close()
         iterator = emptyList<Row>().iterator()
     }
 
     /**
-     * LEFT OUTER JOIN (LATERAL)
+     * LEFT OUTER JOIN (NON-LATERAL)
      *
      * Algorithm:
      * ```
+     * rhsRows = materialize(rhs)
      * for lhsRecord in lhs:
-     *   for rhsRecord in rhs(lhsRecord):
+     *   matched = false
+     *   for rhsRecord in rhsRows:
      *     if (condition matches):
-     *       conditionMatched = true
+     *       matched = true
      *       yield(lhsRecord + rhsRecord)
-     *   if (!conditionMatched):
+     *   if (!matched):
      *     yield(lhsRecord + NULL_RECORD)
      * ```
-     *
-     * Development Note: The non-lateral version wouldn't need to push to the current environment.
      */
     private fun implementation() = iterator {
         for (lhsRecord in lhs) {
             var lhsMatched = false
-            rhs.open(env.push(lhsRecord))
-            for (rhsRecord in rhs) {
+            for (rhsRecord in rhsRows) {
                 checkInterrupted()
                 val input = lhsRecord.concat(rhsRecord)
                 val result = condition.eval(env.push(input))
@@ -81,7 +80,6 @@ internal class RelOpJoinOuterLeft(
                     yield(lhsRecord.concat(rhsRecord))
                 }
             }
-            rhs.close()
             if (!lhsMatched) {
                 yield(lhsRecord.concat(rhsPadded))
             }

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/plan/PRel.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/plan/PRel.kt
@@ -15,6 +15,7 @@ internal sealed class PRel {
     data class Filter(val input: PRel, val predicate: PExpr, override val type: RelType? = null) : PRel()
     data class Project(val input: PRel, val projections: List<PExpr>, override val type: RelType? = null) : PRel()
     data class Join(val lhs: PRel, val rhs: PRel, val condition: PExpr, val joinType: PJoinType, override val type: RelType? = null) : PRel()
+    data class Correlate(val lhs: PRel, val rhs: PRel, val joinType: PJoinType, override val type: RelType? = null) : PRel()
     data class Sort(val input: PRel, val collations: List<PCollation>, override val type: RelType? = null) : PRel()
     data class Distinct(val input: PRel, override val type: RelType? = null) : PRel()
     data class Limit(val input: PRel, val limit: PExpr, override val type: RelType? = null) : PRel()

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/ir/Nodes.kt
@@ -11,6 +11,7 @@ import org.partiql.planner.internal.ir.builder.RelBuilder
 import org.partiql.planner.internal.ir.builder.RelOpAggregateBuilder
 import org.partiql.planner.internal.ir.builder.RelOpAggregateCallResolvedBuilder
 import org.partiql.planner.internal.ir.builder.RelOpAggregateCallUnresolvedBuilder
+import org.partiql.planner.internal.ir.builder.RelOpCorrelateBuilder
 import org.partiql.planner.internal.ir.builder.RelOpDistinctBuilder
 import org.partiql.planner.internal.ir.builder.RelOpErrBuilder
 import org.partiql.planner.internal.ir.builder.RelOpExceptBuilder
@@ -823,6 +824,7 @@ internal data class Rel(
             is Offset -> visitor.visitRelOpOffset(this, ctx)
             is Project -> visitor.visitRelOpProject(this, ctx)
             is Join -> visitor.visitRelOpJoin(this, ctx)
+            is Correlate -> visitor.visitRelOpCorrelate(this, ctx)
             is Aggregate -> visitor.visitRelOpAggregate(this, ctx)
             is Exclude -> visitor.visitRelOpExclude(this, ctx)
             is Err -> visitor.visitRelOpErr(this, ctx)
@@ -1183,6 +1185,30 @@ internal data class Rel(
             internal companion object {
                 @JvmStatic
                 internal fun builder(): RelOpJoinBuilder = RelOpJoinBuilder()
+            }
+        }
+
+        internal data class Correlate(
+            @JvmField internal val lhs: Rel,
+            @JvmField internal val rhs: Rel,
+            @JvmField internal val type: Type,
+        ) : Op() {
+            public override val children: List<PlanNode> by lazy {
+                val kids = mutableListOf<PlanNode?>()
+                kids.add(lhs)
+                kids.add(rhs)
+                kids.filterNotNull()
+            }
+
+            override fun <R, C> accept(visitor: PlanVisitor<R, C>, ctx: C): R = visitor.visitRelOpCorrelate(this, ctx)
+
+            internal enum class Type {
+                INNER, LEFT,
+            }
+
+            internal companion object {
+                @JvmStatic
+                internal fun builder(): RelOpCorrelateBuilder = RelOpCorrelateBuilder()
             }
         }
 

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/PlanTransform.kt
@@ -329,6 +329,16 @@ internal class PlanTransform(private val flags: Set<PlannerFlag>, private val us
             return operators.join(lhs, rhs, condition, joinType)
         }
 
+        override fun visitRelOpCorrelate(node: IRel.Op.Correlate, ctx: PType): Any {
+            val lhs = visitRel(node.lhs, ctx)
+            val rhs = visitRel(node.rhs, ctx)
+            val joinType = when (node.type) {
+                IRel.Op.Correlate.Type.INNER -> JoinType.INNER()
+                IRel.Op.Correlate.Type.LEFT -> JoinType.LEFT()
+            }
+            return operators.correlate(lhs, rhs, joinType)
+        }
+
         override fun visitRelOpExclude(node: IRel.Op.Exclude, ctx: PType): Any {
             val input = visitRel(node.input, ctx)
             val paths = node.paths.mapNotNull { visitRelOpExcludePath(it, ctx) }

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/PlanTyper.kt
@@ -192,6 +192,70 @@ internal class PlanTyper(private val env: Env, config: Context, private val flag
     }
 
     /**
+     * Returns true if [node] contains any Rex.Op.Var.Local that references the join's LHS scope.
+     *
+     * We want to be able to assert on whether a variable introduced in LHS is referenced in RHS.
+     * For example:
+     *  1. Direct path reference: `FROM t, t.items`.
+     *  2. Subquery `FROM t INNER JOIN (SELECT ... FROM ... WHERE t.n > ...)
+     *
+     * Recall that RelTyper has a `List<Scope>` field, representing all scopes visible from enclosing contexts.
+     * We call the RelType's `List<Scope>` field `outer`.
+     *
+     * Now consider `FROM LHS, RHS`, LHS introduce a new Scope, `Scope(lhs.type.schema, outer)`,
+     * and when resolving the RHS, the environment we used are `outer + lhsScope`.
+     *
+     * It is entirely possible that RHS itself introduces additional scope (i.e, Subquery).
+     * To measure the scope introduced between the RHS root and node v, we defined a function `nesting`,
+     * nesting(v): For a node v in the typed RHS tree, defined recursively:
+     *  - nesting(RHS root) = 0
+     *  - nesting(v) = nesting(parent) + 1, if parent introduced an additional scope.
+     *  - nesting(v) = nesting(parent) otherwise.
+     *
+     * We claim: A Rex.Op.Var.Local(depth, ref) at node v in the RHS references the LHS scope
+     * iff depth == nesting(v) + 1.
+     *
+     * More formally: Let P(n) be the statement: "For any Rex.Op.Var.Local(depth, ref) at a node v with
+     * nesting(v) = n, the variable references lhsScope iff depth = n + 1.
+     *
+     * Base case (nesting=0):
+     * At nesting 0, the variable lives directly in the RHS scan's rex.
+     * The RHS scan types its rex by creating Scope(schema=[], outer=outer_rhs), that is: |outer_rhs| = |outer_lhs| + 1.
+     * Scope.matchRoot resolves at depth=d by accessing outer[|outer_rhs| - d].
+     * lhsScope is at index |outer_lhs| = |outer_rhs| - 1.
+     * So depth to reach lhsScope: |outer_rhs| - d = |outer_lhs| → d = |outer_rhs| - |outer_lhs| = 1.
+     * Therefore, depth = 1 === 0 + 1 (nesting + 1). P(0) holds true.
+     *
+     * Inductive step: Assume P(n) holds. We prove P(n + 1).
+     *
+     * A node v with nesting(v) = n + 1
+     * means v is inside a scope-introducing boundary (SELECT, Subquery, Pivot) whose parent has nesting n.
+     *
+     * This means upon resolving the node v, outer = previous_outer + [ previous_scope ].
+     *
+     * The new scope used for resolution has outer list size S_new = S_previous + 1.
+     * lhsScope is still at index |outer_lhs|.
+     *
+     * Depth to reach lhsScope = S_new - |outer_lhs| = (S_old + 1) - |outer_lhs| = (S_old - |outer_lhs|) + 1.
+     * Since S_old - |outer_lhs| was the previous depth (nesting_old + 1), we get:
+     * depth = nesting_old + 1 + 1 === nesting_new + 1.
+     *
+     * Depth to reach lhsScope from the new scope: S_new - |outer_lhs|.
+     *
+     * From P(n), we know S_previous - |outer_lhs| = n + 1. Therefore:
+     *  S_new - |outer_lhs| = (S_previous + 1) - |outer_lhs| = (S_previous - |outer_lhs|) + 1 = (n + 1) + 1 = n + 2.
+     */
+    private fun hasOuterReference(node: PlanNode, nesting: Int = 0): Boolean {
+        if (node is Rex && node.op is Rex.Op.Var.Local) {
+            return node.op.depth == nesting + 1
+        }
+        if (node is Rex && (node.op is Rex.Op.Select || node.op is Rex.Op.Subquery || node.op is Rex.Op.Pivot)) {
+            return node.children.any { hasOuterReference(it, nesting + 1) }
+        }
+        return node.children.any { hasOuterReference(it, nesting) }
+    }
+
+    /**
      * Types the relational operators of a query expression.
      *
      * @property outer represents the outer variable scopes of a query expression — only used by scan variable resolution.
@@ -708,15 +772,31 @@ internal class PlanTyper(private val env: Env, config: Context, private val flag
             }
             val rhs = RelTyper(stack, Strategy.GLOBAL).visitRel(node.rhs, ctx)
 
+            // Detect correlation: does the RHS reference the LHS scope?
+            val isLateral = hasOuterReference(rhs)
+
             // Calculate output schema given JOIN type
             val schema = lhs.type.schema + rhs.type.schema
             val type = relType(schema, ctx!!.props)
 
-            // Type the condition on the output schema
-            val typeEnv = TypeEnv(env, Scope(type.schema, outer))
-            val condition = node.rex.type(typeEnv)
-
-            val op = relOpJoin(lhs, rhs, condition, node.type)
+            val op = if (isLateral) {
+                val correlateType = when (node.type) {
+                    Rel.Op.Join.Type.INNER -> Rel.Op.Correlate.Type.INNER
+                    Rel.Op.Join.Type.LEFT -> Rel.Op.Correlate.Type.LEFT
+                    else -> error("Correlated RIGHT/FULL join should not occur")
+                }
+                // Type condition in the RHS scope (LHS at depth=1, RHS at depth=0)
+                val rhsTypeEnv = TypeEnv(env, Scope(rhs.type.schema, stack))
+                val condition = node.rex.type(rhsTypeEnv)
+                // Wrap condition as filter on RHS
+                val finalRhs = rel(rhs.type, relOpFilter(rhs, condition))
+                Rel.Op.Correlate(lhs, finalRhs, correlateType)
+            } else {
+                // Type condition on the combined output schema
+                val typeEnv = TypeEnv(env, Scope(type.schema, outer))
+                val condition = node.rex.type(typeEnv)
+                relOpJoin(lhs, rhs, condition, node.type)
+            }
             return rel(type, op)
         }
 

--- a/partiql-planner/src/main/resources/partiql_plan_internal.ion
+++ b/partiql-planner/src/main/resources/partiql_plan_internal.ion
@@ -359,6 +359,16 @@ rel::{
       ],
     },
 
+    // Correlated (lateral) join. The RHS references bindings from the LHS.
+    correlate::{
+      lhs: rel,
+      rhs: rel,
+      type: [
+        INNER, // Inner Join
+        LEFT,  // Left Outer Join
+      ],
+    },
+
     aggregate::{
       input:    rel,
       strategy: [ FULL, PARTIAL ],

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/CorrelatedJoinClassificationTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/CorrelatedJoinClassificationTest.kt
@@ -121,6 +121,12 @@ internal class CorrelatedJoinClassificationTest {
     }
 
     @Test
+    fun `correlated - implicit path lateral reference (nesting=0)`() {
+        val stmt = plan("SELECT VALUE x FROM << {'items': [1, 2]} >> AS t INNER JOIN items AS x ON true")
+        assertCorrelate(stmt, "Path lateral: t.items references LHS at nesting=0")
+    }
+
+    @Test
     fun `correlated - path lateral with ON condition`() {
         // Path lateral with non-trivial ON condition. Condition should be pushed as Filter on RHS.
         val stmt = plan(

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/CorrelatedJoinClassificationTest.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/CorrelatedJoinClassificationTest.kt
@@ -1,0 +1,269 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file.
+ */
+
+package org.partiql.planner.internal.typer
+
+import org.junit.jupiter.api.Test
+import org.partiql.parser.PartiQLParser
+import org.partiql.planner.internal.Env
+import org.partiql.planner.internal.ir.PlanNode
+import org.partiql.planner.internal.ir.Rel
+import org.partiql.planner.internal.ir.Statement
+import org.partiql.planner.internal.transforms.AstToPlan
+import org.partiql.planner.internal.transforms.NormalizeFromSource
+import org.partiql.planner.internal.transforms.NormalizeGroupBy
+import org.partiql.spi.Context
+import org.partiql.spi.catalog.Catalog
+import org.partiql.spi.catalog.Session
+import org.partiql.spi.errors.PErrorListener
+
+/**
+ * Tests verifying that the planner correctly classifies joins as correlated (Rel.Op.Correlate)
+ * or non-correlated (Rel.Op.Join) based on whether the RHS references the LHS scope.
+ *
+ * Each test demonstrates a specific scenario that exercises the hasOuterReference walk,
+ * particularly the nesting counter that tracks scope boundaries (Select, Subquery, Pivot).
+ */
+internal class CorrelatedJoinClassificationTest {
+
+    private val parser = PartiQLParser.standard()
+
+    private fun plan(query: String): Statement {
+        val parseResult = parser.parse(query)
+        val stmt = parseResult.statements[0]
+        val catalog = Catalog.builder().name("memory").build()
+        val session = Session.builder().catalog("memory").catalogs(catalog).build()
+        val env = Env(session, PErrorListener.abortOnError())
+        val normalized = NormalizeFromSource.apply(stmt)
+        val normalized2 = NormalizeGroupBy.apply(normalized)
+        val root = AstToPlan.apply(normalized2, env)
+        val typer = PlanTyper(env, Context.of(PErrorListener.abortOnError()), emptySet())
+        return typer.resolve(root)
+    }
+
+    private fun findFirstJoinOrCorrelate(node: PlanNode): Rel.Op? {
+        if (node is Rel) {
+            if (node.op is Rel.Op.Join || node.op is Rel.Op.Correlate) {
+                return node.op
+            }
+        }
+        for (child in node.children) {
+            val found = findFirstJoinOrCorrelate(child)
+            if (found != null) return found
+        }
+        return null
+    }
+
+    private fun assertCorrelate(stmt: Statement, msg: String) {
+        val op = findFirstJoinOrCorrelate(stmt)
+        assert(op is Rel.Op.Correlate) { "$msg — expected Correlate but got ${op?.javaClass?.simpleName}" }
+    }
+
+    private fun assertJoin(stmt: Statement, msg: String) {
+        val op = findFirstJoinOrCorrelate(stmt)
+        assert(op is Rel.Op.Join) { "$msg — expected Join but got ${op?.javaClass?.simpleName}" }
+    }
+
+    // ==========================================================================
+    // Non-correlated: should produce Rel.Op.Join
+    // ==========================================================================
+
+    @Test
+    fun `non-correlated - independent collections`() {
+        val stmt = plan("SELECT VALUE [a, b] FROM << 1, 2 >> AS a INNER JOIN << 10, 20 >> AS b ON a = b")
+        assertJoin(stmt, "Two independent collections with ON condition")
+    }
+
+    @Test
+    fun `non-correlated - cross join of literals`() {
+        val stmt = plan("SELECT VALUE [a, b] FROM << 1, 2 >> AS a, << 10, 20 >> AS b")
+        assertJoin(stmt, "Cross join of independent literals")
+    }
+
+    @Test
+    fun `non-correlated - subquery not referencing LHS`() {
+        val stmt = plan(
+            "SELECT VALUE x FROM << {'id': 1} >> AS t INNER JOIN (SELECT VALUE i FROM << 1, 2, 3 >> AS i WHERE i > 1) AS x ON true"
+        )
+        assertJoin(stmt, "Subquery in RHS does not reference LHS")
+    }
+
+    @Test
+    fun `non-correlated - subquery references outer query not LHS`() {
+        // The subquery inside the join references t1 from the enclosing SELECT, NOT the join's LHS 'a'.
+        // This exercises nesting > 0: inside the subquery, t1 is at depth=3 and nesting=1,
+        // so depth != nesting + 1 (3 != 2), correctly classified as non-correlated.
+        val stmt = plan(
+            "SELECT VALUE (SELECT VALUE x FROM << 1, 2 >> AS a INNER JOIN (SELECT VALUE i FROM << 1, 2, 3 >> AS i WHERE i <= t1) AS x ON true) FROM << 2 >> AS t1"
+        )
+        assertJoin(stmt, "Subquery refs outer query scope, not the join's LHS")
+    }
+
+    // ==========================================================================
+    // Correlated: should produce Rel.Op.Correlate
+    // ==========================================================================
+
+    @Test
+    fun `correlated - path lateral reference (nesting=0)`() {
+        // Direct path on LHS alias. The scan rex 't.items' has depth=1 at nesting=0.
+        // depth == 0 + 1 → correlated.
+        val stmt = plan("SELECT VALUE x FROM << {'items': [1, 2]} >> AS t INNER JOIN t.items AS x ON true")
+        assertCorrelate(stmt, "Path lateral: t.items references LHS at nesting=0")
+    }
+
+    @Test
+    fun `correlated - path lateral with ON condition`() {
+        // Path lateral with non-trivial ON condition. Condition should be pushed as Filter on RHS.
+        val stmt = plan(
+            "SELECT VALUE x FROM << [0, 1, 2], [10, 11, 12] >> AS lhs INNER JOIN lhs AS rhs ON lhs[2] = rhs"
+        )
+        assertCorrelate(stmt, "Path lateral with ON condition pushed to RHS filter")
+    }
+
+    @Test
+    fun `correlated - subquery referencing LHS (nesting=1, Select boundary)`() {
+        // Subquery in RHS references 't.n'. Inside the Select, t.n resolves at depth=2.
+        // nesting=1 (one Select boundary), so depth == 1 + 1 → correlated.
+        val stmt = plan(
+            "SELECT VALUE x FROM << {'id': 1, 'n': 2} >> AS t INNER JOIN (SELECT VALUE i FROM << 1, 2, 3 >> AS i WHERE i <= t.n) AS x ON true"
+        )
+        assertCorrelate(stmt, "Correlated subquery: depth=2 at nesting=1 (Select boundary)")
+    }
+
+    @Test
+    fun `correlated - scalar subquery referencing LHS (nesting=2, Select+Subquery boundaries)`() {
+        // Scalar subquery (Rex.Op.Subquery) inside a Select. The ref to t.n crosses two boundaries.
+        // nesting=2 (Select + Subquery), depth=3, so depth == 2 + 1 → correlated.
+        val stmt = plan(
+            "SELECT VALUE x FROM << {'n': 5} >> AS t INNER JOIN (SELECT VALUE (SELECT t.n FROM << 1 >> AS dummy) FROM << 1 >> AS i) AS x ON true"
+        )
+        assertCorrelate(stmt, "Scalar subquery: depth=3 at nesting=2 (Select + Subquery boundaries)")
+    }
+
+    @Test
+    fun `correlated - nested subquery both referencing LHS`() {
+        // Two levels of subqueries, both referencing t.n from the join's LHS.
+        // Outer subquery: nesting=1, depth=2 → 2 == 1+1 ✓
+        // Inner subquery: nesting=2, depth=3 → 3 == 2+1 ✓
+        val stmt = plan(
+            "SELECT VALUE x FROM << {'n': 3} >> AS t INNER JOIN (SELECT VALUE (SELECT VALUE j FROM << 1 >> AS j WHERE j <= t.n) FROM << 1, 2, 3 >> AS i WHERE i <= t.n) AS x ON true"
+        )
+        assertCorrelate(stmt, "Nested subqueries both referencing LHS at different nesting levels")
+    }
+
+    @Test
+    fun `correlated - LEFT JOIN path lateral`() {
+        // LEFT JOIN with path lateral. Should produce Correlate with LEFT type.
+        val stmt = plan("SELECT VALUE [t.name, x] FROM << {'name': 'a', 'vals': [1, 2]} >> AS t LEFT JOIN t.vals AS x ON true")
+        val op = findFirstJoinOrCorrelate(stmt)
+        assert(op is Rel.Op.Correlate) { "Expected Correlate for LEFT lateral" }
+        assert((op as Rel.Op.Correlate).type == Rel.Op.Correlate.Type.LEFT) { "Expected LEFT type" }
+    }
+
+    // ==========================================================================
+    // Verify ON condition is pushed as Filter for correlated joins
+    // ==========================================================================
+
+    @Test
+    fun `correlated - ON condition becomes Filter on RHS`() {
+        // ON lhs[2] = rhs should be pushed into the RHS as a Filter wrapping the scan.
+        val stmt = plan(
+            "SELECT VALUE rhs FROM << [0, 1, 2], [10, 11, 12] >> AS lhs INNER JOIN lhs AS rhs ON lhs[2] = rhs"
+        )
+        val op = findFirstJoinOrCorrelate(stmt) as Rel.Op.Correlate
+        // The RHS should be a Filter wrapping a Scan
+        assert(op.rhs.op is Rel.Op.Filter) {
+            "Expected RHS to be Filter(Scan(...)) but got ${op.rhs.op.javaClass.simpleName}"
+        }
+    }
+
+    @Test
+    fun `correlated - trivial ON TRUE still wraps Filter`() {
+        // ON true is still wrapped as Filter (optimization to remove it is a separate pass).
+        val stmt = plan("SELECT VALUE x FROM << {'items': [1]} >> AS t INNER JOIN t.items AS x ON true")
+        val op = findFirstJoinOrCorrelate(stmt) as Rel.Op.Correlate
+        assert(op.rhs.op is Rel.Op.Filter) {
+            "Expected RHS to be Filter (condition always pushed) but got ${op.rhs.op.javaClass.simpleName}"
+        }
+    }
+
+    @Test
+    fun `correlated - comma join no ON condition`() {
+        // FROM t, t.items AS x — no explicit ON clause. Parser generates ON TRUE implicitly.
+        val stmt = plan("SELECT VALUE x FROM << {'items': [1, 2]} >> AS t, t.items AS x")
+        assertCorrelate(stmt, "Comma lateral join with no ON condition")
+    }
+
+    @Test
+    fun `non-correlated - comma join no ON condition`() {
+        // FROM a, b — no ON, no correlation
+        val stmt = plan("SELECT VALUE [a, b] FROM << 1 >> AS a, << 2 >> AS b")
+        assertJoin(stmt, "Comma join of independent collections with no ON")
+    }
+
+    // ==========================================================================
+    // Multiple joins
+    // ==========================================================================
+
+    @Test
+    fun `multiple joins - chain of correlated`() {
+        // FROM t, t.a AS a, a.b AS b — both inner joins are correlated
+        // The outermost join (result, b) should be Correlate
+        val stmt = plan("SELECT VALUE b FROM << {'a': [{'b': [1, 2]}]} >> AS t, t.a AS a, a.b AS b")
+        val op = findFirstJoinOrCorrelate(stmt)
+        assert(op is Rel.Op.Correlate) { "Outermost join in chain should be Correlate" }
+    }
+
+    @Test
+    fun `multiple joins - mixed correlated and non-correlated`() {
+        // FROM t, << 1, 2 >> AS a, t.items AS x
+        // First join (t, a) is non-correlated. Second join ((t,a), x) is correlated.
+        val stmt = plan("SELECT VALUE x FROM << {'items': [10]} >> AS t, << 1, 2 >> AS a, t.items AS x")
+        // The outermost join should be Correlate (x references t from LHS)
+        val op = findFirstJoinOrCorrelate(stmt)
+        assert(op is Rel.Op.Correlate) { "Outermost join should be Correlate (x refs t)" }
+        // The inner join should be Join (a is independent)
+        val innerOp = (op as Rel.Op.Correlate).lhs.op
+        assert(innerOp is Rel.Op.Join) { "Inner join should be Join (a is independent) but got ${innerOp.javaClass.simpleName}" }
+    }
+
+    // ==========================================================================
+    // Scope boundaries: Select, Subquery, Pivot
+    // ==========================================================================
+
+    @Test
+    fun `scope boundary - Rex_Op_Select (SELECT VALUE subquery)`() {
+        // The correlated ref crosses one Select boundary (nesting=1, depth=2)
+        val stmt = plan(
+            "SELECT VALUE x FROM << {'n': 2} >> AS t INNER JOIN (SELECT VALUE i FROM << 1, 2, 3 >> AS i WHERE i <= t.n) AS x ON true"
+        )
+        assertCorrelate(stmt, "Select boundary: correlated ref at depth=2, nesting=1")
+    }
+
+    @Test
+    fun `scope boundary - Rex_Op_Subquery (scalar subquery)`() {
+        // The correlated ref crosses Select + Subquery boundaries (nesting=2, depth=3)
+        val stmt = plan(
+            "SELECT VALUE x FROM << {'n': 5} >> AS t INNER JOIN (SELECT VALUE (SELECT t.n FROM << 1 >> AS dummy) FROM << 1 >> AS i) AS x ON true"
+        )
+        assertCorrelate(stmt, "Subquery boundary: correlated ref at depth=3, nesting=2")
+    }
+
+    @Test
+    fun `scope boundary - non-correlated despite deep nesting`() {
+        // Deeply nested subquery but references are all local — not correlated
+        val stmt = plan(
+            "SELECT VALUE x FROM << 1 >> AS t INNER JOIN (SELECT VALUE (SELECT VALUE j + i FROM << 1 >> AS j) FROM << 1, 2 >> AS i) AS x ON true"
+        )
+        assertJoin(stmt, "Deep nesting but all refs are local — non-correlated")
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
Separate correlated joins from non-correlated joins in planner and eval. 
  
The planner now classifies joins into two categories at plan time:
  
  - Correlated (lateral): RHS references LHS bindings → Rel.Op.Correlate
  - Non-correlated: RHS is independent of LHS → Rel.Op.Join
  
The eval layer dispatches them to separate physical operators:
  
  - Correlate → lateral nested-loop (push LHS row into env, open RHS per row)
  - Join → non-lateral nested-loop (materialize RHS once, rescan per LHS row)

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**: Yes.
- Any backward-incompatible changes? **[YES/NO]**: No. 
- Any new external dependencies? **[YES/NO]**: No. 
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES/NO]**: Yes. 

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md