### PR TITLE
fix: Prevent decimal division scale from exceeding precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Thank you to all who have contributed!
 
 ### Fixed
 - Fixed writing `CLOB` values in the CLI text-pretty output as `CAST('<value>' AS CLOB)` until `CLOB` literal is defined.
-- Fixed decimal division result types by preventing scale from exceeding returned precision
+- Fixed decimal division precision and scale reduction when computed precision exceeds 38, preventing invalid result types and missing projected fields
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Thank you to all who have contributed!
 
 ### Fixed
 - Fixed writing `CLOB` values in the CLI text-pretty output as `CAST('<value>' AS CLOB)` until `CLOB` literal is defined.
-- Fixed decimal division precision reduction when computed precision exceeds 38, preventing invalid result types and missing projected fields
+- Fixed decimal division result types by preventing scale from exceeding returned precision
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Thank you to all who have contributed!
 
 ### Fixed
 - Fixed writing `CLOB` values in the CLI text-pretty output as `CAST('<value>' AS CLOB)` until `CLOB` literal is defined.
+- Fixed decimal division precision reduction when computed precision exceeds 38, preventing invalid result types and missing projected fields
 
 ### Removed
 
@@ -42,6 +43,7 @@ Thank you to all who have contributed!
 ### Contributors
 Thank you to all who have contributed!
 - @xd1313113
