### PR TITLE
Fix decimal division precision reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Thank you to all who have contributed!
 ### Deprecated
 
 ### Fixed
+- Fixed decimal division precision reduction when computed precision exceeds 38, preventing invalid result types and missing projected fields
 
 ### Removed
 
@@ -39,6 +40,7 @@ Thank you to all who have contributed!
 
 ### Contributors
 Thank you to all who have contributed!
+- @XuechunHHH
 
 ## [1.5.0](https://github.com/partiql/partiql-lang-kotlin/releases/tag/v1.5.0) - 2026-07-01
 

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DivideTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DivideTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.partiql.eval.internal
+
+import org.junit.jupiter.api.Test
+import org.partiql.eval.Mode
+import org.partiql.spi.types.PType
+import org.partiql.spi.types.PTypeField
+import org.partiql.spi.value.Datum
+import org.partiql.spi.value.Field
+import java.math.BigDecimal
+
+class DivideTest {
+
+    private val ratio = Datum.decimal(
+        BigDecimal("0.32258064516"),
+        38,
+        11,
+    )
+
+    private val unitRatio = Datum.decimal(
+        BigDecimal("1.00000000000"),
+        38,
+        11,
+    )
+
+    private val salaries = Global(
+        name = "salaries",
+        value = Datum.bag(
+            listOf(
+                salary(id = 1, dept = "engineering", amount = "100000.00"),
+                salary(id = 2, dept = "engineering", amount = "210000.00"),
+                salary(id = 3, dept = "hr", amount = "50000.00"),
+            ),
+        ),
+        type = PType.bag(
+            PType.row(
+                PTypeField.of("id", PType.integer()),
+                PTypeField.of("dept", PType.varchar(16)),
+                PTypeField.of("salary", PType.decimal(10, 2)),
+            ),
+        ),
+    )
+
+    @Test
+    fun decimalDivisionReturnsCappedPrecisionAndScale() {
+        SuccessTestCase(
+            input = """
+                CAST(100000.00 AS DECIMAL(10, 2)) /
+                    CAST(310000.00 AS DECIMAL(38, 19))
+            """.trimIndent(),
+            mode = Mode.STRICT(),
+            expected = ratio,
+            jvmEquality = true,
+        ).run()
+    }
+
+    @Test
+    fun permissiveAggregateRatioProjectionRetainsDivisionResult() {
+        SuccessTestCase(
+            input = """
+                SELECT
+                    id,
+                    dept,
+                    salary,
+                    salary / (
+                        SELECT SUM(salary)
+                        FROM salaries AS t2
+                        WHERE t2.dept = t1.dept
+                    ) AS ratio
+                FROM salaries AS t1
+                ORDER BY id
+            """.trimIndent(),
+            mode = Mode.PERMISSIVE(),
+            expected = Datum.array(
+                listOf(
+                    salary(id = 1, dept = "engineering", amount = "100000.00", ratio = ratio),
+                    salary(
+                        id = 2,
+                        dept = "engineering",
+                        amount = "210000.00",
+                        ratio = Datum.decimal(BigDecimal("0.67741935484"), 38, 11),
+                    ),
+                    salary(id = 3, dept = "hr", amount = "50000.00", ratio = unitRatio),
+                ),
+            ),
+            globals = listOf(salaries),
+        ).run()
+    }
+
+    private fun salary(id: Int, dept: String, amount: String, ratio: Datum? = null): Datum {
+        val fields = mutableListOf(
+            Field.of("id", Datum.integer(id)),
+            Field.of("dept", Datum.varchar(dept, 16)),
+            Field.of("salary", Datum.decimal(BigDecimal(amount), 10, 2)),
+        )
+        ratio?.let { fields.add(Field.of("ratio", it)) }
+        return Datum.struct(fields)
+    }
+}

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
@@ -99,15 +99,24 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
     /**
      * SQL Server: p = p1 - s1 + s2 + max(6, s1 + p2 + 1)
      * SQL Server: s = max(6, s1 + p2 + 1)
+     *
+     * If p exceeds 38, reduce the scale to preserve the integral part when it has fewer than 32 digits.
+     * Otherwise, reduce the scale to 6.
      */
     private fun dividePrecisionScale(lhs: PType, rhs: PType): Pair<Int, Int> {
         val (p1, s1) = lhs.precision to lhs.scale
         val (p2, s2) = rhs.precision to rhs.scale
         val p = p1 - s1 + s2 + Math.max(6, s1 + p2 + 1)
         val s = Math.max(6, s1 + p2 + 1)
-        val returnedP = p.coerceAtMost(38)
-        val returnedS = s.coerceAtMost(p)
-        return returnedP to returnedS
+        if (p <= 38) {
+            return p to s
+        }
+        val integralDigits = p - s
+        val returnedS = when {
+            integralDigits < 32 -> s.coerceAtMost(38 - integralDigits)
+            else -> 6
+        }
+        return 38 to returnedS
     }
 
     override fun getRealInstance(realLhs: PType, realRhs: PType): Fn {

--- a/partiql-spi/src/test/kotlin/org/partiql/spi/function/builtins/FnDivideTest.kt
+++ b/partiql-spi/src/test/kotlin/org/partiql/spi/function/builtins/FnDivideTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.partiql.spi.function.builtins
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.partiql.spi.types.PType
+import org.partiql.spi.value.Datum
+import java.math.BigDecimal
+
+class FnDivideTest {
+
+    @ParameterizedTest
+    @MethodSource("divisionCases")
+    fun divisionReturnsValidPrecisionAndScale(case: DivisionCase) {
+        val fn = requireNotNull(FnDivide.getInstance(arrayOf(case.lhs.type, case.rhs.type)))
+
+        assertEquals(case.expectedType, fn.signature.returns)
+
+        val result = fn.invoke(arrayOf(case.lhs, case.rhs))
+        assertEquals(case.expectedType, result.type)
+        assertEquals(case.expectedValue, result.bigDecimal)
+        assertTrue(result.type.scale <= result.type.precision)
+    }
+
+    data class DivisionCase(
+        val name: String,
+        val lhs: Datum,
+        val rhs: Datum,
+        val expectedType: PType,
+        val expectedValue: BigDecimal,
+    ) {
+        override fun toString(): String = name
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun divisionCases(): List<DivisionCase> = listOf(
+            DivisionCase(
+                name = "decimal scale is reduced to preserve integral digits",
+                lhs = Datum.decimal(BigDecimal("100000.00"), 10, 2),
+                rhs = Datum.decimal(BigDecimal("310000.00"), 38, 19),
+                expectedType = PType.decimal(38, 11),
+                expectedValue = BigDecimal("0.32258064516"),
+            ),
+            DivisionCase(
+                name = "numeric scale is reduced to preserve integral digits",
+                lhs = Datum.numeric(BigDecimal("100000.00"), 10, 2),
+                rhs = Datum.numeric(BigDecimal("310000.00"), 38, 19),
+                expectedType = PType.numeric(38, 11),
+                expectedValue = BigDecimal("0.32258064516"),
+            ),
+            DivisionCase(
+                name = "scale reduction preserves capacity for a unit ratio",
+                lhs = Datum.decimal(BigDecimal("100000.00"), 10, 2),
+                rhs = Datum.decimal(BigDecimal("100000.00"), 38, 19),
+                expectedType = PType.decimal(38, 11),
+                expectedValue = BigDecimal("1.00000000000"),
+            ),
+            DivisionCase(
+                name = "uncapped precision and scale are unchanged",
+                lhs = Datum.decimal(BigDecimal("10.00"), 10, 2),
+                rhs = Datum.decimal(BigDecimal("4.00"), 10, 2),
+                expectedType = PType.decimal(23, 13),
+                expectedValue = BigDecimal("2.5000000000000"),
+            ),
+            DivisionCase(
+                name = "large integral part retains minimum division scale",
+                lhs = Datum.decimal(BigDecimal("10"), 38, 0),
+                rhs = Datum.decimal(BigDecimal("2.00"), 10, 2),
+                expectedType = PType.decimal(38, 6),
+                expectedValue = BigDecimal("5.000000"),
+            ),
+            DivisionCase(
+                name = "scale and precision are both capped at maximum precision",
+                lhs = Datum.decimal(BigDecimal("0.5"), 38, 38),
+                rhs = Datum.decimal(BigDecimal.ONE, 1, 0),
+                expectedType = PType.decimal(38, 38),
+                expectedValue = BigDecimal("0.50000000000000000000000000000000000000"),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- Closes #1945

## Description
- Reduce decimal and numeric division scale when computed precision exceeds 38, preserving integral capacity and preventing invalid result types such as `DECIMAL(38,41)`.
- Return `DECIMAL(38,11)` for `DECIMAL(10,2) / DECIMAL(38,19)`, allowing ordinary ratios and ratio `1` to evaluate without disappearing from permissive projections.
- Add direct precision/scale boundary tests and an end-to-end correlated `SUM(DECIMAL)` regression covering both evaluator execution paths.
- Verified with `./gradlew :partiql-spi:test :partiql-eval:test` (1,341 tests, 0 failures; ktlint passed).

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**: Added the decimal division fix and contributor entry.
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md