### PR TITLE
Fixed NullPointerException in RelOpUnpivot when UNPIVOT encounters a typed null value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Thank you to all who have contributed!
 ### Deprecated
 
 ### Fixed
+- Fixed NullPointerException in RelOpUnpivot when UNPIVOT encounters a typed null value
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ Thank you to all who have contributed!
 
 ### Fixed
 - Fixed NullPointerException in RelOpUnpivot when UNPIVOT encounters a typed null value
-Fixed that `SELECT *` does not display column name correctly when `UNPIVOT` is present in `FROM`
+- Fixed SELECT * with UNPIVOT to use named aliases instead of positional names
+
 
 ### Removed
 

--- a/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpUnpivot.kt
+++ b/partiql-eval/src/main/kotlin/org/partiql/eval/internal/operator/rel/RelOpUnpivot.kt
@@ -81,6 +81,9 @@ internal sealed class RelOpUnpivot : ExprRelation {
             if (v.isMissing) {
                 return Datum.struct(emptyList())
             }
+            if (v.isNull) {
+                return Datum.struct(listOf(Field.of("_1", v)))
+            }
             return when (v.type.code()) {
                 PType.STRUCT, PType.ROW, PType.MAP -> v
                 else -> Datum.struct(listOf(Field.of("_1", v)))

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/MapTests.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/MapTests.kt
@@ -949,7 +949,6 @@ class MapTests {
                     )
                 ),
             ),
-            /* TODO: https://github.com/partiql/partiql-lang-kotlin/issues/1930
             SuccessTestCase(
                 name = "UNPIVOT map column with WHERE filter (iterates all rows including null)",
                 globals = catalogGlobals,
@@ -972,7 +971,7 @@ class MapTests {
                         ),
                     )
                 ),
-            ),*/
+            ),
             SuccessTestCase(
                 name = "UNPIVOT map column pre-filtered to Alice (returns key-value pairs)",
                 globals = catalogGlobals,
@@ -996,7 +995,6 @@ class MapTests {
                     )
                 ),
             ),
-            /* TODO: https://github.com/partiql/partiql-lang-kotlin/issues/1930
             SuccessTestCase(
                 name = "UNPIVOT map column pre-filtered to Charlie (typed null wraps as _1)",
                 globals = catalogGlobals,
@@ -1005,14 +1003,14 @@ class MapTests {
                     listOf(
                         Datum.struct(
                             listOf(
-                                Field.of("name", Datum.string("Peter")),
+                                Field.of("name", Datum.string("Charlie")),
                                 Field.of("setting_name", Datum.string("_1")),
-                                Field.of("setting_value", Datum.nullValue()),
+                                Field.of("setting_value", Datum.nullValue(PType.map(PType.string(), PType.string()))),
                             )
                         ),
                     )
                 ),
-            ),*/
+            ),
             SuccessTestCase(
                 name = "UNPIVOT map column pre-filtered to Peter (untyped null wraps as _1)",
                 globals = catalogGlobals,

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/StructTests.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/StructTests.kt
@@ -74,7 +74,6 @@ class StructTests {
 
         @JvmStatic
         fun unpivotTestCases() = listOf(
-            /* TODO: https://github.com/partiql/partiql-lang-kotlin/issues/1930
             SuccessTestCase(
                 name = "UNPIVOT struct column with WHERE filter (iterates all rows including null)",
                 globals = catalogGlobals,
@@ -97,7 +96,7 @@ class StructTests {
                         ),
                     )
                 ),
-            ),*/
+            ),
             SuccessTestCase(
                 name = "UNPIVOT struct column pre-filtered to Alice (returns key-value pairs)",
                 globals = catalogGlobals,
@@ -121,7 +120,6 @@ class StructTests {
                     )
                 ),
             ),
-            /* TODO: https://github.com/partiql/partiql-lang-kotlin/issues/1930
             SuccessTestCase(
                 name = "UNPIVOT struct column pre-filtered to Charlie (typed null wraps as _1)",
                 globals = catalogGlobals,
@@ -132,13 +130,12 @@ class StructTests {
                             listOf(
                                 Field.of("name", Datum.string("Charlie")),
                                 Field.of("setting_name", Datum.string("_1")),
-                                Field.of("setting_value", Datum.nullValue()),
+                                Field.of("setting_value", Datum.nullValue(PType.struct())),
                             )
                         ),
                     )
                 ),
             ),
-            */
             SuccessTestCase(
                 name = "UNPIVOT struct column pre-filtered to Peter (untyped null wraps as _1)",
                 globals = catalogGlobals,


### PR DESCRIPTION
## Relevant Issues
- [Closes/Related To] Issue #XXX

## Description
- Unpivot should treat mismatch type value x as {_1: x} Per 5.2.1 from https://partiql.org/assets/PartiQL-Specification.pdf including NULL

## Other Information
- Updated Unreleased Section in CHANGELOG: **[YES/NO]**: YES
- Any backward-incompatible changes? **[YES/NO]**: No
- Any new external dependencies? **[YES/NO]**: No
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **[YES/NO]** YES

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md