### PR TITLE
Fix `NotImplementedError` thrown by `CAST(... AS TIMESTAMP)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Thank you to all who have contributed!
 -->
 
+## [0.14.10]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+- Fixed `NotImplementedError` thrown by `CAST(... AS TIMESTAMP)
+### Removed
+
+### Security
+
+### Contributors
+Thank you to all who have contributed!
+@xd1313113
+
 ## [0.14.9]
 
 ### Changed

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/transforms/RexConverter.kt
@@ -577,7 +577,7 @@ internal object RexConverter {
                 is Type.Date -> rex(StaticType.DATE, call("cast_date", arg0))
                 is Type.Time -> rex(StaticType.TIME, call("cast_time", arg0))
                 is Type.TimeWithTz -> rex(TimeType(null, true), call("cast_timeWithTz", arg0))
-                is Type.Timestamp -> TODO("Need to rebase main")
+                is Type.Timestamp -> rex(StaticType.TIMESTAMP, call("cast_timestamp", arg0))
                 is Type.TimestampWithTz -> rex(StaticType.TIMESTAMP, call("cast_timeWithTz", arg0))
                 is Type.Interval -> TODO("Static Type does not have Interval type")
                 is Type.Bag -> rex(StaticType.BAG, call("cast_bag", arg0))

--- a/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeLattice.kt
+++ b/partiql-planner/src/main/kotlin/org/partiql/planner/internal/typer/TypeLattice.kt
@@ -339,12 +339,14 @@ internal class TypeLattice private constructor(
                 STRING to coercion(),
                 SYMBOL to explicit(),
                 CLOB to coercion(),
+                TIMESTAMP to unsafe(),
             )
             graph[SYMBOL] = relationships(
                 BOOL to explicit(),
                 STRING to coercion(),
                 SYMBOL to coercion(),
                 CLOB to coercion(),
+                TIMESTAMP to unsafe(),
             )
             graph[CLOB] = relationships(
                 CLOB to coercion(),
@@ -354,7 +356,9 @@ internal class TypeLattice private constructor(
             graph[BLOB] = arrayOfNulls(N)
             graph[DATE] = arrayOfNulls(N)
             graph[TIME] = arrayOfNulls(N)
-            graph[TIMESTAMP] = arrayOfNulls(N)
+            graph[TIMESTAMP] = relationships(
+                TIMESTAMP to coercion(),
+            )
             graph[INTERVAL] = arrayOfNulls(N)
             graph[BAG] = relationships(
                 BAG to coercion(),

--- a/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
+++ b/partiql-planner/src/test/kotlin/org/partiql/planner/internal/typer/PlanTyperTestsPorted.kt
@@ -364,6 +364,20 @@ class PlanTyperTestsPorted {
         )
 
         @JvmStatic
+        fun timestampCastCases() = listOf<TestCase>(
+            SuccessTestCase(
+                name = "cast string to timestamp",
+                query = "CAST('2024-01-15' AS TIMESTAMP)",
+                expected = StaticType.unionOf(StaticType.TIMESTAMP, MISSING),
+            ),
+            SuccessTestCase(
+                name = "cast timestamp to timestamp",
+                query = "CAST(TIMESTAMP '2024-01-15 10:30:00' AS TIMESTAMP)",
+                expected = StaticType.TIMESTAMP,
+            ),
+        )
+
+        @JvmStatic
         fun selectStar() = listOf<TestCase>(
             SuccessTestCase(
                 name = "Test #8",
@@ -3840,6 +3854,11 @@ class PlanTyperTestsPorted {
     @MethodSource("decimalCastCases")
     @Execution(ExecutionMode.CONCURRENT)
     fun testDecimalCast(tc: TestCase) = runTest(tc)
+
+    @ParameterizedTest
+    @MethodSource("timestampCastCases")
+    @Execution(ExecutionMode.CONCURRENT)
+    fun testTimestampCast(tc: TestCase) = runTest(tc)
 
     @ParameterizedTest
     @MethodSource("selectStar")


### PR DESCRIPTION
## Relevant Issues
- None

## Description
 ### Summary
  - Replace `TODO("Need to rebase main")` stub in `RexConverter.visitExprCast` with proper cast implementation
  - Add TIMESTAMP cast relationships to the type lattice (STRING/SYMBOL → TIMESTAMP as unsafe, TIMESTAMP → TIMESTAMP as coercion)
  - Add unit tests for CAST(... AS TIMESTAMP) in PlanTyperTestsPorted

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **No**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md