+- @XuechunHHH
 
 ## [1.5.0](https://github.com/partiql/partiql-lang-kotlin/releases/tag/v1.5.0) - 2026-07-01
 

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DivideTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DivideTest.kt
@@ -26,15 +26,9 @@ import java.math.BigDecimal
 class DivideTest {
 
     private val ratio = Datum.decimal(
-        BigDecimal("0.32258064516"),
+        BigDecimal("0.32258064516129032258064516129032258065"),
         38,
-        11,
-    )
-
-    private val unitRatio = Datum.decimal(
-        BigDecimal("1.00000000000"),
         38,
-        11,
     )
 
     private val salaries = Global(
@@ -43,7 +37,6 @@ class DivideTest {
             listOf(
                 salary(id = 1, dept = "engineering", amount = "100000.00"),
                 salary(id = 2, dept = "engineering", amount = "210000.00"),
-                salary(id = 3, dept = "hr", amount = "50000.00"),
             ),
         ),
         type = PType.bag(
@@ -56,7 +49,7 @@ class DivideTest {
     )
 
     @Test
-    fun decimalDivisionReturnsCappedPrecisionAndScale() {
+    fun decimalDivisionClampsScaleToReturnedPrecision() {
         SuccessTestCase(
             input = """
                 CAST(100000.00 AS DECIMAL(10, 2)) /
@@ -92,9 +85,12 @@ class DivideTest {
                         id = 2,
                         dept = "engineering",
                         amount = "210000.00",
-                        ratio = Datum.decimal(BigDecimal("0.67741935484"), 38, 11),
+                        ratio = Datum.decimal(
+                            BigDecimal("0.67741935483870967741935483870967741935"),
+                            38,
+                            38,
+                        ),
                     ),
-                    salary(id = 3, dept = "hr", amount = "50000.00", ratio = unitRatio),
                 ),
             ),
             globals = listOf(salaries),

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DivideTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DivideTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.partiql.eval.internal
+
+import org.junit.jupiter.api.Test
+import org.partiql.eval.Mode
+import org.partiql.spi.types.PType
+import org.partiql.spi.types.PTypeField
+import org.partiql.spi.value.Datum
+import org.partiql.spi.value.Field
+import java.math.BigDecimal
+
+class DivideTest {
+
+    private val ratio = Datum.decimal(
+        BigDecimal("0.32258064516"),
+        38,
+        11,
+    )
+
+    private val unitRatio = Datum.decimal(
+        BigDecimal("1.00000000000"),
+        38,
+        11,
+    )
+
+    private val salaries = Global(
+        name = "salaries",
+        value = Datum.bag(
+            listOf(
+                salary(id = 1, dept = "engineering", amount = "100000.00"),
+                salary(id = 2, dept = "engineering", amount = "210000.00"),
+                salary(id = 3, dept = "hr", amount = "50000.00"),
+            ),
+        ),
+        type = PType.bag(
+            PType.row(
+                PTypeField.of("id", PType.integer()),
+                PTypeField.of("dept", PType.varchar(16)),
+                PTypeField.of("salary", PType.decimal(10, 2)),
+            ),
+        ),
+    )
+
+    @Test
+    fun decimalDivisionReturnsCappedPrecisionAndScale() {
+        SuccessTestCase(
+            input = """
+                CAST(100000.00 AS DECIMAL(10, 2)) /
+                    CAST(310000.00 AS DECIMAL(38, 19))
+            """.trimIndent(),
+            mode = Mode.STRICT(),
+            expected = ratio,
+            jvmEquality = true,
+        ).run()
+    }
+
+    @Test
+    fun permissiveAggregateRatioProjectionRetainsDivisionResult() {
+        SuccessTestCase(
+            input = """
+                SELECT
+                    id,
+                    dept,
+                    salary,
+                    salary / (
+                        SELECT SUM(salary)
+                        FROM salaries AS t2
+                        WHERE t2.dept = t1.dept
+                    ) AS ratio
+                FROM salaries AS t1
+                ORDER BY id
+            """.trimIndent(),
+            mode = Mode.PERMISSIVE(),
+            expected = Datum.array(
+                listOf(
+                    salary(id = 1, dept = "engineering", amount = "100000.00", ratio = ratio),
+                    salary(
+                        id = 2,
+                        dept = "engineering",
+                        amount = "210000.00",
+                        ratio = Datum.decimal(BigDecimal("0.67741935484"), 38, 11),
+                    ),
+                    salary(id = 3, dept = "hr", amount = "50000.00", ratio = unitRatio),
+                ),
+            ),
+            globals = listOf(salaries),
+        ).run()
+    }
+
+    private fun salary(id: Int, dept: String, amount: String, ratio: Datum? = null): Datum {
+        val fields = mutableListOf(
+            Field.of("id", Datum.integer(id)),
+            Field.of("dept", Datum.varchar(dept, 16)),
+            Field.of("salary", Datum.decimal(BigDecimal(amount), 10, 2)),
+        )
+        ratio?.let { fields.add(Field.of("ratio", it)) }
+        return Datum.struct(fields)
+    }
+}

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DivideTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/DivideTest.kt
@@ -26,9 +26,15 @@ import java.math.BigDecimal
 class DivideTest {
 
     private val ratio = Datum.decimal(
-        BigDecimal("0.32258064516129032258064516129032258065"),
+        BigDecimal("0.32258064516"),
         38,
+        11,
+    )
+
+    private val unitRatio = Datum.decimal(
+        BigDecimal("1.00000000000"),
         38,
+        11,
     )
 
     private val salaries = Global(
@@ -37,6 +43,7 @@ class DivideTest {
             listOf(
                 salary(id = 1, dept = "engineering", amount = "100000.00"),
                 salary(id = 2, dept = "engineering", amount = "210000.00"),
+                salary(id = 3, dept = "hr", amount = "50000.00"),
             ),
         ),
         type = PType.bag(
@@ -49,7 +56,7 @@ class DivideTest {
     )
 
     @Test
-    fun decimalDivisionClampsScaleToReturnedPrecision() {
+    fun decimalDivisionReducesScaleToPreserveIntegralDigits() {
         SuccessTestCase(
             input = """
                 CAST(100000.00 AS DECIMAL(10, 2)) /
@@ -86,11 +93,12 @@ class DivideTest {
                         dept = "engineering",
                         amount = "210000.00",
                         ratio = Datum.decimal(
-                            BigDecimal("0.67741935483870967741935483870967741935"),
+                            BigDecimal("0.67741935484"),
                             38,
-                            38,
+                            11,
                         ),
                     ),
+                    salary(id = 3, dept = "hr", amount = "50000.00", ratio = unitRatio),
                 ),
             ),
             globals = listOf(salaries),

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
@@ -98,11 +98,14 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
 
     /**
      * SQL defines exact numeric result precision and scale as implementation-defined.
-     * Preserve PartiQL's existing division behavior, introduced in
-     * [PR #1651](https://github.com/partiql/partiql-lang-kotlin/pull/1651) using the
-     * [SQL Server formula](https://learn.microsoft.com/sql/t-sql/data-types/precision-scale-and-length-transact-sql):
+     * PartiQL's division behavior, introduced in
+     * [PR #1651](https://github.com/partiql/partiql-lang-kotlin/pull/1651), follows the
+     * [SQL Server precision and scale rules](https://learn.microsoft.com/sql/t-sql/data-types/precision-scale-and-length-transact-sql):
      * p = p1 - s1 + s2 + max(6, s1 + p2 + 1)
      * s = max(6, s1 + p2 + 1)
+     *
+     * If p exceeds 38, reduce the scale to preserve the integral part when at least
+     * the minimum scale of 6 remains. Otherwise, reduce the scale to 6.
      */
     private fun dividePrecisionScale(lhs: PType, rhs: PType): Pair<Int, Int> {
         val (p1, s1) = lhs.precision to lhs.scale
@@ -110,8 +113,14 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
         val p = p1 - s1 + s2 + Math.max(6, s1 + p2 + 1)
         val s = Math.max(6, s1 + p2 + 1)
         val returnedP = p.coerceAtMost(38)
-        val returnedS = s.coerceAtMost(returnedP)
-        return returnedP to returnedS
+        val integralDigits = p - s
+        val remainingScale = 38 - integralDigits
+        val returnedS = when {
+            p <= 38 -> s
+            remainingScale >= 6 -> s.coerceAtMost(remainingScale)
+            else -> 6
+        }
+        return returnedP to returnedS.coerceAtMost(returnedP)
     }
 
     override fun getRealInstance(realLhs: PType, realRhs: PType): Fn {

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
@@ -99,15 +99,24 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
     /**
      * SQL Server: p = p1 - s1 + s2 + max(6, s1 + p2 + 1)
      * SQL Server: s = max(6, s1 + p2 + 1)
+     *
+     * If p exceeds 38, reduce the scale to preserve the integral part when it has fewer than 32 digits.
+     * Otherwise, reduce the scale to 6.
      */
     private fun dividePrecisionScale(lhs: PType, rhs: PType): Pair<Int, Int> {
         val (p1, s1) = lhs.precision to lhs.scale
         val (p2, s2) = rhs.precision to rhs.scale
         val p = p1 - s1 + s2 + Math.max(6, s1 + p2 + 1)
         val s = Math.max(6, s1 + p2 + 1)
-        val returnedP = p.coerceAtMost(38)
-        val returnedS = s.coerceAtMost(p)
-        return returnedP to returnedS
+        if (p <= 38) {
+            return p to s
+        }
+        val integralDigits = p - s
+        val returnedS = when {
+            integralDigits < 32 -> s.coerceAtMost(38 - integralDigits)
+            else -> 6
+        }
+        return 38 to returnedS
     }
 
     override fun getRealInstance(realLhs: PType, realRhs: PType): Fn {

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
@@ -98,7 +98,9 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
 
     /**
      * SQL defines exact numeric result precision and scale as implementation-defined.
-     * Preserve PartiQL's existing division behavior:
+     * Preserve PartiQL's existing division behavior, introduced in
+     * [PR #1651](https://github.com/partiql/partiql-lang-kotlin/pull/1651) using the
+     * [SQL Server formula](https://learn.microsoft.com/sql/t-sql/data-types/precision-scale-and-length-transact-sql):
      * p = p1 - s1 + s2 + max(6, s1 + p2 + 1)
      * s = max(6, s1 + p2 + 1)
      */

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
@@ -97,11 +97,10 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
     }
 
     /**
-     * SQL Server: p = p1 - s1 + s2 + max(6, s1 + p2 + 1)
-     * SQL Server: s = max(6, s1 + p2 + 1)
-     *
-     * If p exceeds 38, reduce the scale to preserve the integral part when it has fewer than 32 digits.
-     * Otherwise, reduce the scale to 6.
+     * SQL defines exact numeric result precision and scale as implementation-defined.
+     * Preserve PartiQL's existing division behavior:
+     * p = p1 - s1 + s2 + max(6, s1 + p2 + 1)
+     * s = max(6, s1 + p2 + 1)
      */
     private fun dividePrecisionScale(lhs: PType, rhs: PType): Pair<Int, Int> {
         val (p1, s1) = lhs.precision to lhs.scale
@@ -109,13 +108,8 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
         val p = p1 - s1 + s2 + Math.max(6, s1 + p2 + 1)
         val s = Math.max(6, s1 + p2 + 1)
         val returnedP = p.coerceAtMost(38)
-        val integralDigits = p - s
-        val returnedS = when {
-            p <= 38 -> s
-            integralDigits < 32 -> s.coerceAtMost(38 - integralDigits)
-            else -> 6
-        }
-        return returnedP to returnedS.coerceAtMost(returnedP)
+        val returnedS = s.coerceAtMost(returnedP)
+        return returnedP to returnedS
     }
 
     override fun getRealInstance(realLhs: PType, realRhs: PType): Fn {

--- a/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
+++ b/partiql-spi/src/main/kotlin/org/partiql/spi/function/builtins/FnDivide.kt
@@ -108,15 +108,14 @@ internal object FnDivide : DiadicArithmeticOperator("divide") {
         val (p2, s2) = rhs.precision to rhs.scale
         val p = p1 - s1 + s2 + Math.max(6, s1 + p2 + 1)
         val s = Math.max(6, s1 + p2 + 1)
-        if (p <= 38) {
-            return p to s
-        }
+        val returnedP = p.coerceAtMost(38)
         val integralDigits = p - s
         val returnedS = when {
+            p <= 38 -> s
             integralDigits < 32 -> s.coerceAtMost(38 - integralDigits)
             else -> 6
         }
-        return 38 to returnedS
+        return returnedP to returnedS.coerceAtMost(returnedP)
     }
 
     override fun getRealInstance(realLhs: PType, realRhs: PType): Fn {

--- a/partiql-spi/src/test/kotlin/org/partiql/spi/function/builtins/FnDivideTest.kt
+++ b/partiql-spi/src/test/kotlin/org/partiql/spi/function/builtins/FnDivideTest.kt
@@ -17,8 +17,12 @@ package org.partiql.spi.function.builtins
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.partiql.spi.errors.PError
+import org.partiql.spi.errors.PRuntimeException
 import org.partiql.spi.types.PType
 import org.partiql.spi.value.Datum
 import java.math.BigDecimal
@@ -36,6 +40,20 @@ class FnDivideTest {
         assertEquals(case.expectedType, result.type)
         assertEquals(case.expectedValue, result.bigDecimal)
         assertTrue(result.type.scale <= result.type.precision)
+    }
+
+    @Test
+    fun divisionRejectsIntegralOverflowWithoutTruncation() {
+        val lhs = Datum.decimal(BigDecimal("999999999999999999999999999999999"), 38, 0)
+        val rhs = Datum.decimal(BigDecimal("1.00"), 10, 2)
+        val fn = requireNotNull(FnDivide.getInstance(arrayOf(lhs.type, rhs.type)))
+
+        assertEquals(PType.decimal(38, 6), fn.signature.returns)
+
+        val error = assertThrows<PRuntimeException> {
+            fn.invoke(arrayOf(lhs, rhs))
+        }
+        assertEquals(PError.NUMERIC_VALUE_OUT_OF_RANGE, error.error.code())
     }
 
     data class DivisionCase(
@@ -81,18 +99,18 @@ class FnDivideTest {
                 expectedValue = BigDecimal("2.5000000000000"),
             ),
             DivisionCase(
-                name = "scale uses remaining precision after preserving integral digits",
-                lhs = Datum.decimal(BigDecimal("10"), 29, 0),
-                rhs = Datum.decimal(BigDecimal("2"), 9, 0),
+                name = "remaining scale preserves a 29-digit integral part",
+                lhs = Datum.decimal(BigDecimal("99999999999999999999999999999"), 29, 0),
+                rhs = Datum.decimal(BigDecimal.ONE, 9, 0),
                 expectedType = PType.decimal(38, 9),
-                expectedValue = BigDecimal("5.000000000"),
+                expectedValue = BigDecimal("99999999999999999999999999999.000000000"),
             ),
             DivisionCase(
-                name = "large integral part retains minimum division scale",
-                lhs = Datum.decimal(BigDecimal("10"), 38, 0),
-                rhs = Datum.decimal(BigDecimal("2.00"), 10, 2),
+                name = "minimum scale preserves a 32-digit integral part",
+                lhs = Datum.decimal(BigDecimal("99999999999999999999999999999999"), 38, 0),
+                rhs = Datum.decimal(BigDecimal("1.00"), 10, 2),
                 expectedType = PType.decimal(38, 6),
-                expectedValue = BigDecimal("5.000000"),
+                expectedValue = BigDecimal("99999999999999999999999999999999.000000"),
             ),
             DivisionCase(
                 name = "scale and precision are both capped at maximum precision",

--- a/partiql-spi/src/test/kotlin/org/partiql/spi/function/builtins/FnDivideTest.kt
+++ b/partiql-spi/src/test/kotlin/org/partiql/spi/function/builtins/FnDivideTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.partiql.spi.function.builtins
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.partiql.spi.types.PType
+import org.partiql.spi.value.Datum
+import java.math.BigDecimal
+
+class FnDivideTest {
+
+    @ParameterizedTest
+    @MethodSource("divisionCases")
+    fun divisionReturnsValidPrecisionAndScale(case: DivisionCase) {
+        val fn = requireNotNull(FnDivide.getInstance(arrayOf(case.lhs.type, case.rhs.type)))
+
+        assertEquals(case.expectedType, fn.signature.returns)
+
+        val result = fn.invoke(arrayOf(case.lhs, case.rhs))
+        assertEquals(case.expectedType, result.type)
+        assertEquals(case.expectedValue, result.bigDecimal)
+        assertTrue(result.type.scale <= result.type.precision)
+    }
+
+    data class DivisionCase(
+        val name: String,
+        val lhs: Datum,
+        val rhs: Datum,
+        val expectedType: PType,
+        val expectedValue: BigDecimal,
+    ) {
+        override fun toString(): String = name
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun divisionCases(): List<DivisionCase> = listOf(
+            DivisionCase(
+                name = "decimal scale is reduced to preserve integral digits",
+                lhs = Datum.decimal(BigDecimal("100000.00"), 10, 2),
+                rhs = Datum.decimal(BigDecimal("310000.00"), 38, 19),
+                expectedType = PType.decimal(38, 11),
+                expectedValue = BigDecimal("0.32258064516"),
+            ),
+            DivisionCase(
+                name = "numeric scale is reduced to preserve integral digits",
+                lhs = Datum.numeric(BigDecimal("100000.00"), 10, 2),
+                rhs = Datum.numeric(BigDecimal("310000.00"), 38, 19),
+                expectedType = PType.numeric(38, 11),
+                expectedValue = BigDecimal("0.32258064516"),
+            ),
+            DivisionCase(
+                name = "scale reduction preserves capacity for a unit ratio",
+                lhs = Datum.decimal(BigDecimal("100000.00"), 10, 2),
+                rhs = Datum.decimal(BigDecimal("100000.00"), 38, 19),
+                expectedType = PType.decimal(38, 11),
+                expectedValue = BigDecimal("1.00000000000"),
+            ),
+            DivisionCase(
+                name = "uncapped precision and scale are unchanged",
+                lhs = Datum.decimal(BigDecimal("10.00"), 10, 2),
+                rhs = Datum.decimal(BigDecimal("4.00"), 10, 2),
+                expectedType = PType.decimal(23, 13),
+                expectedValue = BigDecimal("2.5000000000000"),
+            ),
+            DivisionCase(
+                name = "large integral part retains minimum division scale",
+                lhs = Datum.decimal(BigDecimal("10"), 38, 0),
+                rhs = Datum.decimal(BigDecimal("2.00"), 10, 2),
+                expectedType = PType.decimal(38, 6),
+                expectedValue = BigDecimal("5.000000"),
+            ),
+            DivisionCase(
+                name = "scale and precision are both capped at maximum precision",
+                lhs = Datum.decimal(BigDecimal("0.5"), 38, 38),
+                rhs = Datum.decimal(BigDecimal.ONE, 1, 0),
+                expectedType = PType.decimal(38, 38),
+                expectedValue = BigDecimal("0.50000000000000000000000000000000000000"),
+            ),
+        )
+    }
+}

--- a/partiql-spi/src/test/kotlin/org/partiql/spi/function/builtins/FnDivideTest.kt
+++ b/partiql-spi/src/test/kotlin/org/partiql/spi/function/builtins/FnDivideTest.kt
@@ -53,18 +53,25 @@ class FnDivideTest {
         @JvmStatic
         fun divisionCases(): List<DivisionCase> = listOf(
             DivisionCase(
-                name = "decimal scale is clamped to returned precision",
+                name = "decimal scale is reduced to preserve integral digits",
                 lhs = Datum.decimal(BigDecimal("100000.00"), 10, 2),
                 rhs = Datum.decimal(BigDecimal("310000.00"), 38, 19),
-                expectedType = PType.decimal(38, 38),
-                expectedValue = BigDecimal("0.32258064516129032258064516129032258065"),
+                expectedType = PType.decimal(38, 11),
+                expectedValue = BigDecimal("0.32258064516"),
             ),
             DivisionCase(
-                name = "numeric scale is clamped to returned precision",
+                name = "numeric scale is reduced to preserve integral digits",
                 lhs = Datum.numeric(BigDecimal("100000.00"), 10, 2),
                 rhs = Datum.numeric(BigDecimal("310000.00"), 38, 19),
-                expectedType = PType.numeric(38, 38),
-                expectedValue = BigDecimal("0.32258064516129032258064516129032258065"),
+                expectedType = PType.numeric(38, 11),
+                expectedValue = BigDecimal("0.32258064516"),
+            ),
+            DivisionCase(
+                name = "scale reduction preserves capacity for a unit ratio",
+                lhs = Datum.decimal(BigDecimal("100000.00"), 10, 2),
+                rhs = Datum.decimal(BigDecimal("100000.00"), 38, 19),
+                expectedType = PType.decimal(38, 11),
+                expectedValue = BigDecimal("1.00000000000"),
             ),
             DivisionCase(
                 name = "uncapped precision and scale are unchanged",
@@ -74,18 +81,18 @@ class FnDivideTest {
                 expectedValue = BigDecimal("2.5000000000000"),
             ),
             DivisionCase(
-                name = "valid capped precision and scale are unchanged",
+                name = "scale uses remaining precision after preserving integral digits",
                 lhs = Datum.decimal(BigDecimal("10"), 29, 0),
                 rhs = Datum.decimal(BigDecimal("2"), 9, 0),
-                expectedType = PType.decimal(38, 10),
-                expectedValue = BigDecimal("5.0000000000"),
+                expectedType = PType.decimal(38, 9),
+                expectedValue = BigDecimal("5.000000000"),
             ),
             DivisionCase(
-                name = "large integral capacity does not force scale reduction",
+                name = "large integral part retains minimum division scale",
                 lhs = Datum.decimal(BigDecimal("10"), 38, 0),
                 rhs = Datum.decimal(BigDecimal("2.00"), 10, 2),
-                expectedType = PType.decimal(38, 11),
-                expectedValue = BigDecimal("5.00000000000"),
+                expectedType = PType.decimal(38, 6),
+                expectedValue = BigDecimal("5.000000"),
             ),
             DivisionCase(
                 name = "scale and precision are both capped at maximum precision",

--- a/partiql-spi/src/test/kotlin/org/partiql/spi/function/builtins/FnDivideTest.kt
+++ b/partiql-spi/src/test/kotlin/org/partiql/spi/function/builtins/FnDivideTest.kt
@@ -53,25 +53,18 @@ class FnDivideTest {
         @JvmStatic
         fun divisionCases(): List<DivisionCase> = listOf(
             DivisionCase(
-                name = "decimal scale is reduced to preserve integral digits",
+                name = "decimal scale is clamped to returned precision",
                 lhs = Datum.decimal(BigDecimal("100000.00"), 10, 2),
                 rhs = Datum.decimal(BigDecimal("310000.00"), 38, 19),
-                expectedType = PType.decimal(38, 11),
-                expectedValue = BigDecimal("0.32258064516"),
+                expectedType = PType.decimal(38, 38),
+                expectedValue = BigDecimal("0.32258064516129032258064516129032258065"),
             ),
             DivisionCase(
-                name = "numeric scale is reduced to preserve integral digits",
+                name = "numeric scale is clamped to returned precision",
                 lhs = Datum.numeric(BigDecimal("100000.00"), 10, 2),
                 rhs = Datum.numeric(BigDecimal("310000.00"), 38, 19),
-                expectedType = PType.numeric(38, 11),
-                expectedValue = BigDecimal("0.32258064516"),
-            ),
-            DivisionCase(
-                name = "scale reduction preserves capacity for a unit ratio",
-                lhs = Datum.decimal(BigDecimal("100000.00"), 10, 2),
-                rhs = Datum.decimal(BigDecimal("100000.00"), 38, 19),
-                expectedType = PType.decimal(38, 11),
-                expectedValue = BigDecimal("1.00000000000"),
+                expectedType = PType.numeric(38, 38),
+                expectedValue = BigDecimal("0.32258064516129032258064516129032258065"),
             ),
             DivisionCase(
                 name = "uncapped precision and scale are unchanged",
@@ -81,11 +74,18 @@ class FnDivideTest {
                 expectedValue = BigDecimal("2.5000000000000"),
             ),
             DivisionCase(
-                name = "large integral part retains minimum division scale",
+                name = "valid capped precision and scale are unchanged",
+                lhs = Datum.decimal(BigDecimal("10"), 29, 0),
+                rhs = Datum.decimal(BigDecimal("2"), 9, 0),
+                expectedType = PType.decimal(38, 10),
+                expectedValue = BigDecimal("5.0000000000"),
+            ),
+            DivisionCase(
+                name = "large integral capacity does not force scale reduction",
                 lhs = Datum.decimal(BigDecimal("10"), 38, 0),
                 rhs = Datum.decimal(BigDecimal("2.00"), 10, 2),
-                expectedType = PType.decimal(38, 6),
-                expectedValue = BigDecimal("5.000000"),
+                expectedType = PType.decimal(38, 11),
+                expectedValue = BigDecimal("5.00000000000"),
             ),
             DivisionCase(
                 name = "scale and precision are both capped at maximum precision",

--- a/partiql-spi/src/test/kotlin/org/partiql/spi/function/builtins/FnDivideTest.kt
+++ b/partiql-spi/src/test/kotlin/org/partiql/spi/function/builtins/FnDivideTest.kt
@@ -94,6 +94,20 @@ class FnDivideTest {
                 expectedType = PType.decimal(38, 38),
                 expectedValue = BigDecimal("0.50000000000000000000000000000000000000"),
             ),
+            DivisionCase(
+                name = "scale is clamped for malformed input below maximum precision",
+                lhs = Datum.decimal(BigDecimal.ZERO, 1, 2),
+                rhs = Datum.decimal(BigDecimal.ONE, 1, 0),
+                expectedType = PType.decimal(5, 5),
+                expectedValue = BigDecimal("0.00000"),
+            ),
+            DivisionCase(
+                name = "scale is clamped for malformed input above maximum precision",
+                lhs = Datum.decimal(BigDecimal.ZERO, 1, 2),
+                rhs = Datum.decimal(BigDecimal.ONE, 38, 0),
+                expectedType = PType.decimal(38, 38),
+                expectedValue = BigDecimal("0.00000000000000000000000000000000000000"),
+            ),
         )
     }
 }


### PR DESCRIPTION
## Relevant Issues
- Closes #1945

## Description
- Clamp DECIMAL and NUMERIC division result scale to the returned precision, preventing invalid result types such as `DECIMAL(38,41)`.
- Preserve the existing PartiQL division precision/scale formula and rounding behavior; this change does not introduce a new overflow-reduction policy.
- Return `DECIMAL(38,38)` for `DECIMAL(10,2) / DECIMAL(38,19)` instead of the invalid `DECIMAL(38,41)`, allowing representable ratios to remain in permissive projections.
- Add direct precision/scale boundary tests and an end-to-end correlated `SUM(DECIMAL)` regression covering both evaluator execution paths.

## Verification
- `./gradlew :partiql-spi:test --tests org.partiql.spi.function.builtins.FnDivideTest :partiql-eval:test --tests org.partiql.eval.internal.DivideTest`
- `./gradlew :partiql-spi:ktlintMainSourceSetCheck`

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md