### PR TITLE
Fix VARCHAR cast padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Thank you to all who have contributed!
 - Fixed `NullPointerException` during AST traversal by guarding nullable child fields in `getChildren()` for `WindowFunctionType.Lead`/`.Lag`, `AttributeConstraint`, and `TableConstraint.Unique`.
 - Fixed writing `CLOB` values in the CLI text-pretty output as `CAST('<value>' AS CLOB)` until `CLOB` literal is defined.
 - Fixed decimal division precision and scale reduction when computed precision exceeds 38, preventing invalid result types and missing projected fields
+- Fixed `VARCHAR` casts padding values shorter than the declared maximum length.
 
 ### Removed
 

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/operator/rex/CastTableTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/operator/rex/CastTableTest.kt
@@ -1,20 +1,10 @@
 package org.partiql.eval.internal.operator.rex
 
 import org.junit.jupiter.api.Test
-import org.partiql.spi.types.PType
-import org.partiql.spi.value.Datum
-import kotlin.test.assertEquals
 
 class CastTableTest {
     @Test
     fun printCastTable() {
         println(CastTable)
-    }
-
-    @Test
-    fun varcharDoesNotPadValues() {
-        val actual = CastTable.cast(Datum.string("a"), PType.varchar(20))
-
-        assertEquals("a", actual.string)
     }
 }

--- a/partiql-eval/src/test/kotlin/org/partiql/eval/internal/operator/rex/CastTableTest.kt
+++ b/partiql-eval/src/test/kotlin/org/partiql/eval/internal/operator/rex/CastTableTest.kt
@@ -1,10 +1,20 @@
 package org.partiql.eval.internal.operator.rex
 
 import org.junit.jupiter.api.Test
+import org.partiql.spi.types.PType
+import org.partiql.spi.value.Datum
+import kotlin.test.assertEquals
 
 class CastTableTest {
     @Test
     fun printCastTable() {
         println(CastTable)
+    }
+
+    @Test
+    fun varcharDoesNotPadValues() {
+        val actual = CastTable.cast(Datum.string("a"), PType.varchar(20))
+
+        assertEquals("a", actual.string)
     }
 }

--- a/partiql-spi/src/main/java/org/partiql/spi/value/Datum.java
+++ b/partiql-spi/src/main/java/org/partiql/spi/value/Datum.java
@@ -710,17 +710,10 @@ public interface Datum extends Iterable<Datum> {
     @NotNull
     static Datum varchar(@NotNull String value, int length) throws PRuntimeException {
         // TODO: Error or coerce here? Right now coerce, though I think this should likely error.
-        String newValue;
         if (length <= 0) {
             throw PErrors.wrappedException(new IllegalArgumentException("VARCHAR of length " + length + " not allowed."));
         }
-        if (value.length() < length) {
-            newValue = String.format("%-" + length + "." + length + "s", value);
-        } else if (value.length() == length) {
-            newValue = value;
-        } else {
-            newValue = value.substring(0, length);
-        }
+        String newValue = value.length() <= length ? value : value.substring(0, length);
         return new DatumString(newValue, PType.varchar(length));
     }
 

--- a/partiql-spi/src/test/kotlin/org/partiql/spi/value/DatumStringTest.kt
+++ b/partiql-spi/src/test/kotlin/org/partiql/spi/value/DatumStringTest.kt
@@ -20,9 +20,24 @@ import kotlin.test.assertEquals
 
 class DatumStringTest {
     @Test
-    fun varcharDoesNotPadValues() {
+    fun varcharPreservesValuesShorterThanLength() {
         val datum = Datum.varchar("a", 20)
 
         assertEquals("a", datum.string)
+    }
+
+    @Test
+    fun varcharPreservesValuesAtLength() {
+        val value = "a".repeat(20)
+        val datum = Datum.varchar(value, 20)
+
+        assertEquals(value, datum.string)
+    }
+
+    @Test
+    fun varcharTruncatesValuesLongerThanLength() {
+        val datum = Datum.varchar("a".repeat(30), 20)
+
+        assertEquals("a".repeat(20), datum.string)
     }
 }

--- a/partiql-spi/src/test/kotlin/org/partiql/spi/value/DatumStringTest.kt
+++ b/partiql-spi/src/test/kotlin/org/partiql/spi/value/DatumStringTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.partiql.spi.value
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class DatumStringTest {
+    @Test
+    fun varcharDoesNotPadValues() {
+        val datum = Datum.varchar("a", 20)
+
+        assertEquals("a", datum.string)
+    }
+}


### PR DESCRIPTION
## Relevant Issues
- Closes #1931

## Description
- Stop `VARCHAR(n)` casts from padding values shorter than `n` while preserving truncation for overlength strings and existing `CHAR` behavior.
- Tests: SPI and evaluator test suites, build, ktlint, detekt, API checks, and packaging passed.

## Other Information
- Updated Unreleased Section in CHANGELOG: **YES**
- Any backward-incompatible changes? **NO**
- Any new external dependencies? **NO**
- Do your changes comply with the [contributing][cg] and [code style][csg] guidelines? **YES**

## License Information

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

<!-- DO NOT DELETE BELOW -->

[cg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CONTRIBUTING.md
[csg]: https://github.com/partiql/partiql-lang-kotlin/blob/main/CODE_STYLE.md
